### PR TITLE
release: v1.247347.6

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,13 @@
 ========================================================================
+Amazon CloudWatch Agent 1.247347.6 (2021-03-24)
+========================================================================
+
+Bug fixes:
+
+* Fix prometheus metric type error when relabel job, instance and __name__
+* Fix pod detection for k8s containerd runtime, though container filesystem metric is not supported by cadvisor for containerd.
+
+========================================================================
 Amazon CloudWatch Agent 1.247347.5 (2021-02-22)
 ========================================================================
 


### PR DESCRIPTION
# Description of the issue

Release v1.247347.6 https://github.com/aws/amazon-cloudwatch-agent/milestone/1?closed=1

# Description of changes

- prometheus relabel for job, instance and __name__
- contianerd support (without out container filesystem #192 )

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

N/A




