### PR TITLE
fix: Message size limit should be 1M-header size

### DIFF
--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -27,7 +27,7 @@ const (
 	defaultFlushTimeout = 5 * time.Second
 	eventHeaderSize     = 26
 	truncatedSuffix     = "[Truncated...]"
-	msgSizeLimit        = 256 * 1024
+	msgSizeLimit        = 256*1024 - eventHeaderSize
 
 	maxRetryTimeout    = 14*24*time.Hour + 10*time.Minute
 	metricRetryTimeout = 2 * time.Minute


### PR DESCRIPTION
*Description of changes:*

The limit of a single log event is 1M - 26 bytes (header size)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
