### PR TITLE
enable flag to force ec2 mode

### DIFF
--- a/cmd/start-amazon-cloudwatch-agent/start-amazon-cloudwatch-agent.go
+++ b/cmd/start-amazon-cloudwatch-agent/start-amazon-cloudwatch-agent.go
@@ -37,13 +37,21 @@ var (
 
 	translatorBinaryPath string
 	agentBinaryPath      string
+	agentMode            string
 )
 
 // We use an environment variable here because we need this condition before the translator reads agent config json file.
+var forceModeEc2 = os.Getenv(config.FORCE_MODE_EC2)
 var runInContainer = os.Getenv(config.RUN_IN_CONTAINER)
 
 func translateConfig() error {
-	args := []string{"--output", tomlConfigPath, "--mode", "auto"}
+	if forceModeEc2 == config.FORCE_MODE_EC2_TRUE {
+		agentMode = "ec2"
+	} else {
+		agentMode = "auto"
+	}
+
+	args := []string{"--output", tomlConfigPath, "--mode", agentMode}
 	if runInContainer == config.RUN_IN_CONTAINER_TRUE {
 		args = append(args, "--input-dir", CONFIG_DIR_IN_CONTAINE)
 	} else {

--- a/cmd/start-amazon-cloudwatch-agent/start-amazon-cloudwatch-agent.go
+++ b/cmd/start-amazon-cloudwatch-agent/start-amazon-cloudwatch-agent.go
@@ -37,21 +37,13 @@ var (
 
 	translatorBinaryPath string
 	agentBinaryPath      string
-	agentMode            string
 )
 
 // We use an environment variable here because we need this condition before the translator reads agent config json file.
-var forceModeEc2 = os.Getenv(config.FORCE_MODE_EC2)
 var runInContainer = os.Getenv(config.RUN_IN_CONTAINER)
 
 func translateConfig() error {
-	if forceModeEc2 == config.FORCE_MODE_EC2_TRUE {
-		agentMode = "ec2"
-	} else {
-		agentMode = "auto"
-	}
-
-	args := []string{"--output", tomlConfigPath, "--mode", agentMode}
+	args := []string{"--output", tomlConfigPath, "--mode", "auto"}
 	if runInContainer == config.RUN_IN_CONTAINER_TRUE {
 		args = append(args, "--input-dir", CONFIG_DIR_IN_CONTAINE)
 	} else {

--- a/translator/config/envconst.go
+++ b/translator/config/envconst.go
@@ -8,6 +8,8 @@ const (
 	RUN_IN_CONTAINER_TRUE   = "True"
 	USE_DEFAULT_CONFIG      = "USE_DEFAULT_CONFIG"
 	USE_DEFAULT_CONFIG_TRUE = "True"
+	FORCE_MODE_EC2          = "FORCE_MODE_EC2"
+	FORCE_MODE_EC2_TRUE     = "True"
 	HOST_NAME               = "HOST_NAME"
 	POD_NAME                = "POD_NAME"
 	HOST_IP                 = "HOST_IP"

--- a/translator/config/envconst.go
+++ b/translator/config/envconst.go
@@ -6,10 +6,10 @@ package config
 const (
 	RUN_IN_CONTAINER        = "RUN_IN_CONTAINER"
 	RUN_IN_CONTAINER_TRUE   = "True"
+	RUN_IN_AWS          	= "RUN_IN_AWS"
+	RUN_IN_AWS_TRUE         = "True"
 	USE_DEFAULT_CONFIG      = "USE_DEFAULT_CONFIG"
 	USE_DEFAULT_CONFIG_TRUE = "True"
-	FORCE_MODE_EC2          = "FORCE_MODE_EC2"
-	FORCE_MODE_EC2_TRUE     = "True"
 	HOST_NAME               = "HOST_NAME"
 	POD_NAME                = "POD_NAME"
 	HOST_IP                 = "HOST_IP"

--- a/translator/util/sdkutil.go
+++ b/translator/util/sdkutil.go
@@ -25,10 +25,16 @@ const (
 
 var DetectRegion func(mode string, credsConfig map[string]string) string = detectRegion
 var DetectCredentialsPath func() string = detectCredentialsPath
+var runInAws = os.Getenv(config.RUN_IN_AWS)
 
 func DetectAgentMode(configuredMode string) string {
 	if configuredMode != "auto" {
 		return configuredMode
+	}
+
+	if runInAws == config.RUN_IN_AWS_TRUE {
+		fmt.Println("I! Detected from ENV instance is EC2")
+		return config.ModeEC2
 	}
 
 	if defaultEC2Region() != "" {


### PR DESCRIPTION
# Description of the issue
When running CloudWatch Agent on Fargate the agent container determines the environment as `OnPrem` since the metadata service is unavailable on Fargate. Afterwards the generated `toml` expects a credentials file at `.aws/credentials` instead of using the attached role. #118 

# Description of changes
This PR adds an ENV flag `RUN_IN_AWS=True` that would force the agent to skip metadata check allowing it to fallback to the usual credentials procedure. The downside is that the agent is unable to automatically determine the region and other variables that are dependent on the metadata service e.g. `{instance_id}` don’t work.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._




