### PR TITLE
chore: move starting log after we complete the log setup

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -170,7 +170,6 @@ func runAgent(ctx context.Context,
 	inputFilters []string,
 	outputFilters []string,
 ) error {
-	log.Printf("I! Starting AmazonCloudWatchAgent %s", agentinfo.Version())
 	if *fConfig == "" {
 		return fmt.Errorf("No config file specified")
 	}
@@ -236,6 +235,7 @@ func runAgent(ctx context.Context,
 	}
 
 	logger.SetupLogging(logConfig)
+	log.Printf("I! Starting AmazonCloudWatchAgent %s", agentinfo.Version())
 
 	if *fTest || *fTestWait != 0 {
 		testWaitDuration := time.Duration(*fTestWait) * time.Second


### PR DESCRIPTION
# Description of the issue
The version information is missing in the amazon-cloudwatch-agent.log

# Description of changes
move it after we complete the log setup

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
```2020-07-24T19:22:30Z I! Starting AmazonCloudWatchAgent 1.247345.7```




