### PR TITLE
cadvisor: Fix pod detection for containerd runtime on k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,12 @@ config-downloader: copy-version-file
 	$(WIN_BUILD)/config-downloader.exe github.com/aws/amazon-cloudwatch-agent/cmd/config-downloader
 	$(DARWIN_BUILD)/config-downloader github.com/aws/amazon-cloudwatch-agent/cmd/config-downloader
 
+# A fast build that only builds amd64, we don't need wizard and config downloader
+build-for-docker:
+	$(LINUX_AMD64_BUILD)/amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent
+	$(LINUX_AMD64_BUILD)/start-amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/start-amazon-cloudwatch-agent
+	$(LINUX_AMD64_BUILD)/config-translator github.com/aws/amazon-cloudwatch-agent/cmd/config-translator
+
 fmt:
 	go fmt ./...
 

--- a/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
+++ b/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
@@ -158,6 +158,9 @@ spec:
             - name: varlibdocker
               mountPath: /var/lib/docker
               readOnly: true
+            - name: containerdsock
+              mountPath: /run/containerd/containerd.sock
+              readOnly: true
             - name: sys
               mountPath: /sys
               readOnly: true
@@ -177,6 +180,9 @@ spec:
         - name: varlibdocker
           hostPath:
             path: /var/lib/docker
+        - name: containerdsock
+          hostPath:
+            path: /run/containerd/containerd.sock
         - name: sys
           hostPath:
             path: /sys

--- a/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+++ b/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
@@ -56,6 +56,9 @@ spec:
             - name: varlibdocker
               mountPath: /var/lib/docker
               readOnly: true
+            - name: containerdsock
+              mountPath: /run/containerd/containerd.sock
+              readOnly: true
             - name: sys
               mountPath: /sys
               readOnly: true
@@ -75,6 +78,9 @@ spec:
         - name: varlibdocker
           hostPath:
             path: /var/lib/docker
+        - name: containerdsock
+          hostPath:
+            path: /run/containerd/containerd.sock
         - name: sys
           hostPath:
             path: /sys

--- a/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -140,6 +140,9 @@ spec:
             - name: varlibdocker
               mountPath: /var/lib/docker
               readOnly: true
+            - name: containerdsock
+              mountPath: /run/containerd/containerd.sock
+              readOnly: true
             - name: sys
               mountPath: /sys
               readOnly: true
@@ -159,6 +162,9 @@ spec:
         - name: varlibdocker
           hostPath:
             path: /var/lib/docker
+        - name: containerdsock
+          hostPath:
+            path: /run/containerd/containerd.sock
         - name: sys
           hostPath:
             path: /sys

--- a/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -140,6 +140,9 @@ spec:
             - name: varlibdocker
               mountPath: /var/lib/docker
               readOnly: true
+            - name: containerdsock
+              mountPath: /run/containerd/containerd.sock
+              readOnly: true
             - name: sys
               mountPath: /sys
               readOnly: true
@@ -159,6 +162,9 @@ spec:
         - name: varlibdocker
           hostPath:
             path: /var/lib/docker
+        - name: containerdsock
+          hostPath:
+            path: /run/containerd/containerd.sock
         - name: sys
           hostPath:
             path: /sys

--- a/internal/containerinsightscommon/const.go
+++ b/internal/containerinsightscommon/const.go
@@ -92,4 +92,7 @@ const (
 	TypeContainer       = "Container"
 	TypeContainerFS     = "ContainerFS"
 	TypeContainerDiskIO = "ContainerDiskIO"
+	// Special type for pause container, introduced in https://github.com/aws/amazon-cloudwatch-agent/issues/188
+	// because containerd does not set container name pause container name to POD like docker does.
+	TypeInfraContainer = "InfraContainer"
 )

