### PR TITLE
fix: Skip tags with empty values

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -110,7 +110,7 @@ func (l *LogAgent) Run(ctx context.Context) {
 				}
 			}
 		case <-ctx.Done():
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
patch from telegraf: https://github.com/influxdata/telegraf/pull/4785

# Description of the issue
empty value of tags will cause the cloudwatch return error
like:
```
2020-09-19T04:25:37Z E! cloudwatch: code: InvalidParameter, message: 1 validation error(s) found., original error: InvalidParameter: 1 validation error(s) found.
caused by: ParamMinLenError: minimum field size of 1, PutMetricDataInput.MetricData[0].Dimensions[0].Value.
2020-09-19T04:25:37Z W! 0 retries, going to sleep 200ms before retrying.
2020-09-19T04:25:37Z E! WriteToCloudWatch failure, err:  InvalidParameter: 1 validation error(s) found.
- minimum field size of 1, PutMetricDataInput.MetricData[0].Dimensions[0].Value.
```

# Description of changes
It was been fixed in telegraf, just patch it from https://github.com/influxdata/telegraf/pull/4785
And exclude "host" dimension if the value is empty

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. with following json and command, there is no error in the amazon-cloudwtach-agent.log
Json:
```
{
            "agent": {
                "debug": true
            },
            "metrics": {
                "namespace": "testop",
                "metrics_collected": {

                    "statsd": {
                        "metrics_aggregation_interval": 60,
                        "metrics_collection_interval": 10,
                        "service_address": ":8125"
                    }
                }
            }
        }
```

command:
```
echo -n "test.task:1|c|#host:,metric_type:,test:test" | nc -w 1 -u -4 localhost 8125
```



