### PR TITLE
ignore +/-Inf values in prometheus metrics

### DIFF
--- a/plugins/inputs/prometheus_scraper/metrics_receiver.go
+++ b/plugins/inputs/prometheus_scraper/metrics_receiver.go
@@ -5,12 +5,13 @@ package prometheus_scraper
 
 import (
 	"errors"
+	"log"
+	"math"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/value"
 	"github.com/prometheus/prometheus/storage"
-	"log"
-	"math"
 )
 
 type PrometheusMetricBatch []*PrometheusMetric
@@ -23,8 +24,9 @@ type PrometheusMetric struct {
 	timeInMS    int64 // Unix time in milli-seconds
 }
 
-func (pm *PrometheusMetric) isValueStale() bool {
-	return value.IsStaleNaN(pm.metricValue) || math.IsNaN(pm.metricValue)
+func (pm *PrometheusMetric) isValueValid() bool {
+	//treat NaN and +/-Inf values as invalid as emf log doesn't support them
+	return !value.IsStaleNaN(pm.metricValue) && !math.IsNaN(pm.metricValue) && !math.IsInf(pm.metricValue, 0)
 }
 
 // metricsReceiver implement interface Appender for prometheus scarper to append metrics

--- a/plugins/inputs/prometheus_scraper/metrics_receiver_test.go
+++ b/plugins/inputs/prometheus_scraper/metrics_receiver_test.go
@@ -55,7 +55,7 @@ func Test_metricAppender_isValueStale(t *testing.T) {
 	nonStaleValue := PrometheusMetric{
 		metricValue: 10.0,
 	}
-	assert.False(t, nonStaleValue.isValueStale())
+	assert.True(t, nonStaleValue.isValueValid())
 }
 
 func Test_metricAppender_Rollback(t *testing.T) {


### PR DESCRIPTION
# Description of the issue
When prometheus metrics contain "+Inf" or "-Inf" values, cloudwatchlog fails to convert the metrics to emf log: https://github.com/aws/amazon-cloudwatch-agent/blob/master/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go#L230-L233. In this case, cloudwatch agent sends the ill-formatted log which cause a backend error:
```
2021-01-30T21:51:57Z E! [outputs.cloudwatchlogs] Aws error received when sending logs to /aws/containerinsights/lon-dev-2/prometheus/kubernetes-apiservers: InvalidParameter: 1 validation error(s) found.

minimum field size of 1, PutLogEventsInput.LogEvents[44].Message
```
This prevents the creation of log stream and blocks other normal metrics from publishing. 

# Description of changes
Since those Inf values are not useful, we should ignore them. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
I did manual testing and found the fix works.



