### PR TITLE
chore: do not own /opt/aws in rpm spec

### DIFF
--- a/packaging/linux/amazon-cloudwatch-agent.spec
+++ b/packaging/linux/amazon-cloudwatch-agent.spec
@@ -41,7 +41,6 @@ ln -f -s /opt/aws/amazon-cloudwatch-agent/var ${RPM_BUILD_ROOT}/var/run/amazon/a
 ln -f -s /opt/aws/amazon-cloudwatch-agent/cwagent-otel-collector/var ${RPM_BUILD_ROOT}/var/run/amazon/cwagent-otel-collector
 
 %files
-%dir /opt/aws
 %dir /opt/aws/amazon-cloudwatch-agent
 %dir /opt/aws/amazon-cloudwatch-agent/bin
 %dir /opt/aws/amazon-cloudwatch-agent/doc


### PR DESCRIPTION
# Description of the issue
amazon-cloudwatch-agent own /opt/aws directory, it may conflict with other packages.

# Description of changes
do not own /opt/aws in rpm spec

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._




