### PR TITLE
prom: Add more regex to match new haproxy backend format

### DIFF
--- a/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -48,7 +48,7 @@ data:
                 },
                 {
                   "source_labels": ["Service", "backend"],
-                  "label_matcher": ".*haproxy-ingress-.*metrics;(httpback-shared-backend|httpback-default-backend|httpsback-shared-backend|_default_backend)",
+                  "label_matcher": ".*haproxy-ingress-.*metrics;(httpback-shared-backend|httpback-default-backend|httpsback-shared-backend|_default_backend|.*backend_http)",
                   "dimensions": [["Service","Namespace","ClusterName","backend","code"]],
                   "metric_selectors": [
                     "^haproxy_backend_http_responses_total$"


### PR DESCRIPTION
# Description of the issue

It is now `$namespace_$servicename-default-backend_http`, it was `_default_backend` when using helm chart 0.11.4. This new regex should work for 0.12.0

# Description of changes

A new regex 'or'

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

Internal integ test



