### PR TITLE
fix: Call done fn in reverse order, increase offsetCh size

### DIFF
--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -67,7 +67,7 @@ func NewTailerSrc(
 		maxEventSize:   maxEventSize,
 		truncateSuffix: truncateSuffix,
 
-		offsetCh: make(chan int64, 100),
+		offsetCh: make(chan int64, 2000),
 		done:     make(chan struct{}),
 	}
 	go ts.runSaveState()

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -201,7 +201,8 @@ func (p *pusher) send() {
 				}
 			}
 
-			for _, done := range p.doneCallbacks {
+			for i := len(p.doneCallbacks) - 1; i >= 0; i-- {
+				done := p.doneCallbacks[i]
 				done()
 			}
 


### PR DESCRIPTION
# Description of the issue
save state offset channel has a chance of being full in large batches and result in reduced accuracy of recorded offset

# Description of changes
Call done functions in reverse order would allow larger offset gets sent back first, also increase the buffer size to reduce the possibility of offset discard.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.




