### PR TITLE
Add ecs service endpoint-based discovery for prometheus

### DIFF
--- a/internal/ecsservicediscovery/README.md
+++ b/internal/ecsservicediscovery/README.md
@@ -35,6 +35,15 @@ Two modes can be enabled together and CWAgent will de-dup the discovered targets
 |docker_label         | Optional    | docker label based service discovery configurations. If this structure is nil, docker label based service discovery is disabled                |
 |task_definition_list | Optional    | ECS task definition based service discovery configurations slice. If this slice is empty, task definition based service discovery is disabled  |
 
+#### Service Endpoint Based Auto Discovery
+
+|Configuration Field  |             | Description                                                   |
+|---------------------|-------------|---------------------------------------------------------------|
+|sd_service_name_pattern         | Mandatory   | ECS service name regex pattern             |
+|sd_metrics_ports                | Mandatory   | semicolon separated containerPort for Prometheus metrics.    |
+|sd_container_name_pattern       | Optional    | ECS task container name regex pattern                        |
+|sd_metrics_path                 | Optional    | Prometheus metric path. If not specified, the default path /metrics is assumed        |
+|sd_job_name                     | Optional    | Prometheus scrape job name. If not specified, the job name in prometheus.yaml is used   |
 
 #### Docker Label Based Auto Discovery Configuration
 

--- a/internal/ecsservicediscovery/config_test.go
+++ b/internal/ecsservicediscovery/config_test.go
@@ -20,3 +20,14 @@ func Test_TaskDefinitionConfig_init(t *testing.T) {
 	config.init()
 	assert.True(t, reflect.DeepEqual(config.metricsPortList, []int{11, 12, 13, 14}))
 }
+
+func Test_ServiceNameForTasksConfig_init(t *testing.T) {
+	config := ServiceNameForTasksConfig{
+		JobName: "test_job_1",
+		MetricsPorts: "11;12;	 13 ;a;14  ",
+		ServiceNamePattern: "^task.*$",
+	}
+
+	config.init()
+	assert.True(t, reflect.DeepEqual(config.metricsPortList, []int{11, 12, 13, 14}))
+}

