### PR TITLE
fix: merge procstat plugin as list, then it will not fail if there ar…

### DIFF
--- a/translator/jsonconfig/mergeJsonConfig_test.go
+++ b/translator/jsonconfig/mergeJsonConfig_test.go
@@ -39,6 +39,7 @@ var testDataList = []TestData{
 	{"MixedSection_LogsMetricCollectedConfig", 10, 2, false},
 	{"SeparateSection_LogsMetricAndLog", 11, 2, false},
 	{"SeparateSection_PrometheusAndLog", 12, 2, false},
+	{"SeparateSection_PrometheusAndLog", 13, 2, false},
 }
 
 func TestMergeJsonConfigMaps(t *testing.T) {

--- a/translator/jsonconfig/mergeJsonConfig_test.go
+++ b/translator/jsonconfig/mergeJsonConfig_test.go
@@ -39,7 +39,7 @@ var testDataList = []TestData{
 	{"MixedSection_LogsMetricCollectedConfig", 10, 2, false},
 	{"SeparateSection_LogsMetricAndLog", 11, 2, false},
 	{"SeparateSection_PrometheusAndLog", 12, 2, false},
-	{"SeparateSection_PrometheusAndLog", 13, 2, false},
+	{"Two_procstat", 13, 2, false},
 }
 
 func TestMergeJsonConfigMaps(t *testing.T) {

--- a/translator/jsonconfig/sampleJsonConfig/test_13/expected_output.json
+++ b/translator/jsonconfig/sampleJsonConfig/test_13/expected_output.json
@@ -1,0 +1,32 @@
+{
+  "agent": {
+    "logfile": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+  },
+  "metrics": {
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "procstat": [
+        {
+          "exe": "KAVFS",
+          "measurement": [
+            "pid_count"
+          ]
+        },
+        {
+          "exe": "W3SVC",
+          "measurement": [
+            "pid_count"
+          ]
+        },
+        {
+          "exe": "IISADMIN",
+          "measurement": [
+            "pid_count"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/translator/jsonconfig/sampleJsonConfig/test_13/input_1.json
+++ b/translator/jsonconfig/sampleJsonConfig/test_13/input_1.json
@@ -1,0 +1,18 @@
+{
+  "agent": {
+    "logfile": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+  },
+  "metrics": {
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "procstat": [{
+        "exe": "KAVFS",
+        "measurement": [
+          "pid_count"
+        ]
+      }]
+    }
+  }
+}

--- a/translator/jsonconfig/sampleJsonConfig/test_13/input_2.json
+++ b/translator/jsonconfig/sampleJsonConfig/test_13/input_2.json
@@ -1,0 +1,19 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "procstat": [
+        {
+          "exe": "W3SVC",
+          "measurement": [
+            "pid_count"
+          ]
+        },
+        {
+          "exe": "IISADMIN",
+          "measurement": [
+            "pid_count"
+          ]
+        }]
+    }
+  }
+}

--- a/translator/translate/metrics/metrics_collect/procstat/procstat.go
+++ b/translator/translate/metrics/metrics_collect/procstat/procstat.go
@@ -5,6 +5,8 @@ package procstat
 
 import (
 	"github.com/aws/amazon-cloudwatch-agent/translator"
+	"github.com/aws/amazon-cloudwatch-agent/translator/jsonconfig/mergeJsonRule"
+	"github.com/aws/amazon-cloudwatch-agent/translator/jsonconfig/mergeJsonUtil"
 	parent "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/util"
 )
@@ -57,8 +59,15 @@ func (p *Procstat) ApplyRule(input interface{}) (returnKey string, returnVal int
 	return
 }
 
+var MergeRuleMap = map[string]mergeJsonRule.MergeRule{}
+
+func (c *Procstat) Merge(source map[string]interface{}, result map[string]interface{}) {
+	mergeJsonUtil.MergeList(source, result, SectionKey)
+}
+
 func init() {
 	m := new(Procstat)
 	parent.RegisterLinuxRule(SectionKey, m)
 	parent.RegisterWindowsRule(SectionKey, m)
+	parent.MergeRuleMap[SectionKey] = m
 }


### PR DESCRIPTION
…e two procstat plugins defined in different json


# Description of the issue
It is to fix: https://github.com/aws/amazon-cloudwatch-agent/issues/133
procstat input exists in different json files causes translator failure.

# Description of changes
consder procstat as a list, merge all of the porcstat configuration to a list.

Attent: it will not merge the same contents, like following there are  two procstat segments, they will merged into one, and finally, there will be 3 procstat plugins. although`Test1Program` exist in two segments, we will not merge two `Test1Program`  into 1. 

```
      "procstat": [{
        "exe": "Test1Program",
        "measurement": [
          "pid_count"
        ]
      }]
```

and 

```
      "procstat": [
        {
          "exe": "Test1Program",
          "measurement": [
            "pid_count"
          ]
        },
        {
          "exe": "Test2Program",
          "measurement": [
            "pid_count"
          ]
        }]
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
unittest





