### PR TITLE
chore: reset the eventbatch after print the debug information

### DIFF
--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -214,10 +214,11 @@ func (p *pusher) send() {
 			for _, done := range p.doneCallbacks {
 				done()
 			}
-			p.reset()
 
 			p.Log.Debugf("Pusher published %v log events with size %v KB in %v.", len(p.events), p.bufferredSize/1024, time.Since(startTime))
 			p.addStats("rawSize", float64(p.bufferredSize))
+
+			p.reset()
 
 			return
 		}


### PR DESCRIPTION
# Description of the issue
found the meaningless log.
2020-07-27T05:55:02Z D! [outputs.cloudwatchlogs] Pusher published 0 log events with size 0 KB in 878.74446ms

# Description of changes
The stats is not correct

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests





