### PR TITLE
chore: fix timestamp parse error if timestamp_format starts with space

### DIFF
--- a/plugins/inputs/logfile/fileconfig_test.go
+++ b/plugins/inputs/logfile/fileconfig_test.go
@@ -106,6 +106,31 @@ func TestTimestampParser(t *testing.T) {
 		fmt.Sprintf("The timestampFromLogLine value %v is not the same as expected %v.", timestamp, expectedTimestamp))
 }
 
+func TestTimestampParserWithPadding(t *testing.T) {
+	timestampRegex := "(\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})"
+	timestampLayout := "1 2 15:04:05"
+	timezone := "UTC"
+	timezoneLoc := time.UTC
+	timestampRegexP, err := regexp.Compile(timestampRegex)
+	require.NoError(t, err, fmt.Sprintf("Failed to compile regex %s", timestampRegex))
+	fileConfig := &FileConfig{
+		TimestampRegex:  timestampRegex,
+		TimestampRegexP: timestampRegexP,
+		TimestampLayout: timestampLayout,
+		Timezone:        timezone,
+		TimezoneLoc:     timezoneLoc}
+
+	logEntry := fmt.Sprintf(" 2 1 07:10:06 instance-id: i-02fce21a425a2efb3")
+	timestamp := fileConfig.timestampFromLogLine(logEntry)
+	assert.Equal(t, 7, timestamp.Hour(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "7", timestamp.Hour() ))
+	assert.Equal(t, 10, timestamp.Minute(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "10", timestamp.Minute() ))
+
+	logEntry = fmt.Sprintf("2 1 07:10:06 instance-id: i-02fce21a425a2efb3")
+	timestamp = fileConfig.timestampFromLogLine(logEntry)
+	assert.Equal(t, 7, timestamp.Hour(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "7", timestamp.Hour() ))
+	assert.Equal(t, 10, timestamp.Minute(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "10", timestamp.Minute() ))
+}
+
 func TestTimestampParserWithFracSeconds(t *testing.T) {
 	timestampRegex := "(\\d{2} \\w{3} \\d{4} \\d{2}:\\d{2}:\\d{2},(\\d{1,9}) \\w{3})"
 	timestampLayout := "02 Jan 2006 15:04:05,.000 MST"

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
@@ -84,6 +84,98 @@ func TestTimestampFormat(t *testing.T) {
 	assert.Equal(t, expectVal, val)
 }
 
+func TestTimestampFormatAll(t *testing.T) {
+	tests := []struct {
+		input string
+		expected interface{}
+	}{
+		{
+			input: `{
+					"collect_list":[
+						{
+							"file_path":"path1",
+							"timestamp_format":"%H:%M:%S %y %b %-d"
+						}
+					]
+				}`,
+			expected:  []interface{}{map[string]interface{}{
+				"file_path":"path1",
+				"from_beginning":   true,
+				"pipe":             false,
+				"timestamp_layout": "15:04:05 06 Jan 2",
+				"timestamp_regex":  "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2})",
+				}},
+		},
+		{
+			input: `{
+					"collect_list":[
+						{
+							"file_path":"path1",
+							"timestamp_format":"%-m %-d %H:%M:%S"
+						}
+					]
+				}`,
+			expected:  []interface{}{map[string]interface{}{
+				"file_path":"path1",
+				"from_beginning":   true,
+				"pipe":             false,
+				"timestamp_layout": "1 2 15:04:05",
+				"timestamp_regex":  "(\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
+			}},
+		},
+		{
+			input: `{
+					"collect_list":[
+						{
+							"file_path":"path1",
+							"timestamp_format":"%-d %-m %H:%M:%S"
+						}
+					]
+				}`,
+			expected:  []interface{}{map[string]interface{}{
+				"file_path":"path1",
+				"from_beginning":   true,
+				"pipe":             false,
+				"timestamp_layout": "2 1 15:04:05",
+				"timestamp_regex":  "(\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
+			}},
+		},
+		{
+			input: `{
+					"collect_list":[
+						{
+							"file_path":"path1",
+							"timestamp_format":"%-S %-d %-m %H:%M:%S"
+						}
+					]
+				}`,
+			expected:  []interface{}{map[string]interface{}{
+				"file_path":"path1",
+				"from_beginning":   true,
+				"pipe":             false,
+				"timestamp_layout": "5 2 1 15:04:05",
+				"timestamp_regex":  "(\\d{1,2} \\s{0,1}\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		result := applyRule1(t, tt.input)
+		assert.Equal(t, tt.expected, result)
+	}
+}
+
+func applyRule1(t *testing.T, buf string) interface{} {
+	f := new(FileConfig)
+	var input interface{}
+	e := json.Unmarshal([]byte(buf), &input)
+	if e != nil {
+		assert.Fail(t, e.Error())
+	}
+	_, val := f.ApplyRule(input)
+	return val
+}
+
 //stdNumMonth     // "1"         //%-m
 //stdDay          // "2"         //%-d
 //-hour:-minute:-seconds does not work for golang parser.

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleTimestampFormat.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleTimestampFormat.go
@@ -146,6 +146,13 @@ func (t *TimestampRegax) ApplyRule(input interface{}) (returnKey string, returnV
 		//If user provide with the specific timestamp_format, use the one that user provide
 		res := checkAndReplace(val.(string), TimeFormatRegexEscapeMap)
 		res = checkAndReplace(res, TimeFormatRexMap)
+		// remove the prefix, if the format startswith "%-m" or "%-d", there is an "\\s{0,1}" at the beginning.
+		// like "timestamp_format": "%-m %-d %H:%M:%S" will be converted into following layout and regex
+		//      timestamp_layout = "1 2 15:04:05"
+		//      timestamp_regex = "(\\s{0,1}\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})"
+		// following timestamp string " 2 1 07:10:06" matches the regex, but it can not match the layout.
+		// After the prefix "\\s{0,1}", it can match both the regex and layout.
+		res = strings.TrimPrefix(res, "\\s{0,1}")
 		res = "(" + res + ")"
 		returnKey = "timestamp_regex"
 		returnVal = res


### PR DESCRIPTION
# Description of the issue
 if the format startswith "%-m" or "%-d", there is an "\\s{0,1}" at the beginning of timestamp_regex.
like "timestamp_format": "%-m %-d %H:%M:%S" will be converted into following layout and regex
timestamp_layout = "1 2 15:04:05"
timestamp_regex = "(\\s{0,1}\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})"
following timestamp string " 2 1 07:10:06" matches the regex, but it can not match the layout.
		
# Description of changes
Remove the \\s{0,1} prefix 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unittest