--- a/internal/ecsservicediscovery/processorstats.go
+++ b/internal/ecsservicediscovery/processorstats.go
@@ -13,6 +13,7 @@ const (
 	AWSAPIDescribeContainerInstances = "AWSCLI_DescribeContainerInstances"
 	AWSCLIDescribeInstancesRequest   = "AWSCLI_DescribeInstancesRequest"
 	AWSCLIDescribeTaskDefinition     = "AWSCLI_DescribeTaskDefinition"
+	AWSCLIListServices               = "AWSCLI_ListServices"
 	AWSCLIListTasks                  = "AWSCLI_ListTasks"
 	AWSCLIDescribeTasks              = "AWSCLI_DescribeTasks"
 	LRUCacheGetEC2MetaData           = "LRUCache_Get_EC2MetaData"

--- a/internal/ecsservicediscovery/servicediscovery.go
+++ b/internal/ecsservicediscovery/servicediscovery.go
@@ -38,6 +38,7 @@ func (sd *ServiceDiscovery) init() {
 func (sd *ServiceDiscovery) initClusterProcessorPipeline() {
 	sd.clusterProcessors = append(sd.clusterProcessors, NewTaskProcessor(sd.svcEcs, &sd.stats))
 	sd.clusterProcessors = append(sd.clusterProcessors, NewTaskDefinitionProcessor(sd.svcEcs, &sd.stats))
+	sd.clusterProcessors = append(sd.clusterProcessors, NewServiceEndpointDiscoveryProcessor(sd.svcEcs, sd.Config.ServiceNamesForTasks, &sd.stats))
 	sd.clusterProcessors = append(sd.clusterProcessors, NewDockerLabelDiscoveryProcessor(sd.Config.DockerLabel))
 	sd.clusterProcessors = append(sd.clusterProcessors, NewTaskDefinitionDiscoveryProcessor(sd.Config.TaskDefinitions))
 	sd.clusterProcessors = append(sd.clusterProcessors, NewTaskFilterProcessor())
@@ -86,8 +87,8 @@ func (sd *ServiceDiscovery) validateConfig() bool {
 		return false
 	}
 
-	if sd.Config.DockerLabel == nil && len(sd.Config.TaskDefinitions) == 0 {
-		log.Printf("E! Neither docker label based discovery nor task definition based discovery is enabled.\n")
+	if sd.Config.DockerLabel == nil && len(sd.Config.TaskDefinitions) == 0 && len(sd.Config.ServiceNamesForTasks) == 0 {
+		log.Printf("E! Neither docker label based discovery, nor task definition based discovery, nor service name based discovery is enabled.\n")
 		return false
 	}
 

--- a/internal/ecsservicediscovery/servicediscovery_test.go
+++ b/internal/ecsservicediscovery/servicediscovery_test.go
@@ -4,9 +4,10 @@
 package ecsservicediscovery
 
 import (
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ServiceDiscovery_InitPipelines(t *testing.T) {
@@ -17,7 +18,7 @@ func Test_ServiceDiscovery_InitPipelines(t *testing.T) {
 	p := &ServiceDiscovery{Config: &config}
 	p.initClusterProcessorPipeline()
 
-	assert.Equal(t, 7, len(p.clusterProcessors))
+	assert.Equal(t, 8, len(p.clusterProcessors))
 }
 
 func Test_StartECSServiceDiscovery_NilConfig(t *testing.T) {

--- a/internal/ecsservicediscovery/serviceendpointdiscoveryprocessor.go
+++ b/internal/ecsservicediscovery/serviceendpointdiscoveryprocessor.go
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package ecsservicediscovery
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+// Tag the Tasks that match the Service Name based Service Discovery
+type ServiceEndpointDiscoveryProcessor struct {
+	serviceNamesForTasksConfig []*ServiceNameForTasksConfig
+	svcEcs                     *ecs.ECS
+	stats                      *ProcessorStats
+}
+
+func minInt(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func NewServiceEndpointDiscoveryProcessor(ecs *ecs.ECS, serviceNamesForTasks []*ServiceNameForTasksConfig, s *ProcessorStats) *ServiceEndpointDiscoveryProcessor {
+	for _, v := range serviceNamesForTasks {
+		v.init()
+	}
+
+	return &ServiceEndpointDiscoveryProcessor{
+		serviceNamesForTasksConfig: serviceNamesForTasks,
+		svcEcs:                     ecs,
+		stats:                      s,
+	}
+}
+
+func (p *ServiceEndpointDiscoveryProcessor) Process(cluster string, taskList []*DecoratedTask) ([]*DecoratedTask, error) {
+	if len(p.serviceNamesForTasksConfig) == 0 {
+		return taskList, nil
+	}
+	idToServiceName := make(map[string]string)
+	var servicesToDescribe []*string
+	req := &ecs.ListServicesInput{Cluster: &cluster}
+	for {
+		listServiceResp, listServiceErr := p.svcEcs.ListServices(req)
+		p.stats.AddStats(AWSCLIListServices)
+		if listServiceErr != nil {
+			return taskList, newServiceDiscoveryError("Failed to list service ARNs for "+cluster, &listServiceErr)
+		}
+		servicesToDescribe = p.processServices(listServiceResp, servicesToDescribe)
+		if listServiceResp.NextToken == nil {
+			break
+		}
+		req.NextToken = listServiceResp.NextToken
+	}
+	describeServiceErr := p.mapDeploymentIDs(cluster, servicesToDescribe, idToServiceName)
+	if describeServiceErr != nil {
+		return taskList, describeServiceErr
+	}
+	p.processDecoratedTasks(taskList, idToServiceName)
+	return taskList, nil
+}
+
+func (p *ServiceEndpointDiscoveryProcessor) processServices(listServiceResp *ecs.ListServicesOutput, servicesToDescribe []*string) []*string {
+	for _, serviceArn := range listServiceResp.ServiceArns {
+		splitArn := strings.Split(*serviceArn, "/")
+		serviceNameFromArn := splitArn[len(splitArn)-1]
+		for _, serviceName := range p.serviceNamesForTasksConfig {
+			if serviceName.serviceNameRegex.MatchString(serviceNameFromArn) {
+				servicesToDescribe = append(servicesToDescribe, serviceArn)
+				break
+			}
+		}
+	}
+	return servicesToDescribe
+}
+
+func (p *ServiceEndpointDiscoveryProcessor) mapDeploymentIDs(cluster string, servicesForInput []*string, idToServiceName map[string]string) error {
+	for startIndex := 0; startIndex < len(servicesForInput); startIndex += 10 {
+		endIndex := minInt(startIndex+10, len(servicesForInput))
+		req := &ecs.DescribeServicesInput{Cluster: &cluster, Services: servicesForInput[startIndex:endIndex]}
+		describeServiceResp, describeServiceErr := p.svcEcs.DescribeServices(req)
+		for _, describedService := range describeServiceResp.Services {
+			for _, deployment := range describedService.Deployments {
+				if *deployment.Status == "ACTIVE" || *deployment.Status == "PRIMARY" {
+					if describedService.ServiceName != nil {
+						idToServiceName[*deployment.Id] = *describedService.ServiceName
+					}
+				}
+			}
+		}
+		if describeServiceErr != nil {
+			return newServiceDiscoveryError("Failed to describe service ARNs for "+cluster, &describeServiceErr)
+		}
+	}
+	return nil
+}
+
+func (p *ServiceEndpointDiscoveryProcessor) processDecoratedTasks(taskList []*DecoratedTask, idToServiceName map[string]string) {
+	for _, v := range taskList {
+		if v.Task.StartedBy != nil {
+			if val, ok := idToServiceName[*v.Task.StartedBy]; ok {
+				if p.validateServiceNameDiscoveredTask(val, v, p.serviceNamesForTasksConfig) {
+					v.ServiceName = val
+				}
+			}
+		}
+	}
+	return
+}
+
+func (p *ServiceEndpointDiscoveryProcessor) validateServiceNameDiscoveredTask(serviceName string, task *DecoratedTask, serviceNamesForTasksConfig []*ServiceNameForTasksConfig) bool {
+	for _, serviceConfig := range serviceNamesForTasksConfig {
+		if serviceConfig.serviceNameRegex.MatchString(serviceName) {
+			if serviceConfig.ContainerNamePattern == "" || checkContainerNamePatternService(task.TaskDefinition.ContainerDefinitions, serviceConfig) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func checkContainerNamePatternService(containers []*ecs.ContainerDefinition, config *ServiceNameForTasksConfig) bool {
+	for _, c := range containers {
+		if config.containerNameRegex.MatchString(aws.StringValue(c.Name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *ServiceEndpointDiscoveryProcessor) ProcessorName() string {
+	return "ServiceEndpointDiscoveryProcessor"
+}

--- a/internal/ecsservicediscovery/serviceendpointdiscoveryprocessor_test.go
+++ b/internal/ecsservicediscovery/serviceendpointdiscoveryprocessor_test.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package ecsservicediscovery
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
+)
+
+func buildTestingTasksforServiceName() []*DecoratedTask {
+	matchingID1 := "jghsdf3242"
+	matchingID2 := "sdfdagfsdg"
+	matchingID3 := "jfdnvufhsn"
+	mismatchingID := "fnfjucnadz"
+	containerNameMatch := "PatternMatch"
+	containerNameMismatch := "InvalidPattern"
+	return []*DecoratedTask{
+		{
+			TaskDefinition: &ecs.TaskDefinition{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: &containerNameMismatch,
+					},
+				},
+			},
+			Task: &ecs.Task{
+				StartedBy: &matchingID1,
+			},
+		},
+		{
+			TaskDefinition: &ecs.TaskDefinition{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: &containerNameMatch,
+					},
+				},
+			},
+			Task: &ecs.Task{
+				StartedBy: &matchingID2,
+			},
+		},
+		{
+			TaskDefinition: &ecs.TaskDefinition{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: &containerNameMismatch,
+					},
+				},
+			},
+			Task: &ecs.Task{
+				StartedBy: &matchingID3,
+			},
+		},
+		{
+			TaskDefinition: &ecs.TaskDefinition{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: &containerNameMatch,
+					},
+				},
+			},
+			Task: &ecs.Task{
+				StartedBy: &mismatchingID,
+			},
+		},
+	}
+}
+
+func Test_ServiceNameDiscoveryProcessor_Normal(t *testing.T) {
+	config := []*ServiceNameForTasksConfig{
+		{ServiceNamePattern: "ServiceWithContainerNamePattern[1-9]+", ContainerNamePattern: "PatternMatch"},
+		{ServiceNamePattern: "ServiceWithoutContainerNamePattern[1-9]+"},
+	}
+	var stats ProcessorStats
+	taskList := buildTestingTasksforServiceName()
+	mockSvc := &ecs.ECS{}
+	p := NewServiceEndpointDiscoveryProcessor(mockSvc, config, &stats)
+	assert.Equal(t, "ServiceEndpointDiscoveryProcessor", p.ProcessorName())
+	mismatchContainerMatchingID1 := "jghsdf3242"
+	matchingContainerMatchingID := "sdfdagfsdg"
+	mismatchContainerMatchingID2 := "jfdnvufhsn"
+	idToServiceName := make(map[string]string)
+	idToServiceName[mismatchContainerMatchingID1] = "ServiceWithContainerNamePattern1"
+	idToServiceName[matchingContainerMatchingID] = "ServiceWithContainerNamePattern2"
+	idToServiceName[mismatchContainerMatchingID2] = "ServiceWithoutContainerNamePattern3"
+	p.processDecoratedTasks(taskList, idToServiceName)
+	for _, v := range taskList {
+		assert.False(t, v.DockerLabelBased)
+		assert.False(t, v.TaskDefinitionBased)
+	}
+	assert.True(t, taskList[0].ServiceName == "")
+	assert.False(t, taskList[1].ServiceName == "")
+	assert.False(t, taskList[2].ServiceName == "")
+	assert.True(t, taskList[3].ServiceName == "")
+}

--- a/internal/ecsservicediscovery/taskfilterprocessor.go
+++ b/internal/ecsservicediscovery/taskfilterprocessor.go
@@ -15,7 +15,7 @@ func NewTaskFilterProcessor() *TaskFilterProcessor {
 func (p *TaskFilterProcessor) Process(cluster string, taskList []*DecoratedTask) ([]*DecoratedTask, error) {
 	var filteredClusterTasks []*DecoratedTask
 	for _, v := range taskList {
-		if v.DockerLabelBased || v.TaskDefinitionBased {
+		if v.ServiceName != "" || v.DockerLabelBased || v.TaskDefinitionBased {
 			filteredClusterTasks = append(filteredClusterTasks, v)
 		}
 	}

--- a/internal/ecsservicediscovery/taskfilterprocessor_test.go
+++ b/internal/ecsservicediscovery/taskfilterprocessor_test.go
@@ -4,14 +4,39 @@
 package ecsservicediscovery
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func buildTestingTasksforTaskFilter() []*DecoratedTask {
 
 	return []*DecoratedTask{
+		&DecoratedTask{
+			ServiceName:         "true",
+			DockerLabelBased:    true,
+			TaskDefinitionBased: true,
+			TaskDefinition:      &ecs.TaskDefinition{},
+		},
+		&DecoratedTask{
+			ServiceName:         "true",
+			DockerLabelBased:    true,
+			TaskDefinitionBased: false,
+			TaskDefinition:      &ecs.TaskDefinition{},
+		},
+		&DecoratedTask{
+			ServiceName:         "true",
+			DockerLabelBased:    false,
+			TaskDefinitionBased: true,
+			TaskDefinition:      &ecs.TaskDefinition{},
+		},
+		&DecoratedTask{
+			ServiceName:         "true",
+			DockerLabelBased:    false,
+			TaskDefinitionBased: false,
+			TaskDefinition:      &ecs.TaskDefinition{},
+		},
 		&DecoratedTask{
 			DockerLabelBased:    true,
 			TaskDefinitionBased: true,
@@ -40,7 +65,7 @@ func Test_NewTaskFilterProcessor_Normal(t *testing.T) {
 	assert.Equal(t, "TaskFilterProcessor", p.ProcessorName())
 	taskList := buildTestingTasksforTaskFilter()
 	taskList, _ = p.Process("test_ecs_cluster_name", taskList)
-	assert.Equal(t, 3, len(taskList))
+	assert.Equal(t, 7, len(taskList))
 }
 
 func Test_NewTaskFilterProcessor_Empty(t *testing.T) {

--- a/internal/ecsservicediscovery/taskprocessor.go
+++ b/internal/ecsservicediscovery/taskprocessor.go
@@ -4,8 +4,9 @@
 package ecsservicediscovery
 
 import (
-	"github.com/aws/aws-sdk-go/service/ecs"
 	"log"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
 // Get all running tasks for the target cluster

--- a/translator/config/schema.go
+++ b/translator/config/schema.go
@@ -812,6 +812,12 @@ var schema = `{
             "$ref": "#/definitions/ecsServiceDiscoveryDefinition/definitions/taskDefinitionList"
           }
         },
+        "service_name_list_for_tasks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ecsServiceDiscoveryDefinition/definitions/serviceNameListForTasks"
+          }
+        },
         "sd_cluster_region": {
           "description": "ECS cluster region",
           "type": "string"
@@ -871,6 +877,32 @@ var schema = `{
             },
             "sd_task_definition_arn_pattern": {
               "description": "ECS task definition pattern which expose the Prometheus metrics",
+              "type": "string"
+            }
+          }
+        },
+        "serviceNameListForTasks": {
+          "type": "object",
+          "descriptions": "Define ECS service discovery based on service names",
+          "properties": {
+            "sd_container_name_pattern": {
+              "description": "ECS container name pattern which expose the Prometheus metrics",
+              "type": "string"
+            },
+            "sd_job_name": {
+              "description": "Service discovery result job name",
+              "type": "string"
+            },
+            "sd_metrics_path": {
+              "description": "Prometheus metrics path of the exporters",
+              "type": "string"
+            },
+            "sd_metrics_ports": {
+              "description": "Prometheus metrics port list of the exporters",
+              "type": "string"
+            },
+            "sd_service_name_pattern":{
+              "description": "ECS service name pattern responsible for tasks which expose the Prometheus metrics",
               "type": "string"
             }
           }

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -800,6 +800,12 @@
             "$ref": "#/definitions/ecsServiceDiscoveryDefinition/definitions/taskDefinitionList"
           }
         },
+        "service_name_list_for_tasks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ecsServiceDiscoveryDefinition/definitions/serviceNameListForTasks"
+          }
+        },
         "sd_cluster_region": {
           "description": "ECS cluster region",
           "type": "string"
@@ -859,6 +865,32 @@
             },
             "sd_task_definition_arn_pattern": {
               "description": "ECS task definition pattern which expose the Prometheus metrics",
+              "type": "string"
+            }
+          }
+        },
+        "serviceNameListForTasks": {
+          "type": "object",
+          "descriptions": "Define ECS service discovery based on service names",
+          "properties": {
+            "sd_container_name_pattern": {
+              "description": "ECS container name pattern which expose the Prometheus metrics",
+              "type": "string"
+            },
+            "sd_job_name": {
+              "description": "Service discovery result job name",
+              "type": "string"
+            },
+            "sd_metrics_path": {
+              "description": "Prometheus metrics path of the exporters",
+              "type": "string"
+            },
+            "sd_metrics_ports": {
+              "description": "Prometheus metrics port list of the exporters",
+              "type": "string"
+            },
+            "sd_service_name_pattern":{
+              "description": "ECS service name pattern responsible for tasks which expose the Prometheus metrics",
               "type": "string"
             }
           }

--- a/translator/totomlconfig/sampleConfig/prometheus_config_linux.conf
+++ b/translator/totomlconfig/sampleConfig/prometheus_config_linux.conf
@@ -29,6 +29,18 @@
         sd_metrics_path_label = "ECS_PROMETHEUS_METRICS_PATH"
         sd_port_label = "ECS_PROMETHEUS_EXPORTER_PORT_SUBSET"
 
+      [[inputs.prometheus_scraper.ecs_service_discovery.service_name_list_for_tasks]]
+        sd_container_name_pattern = "nginx-prometheus-exporter"
+        sd_job_name = "service_name_1"
+        sd_metrics_path = "/metrics"
+        sd_metrics_ports = "9113"
+        sd_service_name_pattern = ".*-application-stack"
+
+      [[inputs.prometheus_scraper.ecs_service_discovery.service_name_list_for_tasks]]
+        sd_metrics_path = "/stats/metrics"
+        sd_metrics_ports = "9114"
+        sd_service_name_pattern = "run-application-stack"
+
       [[inputs.prometheus_scraper.ecs_service_discovery.task_definition_list]]
         sd_job_name = "task_def_1"
         sd_metrics_path = "/stats/metrics"

--- a/translator/totomlconfig/sampleConfig/prometheus_config_linux.json
+++ b/translator/totomlconfig/sampleConfig/prometheus_config_linux.json
@@ -27,6 +27,20 @@
               "sd_task_definition_arn_pattern": "task_def_2"
             }
           ],
+          "service_name_list_for_tasks": [
+            {
+              "sd_job_name": "service_name_1",
+              "sd_metrics_path": "/metrics",
+              "sd_metrics_ports": "9113",
+              "sd_service_name_pattern": ".*-application-stack",
+              "sd_container_name_pattern": "nginx-prometheus-exporter"
+            },
+            {
+              "sd_metrics_path":"/stats/metrics",
+              "sd_metrics_ports": "9114",
+              "sd_service_name_pattern": "run-application-stack"
+            }
+          ],
           "sd_cluster_region": "us-west-1",
           "sd_frequency": "1m",
           "sd_result_file": "/tmp/cwagent_ecs_auto_sd.yaml",

--- a/translator/totomlconfig/sampleConfig/prometheus_config_windows.conf
+++ b/translator/totomlconfig/sampleConfig/prometheus_config_windows.conf
@@ -29,6 +29,18 @@
         sd_metrics_path_label = "ECS_PROMETHEUS_METRICS_PATH"
         sd_port_label = "ECS_PROMETHEUS_EXPORTER_PORT_SUBSET"
 
+      [[inputs.prometheus_scraper.ecs_service_discovery.service_name_list_for_tasks]]
+        sd_container_name_pattern = "nginx-prometheus-exporter"
+        sd_job_name = "service_name_1"
+        sd_metrics_path = "/metrics"
+        sd_metrics_ports = "9113"
+        sd_service_name_pattern = ".*-application-stack"
+
+      [[inputs.prometheus_scraper.ecs_service_discovery.service_name_list_for_tasks]]
+        sd_metrics_path = "/stats/metrics"
+        sd_metrics_ports = "9114"
+        sd_service_name_pattern = "run-application-stack"
+
       [[inputs.prometheus_scraper.ecs_service_discovery.task_definition_list]]
         sd_job_name = "task_def_1"
         sd_metrics_path = "/stats/metrics"

--- a/translator/totomlconfig/sampleConfig/prometheus_config_windows.json
+++ b/translator/totomlconfig/sampleConfig/prometheus_config_windows.json
@@ -27,6 +27,20 @@
               "sd_task_definition_arn_pattern": "task_def_2"
             }
           ],
+          "service_name_list_for_tasks": [
+            {
+              "sd_job_name": "service_name_1",
+              "sd_metrics_path": "/metrics",
+              "sd_metrics_ports": "9113",
+              "sd_service_name_pattern": ".*-application-stack",
+              "sd_container_name_pattern": "nginx-prometheus-exporter"
+            },
+            {
+              "sd_metrics_path":"/stats/metrics",
+              "sd_metrics_ports": "9114",
+              "sd_service_name_pattern": "run-application-stack"
+            }
+          ],
           "sd_cluster_region": "us-west-1",
           "sd_frequency": "1m",
           "sd_result_file": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\cwagent_ecs_auto_sd.yaml",

--- a/translator/totomlconfig/toTomlConfig.go
+++ b/translator/totomlconfig/toTomlConfig.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/dockerlabel"
+	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/taskdefinition"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus/emfprocessor"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/append_dimensions"

--- a/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDContainerNamePattern.go
+++ b/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDContainerNamePattern.go
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package serviceendpoint
+
+const (
+	SectionKeySDContainerNamePattern = "sd_container_name_pattern"
+)
+
+type SDContainerNamePattern struct {
+}
+
+// Optional Key
+func (d *SDContainerNamePattern) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+
+	im := input.(map[string]interface{})
+	if val, ok := im[SectionKeySDContainerNamePattern]; !ok {
+		returnKey = ""
+		returnVal = ""
+	} else {
+		returnKey = SectionKeySDContainerNamePattern
+		returnVal = val
+	}
+	return
+}
+
+func init() {
+	RegisterRule(SectionKeySDContainerNamePattern, new(SDContainerNamePattern))
+}

--- a/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDJobName.go
+++ b/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDJobName.go
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package serviceendpoint
+
+const (
+	SectionKeySDJobName = "sd_job_name"
+)
+
+type SDJobName struct {
+}
+
+// Optional Key
+func (d *SDJobName) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	im := input.(map[string]interface{})
+	if val, ok := im[SectionKeySDJobName]; !ok {
+		returnKey = ""
+		returnVal = ""
+	} else {
+		returnKey = SectionKeySDJobName
+		returnVal = val
+	}
+	return
+}
+
+func init() {
+	RegisterRule(SectionKeySDJobName, new(SDJobName))
+}

--- a/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDMetricsPath.go
+++ b/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDMetricsPath.go
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package serviceendpoint
+
+const (
+	SectionKeySDMetricsPath = "sd_metrics_path"
+)
+
+type SDMetricsPath struct {
+}
+
+// Optional Key
+func (d *SDMetricsPath) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	im := input.(map[string]interface{})
+	if val, ok := im[SectionKeySDMetricsPath]; !ok {
+		returnKey = ""
+		returnVal = ""
+
+	} else {
+		returnKey = SectionKeySDMetricsPath
+		returnVal = val
+	}
+	return
+}
+
+func init() {
+	RegisterRule(SectionKeySDMetricsPath, new(SDMetricsPath))
+}

