### PR TITLE
add `CWAGENT_VERSION` file and `build` folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea
 vendor
 release
+build
+CWAGENT_VERSION
 .DS_Store
 .vscode
 *.iml


### PR DESCRIPTION
# Description of the issue
According to 93ed049dcca2173cb2209ea06226847a03fe7ba5 and https://github.com/aws/amazon-cloudwatch-agent/blob/v1.247348.0/Makefile, both are not needed as source file now and removed by `make clean`. It is safer to ignore these files not to commit them by mistake.

# Description of changes
Add `CWAGENT_VERSION` file and `build` folder to `.gitignore`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
`make build && make test` is succeeded.