### PR TITLE
Fix cadvisor name pattern for docker systemd cgroup driver

### DIFF
--- a/plugins/inputs/cadvisor/container_info_processor_test.go
+++ b/plugins/inputs/cadvisor/container_info_processor_test.go
@@ -1,0 +1,39 @@
+package cadvisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsContainerInContainer(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		dind bool
+	}{
+		{
+			"guranteed",
+			"/kubepods.slice/kubepods-podc8f7bb69_65f2_4b61_ae5a_9b19ac47a239.slice/docker-523b624a86a2a74c2bedf586d8448c86887ef7858a8dec037d6559e5ad3fccb5.scope",
+			false,
+		},
+		{
+			"guranteed-dind",
+			"/kubepods.slice/kubepods-burstable-podc9adcee4_c874_4dad_8bc8_accdbd67ac3a.slice/docker-e58cfbc8b67f6e1af458efdd31cb2a8abdbf9f95db64f4c852b701285a09d40e.scope/docker/fb651068cfbd4bf3d45fb092ec9451f8d1a36b3753687bbaa0a9920617eae5b9",
+			true,
+		},
+		{
+			"burstable",
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podab0e310c_0bdb_48e8_ac87_81a701514645.slice/docker-caa8a5e51cd6610f8f0110b491e8187d23488b9635acccf0355a7975fd3ff158.scope",
+			false,
+		},
+		{
+			"burstable-dind",
+			"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podc9adcee4_c874_4dad_8bc8_accdbd67ac3a.slice/docker-e58cfbc8b67f6e1af458efdd31cb2a8abdbf9f95db64f4c852b701285a09d40e.scope/docker/fb651068cfbd4bf3d45fb092ec9451f8d1a36b3753687bbaa0a9920617eae5b9",
+			true,
+		},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.dind, isContainerInContainer(c.path), c.name)
+	}
+}

--- a/plugins/inputs/cadvisor/extractors/cpu_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/cpu_extractor.go
@@ -4,7 +4,6 @@
 package extractors
 
 import (
-	"log"
 	"time"
 
 	. "github.com/aws/amazon-cloudwatch-agent/internal/containerinsightscommon"
@@ -31,7 +30,6 @@ func (c *CpuMetricExtractor) recordPreviousInfo(info *cInfo.ContainerInfo) {
 func (c *CpuMetricExtractor) GetValue(info *cInfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
 	if info.Spec.Labels[containerNameLable] == infraContainerName {
-		log.Printf("D! skip CPU because %s is %s", containerNameLable, infraContainerName)
 		return metrics
 	}
 
@@ -49,12 +47,7 @@ func (c *CpuMetricExtractor) GetValue(info *cInfo.ContainerInfo, containerType s
 			metric.fields[MetricName(containerType, CpuSystem)] = float64(curStats.Cpu.Usage.System-preStats.Cpu.Usage.System) / float64(deltaCTimeInNano) * decimalToMillicores
 
 			metrics = append(metrics, metric)
-			log.Printf("D! add CPU metric for %s", info.Name)
-		} else {
-			log.Printf("D! skip CPU metric because delat time is too small %d", deltaCTimeInNano)
 		}
-	} else {
-		log.Printf("D! can't find previous info for %s", info.Name)
 	}
 	c.recordPreviousInfo(info)
 	return metrics

--- a/plugins/inputs/cadvisor/extractors/cpu_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/cpu_extractor.go
@@ -4,6 +4,7 @@
 package extractors
 
 import (
+	"log"
 	"time"
 
 	. "github.com/aws/amazon-cloudwatch-agent/internal/containerinsightscommon"
@@ -30,6 +31,7 @@ func (c *CpuMetricExtractor) recordPreviousInfo(info *cInfo.ContainerInfo) {
 func (c *CpuMetricExtractor) GetValue(info *cInfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
 	if info.Spec.Labels[containerNameLable] == infraContainerName {
+		log.Printf("D! skip CPU because %s is %s", containerNameLable, infraContainerName)
 		return metrics
 	}
 
@@ -47,7 +49,12 @@ func (c *CpuMetricExtractor) GetValue(info *cInfo.ContainerInfo, containerType s
 			metric.fields[MetricName(containerType, CpuSystem)] = float64(curStats.Cpu.Usage.System-preStats.Cpu.Usage.System) / float64(deltaCTimeInNano) * decimalToMillicores
 
 			metrics = append(metrics, metric)
+			log.Printf("D! add CPU metric for %s", info.Name)
+		} else {
+			log.Printf("D! skip CPU metric because delat time is too small %d", deltaCTimeInNano)
 		}
+	} else {
+		log.Printf("D! can't find previous info for %s", info.Name)
 	}
 	c.recordPreviousInfo(info)
 	return metrics

--- a/plugins/inputs/cadvisor/extractors/extractor.go
+++ b/plugins/inputs/cadvisor/extractors/extractor.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	containerNameLable = "io.kubernetes.container.name"
+	// TODO: https://github.com/containerd/cri/issues/922#issuecomment-423729537 the container name can be empty on containerd
 	infraContainerName = "POD"
 	Metrics            = "Metrics"
 	Dimensions         = "Dimensions"

--- a/plugins/inputs/cadvisor/extractors/mem_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/mem_extractor.go
@@ -4,6 +4,7 @@
 package extractors
 
 import (
+	"log"
 	"time"
 
 	. "github.com/aws/amazon-cloudwatch-agent/internal/containerinsightscommon"
@@ -26,6 +27,7 @@ func (m *MemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
 	if info.Spec.Labels[containerNameLable] == infraContainerName {
+		log.Printf("D! skip memory because %s is %s", containerNameLable, infraContainerName)
 		return metrics
 	}
 
@@ -55,6 +57,7 @@ func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType s
 
 	m.recordPreviousInfo(info)
 	metrics = append(metrics, metric)
+	log.Printf("D! add Memory metric for %s", info.Name)
 	return metrics
 }
 

--- a/plugins/inputs/cadvisor/extractors/mem_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/mem_extractor.go
@@ -4,7 +4,6 @@
 package extractors
 
 import (
-	"log"
 	"time"
 
 	. "github.com/aws/amazon-cloudwatch-agent/internal/containerinsightscommon"
@@ -27,7 +26,6 @@ func (m *MemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
 	if info.Spec.Labels[containerNameLable] == infraContainerName {
-		log.Printf("D! skip memory because %s is %s", containerNameLable, infraContainerName)
 		return metrics
 	}
 
@@ -57,7 +55,6 @@ func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType s
 
 	m.recordPreviousInfo(info)
 	metrics = append(metrics, metric)
-	log.Printf("D! add Memory metric for %s", info.Name)
 	return metrics
 }
 


### PR DESCRIPTION
# Description of the issue

When using `systemd` instead of `cgroupfs` as docker cgroup driver the pattern in cgroup path has changed due to the prefix. And it breaks two places

- nested container detection, we were counting the prefix, so all the container got treated as nested container
  - the detection is for https://github.com/aws-samples/amazon-cloudwatch-container-insights/issues/21 and introduced in #5 
- pod name, we are using `podPodId` but now it is `kubepods-burstable-podPodId`

# Description of changes

- count number of segments to detect if it is a nested container
- use parent folder of a container as a pod

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- create a new cluster using latest eksctl unmanged node group
- deploy the old agent, there is no pod memory and cluster in container insight dashboard
- deploy the new one, the metrics will show up