--- a/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDMetricsPorts.go
+++ b/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDMetricsPorts.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package serviceendpoint
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+)
+
+const (
+	SectionKeySDMetricsPorts = "sd_metrics_ports"
+	expectedRegex            = "^[1-9][0-9]{0,4}(;[\\s]*[1-9][0-9]{0,4})*$"
+)
+
+type SDMetricsPorts struct {
+}
+
+// Mandatory Key
+func (d *SDMetricsPorts) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	im := input.(map[string]interface{})
+	if val, ok := im[SectionKeySDMetricsPorts]; !ok {
+		returnKey = ""
+		returnVal = ""
+		translator.AddErrorMessages(GetCurPath()+SectionKeySDMetricsPorts, "mandatory key: sd_metrics_ports is not defined.")
+	} else {
+		if !checkMetricPortString(val.(string)) {
+			translator.AddErrorMessages(GetCurPath()+SectionKeySDMetricsPorts, fmt.Sprintf("sd_metrics_ports does not follow pattern: %v.", expectedRegex))
+		}
+		returnKey = SectionKeySDMetricsPorts
+		returnVal = val
+	}
+	return
+}
+
+func checkMetricPortString(portsConfig string) bool {
+	ret, err := regexp.MatchString(expectedRegex, portsConfig)
+	if err != nil || !ret {
+		return false
+	}
+	return true
+}
+
+func init() {
+	RegisterRule(SectionKeySDMetricsPorts, new(SDMetricsPorts))
+}

