### PR TITLE
fix: log event with zero time is not handled properly

### DIFF
--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -129,8 +129,8 @@ func (p *pusher) start() {
 
 			// A batch of log events in a single request cannot span more than 24 hours.
 			et := e.Time()
-			if (p.minT != nil && et.Sub(*p.minT) > 24*time.Hour) ||
-				(p.maxT != nil && p.maxT.Sub(et) > 24*time.Hour) {
+			if !et.IsZero() && // event with zero time is handled by convertEvent method
+				((p.minT != nil && et.Sub(*p.minT) > 24*time.Hour) || (p.maxT != nil && p.maxT.Sub(et) > 24*time.Hour)) {
 				p.send()
 			}
 
@@ -147,7 +147,7 @@ func (p *pusher) start() {
 			p.events = append(p.events, ce)
 			p.doneCallbacks = append(p.doneCallbacks, e.Done)
 			p.bufferredSize += size
-			if p.minT == nil || p.minT.After(et) {
+			if p.minT == nil || (!et.IsZero() && p.minT.After(et)) {
 				p.minT = &et
 			}
 			if p.maxT == nil || p.maxT.Before(et) {


### PR DESCRIPTION
# Description of the issue
Improper handling of log event without timestamp results in too frequent API call

# Description of changes
- zero time event should be ignored for checking if event is within 24hrs
- zero time event should not be used for recording minT in the batch

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.