--- a/plugins/inputs/cadvisor/container_info_processor.go
+++ b/plugins/inputs/cadvisor/container_info_processor.go
@@ -167,6 +167,7 @@ func processContainer(info *cinfo.ContainerInfo, detailMode bool, containerOrche
 func processPod(info *cinfo.ContainerInfo, podKeys map[string]podKey) []*extractors.CAdvisorMetric {
 	var result []*extractors.CAdvisorMetric
 	if isContainerInContainer(info.Name) {
+		log.Printf("D! drop metric because it's nested container, name %s", info.Name)
 		return result
 	}
 

--- a/plugins/inputs/cadvisor/container_info_processor.go
+++ b/plugins/inputs/cadvisor/container_info_processor.go
@@ -133,6 +133,11 @@ func processContainer(info *cinfo.ContainerInfo, detailMode bool, containerOrche
 			tags[ContainerNamekey] = containerName
 			tags[ContainerIdkey] = path.Base(info.Name)
 			containerType = TypeContainer
+
+			// TODO(pingleig): wait for upstream fix https://github.com/aws/amazon-cloudwatch-agent/issues/192
+			if !info.Spec.HasFilesystem {
+				log.Printf("D! containerd does not have container filesystem metrics from cadvisor, See https://github.com/aws/amazon-cloudwatch-agent/issues/192")
+			}
 		}
 	} else {
 		containerType = TypeNode

--- a/plugins/inputs/cadvisor/container_info_processor.go
+++ b/plugins/inputs/cadvisor/container_info_processor.go
@@ -67,9 +67,11 @@ func processContainers(cInfos []*cinfo.ContainerInfo, detailMode bool, container
 			metrics = append(metrics, processPod(cInfo, podKeys)...)
 		}
 	}
-	// This happens when our cgroup path based pod detection logic is not working.
+	// This happens when our cgroup path and label based pod detection logic is not working.
+	// contained https://github.com/aws/amazon-cloudwatch-agent/issues/188
+	// docker systemd https://github.com/aws/amazon-cloudwatch-agent/pull/171
 	if len(metrics) == beforePod {
-		log.Printf("W! No pod metric collected, metrics count is still %d", beforePod)
+		log.Printf("W! No pod metric collected, metrics count is still %d is containerd socket mounted? https://github.com/aws/amazon-cloudwatch-agent/issues/188", beforePod)
 	}
 
 	metrics = mergeMetrics(metrics)
@@ -99,9 +101,6 @@ func processContainer(info *cinfo.ContainerInfo, detailMode bool, containerOrche
 			return result, pKey
 		}
 
-		if len(info.Spec.Labels) == 0 {
-			log.Printf("W! no label found from container spec, is containerd socket mounted? https://github.com/aws/amazon-cloudwatch-agent/issues/188")
-		}
 		// Only a container has all these three labels set.
 		containerName := info.Spec.Labels[containerNameLable]
 		namespace := info.Spec.Labels[namespaceLable]

--- a/plugins/inputs/cadvisor/extractors/diskio_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/diskio_extractor.go
@@ -90,7 +90,7 @@ func (d *DiskIOMetricExtractor) CleanUp(now time.Time) {
 
 func NewDiskIOMetricExtractor() *DiskIOMetricExtractor {
 	return &DiskIOMetricExtractor{
-		preInfos: mapWithExpiry.NewMapWithExpiry(CleanInteval),
+		preInfos: mapWithExpiry.NewMapWithExpiry(CleanInterval),
 	}
 }
 

--- a/plugins/inputs/cadvisor/extractors/fs_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/fs_extractor.go
@@ -26,7 +26,7 @@ func (f *FileSystemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 
 func (f *FileSystemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
-	if containerType == TypePod || info.Spec.Labels[containerNameLable] == infraContainerName {
+	if containerType == TypePod || containerType == TypeInfraContainer {
 		return metrics
 	}
 

--- a/plugins/inputs/cadvisor/extractors/fs_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/fs_extractor.go
@@ -60,6 +60,7 @@ func (f *FileSystemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containe
 			metric.fields[MetricName(containerType, FSInodesfree)] = v.InodesFree
 		}
 
+		metric.cgroupPath = info.Name
 		metrics = append(metrics, metric)
 	}
 	return metrics

--- a/plugins/inputs/cadvisor/extractors/fs_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/fs_extractor.go
@@ -28,7 +28,6 @@ func (f *FileSystemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 func (f *FileSystemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
 	if containerType == TypePod || containerType == TypeInfraContainer {
-		log.Printf("D! fs ignore type %q path %s", containerType, info.Name)
 		return metrics
 	}
 

--- a/plugins/inputs/cadvisor/extractors/fs_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/fs_extractor.go
@@ -20,6 +20,7 @@ type FileSystemMetricExtractor struct {
 	allowListRegexP *regexp.Regexp
 }
 
+// TODO(pingleig): it is always false for container using containerd https://github.com/aws/amazon-cloudwatch-agent/issues/192
 func (f *FileSystemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 	return info.Spec.HasFilesystem
 }
@@ -27,6 +28,7 @@ func (f *FileSystemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 func (f *FileSystemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
 	if containerType == TypePod || containerType == TypeInfraContainer {
+		log.Printf("D! fs ignore type %q path %s", containerType, info.Name)
 		return metrics
 	}
 

--- a/plugins/inputs/cadvisor/extractors/mem_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/mem_extractor.go
@@ -25,11 +25,12 @@ func (m *MemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 
 func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
-	if info.Spec.Labels[containerNameLable] == infraContainerName {
+	if containerType == TypeInfraContainer {
 		return metrics
 	}
 
 	metric := newCadvisorMetric(containerType)
+	metric.cgroupPath = info.Name
 	curStats := GetStats(info)
 
 	metric.fields[MetricName(containerType, MemUsage)] = curStats.Memory.Usage
@@ -64,6 +65,6 @@ func (m *MemMetricExtractor) CleanUp(now time.Time) {
 
 func NewMemMetricExtractor() *MemMetricExtractor {
 	return &MemMetricExtractor{
-		preInfos: mapWithExpiry.NewMapWithExpiry(CleanInteval),
+		preInfos: mapWithExpiry.NewMapWithExpiry(CleanInterval),
 	}
 }

--- a/plugins/inputs/cadvisor/extractors/net_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/net_extractor.go
@@ -90,6 +90,7 @@ func (n *NetMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType s
 							metric.fields[MetricName(mType, k)] = v
 						}
 
+						metric.cgroupPath = info.Name
 						metrics = append(metrics, metric)
 						break
 					}
@@ -101,6 +102,7 @@ func (n *NetMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType s
 				for k, v := range aggregatedFields {
 					metric.fields[MetricName(containerType, k)] = v
 				}
+				metric.cgroupPath = info.Name
 				metrics = append(metrics, metric)
 			}
 		}

--- a/plugins/inputs/cadvisor/extractors/net_extractor.go
+++ b/plugins/inputs/cadvisor/extractors/net_extractor.go
@@ -39,9 +39,13 @@ func (n *NetMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 func (n *NetMetricExtractor) GetValue(info *cinfo.ContainerInfo, containerType string) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
 
-	// Just a protection here, there is no Container level Net metrics
-	if (containerType == TypePod && info.Spec.Labels[containerNameLable] != infraContainerName) || containerType == TypeContainer {
+	// Ignore both pod and container because the network metrics comes from InfraContainer.
+	if containerType == TypePod || containerType == TypeContainer {
 		return metrics
+	}
+	// Rename type to pod so the metric name prefix is pod_
+	if containerType == TypeInfraContainer {
+		containerType = TypePod
 	}
 
 	if preInfo, ok := n.preInfos.Get(info.Name); ok {
@@ -112,7 +116,7 @@ func (n *NetMetricExtractor) CleanUp(now time.Time) {
 
 func NewNetMetricExtractor() *NetMetricExtractor {
 	return &NetMetricExtractor{
-		preInfos: mapWithExpiry.NewMapWithExpiry(CleanInteval),
+		preInfos: mapWithExpiry.NewMapWithExpiry(CleanInterval),
 	}
 }
 

--- a/plugins/inputs/cadvisor/merger.go
+++ b/plugins/inputs/cadvisor/merger.go
@@ -5,6 +5,7 @@ package cadvisor
 
 import (
 	"fmt"
+
 	. "github.com/aws/amazon-cloudwatch-agent/internal/containerinsightscommon"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/cadvisor/extractors"
 )


### PR DESCRIPTION
# Description of the issue

Fix #188 k8s cluster using containerd runtime was not able to get pod metrics because

- contained socket is not mounted
- pod detection logic relies on pause container with name 'POD`, which is only the case for docker

# Description of changes

- [x] Define a new constant `TypeInfraContainer` and remove most usage on `POD` container name.
- [x] update all the manifest to mount containerd
- [x] deal with `kubernetes>docker>container_id`  not sure if it is used by any place (it comes from k8s api server though, not cadvisor), just use containerd in json path when it is containerd
- [x] container file system metric like `container_filesystem_utilization` is missing in structured log https://github.com/aws/amazon-cloudwatch-agent/issues/192, it's known issue in cadviisor.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- [x] containerd cluster using kops w/ k8s version 1.20.4
- [x] docker cluster using kops/eks



