### PR TITLE
Enable logging error request to CloudWatch by default

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -135,6 +135,7 @@ func (c *CloudWatch) Connect() error {
 		configProvider,
 		&aws.Config{
 			Endpoint: aws.String(c.EndpointOverride),
+			LogLevel: aws.LogLevel(aws.LogDebugWithRequestErrors),
 		})
 
 	svc.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{opPutLogEvents, opPutMetricData}))

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -112,6 +112,7 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 		credentialConfig.Credentials(),
 		&aws.Config{
 			Endpoint: aws.String(c.EndpointOverride),
+			LogLevel: aws.LogLevel(aws.LogDebugWithRequestErrors),
 		},
 	)
 	client.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{"PutLogEvents"}))


### PR DESCRIPTION
# Description of the issue
I was trying to see how come metrics scrapped from CW agent's Prometheus was not ended up in CW. I saw bunch of errors like `2021-02-04T17:50:28Z W! message is dropped due to nonblocking fifo queue is full`, but I can't really figured out why the fifo queue is full. I am suspecting it is because sending request to CW failed for some reason; having error log would help here.

# Description of changes
By enabling the failed request log, I can can at least tell if CW agent is attempting to contactCW. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Simple config change, no test added. All current tests passed.




