### PR TITLE
fix: add nologin for cwagent user

### DIFF
--- a/packaging/debian/preinst
+++ b/packaging/debian/preinst
@@ -21,6 +21,6 @@ if ! grep "^cwagent:" /etc/group >/dev/null 2>&1; then
 fi
 
 if ! id cwagent >/dev/null 2>&1; then
-    useradd -r -M cwagent -d /home/cwagent -g cwagent >/dev/null 2>&1
+    useradd -r -M cwagent -d /home/cwagent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh))) >/dev/null 2>&1
     echo "create user cwagent, result: $?"
 fi

--- a/packaging/linux/amazon-cloudwatch-agent.spec
+++ b/packaging/linux/amazon-cloudwatch-agent.spec
@@ -82,7 +82,7 @@ if ! grep "^cwagent:" /etc/group >/dev/null 2>&1; then
 fi
 
 if ! id cwagent >/dev/null 2>&1; then
-    useradd -r -M cwagent -d /home/cwagent -g cwagent >/dev/null 2>&1
+    useradd -r -M cwagent -d /home/cwagent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh))) >/dev/null 2>&1
     echo "create user cwagent, result: $?"
 fi
 


### PR DESCRIPTION
*Issue #, if available:*
It maybe a security concern for some users. So we want to make `cwagent` with nologin, 

*Description of changes:*

nologin displays a message that an account is not available and exits non-zero. It is intended as a replacement shell field to deny login access to an account.
The command path of nologin is different by Linux distribution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
