### PR TITLE
1. Expanding the translator capability by exposing an API to override…

### DIFF
--- a/translator/config/schema.go
+++ b/translator/config/schema.go
@@ -983,6 +983,10 @@ func GetJsonSchema() string {
 	return schema
 }
 
+func OverwriteSchema(newSchema string) {
+	schema = newSchema
+}
+
 // Translate Sample:
 // (root).agent.metrics_collection_interval -> /agent/metrics_collection_interval
 // (root).metrics.metrics_collected.cpu.resources.1 -> /metrics/metrics_collected/cpu/resources/1

--- a/translator/setMetricPath.go
+++ b/translator/setMetricPath.go
@@ -28,7 +28,10 @@ func SetMetricPath(result map[string]interface{}, sectionKey string) {
 				input := inputIntf.(map[string]interface{})
 				if val, ok := input[tagKey]; ok {
 					tags := val.(map[string]interface{})
-					tags[routingTagKey] = sectionKey
+					// If a plugin already has its own metricPath value, we do not want to override its value.
+					if _, ok := tags[routingTagKey]; !ok {
+						tags[routingTagKey] = sectionKey
+					}
 				} else {
 					input[tagKey] = map[string]interface{}{routingTagKey: sectionKey}
 				}

--- a/translator/setMetricPath_test.go
+++ b/translator/setMetricPath_test.go
@@ -92,6 +92,48 @@ func getExpectedSectionWithTags() map[string]interface{} {
 	}
 }
 
+func getSectionWithTagsMetricPath() map[string]interface{} {
+	input := map[string]interface{}{}
+	input["tags"] = map[string]interface{}{routingTagKey: "metrics"}
+	input["fieldpass"] = "fp1"
+
+	output := map[string]interface{}{}
+	output["namespace"] = "ns1"
+	output["tagpass"] = map[string][]string{routingTagKey: {"anyValue"}}
+	output["tagexclude"] = []string{"someTag"}
+
+	processor := map[string]interface{}{}
+	processor["refresh_interval_seconds"] = "0"
+	processor["tagpass"] = map[string][]string{routingTagKey: {"anyValue"}}
+
+	return map[string]interface{}{
+		"inputs":     map[string]interface{}{"mem": []interface{}{input}},
+		"outputs":    map[string]interface{}{"cloudwatch": []interface{}{output}},
+		"processors": map[string]interface{}{"ec2tagger": []interface{}{processor}},
+	}
+}
+
+func getExpectedSectionWithTagsMetricPath() map[string]interface{} {
+	input := map[string]interface{}{}
+	input["tags"] = map[string]interface{}{routingTagKey: "metrics"}
+	input["fieldpass"] = "fp1"
+
+	output := map[string]interface{}{}
+	output["namespace"] = "ns1"
+	output["tagpass"] = map[string][]string{routingTagKey: {"anyValue", testSection}}
+	output["tagexclude"] = []string{"someTag", routingTagKey}
+
+	processor := map[string]interface{}{}
+	processor["refresh_interval_seconds"] = "0"
+	processor["tagpass"] = map[string][]string{routingTagKey: {"anyValue", testSection}}
+
+	return map[string]interface{}{
+		"inputs":     map[string]interface{}{"mem": []interface{}{input}},
+		"outputs":    map[string]interface{}{"cloudwatch": []interface{}{output}},
+		"processors": map[string]interface{}{"ec2tagger": []interface{}{processor}},
+	}
+}
+
 func getExpectedSectionOneInputWithoutTags() map[string]interface{} {
 	routingTagVal := testSection + linkedCharacter + "mem"
 	input := map[string]interface{}{}
@@ -201,6 +243,14 @@ func TestSetMetricPath_NoTags(t *testing.T) {
 func TestSetMetricPath_Tags(t *testing.T) {
 	actual := getSectionWithTags()
 	expected := getExpectedSectionWithTags()
+
+	SetMetricPath(actual, testSection)
+	assert.Equal(t, expected, actual, "Expected to be equal")
+}
+
+func TestSetMetricPath_TagsWithMetricPath(t *testing.T) {
+	actual := getSectionWithTagsMetricPath()
+	expected := getExpectedSectionWithTagsMetricPath()
 
 	SetMetricPath(actual, testSection)
 	assert.Equal(t, expected, actual, "Expected to be equal")


### PR DESCRIPTION
1. Expanding the translator capability by exposing an API to override the schema 
2. Allowing translator plugins to specify and override the metricPath by setting its own return value.
# Description of the issue
Issue 1. Lack of capability of extending current schema since schema value is hardcoded.
Issue 2. If input plugin metricPath has its own value it should not get different metricPath value as you see below:

`
[inputs.myPlugin.tags]
`
`
           metricPath = "metrics"
`
Should not get logs metricPath.
` 
[inputs.myPlugin.tags]
`
`
           metricPath = "logs"
`
# Description of changes
Issue 1. **OverwriteSchema** method will allow developers to override current schema with flexibility of expanding the translator schema. (adding new plugins, update existing plugins)
Issue 2. If translator plugins already have their own metricPath value, we do not want to override the value.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran **make test** all unit tests passed.





