### PR TITLE
fix: clean up ticker leak

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -125,6 +125,7 @@ func reloadLoop(
 
 		go func(ctx context.Context) {
 			profilerTicker := time.NewTicker(60 * time.Second)
+			defer profilerTicker.Stop()
 			for {
 				select {
 				case <-profilerTicker.C:

--- a/plugins/inputs/awscsm/awscsm_listener.go
+++ b/plugins/inputs/awscsm/awscsm_listener.go
@@ -80,6 +80,7 @@ func (aws *AwsCsmListener) Stop() {
 
 func (aws *AwsCsmListener) aggregate() {
 	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
 	records := &AggregationRecords{}
 	inputChannel := models.AwsCsmInputChannel
 

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -224,6 +224,7 @@ func (ts *tailerSrc) cleanUp() {
 
 func (ts *tailerSrc) runSaveState() {
 	t := time.NewTicker(100 * time.Millisecond)
+	defer t.Stop()
 
 	var offset, lastSavedOffset int64
 	for {

--- a/plugins/outputs/awscsm/awscsm.go
+++ b/plugins/outputs/awscsm/awscsm.go
@@ -217,6 +217,7 @@ func (c *CSM) publishJob() {
 	queue := []awscsmmetrics.Metric{}
 	ring := newRecordRing(int64(c.MemoryLimitInMb) * 1024 * 1024)
 	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
 
 	// Sleeping here to prevent the agent from hitting the
 	// service all at once if multiple instance of the agent

--- a/plugins/outputs/cloudwatch/aggregator.go
+++ b/plugins/outputs/cloudwatch/aggregator.go
@@ -123,6 +123,7 @@ func (durationAgg *durationAggregator) aggregating() {
 	now := time.Now()
 	time.Sleep(now.Truncate(durationAgg.aggregationDuration).Add(durationAgg.aggregationDuration).Sub(now))
 	durationAgg.ticker = time.NewTicker(durationAgg.aggregationDuration)
+	defer durationAgg.ticker.Stop()
 	for {
 		select {
 		case m := <-durationAgg.aggregationChan:

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -204,6 +204,7 @@ func (c *CloudWatch) Write(metrics []telegraf.Metric) error {
 // request can have so we process one Point at a time.
 func (c *CloudWatch) pushMetricDatum() {
 	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case point := <-c.metricChan:
@@ -269,6 +270,7 @@ func (c *CloudWatch) publish() {
 	log.Printf("I! cloudwatch: publish with ForceFlushInterval: %v, Publish Jitter: %v", forceFlushInterval, publishJitter)
 	time.Sleep(now.Truncate(forceFlushInterval).Add(publishJitter).Sub(now))
 	c.pushTicker = time.NewTicker(c.ForceFlushInterval.Duration)
+	defer c.pushTicker.Stop()
 	shouldPublish := false
 	for {
 		select {

--- a/plugins/processors/ecsdecorator/ecsinfo.go
+++ b/plugins/processors/ecsdecorator/ecsinfo.go
@@ -110,6 +110,7 @@ func newECSInfo(hostIP string) (e *ecsInfo) {
 	e.updateRunningTaskCount()
 	go func() {
 		refreshTicker := time.NewTicker(e.refreshInterval)
+		defer refreshTicker.Stop()
 		for {
 			select {
 			case <-refreshTicker.C:

--- a/plugins/processors/k8sdecorator/k8sdecorator.go
+++ b/plugins/processors/k8sdecorator/k8sdecorator.go
@@ -81,6 +81,7 @@ func (k *K8sDecorator) start() {
 
 	go func() {
 		refreshTicker := time.NewTicker(time.Second)
+		defer refreshTicker.Stop()
 		for {
 			select {
 			case <-refreshTicker.C:


### PR DESCRIPTION
Make sure all started tickers are stopped when its go routine exits

# Description of the issue
Currently there are tickers are started but not stopped when its goroutine exits.

# Description of changes
Add defer Stop() call to all started tickers

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
unit test