### PR TITLE
fix: Add timeout to aws client, prevent agent hang from unresponsive backend

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -6,6 +6,7 @@ package cloudwatch
 import (
 	"log"
 	"math"
+	"net/http"
 	"reflect"
 	"runtime"
 	"sort"
@@ -134,7 +135,8 @@ func (c *CloudWatch) Connect() error {
 	svc := cloudwatch.New(
 		configProvider,
 		&aws.Config{
-			Endpoint: aws.String(c.EndpointOverride),
+			Endpoint:   aws.String(c.EndpointOverride),
+			HTTPClient: &http.Client{Timeout: 1 * time.Minute},
 		})
 
 	svc.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{opPutLogEvents, opPutMetricData}))

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -6,6 +6,7 @@ package cloudwatchlogs
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -111,7 +112,8 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 	client := cloudwatchlogs.New(
 		credentialConfig.Credentials(),
 		&aws.Config{
-			Endpoint: aws.String(c.EndpointOverride),
+			Endpoint:   aws.String(c.EndpointOverride),
+			HTTPClient: &http.Client{Timeout: 1 * time.Minute},
 		},
 	)
 	client.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{"PutLogEvents"}))

--- a/translator/translate/logs/metrics_collected/kubernetes/k8sdecorator/ruleClusterName.go
+++ b/translator/translate/logs/metrics_collected/kubernetes/k8sdecorator/ruleClusterName.go
@@ -4,14 +4,16 @@
 package k8sdecorator
 
 import (
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/aws/amazon-cloudwatch-agent/translator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ec2util"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"log"
-	"strings"
-	"time"
 )
 
 const (
@@ -71,6 +73,7 @@ func getClusterNameFromEc2Tagger() string {
 	config := &aws.Config{
 		Region:                        aws.String(region),
 		CredentialsChainVerboseErrors: aws.Bool(true),
+		HTTPClient:                    &http.Client{Timeout: 1 * time.Minute},
 	}
 
 	input := &ec2.DescribeTagsInput{

--- a/translator/translate/logs/util/get_eks_cluster_name.go
+++ b/translator/translate/logs/util/get_eks_cluster_name.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -59,6 +60,7 @@ func GetClusterNameFromEc2Tagger() string {
 	config := &aws.Config{
 		Region:                        aws.String(region),
 		CredentialsChainVerboseErrors: aws.Bool(true),
+		HTTPClient:                    &http.Client{Timeout: 1 * time.Minute},
 	}
 
 	input := &ec2.DescribeTagsInput{


### PR DESCRIPTION
# Description of the issue
Currently the agent does not specify any httpclient when constructing aws clients, which in turn uses the default http client provided by go, which does not have any timeout settings. This means if the backend becomes unresponsive, or connection had issue due to networking issues that prevented the request from finish, it may hang the agent forever.

# Description of changes
Add http timeout to where aws client are created with a custom http
client describe in:
https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/custom-http.html

Only a single Timeout is specified since there is no special reason to
specify the timeout of each part of the request, as the goal is to
prevent unresponsive backend or networking error from hanging the agent
forever.

The timeout parameter covers the whole request as described in:
https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Changes passed unit tests, and no new unit tests needed.




