### PR TITLE
chore: disable cgo for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ config-downloader: copy-version-file
 	GOOS=windows GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/windows_amd64/config-downloader.exe github.com/aws/amazon-cloudwatch-agent/cmd/config-downloader
 
 test:
-	go test -v -failfast ./awscsm/... ./cfg/... ./cmd/... ./handlers/... ./internal/... ./logger/... ./logs/... ./metric/... ./plugins/... ./profiler/... ./tool/... ./translator/...
+	CGO_ENABLED=0 go test -v -failfast ./awscsm/... ./cfg/... ./cmd/... ./handlers/... ./internal/... ./logger/... ./logs/... ./metric/... ./plugins/... ./profiler/... ./tool/... ./translator/...
 
 clean::
 	rm -rf release/ build/


### PR DESCRIPTION
# Description of the issue
https://github.com/aws/amazon-cloudwatch-agent/issues/123

# Description of changes
need to disable cgo for test target, otherwise the test will fail caused by gcc missing.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
make release




