### PR TITLE
fix: add ec2tagger plugin

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -6,6 +6,7 @@ package plugins
 import (
 	//Enable cloudwatch-agent process plugins
 	_ "github.com/aws/amazon-cloudwatch-agent/plugins/processors/delta"
+	_ "github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger"
 	_ "github.com/aws/amazon-cloudwatch-agent/plugins/processors/ecsdecorator"
 	_ "github.com/aws/amazon-cloudwatch-agent/plugins/processors/k8sdecorator"
 
@@ -41,5 +42,4 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/procstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/socket_listener"
 	_ "github.com/influxdata/telegraf/plugins/inputs/swap"
-	_ "github.com/influxdata/telegraf/plugins/processors/ec2tagger"
 )

--- a/plugins/processors/ec2tagger/README.md
+++ b/plugins/processors/ec2tagger/README.md
@@ -1,0 +1,77 @@
+# EC2 Tagger Processor Plugin
+
+Tags metrics with EC2 Metadata and EC2 Instance Tags.
+
+
+## Amazon Authentication
+
+This plugin uses a credential chain for Authentication with the EC2
+API endpoint. In the following order the plugin will attempt to authenticate.
+1. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
+2. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
+3. Shared profile from `profile` attribute
+4. [Environment Variables](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables)
+5. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
+6. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+
+The IAM User or Role making the calls must have permissions to call the EC2 DescribeTags API.
+
+### Configuration:
+
+```toml
+# Configuration for adding EC2 Metadata and Instance Tags to metrics.
+[[processors.ec2tagger]]
+  ##
+  ## ec2tagger calls AWS api to fetch EC2 Metadata and Instance Tags and EBS Volumes associated with the  
+  ## current EC2 Instance and attched those values as tags to the metric.
+  ## 
+  ## Frequency for the plugin to refresh the EC2 Instance Tags and ebs Volumes associated with this Instance.
+  ## Defaults to 0 (no refresh).
+  ## When it is zero, ec2tagger doesn't do refresh to keep the ec2 tags and ebs volumes updated. However, as the
+  ## AWS api request made by ec2tagger might not return the complete values (e.g. initial api call might return a 
+  ## subset of ec2 tags), ec2tagger will retry every 3 minutes until all the tags/volumes (as specified by
+  ## "ec2_instance_tag_keys"/"ebs_device_keys") are retrieved successfully. (Note when the specified list is ["*"],
+  ## there is no way to check if all tags/volumes are retrieved, so there is no retry in that case)
+  # refresh_interval_seconds = 60
+  ##
+  ## Add tags for EC2 Metadata fields.
+  ## Supported fields are: "InstanceId", "ImageId" (aka AMI), "InstanceType"
+  ## If the configuration is not provided or it has an empty list, no EC2 Metadata tags are applied.
+  # ec2_metadata_tags = ["InstanceId", "ImageId", "InstanceType"]
+  ##
+  ## Add tags retrieved from the EC2 Instance Tags associated with this instance.
+  ## If this configuration is not provided, or has an empty list, no EC2 Instance Tags are applied.
+  ## If this configuration contains one entry and its value is "*", then ALL EC2 Instance Tags for the instance are applied.
+  ## Note: This plugin renames the "aws:autoscaling:groupName" EC2 Instance Tag key to be spelled "AutoScalingGroupName".
+  ## This aligns it with the AutoScaling dimension-name seen in AWS CloudWatch.
+  # ec2_instance_tag_keys = ["aws:autoscaling:groupName", "Name"]
+  ##
+  ## Retrieve ebs_volume_id for the specified devices, add ebs_volume_id as tag. The specified devices are
+  ## the values corresponding to the tag key "disk_device_tag_key" in the input metric.  
+  ## If this configuration is not provided, or has an empty list, no ebs volume is applied.
+  ## If this configuration contains one entry and its value is "*", then all ebs volume for the instance are applied.
+  # ebs_device_keys = ["/dev/xvda", "/dev/nvme0n1"]
+  ##
+  ## Specify which tag to use to get the specified disk device name from input Metric
+  # disk_device_tag_key = "device"
+  ##
+  ## Amazon Credentials
+  ## Credentials are loaded in the following order
+  ## 1) Assumed credentials via STS if role_arn is specified
+  ## 2) explicit credentials from 'access_key' and 'secret_key'
+  ## 3) shared profile from 'profile'
+  ## 4) environment variables
+  ## 5) shared credentials file
+  ## 6) EC2 Instance Profile
+  # access_key = ""
+  # secret_key = ""
+  # token = ""
+  # role_arn = ""
+  # profile = ""
+  # shared_credential_file = ""
+```
+
+### Filters:
+
+Processor plugins support the standard tag filter settings just like everything else.
+

--- a/plugins/processors/ec2tagger/ebsvolume.go
+++ b/plugins/processors/ec2tagger/ebsvolume.go
@@ -1,0 +1,75 @@
+package ec2tagger
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type EbsVolume struct {
+	// device name to volumeId mapping
+	dev2Vol map[string]string
+	sync.RWMutex
+}
+
+func NewEbsVolume() *EbsVolume {
+	return &EbsVolume{dev2Vol: make(map[string]string)}
+}
+
+func (e *EbsVolume) addEbsVolumeMapping(zone *string, attachement *ec2.VolumeAttachment) {
+	// *attachement.Device is sth like: /dev/xvda
+	devPath := findNvmeBlockNameIfPresent(*attachement.Device)
+	if devPath == "" {
+		devPath = *attachement.Device
+	}
+
+	e.Lock()
+	defer e.Unlock()
+	e.dev2Vol[devPath] = fmt.Sprintf("aws://%s/%s", *zone, *attachement.VolumeId)
+}
+
+// find nvme block name by symlink, if symlink doesn't exist, return ""
+func findNvmeBlockNameIfPresent(devName string) string {
+	// for nvme(ssd), there is a symlink from devName to nvme block name, i.e. /dev/xvda -> /dev/nvme0n1
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
+	hasRootFs := true
+	if _, err := os.Lstat("/rootfs/proc"); os.IsNotExist(err) {
+		hasRootFs = false
+	}
+	nvmeName := ""
+
+	if hasRootFs {
+		devName = "/rootfs" + devName
+	}
+
+	if info, err := os.Lstat(devName); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			if path, err := filepath.EvalSymlinks(devName); err == nil {
+				nvmeName = path
+			}
+		}
+	}
+
+	if nvmeName != "" && hasRootFs {
+		nvmeName = strings.TrimPrefix(nvmeName, "/rootfs")
+	}
+	return nvmeName
+}
+
+func (e *EbsVolume) getEbsVolumeId(devName string) string {
+	e.RLock()
+	defer e.RUnlock()
+
+	for k, v := range e.dev2Vol {
+		// The key of dev2Vol is device name like nvme0n1, while the input devName could be a partition name like nvme0n1p1
+		if strings.HasPrefix(devName, k) {
+			return v
+		}
+	}
+
+	return ""
+}

