### PR TITLE
chore: do not need to evaluate the symlink for all of the log files

### DIFF
--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -438,21 +438,6 @@ func generateLogStreamName(fileName string, streamName string) string {
 // Directory should be skipped.
 // This func is to determine whether the file is actually a directory or a symbolic link pointing to a directory
 func isDirectory(filename string, matchedFileInfo os.FileInfo) (bool, error) {
-	//path, err := filepath.EvalSymlinks(filename)
-	//if err != nil {
-	//	return false, err
-	//}
-	//
-	//info, err := os.Stat(path)
-	//if err != nil {
-	//	return false, err
-	//}
-	//if info != nil {
-	//	return info.IsDir(), nil
-	//}
-	//return false, nil
-
-
 	if matchedFileInfo.IsDir() {
 		return true, nil
 	}


### PR DESCRIPTION
# Description of the issue
When there are lots of log rotated files, agent will take lots of cpu to scan all of the logs. most of the cpu is used at the file operation, like filepath.EvalSymlinks and os.Stat

# Description of changes
if the file is not Symlinks, do not need to do such operations.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
100,000 files, original cpu usage is 95%, now it is 41%




