### PR TITLE
fix: exclude the user dimension in procstat

### DIFF
--- a/translator/totomlconfig/sampleConfig/complete_linux_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_linux_config.conf
@@ -96,6 +96,15 @@
       "aws:StorageResolution" = "true"
       metricPath = "metrics"
 
+  [[inputs.procstat]]
+    fieldpass = ["cpu_usage", "memory_rss"]
+    pid_file = "/var/run/example1.pid"
+    pid_finder = "native"
+    tagexclude = ["user"]
+    [inputs.procstat.tags]
+      "aws:StorageResolution" = "true"
+      metricPath = "metrics"
+
   [[inputs.socket_listener]]
     data_format = "emf"
     name_override = "emf"

--- a/translator/totomlconfig/sampleConfig/complete_linux_config.json
+++ b/translator/totomlconfig/sampleConfig/complete_linux_config.json
@@ -114,7 +114,16 @@
           "sleeping",
           "dead"
         ]
-      }
+      },
+      "procstat": [
+        {
+          "pid_file": "/var/run/example1.pid",
+          "measurement": [
+            "cpu_usage",
+            "memory_rss"
+          ]
+        }
+      ]
     },
     "append_dimensions": {
       "ImageId": "${aws:ImageId}",

--- a/translator/totomlconfig/sampleConfig/complete_windows_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_windows_config.conf
@@ -37,6 +37,14 @@
     [inputs.logfile.tags]
       metricPath = "logs"
 
+  [[inputs.procstat]]
+    exe = "agent"
+    fieldpass = ["cpu_time_system", "cpu_time_user"]
+    pid_finder = "native"
+    tagexclude = ["user"]
+    [inputs.procstat.tags]
+      metricPath = "metrics"
+
   [[inputs.socket_listener]]
     data_format = "emf"
     name_override = "emf"

--- a/translator/totomlconfig/sampleConfig/complete_windows_config.json
+++ b/translator/totomlconfig/sampleConfig/complete_windows_config.json
@@ -91,7 +91,16 @@
           "d1": "win_foo",
           "d2": "win_bar"
         }
-      }
+      },
+      "procstat": [
+        {
+          "exe": "agent",
+          "measurement": [
+            "cpu_time_system",
+            "cpu_time_user"
+          ]
+        }
+      ]
     },
     "append_dimensions": {
       "ImageId": "${aws:ImageId}",

--- a/translator/translate/metrics/metrics_collect/procstat/procstat_test.go
+++ b/translator/translate/metrics/metrics_collect/procstat/procstat_test.go
@@ -32,6 +32,7 @@ func TestExeConfig(t *testing.T) {
 		"exe":        "amazon-cloudwat",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
+		"tagexclude": []string{"user"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -50,6 +51,7 @@ func TestPidFileConfig(t *testing.T) {
 		"pid_file":   "/var/run/sshd",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
+		"tagexclude": []string{"user"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -68,6 +70,7 @@ func TestPatternConfig(t *testing.T) {
 		"pattern":    "sshd",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
+		"tagexclude": []string{"user"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -90,6 +93,7 @@ func TestMultiLookupConfig(t *testing.T) {
 		"pattern":    "sshd",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
+		"tagexclude": []string{"user"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -111,6 +115,7 @@ func TestIntervalConfig(t *testing.T) {
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
 		"interval":   "30s",
 		"tags":       map[string]interface{}{"aws:StorageResolution": "true"},
+		"tagexclude": []string{"user"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -137,11 +142,13 @@ func TestMultiProcessesConfig(t *testing.T) {
 			"pid_file":   "/var/run/sshd",
 			"pid_finder": "native",
 			"fieldpass":  []string{"cpu_usage", "memory_rss"},
+			"tagexclude": []string{"user"},
 		},
 		map[string]interface{}{
 			"exe":        "cloudwatch",
 			"pid_finder": "native",
 			"fieldpass":  []string{"cpu_usage", "memory_rss"},
+			"tagexclude": []string{"user"},
 		},
 	}
 	checkResult(t, input, expectedVal)
@@ -169,6 +176,7 @@ func TestIntervalErrorConfig(t *testing.T) {
 		"pid_file":   "/var/run/sshd",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage"},
+		"tagexclude": []string{"user"},
 	}}
 	checkResult(t, input, expectedVal)
 }

--- a/translator/translate/metrics/metrics_collect/procstat/ruleDropTags.go
+++ b/translator/translate/metrics/metrics_collect/procstat/ruleDropTags.go
@@ -1,0 +1,21 @@
+package procstat
+
+const (
+	tagExcludeKey = "tagexclude"
+)
+
+var (
+	tagExcludeValues = []string{"user"}
+)
+
+type DropTags struct {
+}
+
+func (i *DropTags) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	returnKey, returnVal = tagExcludeKey, tagExcludeValues
+	return
+}
+
+func init() {
+	RegisterRule("dropTags", new(DropTags))
+}


### PR DESCRIPTION
*Issue #, if available:*
1. "user" dimension was added to "procstat", it will break current customer's behavior
*Description of changes:*
1. exclude `user` dimension.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
