### PR TITLE
build: change location of generated CWAGENT_VERSION file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ build: amazon-cloudwatch-agent config-translator start-amazon-cloudwatch-agent a
 create-version-file:
 	@echo Version: ${VERSION}
 	@echo Building time: ${BUILD}
-	echo ${VERSION} > CWAGENT_VERSION
+	mkdir -p build/bin/
+	echo ${VERSION} > build/bin/CWAGENT_VERSION
 
 amazon-cloudwatch-agent: create-version-file
 	@echo Building amazon-cloudwatch-agent


### PR DESCRIPTION
*Description of changes:*

Move the CWAGENT_VERSION file to build/bin since it is generated as part
of the build process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
