### PR TITLE
prom: Add labels for the task and cluster ARNs

### DIFF
--- a/internal/ecsservicediscovery/decoratedtask.go
+++ b/internal/ecsservicediscovery/decoratedtask.go
@@ -18,6 +18,8 @@ const (
 	taskFamilyLabel      = "TaskDefinitionFamily"
 	taskRevisionLabel    = "TaskRevision"
 	taskGroupLabel       = "TaskGroup"
+	taskARNLabel         = "TaskARN"
+	taskClusterARNLabel  = "TaskClusterARN"
 	taskStartedbyLabel   = "StartedBy"
 	taskLaunchTypeLabel  = "LaunchType"
 	taskJobNameLabel     = "job"
@@ -136,6 +138,8 @@ func (t *DecoratedTask) generatePrometheusTarget(
 	revisionStr := fmt.Sprintf("%d", *t.TaskDefinition.Revision)
 	addExporterLabels(labels, taskRevisionLabel, &revisionStr)
 	addExporterLabels(labels, taskGroupLabel, t.Task.Group)
+	addExporterLabels(labels, taskARNLabel, t.Task.TaskArn)
+	addExporterLabels(labels, taskClusterARNLabel, t.Task.ClusterArn)
 	addExporterLabels(labels, taskStartedbyLabel, t.Task.StartedBy)
 	addExporterLabels(labels, taskLaunchTypeLabel, t.Task.LaunchType)
 	if t.EC2Info != nil {


### PR DESCRIPTION
# Description of the issue

Currently the only identifier of the source of an event is the `instance` field from prometheus. This allows you to use the TaskARN and ClusterARN as well by exposing them as labels. This means I can select them as dimensions for example.

# Description of changes

Add two labels for task arn and task cluster arn.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

- [x] yes

# Tests

I tried to test this on my AWS infra but for some reason the image outputted from `make dockerized-build` crashes

```
2021-05-20T17:03:09Z E! [telegraf] Error running agent: No config file specified
```

 while `amazon/cloudwatch-agent` doesn't. Seems completely unrelated to my changes, so any pointers here welcome.




