### PR TITLE
fix: Save the right offset in state file after file trucation

### DIFF
--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -454,25 +454,6 @@ func isDirectory(filename string) (bool, error) {
 	return false, nil
 }
 
-type LogEvent struct {
-	msg    string
-	t      time.Time
-	offset int64
-	src    *tailerSrc
-}
-
-func (le LogEvent) Message() string {
-	return le.msg
-}
-
-func (le LogEvent) Time() time.Time {
-	return le.t
-}
-
-func (le LogEvent) Done() {
-	le.src.Done(le.offset)
-}
-
 func init() {
 	inputs.Add("logfile", func() telegraf.Input {
 		return NewLogFile()


### PR DESCRIPTION
# Description of the issue
Currently, the save state will not decrease the offset after file has
trucated.

# Description of changes
In this fix, we add a sequence number to offset, when file trucation
happens, the sequence number gets increased, and the save state logic
will reset the offset to the lower number

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit test



