### PR TITLE
Avoid cwagent-otel-collector to be auto started from the "stop" state…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ AOC_LDFLAGS += -X github.com/open-telemetry/opentelemetry-collector-contrib/expo
 AOC_LDFLAGS += -X $(AOC_IMPORT_PATH)/tools/version.Version=$(VERSION)
 AOC_LDFLAGS += -X $(AOC_IMPORT_PATH)/tools/version.Date=$(BUILD)
 AOC_LDFLAGS += -X $(AOC_IMPORT_PATH)/pkg/userutils.defaultUser=cwagent
+AOC_LDFLAGS += -X $(AOC_IMPORT_PATH)/pkg/userutils.defaultInstallPath=/opt/aws/amazon-cloudwatch-agent/cwagent-otel-collector/
 AOC_LDFLAGS += -X $(AOC_IMPORT_PATH)/pkg/logger.UnixLogPath=/opt/aws/amazon-cloudwatch-agent/cwagent-otel-collector/logs/cwagent-otel-collector.log
 AOC_LDFLAGS += -X $(AOC_IMPORT_PATH)/pkg/logger.WindowsLogPath=C:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\CWAgentOtelCollector\\Logs\\cwagent-otel-collector.log
 AOC_LDFLAGS += -X $(AOC_IMPORT_PATH)/pkg/extraconfig.unixExtraConfigPath=/opt/aws/amazon-cloudwatch-agent/cwagent-otel-collector/etc/extracfg.txt

--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -126,12 +126,19 @@ agent_start() {
 stop_all() {
     echo "****** processing cwagent-otel-collector ******"
     set +e
-    agent_stop "${CWOC_NAME}"
+    agent_stop_and_disable "${CWOC_NAME}"
     set -e
 
     echo ""
     echo "****** processing amazon-cloudwatch-agent ******"
-    agent_stop "${CWA_NAME}"
+    agent_stop_and_disable "${CWA_NAME}"
+}
+
+agent_stop_and_disable() {
+    agent_name="${1:-}"
+
+    agent_stop "${agent_name}"
+    agent_disable "${agent_name}"
 }
 
 agent_stop() {
@@ -147,6 +154,15 @@ agent_stop() {
     else
         stop "${agent_name}" || return
     fi
+}
+
+# disable cwagent-otel-collector in Systemd, amazon-cloudwatch-agent will not be disabled for now (TBD)
+# cwagent-otel-collector in Upstart are not disabled for now as old version of upstart doesn't support stanza 'Manual'
+agent_disable() {
+  agent_name="${1:-}"
+  if [ "${SYSTEMD}" = 'true' ] && [ "${agent_name}" = "${CWOC_NAME}" ]; then
+      systemctl disable "${agent_name}.service"
+  fi
 }
 
 # support for restart during upgrade via SSM packages
@@ -382,7 +398,7 @@ cwa_config() {
     fi
 
     if [ "${restart}" = 'true' ]; then
-        agent_stop "${CWA_NAME}"
+        agent_stop_and_disable "${CWA_NAME}"
         agent_start "${CWA_NAME}" "${param_mode}"
     fi
 }
@@ -435,7 +451,7 @@ cwoc_config() {
     fi
 
     if [ "${restart}" = 'true' ]; then
-        agent_stop "${CWOC_NAME}"
+        agent_stop_and_disable "${CWOC_NAME}"
         agent_start "${CWOC_NAME}" "${param_mode}"
     fi
 }


### PR DESCRIPTION
# Description of the changes
Update ctl scripts to avoid auto-restart during system reboot when cwagent-otel-collector is in 'stop' state. Note that it only work for cwagent-otel-collector managed by systemd or windows service manager. cwagent-otel-collector managed by upstart is TBD as old version of upstart doesn't support stanza 'Manual'. 

If cwagent-otel-collector managed by Upstart is started during system reboot (in such case, configuration is possibly not provided), it will Exit with return code 0, thus won't be restarted by Upstart.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.




