### PR TITLE
update warning message to indicate missing log

### DIFF
--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -257,7 +257,7 @@ func (p *pusher) send() {
 
 		awsErr, ok := err.(awserr.Error)
 		if !ok {
-			p.Log.Errorf("Non aws error received when sending logs to %v/%v: %v", p.Group, p.Stream, err)
+			p.Log.Errorf("Non aws error received when sending logs to %v/%v: %v. CloudWatch agent will not retry and logs will be missing!", p.Group, p.Stream, err)
 			// Messages will be discarded but done callbacks not called
 			p.reset()
 			return


### PR DESCRIPTION
# Description of changes
Update the warning message to indicate that there will be missing logs when cloudwatch agent received non-aws errors from backend. It is assumed that the non-aws errors can't be recovered automatically so there will be no retry (for performance concerns)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A



