### PR TITLE
prom: Save __name__ before relabel for look up metric type

### DIFF
--- a/plugins/inputs/prometheus_scraper/metric_type_handler_test.go
+++ b/plugins/inputs/prometheus_scraper/metric_type_handler_test.go
@@ -186,12 +186,14 @@ func TestNewMetricsTypeHandler_HandleWithUnknownTarget(t *testing.T) {
 	pmb := make(PrometheusMetricBatch, 0)
 	pmb = append(pmb,
 		&PrometheusMetric{
-			metricName: "m1",
-			tags:       map[string]string{"job": "job_unknown", "instance": "instance_unknown"},
+			metricName:              "m1",
+			metricNameBeforeRelabel: "m1",
+			tags:                    map[string]string{"job": "job_unknown", "instance": "instance_unknown"},
 		},
 		&PrometheusMetric{
-			metricName: "m2",
-			tags:       map[string]string{"job": "job_unknown", "instance": "instance_unknown"},
+			metricName:              "m2",
+			metricNameBeforeRelabel: "m2",
+			tags:                    map[string]string{"job": "job_unknown", "instance": "instance_unknown"},
 		})
 
 	result := metricsTypeHandler.Handle(pmb)
@@ -204,29 +206,34 @@ func TestNewMetricsTypeHandler_HandleWithNormalTarget(t *testing.T) {
 	pmb := make(PrometheusMetricBatch, 0)
 	pmb = append(pmb,
 		&PrometheusMetric{
-			metricName: "m3",
-			tags:       map[string]string{"job": "job1", "instance": "instance1"},
+			metricName:              "m3",
+			metricNameBeforeRelabel: "m3",
+			tags:                    map[string]string{"job": "job1", "instance": "instance1"},
 		},
 		&PrometheusMetric{
-			metricName: "m1",
-			tags:       map[string]string{"job": "job1", "instance": "instance1"},
+			metricName:              "m1",
+			metricNameBeforeRelabel: "m1",
+			tags:                    map[string]string{"job": "job1", "instance": "instance1"},
 		},
 		&PrometheusMetric{
-			metricName: "m2",
-			tags:       map[string]string{"job": "job1", "instance": "instance1"},
+			metricName:              "m2",
+			metricNameBeforeRelabel: "m2",
+			tags:                    map[string]string{"job": "job1", "instance": "instance1"},
 		})
 
 	result := metricsTypeHandler.Handle(pmb)
 	assert.Equal(t, 2, len(result))
 	expectedMetric1 := PrometheusMetric{
-		metricName: "m1",
-		metricType: textparse.MetricTypeCounter,
-		tags:       map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
+		metricName:              "m1",
+		metricNameBeforeRelabel: "m1",
+		metricType:              textparse.MetricTypeCounter,
+		tags:                    map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
 	}
 	expectedMetric2 := PrometheusMetric{
-		metricName: "m2",
-		metricType: textparse.MetricTypeCounter,
-		tags:       map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
+		metricName:              "m2",
+		metricNameBeforeRelabel: "m2",
+		metricType:              textparse.MetricTypeCounter,
+		tags:                    map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
 	}
 	assert.Equal(t, *result[0], expectedMetric1)
 	assert.Equal(t, *result[1], expectedMetric2)
@@ -238,29 +245,34 @@ func TestNewMetricsTypeHandler_HandleWithReplacedJobname(t *testing.T) {
 	pmb := make(PrometheusMetricBatch, 0)
 	pmb = append(pmb,
 		&PrometheusMetric{
-			metricName: "m1",
-			tags:       map[string]string{"job": "job2_replaced", "instance": "instance2"},
+			metricName:              "m1",
+			metricNameBeforeRelabel: "m1",
+			tags:                    map[string]string{"job": "job2_replaced", "instance": "instance2"},
 		},
 		&PrometheusMetric{
-			metricName: "m3",
-			tags:       map[string]string{"job": "job2_replaced", "instance": "instance2"},
+			metricName:              "m3",
+			metricNameBeforeRelabel: "m3",
+			tags:                    map[string]string{"job": "job2_replaced", "instance": "instance2"},
 		},
 		&PrometheusMetric{
-			metricName: "m2",
-			tags:       map[string]string{"job": "job2_replaced", "instance": "instance2"},
+			metricName:              "m2",
+			metricNameBeforeRelabel: "m2",
+			tags:                    map[string]string{"job": "job2_replaced", "instance": "instance2"},
 		})
 
 	result := metricsTypeHandler.Handle(pmb)
 	assert.Equal(t, 2, len(result))
 	expectedMetric1 := PrometheusMetric{
-		metricName: "m1",
-		metricType: textparse.MetricTypeGauge,
-		tags:       map[string]string{"job": "job2_replaced", "instance": "instance2", "prom_metric_type": textparse.MetricTypeGauge},
+		metricName:              "m1",
+		metricNameBeforeRelabel: "m1",
+		metricType:              textparse.MetricTypeGauge,
+		tags:                    map[string]string{"job": "job2_replaced", "instance": "instance2", "prom_metric_type": textparse.MetricTypeGauge},
 	}
 	expectedMetric2 := PrometheusMetric{
-		metricName: "m2",
-		metricType: textparse.MetricTypeGauge,
-		tags:       map[string]string{"job": "job2_replaced", "instance": "instance2", "prom_metric_type": textparse.MetricTypeGauge},
+		metricName:              "m2",
+		metricNameBeforeRelabel: "m2",
+		metricType:              textparse.MetricTypeGauge,
+		tags:                    map[string]string{"job": "job2_replaced", "instance": "instance2", "prom_metric_type": textparse.MetricTypeGauge},
 	}
 	assert.Equal(t, *result[0], expectedMetric1)
 	assert.Equal(t, *result[1], expectedMetric2)
@@ -272,38 +284,45 @@ func TestNewMetricsTypeHandler_HandleWithMetricSuffix(t *testing.T) {
 	pmb := make(PrometheusMetricBatch, 0)
 	pmb = append(pmb,
 		&PrometheusMetric{
-			metricName: "m3_sum",
-			tags:       map[string]string{"job": "job1", "instance": "instance1"},
+			metricName:              "m3_sum",
+			metricNameBeforeRelabel: "m3_sum",
+			tags:                    map[string]string{"job": "job1", "instance": "instance1"},
 		},
 		&PrometheusMetric{
-			metricName: "m1_sum",
-			tags:       map[string]string{"job": "job1", "instance": "instance1"},
+			metricName:              "m1_sum",
+			metricNameBeforeRelabel: "m1_sum",
+			tags:                    map[string]string{"job": "job1", "instance": "instance1"},
 		},
 		&PrometheusMetric{
-			metricName: "m2_count",
-			tags:       map[string]string{"job": "job1", "instance": "instance1"},
+			metricName:              "m2_count",
+			metricNameBeforeRelabel: "m2_count",
+			tags:                    map[string]string{"job": "job1", "instance": "instance1"},
 		},
 		&PrometheusMetric{
-			metricName: "m4_total",
-			tags:       map[string]string{"job": "job1", "instance": "instance1"},
+			metricName:              "m4_total",
+			metricNameBeforeRelabel: "m4_total",
+			tags:                    map[string]string{"job": "job1", "instance": "instance1"},
 		})
 
 	result := metricsTypeHandler.Handle(pmb)
 	assert.Equal(t, 3, len(result))
 	expectedMetric1 := PrometheusMetric{
-		metricName: "m1_sum",
-		metricType: textparse.MetricTypeCounter,
-		tags:       map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
+		metricName:              "m1_sum",
+		metricNameBeforeRelabel: "m1_sum",
+		metricType:              textparse.MetricTypeCounter,
+		tags:                    map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
 	}
 	expectedMetric2 := PrometheusMetric{
-		metricName: "m2_count",
-		metricType: textparse.MetricTypeCounter,
-		tags:       map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
+		metricName:              "m2_count",
+		metricNameBeforeRelabel: "m2_count",
+		metricType:              textparse.MetricTypeCounter,
+		tags:                    map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
 	}
 	expectedMetric4 := PrometheusMetric{
-		metricName: "m4_total",
-		metricType: textparse.MetricTypeCounter,
-		tags:       map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
+		metricName:              "m4_total",
+		metricNameBeforeRelabel: "m4_total",
+		metricType:              textparse.MetricTypeCounter,
+		tags:                    map[string]string{"job": "job1", "instance": "instance1", "prom_metric_type": textparse.MetricTypeCounter},
 	}
 	assert.Equal(t, *result[0], expectedMetric1)
 	assert.Equal(t, *result[1], expectedMetric2)

--- a/plugins/inputs/prometheus_scraper/metrics_receiver.go
+++ b/plugins/inputs/prometheus_scraper/metrics_receiver.go
@@ -17,11 +17,14 @@ import (
 type PrometheusMetricBatch []*PrometheusMetric
 
 type PrometheusMetric struct {
-	tags        map[string]string
-	metricName  string
-	metricValue float64
-	metricType  string
-	timeInMS    int64 // Unix time in milli-seconds
+	tags       map[string]string
+	metricName string
+	// We use this name to look up metric type because user can relabel __name___.
+	// See https://github.com/aws/amazon-cloudwatch-agent/issues/190
+	metricNameBeforeRelabel string
+	metricValue             float64
+	metricType              string
+	timeInMS                int64 // Unix time in milli-seconds
 }
 
 func (pm *PrometheusMetric) isValueValid() bool {
@@ -71,9 +74,10 @@ func (ma *metricAppender) Add(ls labels.Labels, t int64, v float64) (uint64, err
 	}
 
 	pm := &PrometheusMetric{
-		metricName:  metricName,
-		metricValue: v,
-		timeInMS:    t,
+		metricName:              metricName,
+		metricNameBeforeRelabel: ls.Get(savedScrapeNameLabel),
+		metricValue:             v,
+		timeInMS:                t,
 	}
 
 	pm.tags = labelMap


### PR DESCRIPTION
# Description of the issue

Fix #190 

# Description of changes

Save name before relabel using relabel.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- [x] manually
- [x] unit test
- [x] internal integ test