--- a/plugins/processors/ec2tagger/ec2tagger.go
+++ b/plugins/processors/ec2tagger/ec2tagger.go
@@ -1,0 +1,524 @@
+package ec2tagger
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"sync"
+	"time"
+
+	internalaws "github.com/aws/amazon-cloudwatch-agent/cfg/aws"
+	"github.com/aws/amazon-cloudwatch-agent/internal"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+// Reminder, keep this in sync with the plugin's README.md
+const sampleConfig = `
+  ##
+  ## ec2tagger calls AWS api to fetch EC2 Metadata and Instance Tags and EBS Volumes associated with the  
+  ## current EC2 Instance and attched those values as tags to the metric.
+  ## 
+  ## Frequency for the plugin to refresh the EC2 Instance Tags and ebs Volumes associated with this Instance.
+  ## Defaults to 0 (no refresh).
+  ## When it is zero, ec2tagger doesn't do refresh to keep the ec2 tags and ebs volumes updated. However, as the
+  ## AWS api request made by ec2tagger might not return the complete values (e.g. initial api call might return a 
+  ## subset of ec2 tags), ec2tagger will retry every 3 minutes until all the tags/volumes (as specified by
+  ## "ec2_instance_tag_keys"/"ebs_device_keys") are retrieved successfully. (Note when the specified list is ["*"],
+  ## there is no way to check if all tags/volumes are retrieved, so there is no retry in that case)
+  # refresh_interval_seconds = 60
+  ##
+  ## Add tags for EC2 Metadata fields.
+  ## Supported fields are: "InstanceId", "ImageId" (aka AMI), "InstanceType"
+  ## If the configuration is not provided or it has an empty list, no EC2 Metadata tags are applied.
+  # ec2_metadata_tags = ["InstanceId", "ImageId", "InstanceType"]
+  ##
+  ## Add tags retrieved from the EC2 Instance Tags associated with this instance.
+  ## If this configuration is not provided, or has an empty list, no EC2 Instance Tags are applied.
+  ## If this configuration contains one entry and its value is "*", then ALL EC2 Instance Tags for the instance are applied.
+  ## Note: This plugin renames the "aws:autoscaling:groupName" EC2 Instance Tag key to be spelled "AutoScalingGroupName".
+  ## This aligns it with the AutoScaling dimension-name seen in AWS CloudWatch.
+  # ec2_instance_tag_keys = ["aws:autoscaling:groupName", "Name"]
+  ##
+  ## Retrieve ebs_volume_id for the specified devices, add ebs_volume_id as tag. The specified devices are
+  ## the values corresponding to the tag key "disk_device_tag_key" in the input metric.  
+  ## If this configuration is not provided, or has an empty list, no ebs volume is applied.
+  ## If this configuration contains one entry and its value is "*", then all ebs volume for the instance are applied.
+  # ebs_device_keys = ["/dev/xvda", "/dev/nvme0n1"]
+  ##
+  ## Specify which tag to use to get the specified disk device name from input Metric
+  # disk_device_tag_key = "device"
+  ##
+  ## Amazon Credentials
+  ## Credentials are loaded in the following order
+  ## 1) Assumed credentials via STS if role_arn is specified
+  ## 2) explicit credentials from 'access_key' and 'secret_key'
+  ## 3) shared profile from 'profile'
+  ## 4) environment variables
+  ## 5) shared credentials file
+  ## 6) EC2 Instance Profile
+  # access_key = ""
+  # secret_key = ""
+  # token = ""
+  # role_arn = ""
+  # profile = ""
+  # shared_credential_file = ""
+`
+
+const (
+	ec2InstanceTagKeyASG = "aws:autoscaling:groupName"
+	cwDimensionASG       = "AutoScalingGroupName"
+	mdKeyInstanceId      = "InstanceId"
+	mdKeyImageId         = "ImageId"
+	mdKeyInstaneType     = "InstanceType"
+	ebsVolumeId          = "EBSVolumeId"
+)
+
+var (
+	defaultRefreshInterval = 180 * time.Second
+	// backoff retry for ec2 describe instances API call. Assuming the throttle limit is 20 per second. 10 mins allow 12000 API calls.
+	backoffSleepArray = []time.Duration{1 * time.Minute, 1 * time.Minute, 3 * time.Minute, 3 * time.Minute, 3 * time.Minute, 10 * time.Minute}
+)
+
+type metadataLookup struct {
+	instanceId   bool
+	imageId      bool
+	instanceType bool
+}
+
+type ec2ProviderType func(*internalaws.CredentialConfig) ec2iface.EC2API
+
+type ec2Metadata interface {
+	Available() bool
+	GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error)
+}
+
+type Tagger struct {
+	Log                    telegraf.Logger   `toml:"-"`
+	RefreshIntervalSeconds internal.Duration `toml:"refresh_interval_seconds"`
+	EC2MetadataTags        []string          `toml:"ec2_metadata_tags"`
+	EC2InstanceTagKeys     []string          `toml:"ec2_instance_tag_keys"`
+	EBSDeviceKeys          []string          `toml:"ebs_device_keys"`
+	//The tag key in the metrics for disk device
+	DiskDeviceTagKey string `toml:"disk_device_tag_key"`
+
+	// unlike other AWS plugins, this one determines the region from ec2 metadata not user configuration
+	AccessKey string `toml:"access_key"`
+	SecretKey string `toml:"secret_key"`
+	RoleARN   string `toml:"role_arn"`
+	Profile   string `toml:"profile"`
+	Filename  string `toml:"shared_credential_file"`
+	Token     string `toml:"token"`
+
+	ec2TagCache    map[string]string
+	instanceId     string
+	imageId        string // aka AMI
+	instanceType   string
+	started        bool
+	region         string
+	ec2Provider    ec2ProviderType
+	ec2            ec2iface.EC2API
+	ec2metadata    ec2Metadata
+	refreshTicker  *time.Ticker
+	shutdownC      chan bool
+	tagFilters     []*ec2.Filter
+	metadataLookup metadataLookup
+	ebsVolume      *EbsVolume
+
+	sync.RWMutex //to protect ec2TagCache
+}
+
+func (t *Tagger) SampleConfig() string {
+	return sampleConfig
+}
+
+func (t *Tagger) Description() string {
+	return "Configuration for adding EC2 Metadata and Instance Tags and EBS volumes to metrics."
+}
+
+// Apply adds the configured EC2 Metadata and Instance Tags to metrics.
+//
+// This is called serially for ALL metrics (that pass the plugin's tag filters) so keep it fast.
+//
+func (t *Tagger) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	// grab the pointer to the map in case it gets refreshed while we're applying this round of metrics. At least
+	// this batch then will all get the same tags.
+	t.RLock()
+	defer t.RUnlock()
+
+	for _, metric := range in {
+		if t.ec2TagCache != nil {
+			for k, v := range t.ec2TagCache {
+				metric.AddTag(k, v)
+			}
+		}
+		if t.metadataLookup.instanceId {
+			metric.AddTag(mdKeyInstanceId, t.instanceId)
+		}
+		if t.metadataLookup.imageId {
+			metric.AddTag(mdKeyImageId, t.imageId)
+		}
+		if t.metadataLookup.instanceType {
+			metric.AddTag(mdKeyInstaneType, t.instanceType)
+		}
+		if t.ebsVolume != nil && metric.HasTag(t.DiskDeviceTagKey) {
+			devName := metric.Tags()[t.DiskDeviceTagKey]
+			ebsVolId := t.ebsVolume.getEbsVolumeId(devName)
+			if ebsVolId != "" {
+				metric.AddTag(ebsVolumeId, ebsVolId)
+			}
+		}
+	}
+	return in
+}
+
+// updateTags calls EC2 Describe Tags and replaces the Tagger's tagCache with the newly retrieved values
+func (t *Tagger) updateTags() error {
+	tags := make(map[string]string)
+	input := &ec2.DescribeTagsInput{
+		Filters: t.tagFilters,
+	}
+
+	for {
+		result, err := t.ec2.DescribeTags(input)
+		if err != nil {
+			return err
+		}
+		for _, tag := range result.Tags {
+			key := *tag.Key
+			if ec2InstanceTagKeyASG == key {
+				// rename to match CW dimension as applied by AutoScaling service, not the EC2 tag
+				key = cwDimensionASG
+			}
+			tags[key] = *tag.Value
+		}
+		if result.NextToken == nil {
+			break
+		}
+		input.SetNextToken(*result.NextToken)
+	}
+	t.Lock()
+	defer t.Unlock()
+	t.ec2TagCache = tags
+	return nil
+}
+
+// Shutdown currently does not get called, as telegraf does not have a cleanup hook for Filter plugins
+func (t *Tagger) Shutdown() {
+	close(t.shutdownC)
+}
+
+// refreshLoop handles the refresh ticks and also responds to shutdown signal
+func (t *Tagger) refreshLoop(refreshInterval time.Duration, stopAfterFirstSuccess bool) {
+	refreshTicker := time.NewTicker(refreshInterval)
+	defer refreshTicker.Stop()
+	for {
+		select {
+		case <-refreshTicker.C:
+			refreshTags := len(t.EC2InstanceTagKeys) > 0
+			refreshVolumes := len(t.EBSDeviceKeys) > 0
+
+			if stopAfterFirstSuccess {
+				// need refresh tags when it is configured and not all ec2 tags are retrieved
+				refreshTags = refreshTags && !t.ec2TagsRetrieved()
+				// need refresh volumes when it is configured and not all volumes are retrieved
+				refreshVolumes = refreshVolumes && !t.ebsVolumesRetrieved()
+				if !refreshTags && !refreshVolumes {
+					t.Log.Infof("ec2tagger: All tags/volumes are retrieved. Stop refreshTicker.")
+					return
+				}
+			}
+
+			if refreshTags {
+				if err := t.updateTags(); err != nil {
+					t.Log.Warnf("ec2tagger: Error refreshing EC2 tags, keeping old values : +%v", err.Error())
+				}
+			}
+
+			if refreshVolumes {
+				if err := t.updateVolumes(); err != nil {
+					t.Log.Warnf("ec2tagger: Error refreshing EC2 volumes, keeping old values : +%v", err.Error())
+				}
+			}
+
+		case <-t.shutdownC:
+			return
+		}
+	}
+}
+
+func (t *Tagger) ec2TagsRetrieved() bool {
+	allTagsRetrieved := true
+	t.RLock()
+	defer t.RUnlock()
+	if t.ec2TagCache != nil {
+		for _, key := range t.EC2InstanceTagKeys {
+			if key == ec2InstanceTagKeyASG {
+				key = cwDimensionASG
+			}
+			if key == "*" {
+				continue
+			}
+			if _, ok := t.ec2TagCache[key]; !ok {
+				allTagsRetrieved = false
+				break
+			}
+		}
+	}
+	return allTagsRetrieved
+}
+
+//ebsVolumesRetrieved checks if all volumes are successfully retrieved
+func (t *Tagger) ebsVolumesRetrieved() bool {
+	allVolumesRetrieved := true
+
+	for _, key := range t.EBSDeviceKeys {
+		if key == "*" {
+			continue
+		}
+		if volId := t.ebsVolume.getEbsVolumeId(key); volId == "" {
+			allVolumesRetrieved = false
+			break
+		}
+	}
+	return allVolumesRetrieved
+}
+
+//Init() acts as input validation and serves the purpose of updating ec2 tags and ebs volumes if necessary.
+//It will be called when Telegraf is enabling each processor plugin
+func (t *Tagger) Init() error {
+	t.shutdownC = make(chan bool)
+	t.ec2TagCache = map[string]string{}
+
+	for _, tag := range t.EC2MetadataTags {
+		switch tag {
+		case mdKeyInstanceId:
+			t.metadataLookup.instanceId = true
+		case mdKeyImageId:
+			t.metadataLookup.imageId = true
+		case mdKeyInstaneType:
+			t.metadataLookup.instanceType = true
+		default:
+			t.Log.Errorf("ec2tagger: Unsupported EC2 Metadata key: %s", tag)
+		}
+	}
+
+	if !t.ec2metadata.Available() {
+		msg := "ec2tagger: Unable to retrieve InstanceId. This plugin must only be used on an EC2 instance"
+		t.Log.Errorf(msg)
+		return errors.New(msg)
+	}
+
+	doc, err := t.ec2metadata.GetInstanceIdentityDocument()
+	if nil != err {
+		msg := fmt.Sprintf("ec2tagger: Unable to retrieve InstanceId : %+v", err.Error())
+		t.Log.Errorf(msg)
+		return errors.New(msg)
+	}
+
+	t.instanceId = doc.InstanceID
+	t.region = doc.Region
+	t.instanceType = doc.InstanceType
+	t.imageId = doc.ImageID
+
+	t.tagFilters = []*ec2.Filter{
+		{
+			Name:   aws.String("resource-type"),
+			Values: aws.StringSlice([]string{"instance"}),
+		},
+		{
+			Name:   aws.String("resource-id"),
+			Values: aws.StringSlice([]string{t.instanceId}),
+		},
+	}
+
+	useAllTags := len(t.EC2InstanceTagKeys) == 1 && t.EC2InstanceTagKeys[0] == "*"
+
+	if !useAllTags && len(t.EC2InstanceTagKeys) > 0 {
+		// if the customer said 'AutoScalingGroupName' (the CW dimension), do what they mean not what they said
+		// and filter for the EC2 tag name called 'aws:autoscaling:groupName'
+		for i, key := range t.EC2InstanceTagKeys {
+			if cwDimensionASG == key {
+				t.EC2InstanceTagKeys[i] = ec2InstanceTagKeyASG
+			}
+		}
+
+		t.tagFilters = append(t.tagFilters, &ec2.Filter{
+			Name:   aws.String("key"),
+			Values: aws.StringSlice(t.EC2InstanceTagKeys),
+		})
+	}
+
+	if len(t.EC2InstanceTagKeys) > 0 || len(t.EBSDeviceKeys) > 0 {
+		ec2CredentialConfig := &internalaws.CredentialConfig{
+			Region:    t.region,
+			AccessKey: t.AccessKey,
+			SecretKey: t.SecretKey,
+			RoleARN:   t.RoleARN,
+			Profile:   t.Profile,
+			Filename:  t.Filename,
+			Token:     t.Token,
+		}
+		t.ec2 = t.ec2Provider(ec2CredentialConfig)
+		t.initialRetrievalOfTagsAndVolumes() //keep retries until successful retrieval
+		t.refreshLoopToUpdateTagsAndVolumes()
+	}
+	t.Log.Infof("EC2 tagger has started.")
+	return nil
+}
+
+func (t *Tagger) refreshLoopToUpdateTagsAndVolumes() {
+	needRefresh := false
+	stopAfterFirstSuccess := false
+	refreshInterval := t.RefreshIntervalSeconds.Duration
+
+	if t.RefreshIntervalSeconds.Duration.Seconds() == 0 {
+		//when the refresh interval is 0, this means that customer don't want to
+		//update tags/volumes values once they are retrieved successfully. In this case,
+		//we still want to do refresh to make sure all the specified keys for tags/volumes
+		//are fetched successfully because initial retrieval might not get all of them.
+		//When the specified key is "*", there is no way for us to check if all
+		//tags/volumes are fetched. So there is no need to do refresh in this case.
+		needRefresh = !(len(t.EC2InstanceTagKeys) == 1 && t.EC2InstanceTagKeys[0] == "*") ||
+			!(len(t.EBSDeviceKeys) == 1 && t.EBSDeviceKeys[0] == "*")
+		stopAfterFirstSuccess = true
+		refreshInterval = defaultRefreshInterval
+	} else if t.RefreshIntervalSeconds.Duration.Seconds() > 0 {
+		//customer wants to update the tags/volumes with the given refresh interval
+		needRefresh = true
+	}
+
+	if needRefresh {
+		// randomly stagger the time of the first refresh to mitigate throttling if a whole fleet is
+		// restarted at the same time
+		sleepUntilHostJitter(refreshInterval)
+		go t.refreshLoop(refreshInterval, stopAfterFirstSuccess)
+	}
+}
+
+// updateVolumes calls EC2 describe volume
+func (t *Tagger) updateVolumes() error {
+	if t.ebsVolume == nil {
+		t.ebsVolume = NewEbsVolume()
+	}
+
+	input := &ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("attachment.instance-id"),
+				Values: aws.StringSlice([]string{t.instanceId}),
+			},
+		},
+	}
+
+	for {
+		result, err := t.ec2.DescribeVolumes(input)
+		if err != nil {
+			return err
+		}
+		for _, volume := range result.Volumes {
+			for _, attachment := range volume.Attachments {
+				t.ebsVolume.addEbsVolumeMapping(volume.AvailabilityZone, attachment)
+			}
+		}
+		if result.NextToken == nil {
+			break
+		}
+		input.SetNextToken(*result.NextToken)
+	}
+	return nil
+}
+
+func (t *Tagger) retrieveTagsVolumesOnce(prevTagSuccess, prevVolumesSuccess bool) (tagsSuccess, volumesSuccess bool) {
+	tagsSuccess = prevTagSuccess
+	volumesSuccess = prevVolumesSuccess
+	if !prevTagSuccess {
+		if err := t.updateTags(); err != nil {
+			t.Log.Warnf("ec2tagger: Unable to describe ec2 volume for initial retrieval: %v", err)
+		} else {
+			tagsSuccess = true
+		}
+	}
+
+	if !prevVolumesSuccess {
+		if err := t.updateVolumes(); err != nil {
+			t.Log.Errorf("ec2tagger: Unable to describe ec2 volume for initial retrieval: %v", err)
+		} else {
+			volumesSuccess = true
+		}
+	}
+
+	return
+}
+
+// This function never return until calling updateTags() and updateVolumes() succeed or shutdown happen.
+func (t *Tagger) initialRetrievalOfTagsAndVolumes() {
+	retrieveTagsSuccess := len(t.EC2InstanceTagKeys) == 0
+	retrieveVolumesSuccess := len(t.EBSDeviceKeys) == 0
+
+	retrieveTagsSuccess, retrieveVolumesSuccess = t.retrieveTagsVolumesOnce(retrieveTagsSuccess, retrieveVolumesSuccess)
+	if retrieveTagsSuccess && retrieveVolumesSuccess {
+		return
+	}
+
+	index := 0
+	// Adding jitter for the first retry
+	sleepUntilHostJitter(backoffSleepArray[index])
+	// start retry
+	retryTicker := time.NewTicker(backoffSleepArray[index])
+	for {
+		if index < len(backoffSleepArray) {
+			if index > 0 && backoffSleepArray[index] != backoffSleepArray[index-1] {
+				// create a new ticker when the delay is not same as previous one
+				retryTicker.Stop()
+				retryTicker = time.NewTicker(backoffSleepArray[index])
+			}
+			index += 1
+		}
+
+		select {
+		case <-t.shutdownC:
+			retryTicker.Stop()
+		case <-retryTicker.C:
+			retrieveTagsSuccess, retrieveVolumesSuccess = t.retrieveTagsVolumesOnce(retrieveTagsSuccess, retrieveVolumesSuccess)
+			if retrieveTagsSuccess && retrieveVolumesSuccess {
+				t.Log.Infof("ec2tagger: Initial retrieval of tags/volumes succeded")
+				retryTicker.Stop()
+				return
+			}
+		}
+	}
+}
+
+func sleepUntilHostJitter(max time.Duration) {
+	hostName, err := os.Hostname()
+	if err != nil {
+		hostName = "Unknown"
+	}
+	hash := fnv.New64()
+	hash.Write([]byte(hostName))
+	// Right shift the uint64 hash by one to make sure the jitter duration is always positive
+	hostSleepJitter := time.Duration(int64(hash.Sum64()>>1)) % max
+	time.Sleep(hostSleepJitter)
+}
+
+// init adds this plugin to the framework's "processors" registry
+func init() {
+	mdCredentialConfig := &internalaws.CredentialConfig{}
+	mdConfigProvider := mdCredentialConfig.Credentials()
+	ec2Provider := func(ec2CredentialConfig *internalaws.CredentialConfig) ec2iface.EC2API {
+		ec2ConfigProvider := ec2CredentialConfig.Credentials()
+		return ec2.New(ec2ConfigProvider)
+	}
+	processors.Add("ec2tagger", func() telegraf.Processor {
+		return &Tagger{
+			ec2metadata: ec2metadata.New(mdConfigProvider),
+			ec2Provider: ec2Provider,
+		}
+	})
+}

