### PR TITLE
fix: use name under /dev/mapper as device for LVM volumes for disk plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,8 @@ module github.com/aws/amazon-cloudwatch-agent
 
 go 1.13
 
-replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20200902215110-5ec6811a19d9
+replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20201015165757-4470de2d306b
+replace github.com/shirou/gopsutil => github.com/aws/telegraf/patches/gopsutil v0.0.0-20201015165757-4470de2d306b // Temporary fix, pending PR https://github.com/shirou/gopsutil/pull/957
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,10 @@ github.com/aws/telegraf v0.10.2-0.20200830235304-c4cd2e3d15ec h1:NkiVPd2Po+YIWik
 github.com/aws/telegraf v0.10.2-0.20200830235304-c4cd2e3d15ec/go.mod h1:klLKIYh/pKoNn68ZgTyp2aGO+jigfkuUef4g7giWW/8=
 github.com/aws/telegraf v0.10.2-0.20200902215110-5ec6811a19d9 h1:wnp7t2AmMpaFxkv9CHt/rSx5iVzcmVEJlrGN50dwKxc=
 github.com/aws/telegraf v0.10.2-0.20200902215110-5ec6811a19d9/go.mod h1:ky9gF00vk7YHvO7PNu9Eeg7NdX9N1QxnTM0bDy4EDTY=
+github.com/aws/telegraf v0.10.2-0.20201015165757-4470de2d306b h1:39XAqFvDJuEXFZTQi1WTC+9GvfATC4zQ9jJlG1gHY9w=
+github.com/aws/telegraf v0.10.2-0.20201015165757-4470de2d306b/go.mod h1:3v3o4PIQDxTN4b25Uh3GBYf7a+qQjBC2hQ/LziGnxkU=
+github.com/aws/telegraf/patches/gopsutil v0.0.0-20201015165757-4470de2d306b h1:GYHVeoL0yE+Nz4mTAF9/QtHx8ZbjHOoFVwe62kMjrfA=
+github.com/aws/telegraf/patches/gopsutil v0.0.0-20201015165757-4470de2d306b/go.mod h1:NkKkFDm13DuNJIhuqlD52FRMO55q8YDVn85m8K5IinM=
 github.com/benbjohnson/clock v1.0.0 h1:78Jk/r6m4wCi6sndMpty7A//t4dw/RW5fV4ZgDVfX1w=
 github.com/benbjohnson/clock v1.0.0/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20150223135152-b965b613227f/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -897,6 +901,7 @@ golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191220220014-0732a990476f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200107162124-548cf772de50/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
# Description of the issue
gopsutil upgrade results in the "Device" dimension changed from the name
of the symbolic link under /dev/mapper to the actual device by resolving
the symbolic link. This is a breaking for customers thus we added the
original path under /dev/mapper back as "Source" in gopsutil in pull
request:
https://github.com/shirou/gopsutil/pull/957

And make use of this "Source" when it is available in the aws/Telegraf
fork:
https://github.com/aws/telegraf/commit/f7742938b37806a4b1d98f81f3fb5bf50b9bcb3f

# Description of changes
In this commit, we pick up the modified gopsutil and telegraf for the
fix, and would revert to later versions when the changes are upstreamed.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.