### PR TITLE
fix: missing logs when restart agent

### DIFF
--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -155,7 +155,6 @@ func (ts *tailerSrc) runTail() {
 				init = ""
 			} else if ts.isMLStart(text) || msg == "" {
 				init = text
-				offset = line.Offset
 			} else if len(msg) > ts.maxEventSize {
 				continue
 			} else {
@@ -179,6 +178,7 @@ func (ts *tailerSrc) runTail() {
 			}
 
 			msg = init
+			offset = line.Offset
 			cnt = 0
 		case <-t.C:
 			if msg != "" {


### PR DESCRIPTION
# Description of the issue
The offset is not correct when construct the logevent, it may cause missing logevent.

# Description of changes
Delay to set the offset when receive starter log. set the offset after publish prevous logevent.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._




