### PR TITLE
release v1.247348.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,14 @@
 ========================================================================
+Amazon CloudWatch Agent 1.247348.0 (2021-05-28)
+========================================================================
+
+Enhancements and bug fixes:
+
+* Allow ignoring pods metrics with a specific annotation to remove the metrics not needed.(#163)
+* Fix the unnecessary logging entries (#210)
+* Update aws-otel-collector version to v0.10.0 (#216)
+
+========================================================================
 Amazon CloudWatch Agent 1.247347.6 (2021-03-24)
 ========================================================================
 


### PR DESCRIPTION
# Description of the issue

Release v1.247348.0 https://github.com/aws/amazon-cloudwatch-agent/milestone/1?closed=1

# Description of changes

Enhancements and bug fixes:

* Allow ignoring pods metrics with a specific annotation to remove the metrics not needed. (#163)
* Fix the unnecessary logging entries (#210)
* Update aws-otel-collector version to v0.10.0 (#216)

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

N/A




