### PR TITLE
Allow ignoring pods with the aws.amazon.com/cloudwatch-agent: ignore annotation

### DIFF
--- a/plugins/processors/k8sdecorator/stores/podstore.go
+++ b/plugins/processors/k8sdecorator/stores/podstore.go
@@ -142,7 +142,7 @@ func (p *PodStore) Decorate(metric telegraf.Metric, kubernetesBlob map[string]in
 		}
 
 		// Ignore if we're told to ignore
-		if "ignore" == entry.pod.ObjectMeta.Annotations[ignoreAnnotation] {
+		if entry.pod.ObjectMeta.Annotations[ignoreAnnotation] == "ignore" {
 			return false
 		}
 

--- a/plugins/processors/k8sdecorator/stores/podstore.go
+++ b/plugins/processors/k8sdecorator/stores/podstore.go
@@ -28,6 +28,7 @@ const (
 	cpuKey             = "cpu"
 	splitRegexStr      = "\\.|-"
 	kubeProxy          = "kube-proxy"
+	ignoreAnnotation   = "aws.amazon.com/cloudwatch-agent"
 )
 
 var (
@@ -137,6 +138,11 @@ func (p *PodStore) Decorate(metric telegraf.Metric, kubernetesBlob map[string]in
 		if entry == nil {
 			log.Printf("W! no pod is found after reading through kubelet, add a placeholder for %s", podKey)
 			p.setCachedEntry(podKey, &cachedEntry{creation: time.Now()})
+			return false
+		}
+
+		// Ignore if we're told to ignore
+		if "ignore" == entry.pod.ObjectMeta.Annotations[ignoreAnnotation] {
 			return false
 		}
 

--- a/plugins/processors/k8sdecorator/stores/podstore.go
+++ b/plugins/processors/k8sdecorator/stores/podstore.go
@@ -28,7 +28,7 @@ const (
 	cpuKey             = "cpu"
 	splitRegexStr      = "\\.|-"
 	kubeProxy          = "kube-proxy"
-	ignoreAnnotation   = "aws.amazon.com/cloudwatch-agent"
+	ignoreAnnotation   = "aws.amazon.com/cloudwatch-agent-ignore"
 )
 
 var (
@@ -142,7 +142,7 @@ func (p *PodStore) Decorate(metric telegraf.Metric, kubernetesBlob map[string]in
 		}
 
 		// Ignore if we're told to ignore
-		if entry.pod.ObjectMeta.Annotations[ignoreAnnotation] == "ignore" {
+		if strings.EqualFold(entry.pod.ObjectMeta.Annotations[ignoreAnnotation], "true") {
 			return false
 		}
 

--- a/plugins/processors/k8sdecorator/stores/podstore_test.go
+++ b/plugins/processors/k8sdecorator/stores/podstore_test.go
@@ -229,7 +229,7 @@ func TestPodStore_decorateMem(t *testing.T) {
 func TestPodStore_Decorate(t *testing.T) {
 	podStore := &PodStore{nodeInfo: &nodeInfo{NodeCapacity: &NodeCapacity{MemCapacity: 400 * 1024 * 1024, CPUCapacity: 4}}, cache: mapWithExpiry.NewMapWithExpiry(PodsExpiry)}
 	pod := getBaseTestPodInfo()
-	pod.ObjectMeta.Annotations[ignoreAnnotation] = "ignore"
+	pod.ObjectMeta.Annotations[ignoreAnnotation] = "true"
 	podStore.setCachedEntry("namespace:test,podName:test", &cachedEntry{
 		pod:      *pod,
 		creation: time.Now(),


### PR DESCRIPTION
# Description of the issue

Having metrics come in for each CI job with unique names is polluting our metrics and costs more money. I wanted to ignore some pods.

# Description of changes

In the `podstore.Decorate` method of the k8s processor, after we're confident we've got a pod, check the annotations and return false so as to not handle that pod.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

I have this running in our devops cluster where Jenkins is creating pods with these annotations. Automated tests pass, but nothing explicitly tests the method I changed, and I couldn't in a reasonable time figure out how to write a good test for it. If somebody wants to help out let me know.




