### PR TITLE
fix: Log line longer than 4096 gets broken into mulitple log events

### DIFF
--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -188,13 +188,14 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 
 			tailer, err := tail.TailFile(filename,
 				tail.Config{
-					ReOpen:    false,
-					Follow:    true,
-					Location:  seekFile,
-					MustExist: true,
-					Pipe:      fileconfig.Pipe,
-					Poll:      true,
-					IsUTF16:   isutf16,
+					ReOpen:      false,
+					Follow:      true,
+					Location:    seekFile,
+					MustExist:   true,
+					Pipe:        fileconfig.Pipe,
+					Poll:        true,
+					MaxLineSize: fileconfig.MaxEventSize,
+					IsUTF16:     isutf16,
 				})
 
 			if err != nil {


### PR DESCRIPTION
# Description of the issue
Log event bigger than 4096 bytes in a single line gets broken into multiple events.

# Description of changes
Tailer is created without the MaxEventSize, resulting in default buffer
size of 4096 in the bufferedReader in tailer is created. Initialize the
MaxEventSize to the size in fileconfig.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.