### PR TITLE
Fix win unit tests

### DIFF
--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -9,14 +9,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent/logs"
-	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail/winfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/encoding/simplifiedchinese"
@@ -1064,19 +1062,4 @@ func TestGenerateLogGroupName(t *testing.T) {
 		"The log group name %s is not the same as %s.",
 		logGroupName,
 		expectLogGroup))
-}
-
-func createTempFile(dir, prefix string) (*os.File, error) {
-	file, err := ioutil.TempFile(dir, prefix)
-	if runtime.GOOS == "windows" { // winfile open with FILE_SHARE_DELETE, allows the log file be deleted
-		if err := file.Close(); err != nil {
-			return nil, fmt.Errorf("Failed to close created temp file %v: %w", file.Name(), err)
-		}
-
-		file, err = winfile.OpenFile(file.Name(), os.O_RDWR, 0)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to open temp file for writing %v: %w", file.Name(), err)
-		}
-	}
-	return file, err
 }

--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -9,33 +9,20 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent/logs"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail"
-	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail/winfile"
 )
 
 func TestTailerSrc(t *testing.T) {
 
-	file, err := ioutil.TempFile("", "tailsrctest-*.log")
+	file, err := createTempFile("", "tailsrctest-*.log")
 	defer os.Remove(file.Name())
 	if err != nil {
 		t.Errorf("Failed to create temp file: %v", err)
-	}
-
-	if runtime.GOOS == "windows" { // winfile open with FILE_SHARE_DELETE, allows the log file be deleted
-		if err := file.Close(); err != nil {
-			t.Errorf("Failed to close created temp file %v: %v", file.Name(), err)
-		}
-
-		file, err = winfile.OpenFile(file.Name(), os.O_RDWR, 0)
-		if err != nil {
-			t.Errorf("Failed to open temp file for writing %v: %v", file.Name(), err)
-		}
 	}
 
 	statefile, err := ioutil.TempFile("", "tailsrctest-state-*.log")

--- a/plugins/inputs/logfile/tmpfile.go
+++ b/plugins/inputs/logfile/tmpfile.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package logfile
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+func createTempFile(dir, prefix string) (*os.File, error) {
+	return ioutil.TempFile(dir, prefix)
+}

--- a/plugins/inputs/logfile/tmpfile_windows.go
+++ b/plugins/inputs/logfile/tmpfile_windows.go
@@ -1,0 +1,22 @@
+package logfile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail/winfile"
+)
+
+func createTempFile(dir, prefix string) (*os.File, error) {
+	file, err := ioutil.TempFile(dir, prefix)
+	if err := file.Close(); err != nil {
+		return nil, fmt.Errorf("Failed to close created temp file %v: %w", file.Name(), err)
+	}
+
+	file, err = winfile.OpenFile(file.Name(), os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open temp file for writing %v: %w", file.Name(), err)
+	}
+	return file, err
+}


### PR DESCRIPTION
# Description of the issue
There are unit tests disabled or failing for windows os.

# Description of changes
To allow a file to be deleted while being tailed by the agent, the unit tests should create test files with FILE_SHARE_DELETE enabled. This is achieved by opening temp file on windows using the winfile implementation in tail package which enables the FILE_SHARE_DELETE flag.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests