### PR TITLE
chore: remove md5 from jitter caculation

### DIFF
--- a/plugins/outputs/cloudwatch/util.go
+++ b/plugins/outputs/cloudwatch/util.go
@@ -4,12 +4,9 @@
 package cloudwatch
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"log"
-	"os"
+	"math/rand"
 	"sort"
-	"strconv"
 	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent/metric/distribution"
@@ -50,17 +47,10 @@ const (
 )
 
 func publishJitter(publishInterval time.Duration) (publishJitter time.Duration) {
-	hostName, _ := os.Hostname()
-	jitter := computeMD5Hash(hostName, int64(publishInterval.Seconds()))
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	jitter := r.Int63n(int64(publishInterval.Seconds()))
 	publishJitter = time.Duration(jitter) * time.Second
 	return
-}
-
-func computeMD5Hash(value string, max int64) int64 {
-	md5Value := md5.New().Sum([]byte(value))
-	hexString := hex.EncodeToString(md5Value)
-	i, _ := strconv.ParseInt(hexString[:6], 16, 64)
-	return i % max
 }
 
 func setNewDistributionFunc(maxValuesPerDatumLimit int) {

--- a/plugins/outputs/cloudwatch/util_test.go
+++ b/plugins/outputs/cloudwatch/util_test.go
@@ -24,14 +24,6 @@ func TestPublishJitter(t *testing.T) {
 	assert.True(t, publishJitter < time.Minute)
 }
 
-func TestComputeMD5Hash(t *testing.T) {
-	jitter := computeMD5Hash("some-string-value", 60)
-	assert.Equal(t, int64(5), jitter)
-
-	jitter = computeMD5Hash("different-string-value", 60)
-	assert.Equal(t, int64(22), jitter)
-}
-
 func TestSetNewDistributionFunc(t *testing.T) {
 	setNewDistributionFunc(maxValuesPerDatum)
 	_, ok := distribution.NewDistribution().(*seh1.SEH1Distribution)


### PR DESCRIPTION
# Description of the issue
md5 may have security fisk.

# Description of changes
use random instead

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
make




