### PR TITLE
Fix incorrect systemd detection

### DIFF
--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -249,7 +249,7 @@ main() {
     # detect which init system is in use
     if [ "$(/sbin/init --version 2>/dev/null | grep -c upstart)" = 1 ]; then
 	SYSTEMD='false'
-    elif [ "$(systemctl | grep -c -E '\s\-\.mount\s')" = 1 ]; then
+    elif [ "$(systemctl | grep -c '\-\.mount')" -gt 0 ]; then
 	SYSTEMD='true'
     elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
 	echo "sysv-init is not supported" >&2

--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -249,7 +249,7 @@ main() {
     # detect which init system is in use
     if [ "$(/sbin/init --version 2>/dev/null | grep -c upstart)" = 1 ]; then
 	SYSTEMD='false'
-    elif [ "$(systemctl | grep -c '\-\.mount')" -gt 0 ]; then
+    elif [ "$(systemctl | grep -c -E '\s\-\.mount\s')" = 1 ]; then
 	SYSTEMD='true'
     elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
 	echo "sysv-init is not supported" >&2

--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -249,7 +249,7 @@ main() {
     # detect which init system is in use
     if [ "$(/sbin/init --version 2>/dev/null | grep -c upstart)" = 1 ]; then
 	SYSTEMD='false'
-    elif [ "$(systemctl | grep -c '\-\.mount')" = 1 ]; then
+    elif [ "$(systemctl | grep -c -E '\s\-\.mount\s')" = 1 ]; then
 	SYSTEMD='true'
     elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
 	echo "sysv-init is not supported" >&2

--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -249,7 +249,7 @@ main() {
     # detect which init system is in use
     if [ "$(/sbin/init --version 2>/dev/null | grep -c upstart)" = 1 ]; then
 	SYSTEMD='false'
-    elif [ "$(systemctl | grep -c -E '\s\-\.mount\s')" = 1 ]; then
+    elif [ "$(systemctl | grep -c -E '\-\.mount\s')" = 1 ]; then
 	SYSTEMD='true'
     elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
 	echo "sysv-init is not supported" >&2


### PR DESCRIPTION
Closes #131

# Description of the issue
https://github.com/aws/amazon-cloudwatch-agent/issues/131

# Description of changes
It is possible that in some systems the command `systemctl | grep -c '\-\.mount'` will return a value greater than zero. In these circumstances the `amazon-cloudwatch-agent-ctl` script doesn't detect `systemd` correctly. This patch is intended to fix this behavior.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Given that

```
$ systemctl | grep '\-\.mount'
  -.mount                                                                                  loaded active     mounted   Root Mount                                                                
  tmp-.mount_jetbraP6HI4I.mount                                                            loaded active     mounted   /tmp/.mount_jetbraP6HI4I
```


Old behavior 

```
$ [ "$(systemctl | grep -c '\-\.mount')" = 1 ]; echo $?
1
```

New behavior:
```
$ [ "$(systemctl | grep -c -E '\-\.mount\s')" = 1 ]; echo $?
0
```



