### PR TITLE
fix: exclude tag "mode" for disk plugin

### DIFF
--- a/translator/totomlconfig/sampleConfig/advanced_config_linux.conf
+++ b/translator/totomlconfig/sampleConfig/advanced_config_linux.conf
@@ -25,6 +25,7 @@
 
   [[inputs.disk]]
     fieldpass = ["used_percent", "inodes_free"]
+    tagexclude = ["mode"]
     [inputs.disk.tags]
       metricPath = "metrics"
 

--- a/translator/totomlconfig/sampleConfig/basic_config_linux.conf
+++ b/translator/totomlconfig/sampleConfig/basic_config_linux.conf
@@ -18,6 +18,7 @@
 
   [[inputs.disk]]
     fieldpass = ["used_percent"]
+    tagexclude = ["mode"]
     [inputs.disk.tags]
       metricPath = "metrics"
 

--- a/translator/totomlconfig/sampleConfig/complete_linux_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_linux_config.conf
@@ -34,6 +34,7 @@
     ignore_fs = ["sysfs", "devtmpfs"]
     interval = "60s"
     mount_points = ["/", "/dev", "/sys"]
+    tagexclude = ["mode"]
     [inputs.disk.tags]
       d3 = "foo3"
       d4 = "bar4"

--- a/translator/totomlconfig/sampleConfig/standard_config_linux.conf
+++ b/translator/totomlconfig/sampleConfig/standard_config_linux.conf
@@ -25,6 +25,7 @@
 
   [[inputs.disk]]
     fieldpass = ["used_percent", "inodes_free"]
+    tagexclude = ["mode"]
     [inputs.disk.tags]
       metricPath = "metrics"
 

--- a/translator/totomlconfig/sampleConfig/standard_config_linux_with_common_config.conf
+++ b/translator/totomlconfig/sampleConfig/standard_config_linux_with_common_config.conf
@@ -25,6 +25,7 @@
 
   [[inputs.disk]]
     fieldpass = ["used_percent", "inodes_free"]
+    tagexclude = ["mode"]
     [inputs.disk.tags]
       metricPath = "metrics"
 

--- a/translator/translate/metrics/metrics_collect/disk/disk_test.go
+++ b/translator/translate/metrics/metrics_collect/disk/disk_test.go
@@ -42,6 +42,7 @@ func TestDiskSpecificConfig(t *testing.T) {
 			"ignore_fs":    []interface{}{"sysfs", "devtmpfs"},
 			"mount_points": []interface{}{"/", "/dev", "/sys"},
 			"fieldpass":    []string{"free", "total", "used"},
+			"tagexclude":   []string{"mode"},
 		},
 		}
 		assert.Equal(t, expectedVal, actualVal, "Expect to be equal")
@@ -71,7 +72,7 @@ func TestDiskSpecificConfig(t *testing.T) {
 			"ignore_fs":    []interface{}{"sysfs", "devtmpfs"},
 			"mount_points": []interface{}{"/", "/dev", "/sys"},
 			"fieldpass":    []string{"free", "total", "used"},
-			"tagexclude":   []string{"device"},
+			"tagexclude":   []string{"device", "mode"},
 		},
 		}
 		assert.Equal(t, expectedValue, actualValue, "Expect to be equal")
@@ -101,6 +102,7 @@ func TestDiskSpecificConfig(t *testing.T) {
 			"ignore_fs":    []interface{}{"sysfs", "devtmpfs"},
 			"mount_points": []interface{}{"/", "/dev", "/sys"},
 			"fieldpass":    []string{"free", "total", "used"},
+			"tagexclude":   []string{"mode"},
 		},
 		}
 		assert.Equal(t, expectedValue, actualValue, "Expect to be equal")

--- a/translator/translate/metrics/metrics_collect/disk/ruleDropTags.go
+++ b/translator/translate/metrics/metrics_collect/disk/ruleDropTags.go
@@ -10,10 +10,12 @@ const (
 	dropDeviceKey = "drop_device"
 )
 
-type DropDevice struct {
+var tagExcludeValues = []string{"mode"}
+
+type DropTags struct {
 }
 
-func (i *DropDevice) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+func (i *DropTags) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
 	m := input.(map[string]interface{})
 	shouldDropDevice := false //default to be false
 	if val, ok := m[dropDeviceKey]; ok {
@@ -22,17 +24,16 @@ func (i *DropDevice) ApplyRule(input interface{}) (returnKey string, returnVal i
 	}
 
 	if shouldDropDevice {
-		returnKey, returnVal = translator.DefaultCase(tagExcludeKey, []string{"device"}, input)
+		returnKey, returnVal = translator.DefaultCase(tagExcludeKey, append([]string{"device"}, tagExcludeValues...), input)
 	} else {
-		//empty key, value will be ignored when setting the config
-		returnKey = ""
-		returnVal = ""
+		returnKey = tagExcludeKey
+		returnVal = tagExcludeValues
 	}
 
 	return
 }
 
 func init() {
-	i := new(DropDevice)
-	RegisterRule("drop_device", i)
+	i := new(DropTags)
+	RegisterRule("dropTags", i)
 }


### PR DESCRIPTION
# Description of the issue
The new version adds the tag "mode"  which doesn't exist previously.

# Description of changes
We need to remove the tag for consistency.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* built the rpm with the change 
* installed the rpm to an ec2 instance 
* checked the tag "mode" doesn't exist from cloudwatch console




