### PR TITLE
fix: start ec2tagger when no tag or vol are configured

### DIFF
--- a/plugins/processors/ec2tagger/ec2tagger.go
+++ b/plugins/processors/ec2tagger/ec2tagger.go
@@ -376,9 +376,12 @@ func (t *Tagger) Init() error {
 			t.initialRetrievalOfTagsAndVolumes()
 			t.refreshLoopToUpdateTagsAndVolumes()
 		}()
+		t.Log.Infof("ec2tagger: EC2 tagger has started initialization.")
+
+	} else {
+		t.setStarted()
 	}
 
-	t.Log.Infof("ec2tagger: EC2 tagger has started initialization.")
 	return nil
 }
 
@@ -457,11 +460,6 @@ func (t *Tagger) setStarted() {
 func (t *Tagger) initialRetrievalOfTagsAndVolumes() {
 	tagsRetrieved := len(t.EC2InstanceTagKeys) == 0
 	volsRetrieved := len(t.EBSDeviceKeys) == 0
-
-	if tagsRetrieved && volsRetrieved {
-		t.setStarted()
-		return // Quick return when no retrieval is needed
-	}
 
 	retry := 0
 	for {


### PR DESCRIPTION
# Description of the issue
The call for setStarted is missing for the code path for both
ec2instnacetags and ebsvolumes are not configured.

# Description of changes
Call setStarted if no tag or volume retrieval is needed. Added unit test to check ec2tagger is started when no ec2instancetag nor ebsvolumes are configured.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests added and ran



