### PR TITLE
fix: show more info about log src in log agent logging

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -29,6 +29,7 @@ type LogSrc interface {
 	Group() string
 	Stream() string
 	Destination() string
+	Description() string
 	Stop()
 }
 
@@ -96,12 +97,12 @@ func (l *LogAgent) Run(ctx context.Context) {
 					dname := src.Destination()
 					backend, ok := l.backends[dname]
 					if !ok {
-						log.Printf("E! [logagent] Failed to find destination %v/%v for log source %v ", dname, src.Group(), src.Stream())
+						log.Printf("E! [logagent] Failed to find destination %v for log source %v/%v(%v) ", dname, src.Group(), src.Stream(), src.Description())
 						continue
 					}
 					dest := backend.CreateDest(src.Group(), src.Stream())
 					l.destNames[dest] = dname
-					log.Printf("I! [logagent] piping log from %v/%v to %v", src.Group(), src.Stream(), dname)
+					log.Printf("I! [logagent] piping log from %v/%v(%v) to %v", src.Group(), src.Stream(), src.Description(), dname)
 					go l.runSrcToDest(src, dest)
 				}
 			}
@@ -117,7 +118,7 @@ func (l *LogAgent) runSrcToDest(src LogSrc, dest LogDest) {
 	src.SetOutput(func(e LogEvent) {
 		if e == nil {
 			close(eventsCh)
-			log.Printf("I! [logagent] Log src has stopped for %v/%v", src.Group(), src.Stream())
+			log.Printf("I! [logagent] Log src has stopped for %v/%v(%v)", src.Group(), src.Stream(), src.Description())
 			return
 		}
 		eventsCh <- e

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -87,6 +87,10 @@ func (ts tailerSrc) Stream() string {
 	return ts.stream
 }
 
+func (ts tailerSrc) Description() string {
+	return ts.tailer.Filename
+}
+
 func (ts tailerSrc) Destination() string {
 	return ts.destination
 }

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -84,6 +84,10 @@ func (l *windowsEventLog) Stream() string {
 	return l.logStreamName
 }
 
+func (l *windowsEventLog) Description() string {
+	return fmt.Sprintf("%v%v", l.name, l.levels)
+}
+
 func (l *windowsEventLog) Destination() string {
 	return l.destination
 }


### PR DESCRIPTION
*Description of changes:*

Add the log file name as description for tailersrc, and add name and levels as description for windows event log src.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
