### PR TITLE
start: Skip pidfile when running in a container.

### DIFF
--- a/cmd/start-amazon-cloudwatch-agent/path.go
+++ b/cmd/start-amazon-cloudwatch-agent/path.go
@@ -33,7 +33,6 @@ func startAgent(writer io.WriteCloser) error {
 		execArgs := []string{
 			agentBinaryPath, // when using syscall.Exec, must pass binary name as args[0]
 			"-config", tomlConfigPath, "-envconfig", envConfigPath,
-			"-pidfile", AGENT_DIR_LINUX + "/var/amazon-cloudwatch-agent.pid",
 		}
 		if err := syscall.Exec(agentBinaryPath, execArgs, os.Environ()); err != nil {
 			return fmt.Errorf("error exec as agent binary: %w", err)


### PR DESCRIPTION
# Description of the issue

When the agent is running in a container, the use and management of a
pidfile shouldn't be necessary. By making this change, it moves the
agent container one step closer to being able to run entirely with a read
only root file system. While the pid file functionality doesn't prevent
running with a read only file system, it generates an unnecessary error
line in the logs:

2021-05-09T17:03:00Z E! Unable to create pidfile: open /opt/aws/amazon-cloudwatch-agent/var/amazon-cloudwatch-agent.pid: read-only file system

While it is possible to provide a small scratch filesystem for the pid
file, this seems entirely unnecessary.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Sure.

# Tests
_Describe what tests you have done._

None. Only visual inspection of the code in question, and what I believe to be impacted functionality (none).