--- a/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDServiceNamePattern.go
+++ b/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/ruleSDServiceNamePattern.go
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package serviceendpoint
+
+import (
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+)
+
+const (
+	SectionKeySDServiceNamePattern = "sd_service_name_pattern"
+)
+
+type SDServiceNamePattern struct {
+}
+
+// Mandatory Key
+func (d *SDServiceNamePattern) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	im := input.(map[string]interface{})
+	if val, ok := im[SectionKeySDServiceNamePattern]; !ok {
+		returnKey = ""
+		returnVal = ""
+		translator.AddErrorMessages(GetCurPath()+SectionKeySDServiceNamePattern, "sd_service_name_pattern is not defined.")
+	} else {
+		returnKey = SectionKeySDServiceNamePattern
+		returnVal = val
+	}
+	return
+}
+
+func init() {
+	RegisterRule(SectionKeySDServiceNamePattern, new(SDServiceNamePattern))
+}

--- a/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/serviceendpoint.go
+++ b/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/serviceendpoint/serviceendpoint.go
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package serviceendpoint
+
+import (
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+
+	parent "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery"
+)
+
+type Rule translator.Rule
+
+var ChildRule = map[string]Rule{}
+
+const (
+	SubSectionKey = "service_name_list_for_tasks"
+)
+
+func GetCurPath() string {
+	curPath := parent.GetCurPath() + SubSectionKey + "/"
+	return curPath
+}
+
+func RegisterRule(fieldname string, r Rule) {
+	ChildRule[fieldname] = r
+}
+
+type ServiceEndpoint struct {
+}
+
+func (e *ServiceEndpoint) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	im := input.(map[string]interface{})
+	returnKey = SubSectionKey
+
+	if _, ok := im[SubSectionKey]; !ok {
+		returnKey = ""
+		returnVal = ""
+		return
+	}
+
+	configArr := im[SubSectionKey].([]interface{})
+	res := []interface{}{}
+	for i := 0; i < len(configArr); i++ {
+		result := map[string]interface{}{}
+		for _, ruleArr := range ChildRule {
+			key, val := ruleArr.ApplyRule(configArr[i])
+			if key != "" {
+				result[key] = val
+			}
+		}
+		res = append(res, result)
+	}
+
+	returnKey = SubSectionKey
+	returnVal = res
+
+	return
+}
+
+func init() {
+	e := new(ServiceEndpoint)
+	parent.RegisterRule(SubSectionKey, e)
+}


