### PR TITLE
chore: add #! to preinst and prerm for debian pkg for compliance

### DIFF
--- a/packaging/debian/preinst
+++ b/packaging/debian/preinst
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
# Description of the issue
Current preinst and prerm script does not start with '#!' as suggested by debian documentation:
https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
 
# Description of changes
Added '#!/bin/sh' to both scripts

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.




