### PR TITLE
fix: EMF log events gets send 2 times

### DIFF
--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -285,8 +285,9 @@ func (cd *cwDest) AddEvent(e logs.LogEvent) {
 	// Drop events for metric path logs when queue is full
 	if cd.isEMF {
 		cd.pusher.AddEventNonBlocking(e)
+	} else {
+		cd.pusher.AddEvent(e)
 	}
-	cd.pusher.AddEvent(e)
 }
 
 func (cd *cwDest) switchToEMF() {


### PR DESCRIPTION
# Description of the issue
EMF log events are pushed into event queue twice, first AddEventNonBlocking then via AddEvent.

# Description of changes
EMF log events should only be added non blocking by calling AddEventNonBlocking

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.




