### PR TITLE
chore: Enable build mode override via env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,19 @@ VERSION := $(shell echo ${VERSION} | sed -e "s/^v//")
 ifeq ($(VERSION),)
 VERSION := `cat CWAGENT_VERSION`
 endif
+
+# Determine agent build mode, default to PIE mode
+ifndef CWAGENT_BUILD_MODE
+CWAGENT_BUILD_MODE=pie
+endif
+
 BUILD := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS = -s -w
 LDFLAGS +=  -X github.com/aws/amazon-cloudwatch-agent/cfg/agentinfo.VersionStr=${VERSION}
 LDFLAGS +=  -X github.com/aws/amazon-cloudwatch-agent/cfg/agentinfo.BuildStr=${BUILD}
-LINUX_AMD64_BUILD = CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=pie -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/linux_amd64
-LINUX_ARM64_BUILD = GOOS=linux GOARCH=arm64 go build -buildmode=pie -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/linux_arm64
-WIN_BUILD = GOOS=windows GOARCH=amd64 go build -buildmode=pie -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/windows_amd64
+LINUX_AMD64_BUILD = CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=${CWAGENT_BUILD_MODE} -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/linux_amd64
+LINUX_ARM64_BUILD = GOOS=linux GOARCH=arm64 go build -buildmode=${CWAGENT_BUILD_MODE} -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/linux_arm64
+WIN_BUILD = GOOS=windows GOARCH=amd64 go build -buildmode=${CWAGENT_BUILD_MODE} -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/windows_amd64
 DARWIN_BUILD = GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/darwin_amd64
 
 IMAGE = amazon/cloudwatch-agent:$(VERSION)
@@ -63,9 +69,9 @@ update-submodule:
 	
 cwagent-otel-collector: update-submodule
 	@echo Building aws-otel-collector
-	cd $(AOC_BASE_SPACE) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=pie -ldflags="${AOC_LDFLAGS}" -o $(BUILD_SPACE)/bin/linux_amd64/cwagent-otel-collector $(AOC_IMPORT_PATH)/cmd/awscollector
-	cd $(AOC_BASE_SPACE) && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -buildmode=pie -ldflags="${AOC_LDFLAGS}" -o $(BUILD_SPACE)/bin/linux_arm64/cwagent-otel-collector $(AOC_IMPORT_PATH)/cmd/awscollector
-	cd $(AOC_BASE_SPACE) && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -buildmode=pie -ldflags="${AOC_LDFLAGS}" -o $(BUILD_SPACE)/bin/windows_amd64/cwagent-otel-collector.exe $(AOC_IMPORT_PATH)/cmd/awscollector
+	cd $(AOC_BASE_SPACE) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=${CWAGENT_BUILD_MODE} -ldflags="${AOC_LDFLAGS}" -o $(BUILD_SPACE)/bin/linux_amd64/cwagent-otel-collector $(AOC_IMPORT_PATH)/cmd/awscollector
+	cd $(AOC_BASE_SPACE) && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -buildmode=${CWAGENT_BUILD_MODE} -ldflags="${AOC_LDFLAGS}" -o $(BUILD_SPACE)/bin/linux_arm64/cwagent-otel-collector $(AOC_IMPORT_PATH)/cmd/awscollector
+	cd $(AOC_BASE_SPACE) && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -buildmode=${CWAGENT_BUILD_MODE} -ldflags="${AOC_LDFLAGS}" -o $(BUILD_SPACE)/bin/windows_amd64/cwagent-otel-collector.exe $(AOC_IMPORT_PATH)/cmd/awscollector
 
 config-translator: copy-version-file
 	@echo Building config-translator


### PR DESCRIPTION


# Description of the issue
Go compiler has switched to internal linking mode when building in PIE
mode since version 1.15 (https://golang.org/doc/go1.15#linker). This had
a side effect of not able to compile a purely statically linked PIE
binary with CGO disabled, see: https://github.com/golang/go/issues/40711

As a result, the agent binaries build with PIE mode will fail to run in
a container that is built from SCRATCH.

# Description of changes
In this CR we allow the users to
override the build mode with environment variable `CWAGENT_BUILD_MODE`,
allowing a non-PIE binary to be built to be used in a container without
libc.
For example, a non-pie agent can be built with:
```
CWAGENT_BUILD_MODE=default make
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Built locally and tested with simple docker file below:
```
# syntax=docker/dockerfile:1
FROM scratch
COPY amazon-cloudwatch-agent /
CMD ["/amazon-cloudwatch-agent", "-version"]

```



