### PR TITLE
fix: remove useless data structure CloudWatchMetrics

### DIFF
--- a/plugins/inputs/cadvisor/extractors/extractor.go
+++ b/plugins/inputs/cadvisor/extractors/extractor.go
@@ -22,11 +22,6 @@ type MetricExtractor interface {
 	CleanUp(time.Time)
 }
 
-type CloudWatchMetrics struct {
-	metrics    []string
-	dimensions []string
-}
-
 type CAdvisorMetric struct {
 	fields     map[string]interface{}
 	tags       map[string]string


### PR DESCRIPTION
*Issue #, if available:*
Data structure CloudWatchMetrics is useless now

*Description of changes:*
Remove it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