--- a/plugins/processors/ec2tagger/ec2tagger_test.go
+++ b/plugins/processors/ec2tagger/ec2tagger_test.go
@@ -1,0 +1,589 @@
+package ec2tagger
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	internalaws "github.com/aws/amazon-cloudwatch-agent/cfg/aws"
+	"github.com/aws/amazon-cloudwatch-agent/internal"
+	"github.com/influxdata/telegraf"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockEC2Client struct {
+	ec2iface.EC2API
+	//The following fields are used to control how the mocked DescribeTags api behave:
+	//tagsCallCount records how many times DescribeTags has been called
+	//if tagsCallCount <= tagsFailLimit, DescribeTags call fails
+	//if tagsFailLimit < tagsCallCount <= tagsPartialLimit, DescribeTags returns partial tags
+	//if tagsCallCount > tagsPartialLimit, DescribeTags returns all tags
+	//DescribeTags returns updated tags if UseUpdatedTags is true
+	tagsCallCount    int
+	tagsFailLimit    int
+	tagsPartialLimit int
+	UseUpdatedTags   bool
+
+	//The following fields are used to control how the mocked DescribeVolumes api behave:
+	//volumesCallCount records how many times DescribeVolumes has been called
+	//if volumesCallCount <= volumesFailLimit, DescribeVolumes call fails
+	//if volumesFailLimit < tagsCallCount <= volumesPartialLimit, DescribeVolumes returns partial volumes
+	//if volumesCallCount > volumesPartialLimit, DescribeVolumes returns all volumes
+	//DescribeVolumes returns update volumes if UseUpdatedVolumes is true
+	volumesCallCount    int
+	volumesFailLimit    int
+	volumesPartialLimit int
+	UseUpdatedVolumes   bool
+}
+
+// construct the return results for the mocked DescribeTags api
+var tagKey1 = "tagKey1"
+var tagVal1 = "tagVal1"
+var tagDes1 = ec2.TagDescription{Key: &tagKey1, Value: &tagVal1}
+
+var tagKey2 = "tagKey2"
+var tagVal2 = "tagVal2"
+var tagDes2 = ec2.TagDescription{Key: &tagKey2, Value: &tagVal2}
+
+var tagKey3 = "aws:autoscaling:groupName"
+var tagVal3 = "ASG-1"
+var tagDes3 = ec2.TagDescription{Key: &tagKey3, Value: &tagVal3}
+
+var updatedTagVal2 = "updated-tagVal2"
+var updatedTagDes2 = ec2.TagDescription{Key: &tagKey2, Value: &updatedTagVal2}
+
+func (m *mockEC2Client) DescribeTags(*ec2.DescribeTagsInput) (*ec2.DescribeTagsOutput, error) {
+	//partial tags returned when the DescribeTags api are called initially
+	//some tags are not returned because customer just attach them to the ec2 instance
+	//and the api doesn't know about them yet
+	partialTags := ec2.DescribeTagsOutput{
+		NextToken: nil,
+		Tags:      []*ec2.TagDescription{&tagDes1},
+	}
+
+	//all tags are returned when the ec2 metadata service knows about all tags
+	allTags := ec2.DescribeTagsOutput{
+		NextToken: nil,
+		Tags:      []*ec2.TagDescription{&tagDes1, &tagDes2, &tagDes3},
+	}
+
+	//later customer changes the value of the second tag and DescribeTags api returns updated tags
+	allTagsUpdated := ec2.DescribeTagsOutput{
+		NextToken: nil,
+		Tags:      []*ec2.TagDescription{&tagDes1, &updatedTagDes2, &tagDes3},
+	}
+
+	//return error initially to simulate the case
+	//when tags are not ready or customer doesn't have permission to call the api
+	if m.tagsCallCount <= m.tagsFailLimit {
+		m.tagsCallCount++
+		return nil, errors.New("No tags available now")
+	}
+
+	//return partial tags to simulate the case
+	//when the api knows about some but not all tags at early stage
+	if m.tagsCallCount <= m.tagsPartialLimit {
+		m.tagsCallCount++
+		return &partialTags, nil
+	}
+
+	//return all tags to simulate the case
+	//when the api knows about all tags at later stage
+	if m.tagsCallCount >= m.tagsPartialLimit {
+		m.tagsCallCount++
+		//return updated result after customer edits tags
+		if m.UseUpdatedTags {
+			return &allTagsUpdated, nil
+		}
+		return &allTags, nil
+	}
+	return nil, nil
+}
+
+// construct the return results for the mocked DescribeTags api
+var device1 = "/dev/xvdc"
+var volumeId1 = "vol-0303a1cc896c42d28"
+var volumeAttachment1 = ec2.VolumeAttachment{Device: &device1, VolumeId: &volumeId1}
+var availabilityZone = "us-east-1a"
+var volume1 = ec2.Volume{
+	Attachments:      []*ec2.VolumeAttachment{&volumeAttachment1},
+	AvailabilityZone: &availabilityZone,
+}
+
+var device2 = "/dev/xvdf"
+var volumeId2 = "vol-0c241693efb58734a"
+var volumeAttachment2 = ec2.VolumeAttachment{Device: &device2, VolumeId: &volumeId2}
+var volume2 = ec2.Volume{
+	Attachments:      []*ec2.VolumeAttachment{&volumeAttachment2},
+	AvailabilityZone: &availabilityZone,
+}
+
+var volumeId2Updated = "vol-0459607897eaa8148"
+var volumeAttachment2Updated = ec2.VolumeAttachment{Device: &device2, VolumeId: &volumeId2Updated}
+var volume2Updated = ec2.Volume{
+	Attachments:      []*ec2.VolumeAttachment{&volumeAttachment2Updated},
+	AvailabilityZone: &availabilityZone,
+}
+
+func (m *mockEC2Client) DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
+	//volume1 is the initial disk assigned to an ec2 instance when started
+	partialVolumes := ec2.DescribeVolumesOutput{
+		NextToken: nil,
+		Volumes:   []*ec2.Volume{&volume1},
+	}
+
+	//later customer attached volume2 to the running ec2 instance
+	//but this volume might not be known to the api immediately
+	allVolumes := ec2.DescribeVolumesOutput{
+		NextToken: nil,
+		Volumes:   []*ec2.Volume{&volume1, &volume2},
+	}
+
+	//later customer updates by attaching a different ebs volume to the same device name
+	allVolumesUpdated := ec2.DescribeVolumesOutput{
+		NextToken: nil,
+		Volumes:   []*ec2.Volume{&volume1, &volume2Updated},
+	}
+
+	//return error initially to simulate the case
+	//when the volumes are not ready or customer doesn't have permission to call the api
+	if m.volumesCallCount <= m.volumesFailLimit {
+		m.volumesCallCount++
+		return nil, errors.New("No volumes available now")
+	}
+
+	//return partial volumes to simulate the case
+	//when the api knows about some but not all volumes at early stage
+	if m.volumesCallCount <= m.volumesPartialLimit {
+		m.volumesCallCount++
+		return &partialVolumes, nil
+	}
+
+	//return all volumes to simulate the case
+	//when the api knows about all volumes at later stage
+	if m.volumesCallCount > m.volumesPartialLimit {
+		m.volumesCallCount++
+		//return updated result after customer edits volumes
+		if m.UseUpdatedVolumes {
+			return &allVolumesUpdated, nil
+		}
+		return &allVolumes, nil
+	}
+	return nil, nil
+}
+
+type mockEC2Metadata struct {
+	ec2Metadata
+	IsAvailable              bool
+	InstanceIdentityDocument *ec2metadata.EC2InstanceIdentityDocument
+}
+
+var mockedInstanceIdentityDoc = &ec2metadata.EC2InstanceIdentityDocument{
+	InstanceID:   "i-01d2417c27a396e44",
+	Region:       "us-east-1",
+	InstanceType: "m5ad.large",
+	ImageID:      "ami-09edd32d9b0990d49",
+}
+
+func (m *mockEC2Metadata) Available() bool {
+	return m.IsAvailable
+}
+
+func (m *mockEC2Metadata) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
+	if m.InstanceIdentityDocument != nil {
+		return *m.InstanceIdentityDocument, nil
+	}
+	return ec2metadata.EC2InstanceIdentityDocument{}, errors.New("No instance identity document")
+}
+
+func TestInitFailWithNoMetadata(t *testing.T) {
+	assert := assert.New(t)
+	mockMetadata := &mockEC2Metadata{
+		IsAvailable:              false,
+		InstanceIdentityDocument: nil,
+	}
+
+	tagger := Tagger{
+		Log:         testutil.Logger{},
+		ec2metadata: mockMetadata,
+	}
+	err := tagger.Init()
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "ec2tagger: Unable to retrieve InstanceId. This plugin must only be used on an EC2 instance")
+}
+
+func TestInitFailWithNoInstanceIdentityDocument(t *testing.T) {
+	assert := assert.New(t)
+	mockMetadata := &mockEC2Metadata{
+		IsAvailable:              true,
+		InstanceIdentityDocument: nil,
+	}
+
+	tagger := Tagger{
+		Log:         testutil.Logger{},
+		ec2metadata: mockMetadata,
+	}
+	err := tagger.Init()
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "ec2tagger: Unable to retrieve InstanceId :")
+}
+
+//run Init() and check all tags/volumes are retrieved and saved
+func TestInitSuccessWithNoTagsVolumesUpdate(t *testing.T) {
+	assert := assert.New(t)
+	mockMetadata := &mockEC2Metadata{
+		IsAvailable:              true,
+		InstanceIdentityDocument: mockedInstanceIdentityDoc,
+	}
+	ec2Client := &mockEC2Client{
+		tagsCallCount:       0,
+		tagsFailLimit:       0,
+		tagsPartialLimit:    1,
+		UseUpdatedTags:      false,
+		volumesCallCount:    0,
+		volumesFailLimit:    -1,
+		volumesPartialLimit: 0,
+		UseUpdatedVolumes:   false,
+	}
+	ec2Provider := func(*internalaws.CredentialConfig) ec2iface.EC2API {
+		return ec2Client
+	}
+	backoffSleepArray = []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
+	defaultRefreshInterval = 50 * time.Millisecond
+	tagger := Tagger{
+		Log:                    testutil.Logger{},
+		RefreshIntervalSeconds: internal.Duration{Duration: 0},
+		ec2Provider:            ec2Provider,
+		ec2:                    ec2Client,
+		ec2metadata:            mockMetadata,
+		EC2MetadataTags:        []string{"InstanceId", "ImageId", "InstanceType"},
+		EC2InstanceTagKeys:     []string{"tagKey1", "tagKey2", "AutoScalingGroupName"},
+		EBSDeviceKeys:          []string{"/dev/xvdc", "/dev/xvdf"},
+	}
+	err := tagger.Init()
+	assert.Nil(err)
+	//assume one second is long enough for the api to be called many times so that all tags/volumes are retrieved
+	time.Sleep(time.Second)
+	assert.Equal(3, ec2Client.tagsCallCount)
+	assert.Equal(2, ec2Client.volumesCallCount)
+	//check tags and volumes
+	expectedTags := map[string]string{
+		"tagKey1":              "tagVal1",
+		"tagKey2":              "tagVal2",
+		"AutoScalingGroupName": "ASG-1",
+	}
+	assert.Equal(expectedTags, tagger.ec2TagCache)
+	expectedVolumes := map[string]string{
+		"/dev/xvdc": "aws://us-east-1a/vol-0303a1cc896c42d28",
+		"/dev/xvdf": "aws://us-east-1a/vol-0c241693efb58734a",
+	}
+	assert.Equal(expectedVolumes, tagger.ebsVolume.dev2Vol)
+}
+
+//run Init() and check all tags/volumes are retrieved and saved and then updated
+func TestInitSuccessWithTagsVolumesUpdate(t *testing.T) {
+	assert := assert.New(t)
+	mockMetadata := &mockEC2Metadata{
+		IsAvailable:              true,
+		InstanceIdentityDocument: mockedInstanceIdentityDoc,
+	}
+	ec2Client := &mockEC2Client{
+		tagsCallCount:       0,
+		tagsFailLimit:       1,
+		tagsPartialLimit:    2,
+		UseUpdatedTags:      false,
+		volumesCallCount:    0,
+		volumesFailLimit:    -1,
+		volumesPartialLimit: 0,
+		UseUpdatedVolumes:   false,
+	}
+	ec2Provider := func(*internalaws.CredentialConfig) ec2iface.EC2API {
+		return ec2Client
+	}
+	backoffSleepArray = []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
+	defaultRefreshInterval = 10 * time.Millisecond
+	tagger := Tagger{
+		Log: testutil.Logger{},
+		//use millisecond rather than second to speed up test execution
+		RefreshIntervalSeconds: internal.Duration{Duration: 20 * time.Millisecond},
+		ec2Provider:            ec2Provider,
+		ec2:                    ec2Client,
+		ec2metadata:            mockMetadata,
+		EC2MetadataTags:        []string{"InstanceId", "ImageId", "InstanceType"},
+		EC2InstanceTagKeys:     []string{"tagKey1", "tagKey2", "AutoScalingGroupName"},
+		EBSDeviceKeys:          []string{"/dev/xvdc", "/dev/xvdf"},
+	}
+	err := tagger.Init()
+	assert.Nil(err)
+	//assume one second is long enough for the api to be called many times
+	//so that all tags/volumes are retrieved
+	time.Sleep(time.Second)
+	//check tags and volumes
+	expectedTags := map[string]string{
+		"tagKey1":              "tagVal1",
+		"tagKey2":              "tagVal2",
+		"AutoScalingGroupName": "ASG-1",
+	}
+	assert.Equal(expectedTags, tagger.ec2TagCache)
+	expectedVolumes := map[string]string{
+		"/dev/xvdc": "aws://us-east-1a/vol-0303a1cc896c42d28",
+		"/dev/xvdf": "aws://us-east-1a/vol-0c241693efb58734a",
+	}
+	assert.Equal(expectedVolumes, tagger.ebsVolume.dev2Vol)
+
+	//update the tags and volumes
+	ec2Client.UseUpdatedTags = true
+	ec2Client.UseUpdatedVolumes = true
+	//assume one second is long enough for the api to be called many times
+	//so that all tags/volumes are updated
+	time.Sleep(time.Second)
+	expectedTags = map[string]string{
+		"tagKey1":              "tagVal1",
+		"tagKey2":              "updated-tagVal2",
+		"AutoScalingGroupName": "ASG-1",
+	}
+	assert.Equal(expectedTags, tagger.ec2TagCache)
+	expectedVolumes = map[string]string{
+		"/dev/xvdc": "aws://us-east-1a/vol-0303a1cc896c42d28",
+		"/dev/xvdf": "aws://us-east-1a/vol-0459607897eaa8148",
+	}
+	assert.Equal(expectedVolumes, tagger.ebsVolume.dev2Vol)
+}
+
+//run Init() with ec2_instance_tag_keys = ["*"] and ebs_device_keys = ["*"]
+//check there is no attempt to fetch all tags/volumes
+func TestInitSuccessWithWildcardTagVolumeKey(t *testing.T) {
+	assert := assert.New(t)
+	mockMetadata := &mockEC2Metadata{
+		IsAvailable:              true,
+		InstanceIdentityDocument: mockedInstanceIdentityDoc,
+	}
+	ec2Client := &mockEC2Client{
+		tagsCallCount:       0,
+		tagsFailLimit:       0,
+		tagsPartialLimit:    1,
+		UseUpdatedTags:      false,
+		volumesCallCount:    0,
+		volumesFailLimit:    -1,
+		volumesPartialLimit: 0,
+		UseUpdatedVolumes:   false,
+	}
+	ec2Provider := func(*internalaws.CredentialConfig) ec2iface.EC2API {
+		return ec2Client
+	}
+	backoffSleepArray = []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
+	defaultRefreshInterval = 50 * time.Millisecond
+	tagger := Tagger{
+		Log:                    testutil.Logger{},
+		RefreshIntervalSeconds: internal.Duration{Duration: 0},
+		ec2Provider:            ec2Provider,
+		ec2:                    ec2Client,
+		ec2metadata:            mockMetadata,
+		EC2MetadataTags:        []string{"InstanceId", "ImageId", "InstanceType"},
+		EC2InstanceTagKeys:     []string{"*"},
+		EBSDeviceKeys:          []string{"*"},
+	}
+	err := tagger.Init()
+	assert.Nil(err)
+	//assume one second is long enough for the api to be called many times (potentially)
+	time.Sleep(time.Second)
+	//check only partial tags/volumes are returned
+	assert.Equal(2, ec2Client.tagsCallCount)
+	assert.Equal(1, ec2Client.volumesCallCount)
+	//check partial tags/volumes are saved
+	expectedTags := map[string]string{
+		"tagKey1": "tagVal1",
+	}
+	assert.Equal(expectedTags, tagger.ec2TagCache)
+	expectedVolumes := map[string]string{
+		"/dev/xvdc": "aws://us-east-1a/vol-0303a1cc896c42d28",
+	}
+	assert.Equal(expectedVolumes, tagger.ebsVolume.dev2Vol)
+}
+
+//run Init() and then Apply() and check the output metrics contain expected tags
+func TestApplyWithTagsVolumesUpdate(t *testing.T) {
+	assert := assert.New(t)
+	mockMetadata := &mockEC2Metadata{
+		IsAvailable:              true,
+		InstanceIdentityDocument: mockedInstanceIdentityDoc,
+	}
+	ec2Client := &mockEC2Client{
+		tagsCallCount:       0,
+		tagsFailLimit:       0,
+		tagsPartialLimit:    1,
+		UseUpdatedTags:      false,
+		volumesCallCount:    0,
+		volumesFailLimit:    -1,
+		volumesPartialLimit: 0,
+		UseUpdatedVolumes:   false,
+	}
+	ec2Provider := func(*internalaws.CredentialConfig) ec2iface.EC2API {
+		return ec2Client
+	}
+	backoffSleepArray = []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
+	defaultRefreshInterval = 50 * time.Millisecond
+	tagger := Tagger{
+		Log: testutil.Logger{},
+		//use millisecond rather than second to speed up test execution
+		RefreshIntervalSeconds: internal.Duration{Duration: 20 * time.Millisecond},
+		ec2Provider:            ec2Provider,
+		ec2:                    ec2Client,
+		ec2metadata:            mockMetadata,
+		EC2MetadataTags:        []string{"InstanceId", "InstanceType"},
+		EC2InstanceTagKeys:     []string{"tagKey1", "tagKey2", "AutoScalingGroupName"},
+		EBSDeviceKeys:          []string{"/dev/xvdc", "/dev/xvdf"},
+		DiskDeviceTagKey:       "device",
+	}
+	err := tagger.Init()
+	assert.Nil(err)
+	//assume one second is long enough for the api to be called many times
+	//so that all tags/volumes are retrieved
+	time.Sleep(time.Second)
+	input := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{
+				"host": "example.org",
+			},
+			map[string]interface{}{
+				"cpu": 0.11,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"disk",
+			map[string]string{
+				"device": "/dev/xvdc",
+			},
+			map[string]interface{}{
+				"write_bytes": 200,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"disk",
+			map[string]string{
+				"device": "/dev/xvdf",
+			},
+			map[string]interface{}{
+				"write_bytes": 135,
+			},
+			time.Unix(0, 0),
+		),
+	}
+	output := tagger.Apply(input...)
+	expectedOutput := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{
+				"host":                 "example.org",
+				"AutoScalingGroupName": "ASG-1",
+				"InstanceId":           "i-01d2417c27a396e44",
+				"InstanceType":         "m5ad.large",
+				"tagKey1":              "tagVal1",
+				"tagKey2":              "tagVal2",
+			},
+			map[string]interface{}{
+				"cpu": 0.11,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"disk",
+			map[string]string{
+				"AutoScalingGroupName": "ASG-1",
+				"EBSVolumeId":          "aws://us-east-1a/vol-0303a1cc896c42d28",
+				"InstanceId":           "i-01d2417c27a396e44",
+				"InstanceType":         "m5ad.large",
+				"tagKey1":              "tagVal1",
+				"tagKey2":              "tagVal2",
+				"device":               "/dev/xvdc",
+			},
+			map[string]interface{}{
+				"write_bytes": 200,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"disk",
+			map[string]string{
+				"AutoScalingGroupName": "ASG-1",
+				"EBSVolumeId":          "aws://us-east-1a/vol-0c241693efb58734a",
+				"InstanceId":           "i-01d2417c27a396e44",
+				"InstanceType":         "m5ad.large",
+				"tagKey1":              "tagVal1",
+				"tagKey2":              "tagVal2",
+				"device":               "/dev/xvdf",
+			},
+			map[string]interface{}{
+				"write_bytes": 135,
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expectedOutput, output)
+
+	//update tags and volumes and check metrics are updated as well
+	ec2Client.UseUpdatedTags = true
+	ec2Client.UseUpdatedVolumes = true
+	//assume one second is long enough for the api to be called many times
+	//so that all tags/volumes are updated
+	time.Sleep(time.Second)
+	outputUpdated := tagger.Apply(input...)
+	expectedOutputUpdated := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{
+				"host":                 "example.org",
+				"AutoScalingGroupName": "ASG-1",
+				"InstanceId":           "i-01d2417c27a396e44",
+				"InstanceType":         "m5ad.large",
+				"tagKey1":              "tagVal1",
+				"tagKey2":              "updated-tagVal2",
+			},
+			map[string]interface{}{
+				"cpu": 0.11,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"disk",
+			map[string]string{
+				"AutoScalingGroupName": "ASG-1",
+				"EBSVolumeId":          "aws://us-east-1a/vol-0303a1cc896c42d28",
+				"InstanceId":           "i-01d2417c27a396e44",
+				"InstanceType":         "m5ad.large",
+				"tagKey1":              "tagVal1",
+				"tagKey2":              "updated-tagVal2",
+				"device":               "/dev/xvdc",
+			},
+			map[string]interface{}{
+				"write_bytes": 200,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"disk",
+			map[string]string{
+				"AutoScalingGroupName": "ASG-1",
+				"EBSVolumeId":          "aws://us-east-1a/vol-0459607897eaa8148",
+				"InstanceId":           "i-01d2417c27a396e44",
+				"InstanceType":         "m5ad.large",
+				"tagKey1":              "tagVal1",
+				"tagKey2":              "updated-tagVal2",
+				"device":               "/dev/xvdf",
+			},
+			map[string]interface{}{
+				"write_bytes": 135,
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expectedOutputUpdated, outputUpdated)
+}


### PR DESCRIPTION
# Description of the issue
The plugin ec2tagger needs to use the internal aws credential provider. So we need to move it back (from aws telegraf repo).

# Description of changes
* change to use the internal aws config
* enable the customized ec2tagger (inside the repo) rather than the one in aws telegraf repo

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Built the binary and run it in an ec2 instance
* Check the metrics are OK


