### PR TITLE
chore: exit the build script when error occurs

### DIFF
--- a/Tools/src/create_deb.sh
+++ b/Tools/src/create_deb.sh
@@ -2,6 +2,7 @@
 echo "****************************************"
 echo "Creating deb file for Debian Linux ${ARCH}"
 echo "****************************************"
+set -e
 
 AGENT_VERSION=`cat ${PREPKGPATH}/CWAGENT_VERSION`
 BUILD_ROOT="${BUILD_SPACE}/private/linux_${ARCH}/debian"

--- a/Tools/src/create_rpm.sh
+++ b/Tools/src/create_rpm.sh
@@ -2,6 +2,7 @@
 echo "*************************************************"
 echo "Creating rpm file for Amazon Linux and RHEL ${ARCH}"
 echo "*************************************************"
+set -e
 
 SPEC_FILE="${PREPKGPATH}/amazon-cloudwatch-agent.spec"
 BUILD_ROOT="${BUILD_SPACE}/private/linux_${ARCH}/rpm-build"

--- a/Tools/src/create_win.sh
+++ b/Tools/src/create_win.sh
@@ -2,7 +2,7 @@
 echo "****************************************"
 echo "Creating zip file for Windows amd64"
 echo "****************************************"
-
+set -e
 
 BUILD_ROOT="${BUILD_SPACE}/private/windows_${ARCH}/"
 AGENT_VERSION=`cat ${PREPKGPATH}/CWAGENT_VERSION`


### PR DESCRIPTION
# Description of the issue
create_rpm deb win.sh will not report error if there is something wrong.

# Description of changes
add "set -e"  to let shell exit when error occurs

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._




