### PR TITLE
prom: Remove logging all the metrics introduced in #193

### DIFF
--- a/plugins/inputs/prometheus_scraper/metrics_receiver.go
+++ b/plugins/inputs/prometheus_scraper/metrics_receiver.go
@@ -83,7 +83,6 @@ func (ma *metricAppender) Add(ls labels.Labels, t int64, v float64) (uint64, err
 		metricValue:             v,
 		timeInMS:                t,
 	}
-	log.Printf("%s %v", pm.metricName, labelMap)
 
 	// Remove magic labels
 	delete(labelMap, savedScrapeNameLabel)


### PR DESCRIPTION
# Description of the issue

We were logging all the prometheus metrics.  See #209 for detail

# Description of changes

Removed the log.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

Compile




