### PR TITLE
Set cwagent Home Dir to amazon-cloudwatch-agent

### DIFF
--- a/packaging/linux/amazon-cloudwatch-agent.spec
+++ b/packaging/linux/amazon-cloudwatch-agent.spec
@@ -82,7 +82,7 @@ if ! grep "^cwagent:" /etc/group >/dev/null 2>&1; then
 fi
 
 if ! id cwagent >/dev/null 2>&1; then
-    useradd -r -M cwagent -d /home/cwagent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh))) >/dev/null 2>&1
+    useradd -r -M cwagent -d /opt/aws/amazon-cloudwatch-agent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh))) >/dev/null 2>&1
     echo "create user cwagent, result: $?"
 fi
 


### PR DESCRIPTION
Sets the cwagent user home dir to something that actually exists. Makes automated checks for CIS compliance easier to achieve without manual tweaks.

For Amazon Linux, this fails benchmark 6.2.7 Ensure all users' home directories exist (Scored).

From CIS:

```
If the user's home directory does not exist or is unassigned, the user will be placed in "/" and will not be able to write any files or have local environment variables set.
```

# Description of the issue
/home/cwagent is set as the home dir for cwagent, but the path is not created by the installer.

# Description of changes
This changes the home dir of cwagent to /opt/aws/amazon-cloudwatch-agent, which actually exists.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Changed home dir on running system with no ill effects.




