### PR TITLE
fix: diskio plugin can not use metric rename

### DIFF
--- a/translator/totomlconfig/sampleConfig/delta_config_linux.conf
+++ b/translator/totomlconfig/sampleConfig/delta_config_linux.conf
@@ -1,0 +1,63 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.diskio]]
+    fieldpass = ["iops_in_progress", "read_time", "write_time"]
+    [inputs.diskio.tags]
+      ignored_fields_for_delta = "iops_in_progress"
+      metricPath = "metrics"
+      report_deltas = "true"
+
+[outputs]
+
+  [[outputs.cloudwatch]]
+    force_flush_interval = "60s"
+    namespace = "CWAgent"
+    region = "us-east-1"
+    tagexclude = ["host", "metricPath"]
+
+    [[outputs.cloudwatch.metric_decoration]]
+      category = "diskio"
+      name = "iops_in_progress"
+      rename = "DRIVER_DISKIO_IOPS_IN_PROGRESS"
+      unit = "Count"
+
+    [[outputs.cloudwatch.metric_decoration]]
+      category = "diskio"
+      name = "read_time"
+      rename = "DRIVER_DISKIO_READ_TIME"
+      unit = "Milliseconds"
+
+    [[outputs.cloudwatch.metric_decoration]]
+      category = "diskio"
+      name = "write_time"
+      rename = "DRIVER_DISKIO_WRITE_TIME"
+      unit = "Milliseconds"
+    [outputs.cloudwatch.tagpass]
+      metricPath = ["metrics"]
+
+[processors]
+
+  [[processors.delta]]
+
+  [[processors.ec2tagger]]
+    ec2_instance_tag_keys = ["aws:autoscaling:groupName"]
+    ec2_metadata_tags = ["ImageId", "InstanceId", "InstanceType"]
+    refresh_interval_seconds = "0s"
+    [processors.ec2tagger.tagpass]
+      metricPath = ["metrics"]

