### PR TITLE
fix: large number of done callback after tailersrc exit blocks the agent

### DIFF
--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -99,7 +99,13 @@ func (ts tailerSrc) Destination() string {
 }
 
 func (ts tailerSrc) Done(offset int64) {
-	ts.offsetCh <- offset
+	// ts.offsetCh will only be blocked when the runSaveState func has exited,
+	// which only happens when the original file has been removed, thus making
+	// Keeping its offset useless
+	select {
+	case ts.offsetCh <- offset:
+	default:
+	}
 }
 
 func (ts *tailerSrc) Stop() {


### PR DESCRIPTION
# Description of the issue
When there is a large number of logs being sent while the logfile has been removed, the done() callback would block the cloudwatch output from sending futher logs

# Description of changes
Discard any done offset if the offsetCh is blocked, since offsetCh is only blocked when source file has been removed, thus there won't be need to further update the offset file.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