### PR DESCRIPTION
# Description of the issue
This enables CWAgent ECS service discovery based on service name. This functionality is enabled by the following changes to the ecsservicediscovery package, and the config translator.

# Description of changes
**EcsServiceDiscovery:**

config.go has been updated to include a ServiceNameConfig struct, which includes the following parameters:
1. ContainerNamePattern (regex, JSON/TOML key: "sd_container_name_pattern")
2. JobName (JSON/TOML key: "sd_job_name")
3. MetricsPath (JSON/TOML key: "sd_metrics_path")
4. MetricsPorts (JSON/TOML key: "sd_metrics_ports")
5. ServiceNamePattern (regex, JSON/TOML key: "sd_service_name_pattern")

These parameters mirror the parameters for task definition-based discovery, facilitating feature parity between the two discovery methods.

servicediscovery.go now calls a new class, servicenamediscoveryprocessor.go, which identifies tasks based on service name through the following process:

1. While NextToken returned by listService is not null, continue to call listService and
            * For each arn in ListServicesOutput.ServiceArns, extract the service name from each service that matches the regex provided in ServiceNameConfig’s regex.
            * For each batch of 10 service names extracted, and for all service names leftover, run describeServices. For every service described, map each of its deployment IDs to its ServiceName in the processor class variable, p.idToServiceName.
 
2. For each DecoratedTask, check if its Task.StartedBy value maps to any ServiceNames in p.idToServiceName. If it does, change the DecoratedTask's ServiceName value to the returned name, marking the DecoratedTask as service name-based.

taskfilterprocessor.go will now retains all tasks that have non-empty service names.

In decoratedtask.go added function to export target information for tasks that have non-empty service names. Even if more than one discovery process identifies a task, its target information will be exported only once, using a function according to the following priority: ServiceNameBased > DockerLabelBased >TaskDefinitionBased. (Where ServiceNameBased refers to any Decorated task with a non-empty ServiceName value)

processorstats.go now facilitates a count of calls to ECS.ListServices, which is called by servicenamediscoveryprocessor.

**Translator:**

JSON -> TOML translation now recognizes service_name_list entries, and all of their parameters. A new servicename package has been created, including translation rules for each new parameter. This package is now imported by toTomlConfig.go.

Both schema.go and schema.json have been updated to include these new config entries.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
All existing integration tests have been tested.



