### PR TITLE
feat: allow override useragent with json config

### DIFF
--- a/cfg/agentinfo/info.go
+++ b/cfg/agentinfo/info.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 )
 
 const versionFilename = "CWAGENT_VERSION"
@@ -22,6 +24,8 @@ var (
 	BuildStr      string = "No Build Date"
 	InputPlugins  []string
 	OutputPlugins []string
+
+	userAgent string
 )
 
 func Version() string {
@@ -49,7 +53,14 @@ func Plugins() string {
 }
 
 func UserAgent() string {
-	return fmt.Sprintf("%s %s", FullVersion(), Plugins())
+	if userAgent == "" {
+		ua := os.Getenv(envconfig.CWAGENT_USER_AGENT)
+		if ua == "" {
+			ua = fmt.Sprintf("%s %s", FullVersion(), Plugins())
+		}
+		userAgent = ua
+	}
+	return userAgent
 }
 
 func FullVersion() string {

--- a/cfg/agentinfo/info_test.go
+++ b/cfg/agentinfo/info_test.go
@@ -4,11 +4,15 @@
 package agentinfo
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 )
 
 func TestVersionUseInjectedIfAvailable(t *testing.T) {
@@ -79,5 +83,30 @@ func TestPlugins(t *testing.T) {
 	expected := "inputs:(a b c) outputs:(x y z)"
 	if plugins != expected {
 		t.Errorf("wrong plugins string constructed '%v', expecting '%v'", plugins, expected)
+	}
+}
+
+func TestUserAgent(t *testing.T) {
+	userAgent = ""
+	VersionStr = "VSTR"
+	BuildStr = "BSTR"
+	InputPlugins = []string{"a", "b", "c"}
+	OutputPlugins = []string{"x", "y", "z"}
+
+	ua := UserAgent()
+	expected := fmt.Sprintf("CWAgent/VSTR (%v; %v; %v) BSTR inputs:(a b c) outputs:(x y z)", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	if ua != expected {
+		t.Errorf("wrong UserAgent string constructed '%v', expecting '%v'", ua, expected)
+	}
+}
+
+func TestUserAgentEnvOverride(t *testing.T) {
+	userAgent = ""
+	os.Setenv(envconfig.CWAGENT_USER_AGENT, "CUSTOM CWAGENT USER AGENT")
+	expected := "CUSTOM CWAGENT USER AGENT"
+
+	ua := UserAgent()
+	if ua != expected {
+		t.Errorf("UserAgent should use value configured in environment variable CWAGENT_USER_AGENT, but '%v' found, expecting '%v'", ua, expected)
 	}
 }

--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -5,9 +5,10 @@ package envconfig
 
 const (
 	//the following are the names of environment variables
-	HTTP_PROXY      = "HTTP_PROXY"
-	HTTPS_PROXY     = "HTTPS_PROXY"
-	NO_PROXY        = "NO_PROXY"
-	AWS_CSM_ENABLED = "AWS_CSM_ENABLED"
-	AWS_CA_BUNDLE   = "AWS_CA_BUNDLE"
+	HTTP_PROXY         = "HTTP_PROXY"
+	HTTPS_PROXY        = "HTTPS_PROXY"
+	NO_PROXY           = "NO_PROXY"
+	AWS_CSM_ENABLED    = "AWS_CSM_ENABLED"
+	AWS_CA_BUNDLE      = "AWS_CA_BUNDLE"
+	CWAGENT_USER_AGENT = "CWAGENT_USER_AGENT"
 )

--- a/translator/toenvconfig/toEnvConfig.go
+++ b/translator/toenvconfig/toEnvConfig.go
@@ -11,14 +11,24 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 	"github.com/aws/amazon-cloudwatch-agent/internal/csm"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util"
 )
+
+const userAgentKey = "user_agent"
 
 func ToEnvConfig(jsonConfigValue map[string]interface{}) []byte {
 	envVars := make(map[string]string)
 	// If csm has a configuration section, then also turn on csm for the agent itself
 	if _, ok := jsonConfigValue[csm.JSONSectionKey]; ok {
 		envVars[envconfig.AWS_CSM_ENABLED] = "TRUE"
+	}
+
+	// Set CWAGENT_USER_AGENT to env config if specified by the json config in agent section
+	if agentMap, ok := jsonConfigValue[agent.SectionKey].(map[string]interface{}); ok {
+		if userAgent, ok := agentMap[userAgentKey].(string); ok {
+			envVars[envconfig.CWAGENT_USER_AGENT] = userAgent
+		}
 	}
 
 	proxy := util.GetHttpProxy(context.CurrentContext().Proxy())

--- a/translator/toenvconfig/toEnvConfig_test.go
+++ b/translator/toenvconfig/toEnvConfig_test.go
@@ -72,7 +72,9 @@ func TestLogMetricAndLog(t *testing.T) {
 
 func TestCompleteConfig(t *testing.T) {
 	resetContext()
-	expectedEnvVars := map[string]string{}
+	expectedEnvVars := map[string]string{
+		"CWAGENT_USER_AGENT": "CUSTOM USER AGENT VALUE",
+	}
 	checkIfTranslateSucceed(t, ReadFromFile("../totomlconfig/sampleConfig/complete_linux_config.json"), "linux", expectedEnvVars)
 	checkIfTranslateSucceed(t, ReadFromFile("../totomlconfig/sampleConfig/complete_windows_config.json"), "windows", expectedEnvVars)
 }

--- a/translator/totomlconfig/sampleConfig/complete_linux_config.json
+++ b/translator/totomlconfig/sampleConfig/complete_linux_config.json
@@ -3,6 +3,7 @@
     "metrics_collection_interval": 10,
     "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
     "internal": true,
+    "user_agent": "CUSTOM USER AGENT VALUE",
     "credentials": {
       "role_arn": "global_role_arn_value"
     }

--- a/translator/totomlconfig/sampleConfig/complete_windows_config.json
+++ b/translator/totomlconfig/sampleConfig/complete_windows_config.json
@@ -3,6 +3,7 @@
     "metrics_collection_interval": 60,
     "logfile": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log",
     "internal": true,
+    "user_agent": "CUSTOM USER AGENT VALUE",
     "credentials": {
       "role_arn": "global_role_arn_value"
     }


### PR DESCRIPTION
# Description of the issue
Currently there is no way to configure the user-agent string used by the agent.

# Description of changes
Add a new config 'user_agent' under agent section in json config.
Translator will pass on the user agent value via envconfig, and being
set as environment variable, which agentinfo package would pick up with
higher priority.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests



