### PR TITLE
fix: typo in logfile.go s/public_multi_logs/publish_multi_logs/

### DIFF
--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -167,7 +167,7 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 
 			if _, ok := dests[filename]; ok {
 				continue
-			} else if fileconfig.AutoRemoval { // This logic means auto_removal does not work with public_multi_logs
+			} else if fileconfig.AutoRemoval { // This logic means auto_removal does not work with publish_multi_logs
 				for _, dst := range dests {
 					dst.tailer.StopAtEOF() // Stop all other tailers in favor of the newly found file
 				}


### PR DESCRIPTION
# Description of the issue
There is a typo in https://github.com/aws/amazon-cloudwatch-agent/blob/v1.247347.6/plugins/inputs/logfile/logfile.go#L170 .

# Description of changes
Fix the typo  by replacing public_multi_logs with publish_multi_logs

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
make build && make test



