### PR TITLE
chore: add log group and stream info into pusher debug info

### DIFF
--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -215,7 +215,7 @@ func (p *pusher) send() {
 				done()
 			}
 
-			p.Log.Debugf("Pusher published %v log events with size %v KB in %v.", len(p.events), p.bufferredSize/1024, time.Since(startTime))
+			p.Log.Debugf("Pusher published %v log events to group: %v stream: %v with size %v KB in %v.", len(p.events), p.Group, p.Stream, p.bufferredSize/1024, time.Since(startTime))
 			p.addStats("rawSize", float64(p.bufferredSize))
 
 			p.reset()


### PR DESCRIPTION
# Description of the issue
Current debug log from pusher does not show log group and stream information

# Description of changes
Add log group and stream information to the pusher push success log 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests



