### PR TITLE
fix: lazy init of aws credentials

### DIFF
--- a/plugins/processors/ec2tagger/ec2tagger.go
+++ b/plugins/processors/ec2tagger/ec2tagger.go
@@ -439,7 +439,7 @@ func (t *Tagger) retrieveTagsVolumesOnce(prevTagSuccess, prevVolumesSuccess bool
 	volumesSuccess = prevVolumesSuccess
 	if !prevTagSuccess {
 		if err := t.updateTags(); err != nil {
-			t.Log.Warnf("ec2tagger: Unable to describe ec2 volume for initial retrieval: %v", err)
+			t.Log.Warnf("ec2tagger: Unable to describe ec2 tags for initial retrieval: %v", err)
 		} else {
 			tagsSuccess = true
 		}
@@ -509,13 +509,13 @@ func sleepUntilHostJitter(max time.Duration) {
 
 // init adds this plugin to the framework's "processors" registry
 func init() {
-	mdCredentialConfig := &internalaws.CredentialConfig{}
-	mdConfigProvider := mdCredentialConfig.Credentials()
-	ec2Provider := func(ec2CredentialConfig *internalaws.CredentialConfig) ec2iface.EC2API {
-		ec2ConfigProvider := ec2CredentialConfig.Credentials()
-		return ec2.New(ec2ConfigProvider)
-	}
 	processors.Add("ec2tagger", func() telegraf.Processor {
+		mdCredentialConfig := &internalaws.CredentialConfig{}
+		mdConfigProvider := mdCredentialConfig.Credentials()
+		ec2Provider := func(ec2CredentialConfig *internalaws.CredentialConfig) ec2iface.EC2API {
+			ec2ConfigProvider := ec2CredentialConfig.Credentials()
+			return ec2.New(ec2ConfigProvider)
+		}
 		return &Tagger{
 			ec2metadata: ec2metadata.New(mdConfigProvider),
 			ec2Provider: ec2Provider,


### PR DESCRIPTION
# Description of changes
In case that the default aws credentials might be overridden, we need to lazy load the aws credentials to make sure ec2 tagger always pick up the correct credentials. Here we are assuming that the aws credentials are overridden before the ec2tagger instance is created.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.






