### PR TITLE
Add formatted date as a variable

### DIFF
--- a/translator/translate/util/placeholderUtil.go
+++ b/translator/translate/util/placeholderUtil.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ec2util"
@@ -19,6 +20,7 @@ const (
 	localHostnamePlaceholder = "{local_hostname}" //regardless of ec2 metadata
 	ipAddressPlaceholder     = "{ip_address}"
 	awsRegionPlaceholder     = "{aws_region}"
+	datePlaceholder          = "{date}"
 
 	unknownInstanceId = "i-UNKNOWN"
 	unknownHostname   = "UNKNOWN-HOST"
@@ -35,6 +37,7 @@ func ResolvePlaceholder(placeholder string, metadata map[string]string) string {
 	for k, v := range metadata {
 		tmpString = strings.Replace(tmpString, k, v, -1)
 	}
+	tmpString = strings.Replace(tmpString, datePlaceholder, time.Now().Format("2006-01-02"), -1)
 	return tmpString
 }
 


### PR DESCRIPTION
# Description of the issue
We want to be able to truncate old data from our Cloudwatch logs; so we decided to break the Log Streams into individual chunks based on date.

# Description of changes
This PR adds a new placeholder variable `{date}` which can be put in the Log Stream template definition, and will be replaced with the current date in ISO-8601 format (such as "2020-11-02").

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
We've been using this commit in a custom build for over a month now, without issue.



