### PR TITLE
chore: exclude result dimension from procstat plugin

### DIFF
--- a/translator/totomlconfig/sampleConfig/complete_linux_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_linux_config.conf
@@ -101,7 +101,7 @@
     fieldpass = ["cpu_usage", "memory_rss"]
     pid_file = "/var/run/example1.pid"
     pid_finder = "native"
-    tagexclude = ["user"]
+    tagexclude = ["user", "result"]
     [inputs.procstat.tags]
       "aws:StorageResolution" = "true"
       metricPath = "metrics"

--- a/translator/totomlconfig/sampleConfig/complete_windows_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_windows_config.conf
@@ -41,7 +41,7 @@
     exe = "agent"
     fieldpass = ["cpu_time_system", "cpu_time_user"]
     pid_finder = "native"
-    tagexclude = ["user"]
+    tagexclude = ["user", "result"]
     [inputs.procstat.tags]
       metricPath = "metrics"
 

--- a/translator/translate/metrics/metrics_collect/procstat/procstat_test.go
+++ b/translator/translate/metrics/metrics_collect/procstat/procstat_test.go
@@ -35,7 +35,7 @@ func TestExeConfig(t *testing.T) {
 		"exe":        "amazon-cloudwat",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
-		"tagexclude": []string{"user"},
+		"tagexclude": []string{"user", "result"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -54,7 +54,7 @@ func TestPidFileConfig(t *testing.T) {
 		"pid_file":   "/var/run/sshd",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
-		"tagexclude": []string{"user"},
+		"tagexclude": []string{"user", "result"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -73,7 +73,7 @@ func TestPatternConfig(t *testing.T) {
 		"pattern":    "sshd",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
-		"tagexclude": []string{"user"},
+		"tagexclude": []string{"user", "result"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -96,7 +96,7 @@ func TestMultiLookupConfig(t *testing.T) {
 		"pattern":    "sshd",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
-		"tagexclude": []string{"user"},
+		"tagexclude": []string{"user", "result"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -118,7 +118,7 @@ func TestIntervalConfig(t *testing.T) {
 		"fieldpass":  []string{"cpu_usage", "memory_rss"},
 		"interval":   "30s",
 		"tags":       map[string]interface{}{"aws:StorageResolution": "true"},
-		"tagexclude": []string{"user"},
+		"tagexclude": []string{"user", "result"},
 	}}
 	checkResult(t, input, expectedVal)
 }
@@ -145,13 +145,13 @@ func TestMultiProcessesConfig(t *testing.T) {
 			"pid_file":   "/var/run/sshd",
 			"pid_finder": "native",
 			"fieldpass":  []string{"cpu_usage", "memory_rss"},
-			"tagexclude": []string{"user"},
+			"tagexclude": []string{"user", "result"},
 		},
 		map[string]interface{}{
 			"exe":        "cloudwatch",
 			"pid_finder": "native",
 			"fieldpass":  []string{"cpu_usage", "memory_rss"},
-			"tagexclude": []string{"user"},
+			"tagexclude": []string{"user", "result"},
 		},
 	}
 	checkResult(t, input, expectedVal)
@@ -179,7 +179,7 @@ func TestIntervalErrorConfig(t *testing.T) {
 		"pid_file":   "/var/run/sshd",
 		"pid_finder": "native",
 		"fieldpass":  []string{"cpu_usage"},
-		"tagexclude": []string{"user"},
+		"tagexclude": []string{"user", "result"},
 	}}
 	checkResult(t, input, expectedVal)
 }

--- a/translator/translate/metrics/metrics_collect/procstat/ruleDropTags.go
+++ b/translator/translate/metrics/metrics_collect/procstat/ruleDropTags.go
@@ -8,7 +8,7 @@ const (
 )
 
 var (
-	tagExcludeValues = []string{"user"}
+	tagExcludeValues = []string{"user", "result"}
 )
 
 type DropTags struct {


### PR DESCRIPTION
# Description of the issue
New procstat lib introduce a `result` tag, it will bring back compatibility issue.
https://github.com/aws/telegraf/commit/cf2b85f3838f222de9576cf633102b2cb141c48a

# Description of changes
Exclude `result` tag when translation

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
tested on amazonlinux2