--- a/translator/totomlconfig/sampleConfig/delta_config_linux.json
+++ b/translator/totomlconfig/sampleConfig/delta_config_linux.json
@@ -1,0 +1,37 @@
+{
+  "agent": {
+    "region": "us-east-1"
+  },
+  "metrics": {
+    "append_dimensions": {
+      "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+      "ImageId": "${aws:ImageId}",
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}"
+    },
+    "metrics_collected": {
+      "diskio": {
+        "resources": [
+          "*"
+        ],
+        "measurement": [
+          {
+            "name": "diskio_iops_in_progress",
+            "rename": "DRIVER_DISKIO_IOPS_IN_PROGRESS",
+            "unit": "Count"
+          },
+          {
+            "name": "diskio_read_time",
+            "rename": "DRIVER_DISKIO_READ_TIME",
+            "unit": "Milliseconds"
+          },
+          {
+            "name": "diskio_write_time",
+            "rename": "DRIVER_DISKIO_WRITE_TIME",
+            "unit": "Milliseconds"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/totomlconfig/toTomlConfig_test.go
+++ b/translator/totomlconfig/toTomlConfig_test.go
@@ -127,6 +127,11 @@ func TestCsmOnlyConfig(t *testing.T) {
 	checkIfTranslateSucceed(t, ReadFromFile("./sampleConfig/csm_only_config.json"), "./sampleConfig/csm_only_config_linux.conf", "linux")
 }
 
+func TestDeltaConfigLinux(t *testing.T) {
+	resetContext()
+	checkIfTranslateSucceed(t, ReadFromFile("./sampleConfig/delta_config_linux.json"), "./sampleConfig/delta_config_linux.conf", "linux")
+}
+
 func TestCsmServiceAdressesConfig(t *testing.T) {
 	resetContext()
 	checkIfTranslateSucceed(t, ReadFromFile("./sampleConfig/csm_service_addresses.json"), "./sampleConfig/csm_service_addresses_windows.conf", "windows")

--- a/translator/translate/metrics/metrics_collect/diskio/diskio_test.go
+++ b/translator/translate/metrics/metrics_collect/diskio/diskio_test.go
@@ -73,6 +73,111 @@ func TestDiskIOWithIOInProgress(t *testing.T) {
 	}
 }
 
+func TestDiskIOWithIOInProgressWithDiskIOPrefix(t *testing.T) {
+	d := new(DiskIO)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{"diskio": {
+					"resources": [
+						"sda"
+					],
+					"measurement": [
+						"reads",
+						"writes",
+						"read_time",
+						"write_time",
+						"io_time",
+						"diskio_iops_in_progress"
+					],
+					"metrics_collection_interval": 60
+					}}`), &input)
+	if e == nil {
+		_, actual := d.ApplyRule(input)
+
+		d := []interface{}{map[string]interface{}{
+			"devices":   []interface{}{"sda"},
+			"fieldpass": []string{"reads", "writes", "read_time", "write_time", "io_time", "iops_in_progress"},
+			"interval":  "60s",
+			"tags":      map[string]interface{}{"report_deltas": "true", "ignored_fields_for_delta": "iops_in_progress"},
+		},
+		}
+
+		assert.Equal(t, d, actual, "Expected to be equal")
+	}
+}
+
+
+func TestDiskIOWithIOInProgressWithRename(t *testing.T) {
+	d := new(DiskIO)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{"diskio": {
+					"resources": [
+						"sda"
+					],
+					"measurement": [
+						"reads",
+						"writes",
+						"read_time",
+						"write_time",
+						"io_time",
+						{
+                        "name": "iops_in_progress",
+                        "rename": "DRIVER_DISKIO_IOPS_IN_PROGRESS",
+                        "unit": "Count"
+                    	}
+					],
+					"metrics_collection_interval": 60
+					}}`), &input)
+	if e == nil {
+		_, actual := d.ApplyRule(input)
+
+		d := []interface{}{map[string]interface{}{
+			"devices":   []interface{}{"sda"},
+			"fieldpass": []string{"reads", "writes", "read_time", "write_time", "io_time", "iops_in_progress"},
+			"interval":  "60s",
+			"tags":      map[string]interface{}{"report_deltas": "true", "ignored_fields_for_delta": "iops_in_progress"},
+		},
+		}
+
+		assert.Equal(t, d, actual, "Expected to be equal")
+	}
+}
+
+func TestDiskIOWithIOInProgressWithRenameAndDiskIOPrefix(t *testing.T) {
+	d := new(DiskIO)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{"diskio": {
+					"resources": [
+						"sda"
+					],
+					"measurement": [
+						"reads",
+						"writes",
+						"read_time",
+						"write_time",
+						"io_time",
+						{
+                        "name": "diskio_iops_in_progress",
+                        "rename": "DRIVER_DISKIO_IOPS_IN_PROGRESS",
+                        "unit": "Count"
+                    	}
+					],
+					"metrics_collection_interval": 60
+					}}`), &input)
+	if e == nil {
+		_, actual := d.ApplyRule(input)
+
+		d := []interface{}{map[string]interface{}{
+			"devices":   []interface{}{"sda"},
+			"fieldpass": []string{"reads", "writes", "read_time", "write_time", "io_time", "iops_in_progress"},
+			"interval":  "60s",
+			"tags":      map[string]interface{}{"report_deltas": "true", "ignored_fields_for_delta": "iops_in_progress"},
+		},
+		}
+
+		assert.Equal(t, d, actual, "Expected to be equal")
+	}
+}
+
 func TestDiskIOWithReportDeltaTrue(t *testing.T) {
 	d := new(DiskIO)
 	var input interface{}

--- a/translator/translate/metrics/util/deltasutil.go
+++ b/translator/translate/metrics/util/deltasutil.go
@@ -39,10 +39,21 @@ func ProcessReportDeltasForDiskIO(input interface{}, result map[string]interface
 	if val, ok := m[Measurement_Key]; ok {
 		fieldsPass := val.([]interface{})
 		for _, field := range fieldsPass {
-			if field.(string) == Ignored_fields_for_delta {
-				tagsMap := result[Tags_Key].(map[string]interface{})
-				tagsMap[Ignored_fields_for_delta_Key] = field
-				break
+			switch t := field.(type) {
+			case string:
+				if t == Ignored_fields_for_delta || t == "diskio_" + Ignored_fields_for_delta {
+					tagsMap := result[Tags_Key].(map[string]interface{})
+					tagsMap[Ignored_fields_for_delta_Key] = Ignored_fields_for_delta
+					return
+				}
+			case map[string]interface{}:
+				if name, ok := t["name"].(string); ok && (name == Ignored_fields_for_delta  || name == "diskio_" + Ignored_fields_for_delta){
+					tagsMap := result[Tags_Key].(map[string]interface{})
+					tagsMap[Ignored_fields_for_delta_Key] = Ignored_fields_for_delta
+					return
+				}
+			default:
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
# Description of the issue
Translator return error when configure rename metrics in diskio input plutin.
```
            "diskio": {
                "resources": [
                    "*"
                ],
                "measurement": [
                    {
                        "name": "iops_in_progress",
                        "rename": "test_in_progress",
                        "unit": "Count"
                    },
                    {
                        "name": "read_time",
                        "rename": "test_READ_TIME",
                        "unit": "Milliseconds"
                    },
                    {
                        "name": "diskio_write_time",
                        "rename": "test_WRITE_TIME",
                        "unit": "Milliseconds"
                    }
                ]
            },
```

DiskIo can not handle such map object.

# Description of changes
1. supports map in diskio
2. supports diskio prefix in metricname, like "diskio_write_time"

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
added unit test




