### PR TITLE
build: Build docker without open telemetry collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,17 @@ config-downloader: copy-version-file
 	$(DARWIN_BUILD)/config-downloader github.com/aws/amazon-cloudwatch-agent/cmd/config-downloader
 
 # A fast build that only builds amd64, we don't need wizard and config downloader
-build-for-docker:
+build-for-docker: build-for-docker-amd64
+
+build-for-docker-amd64:
 	$(LINUX_AMD64_BUILD)/amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent
 	$(LINUX_AMD64_BUILD)/start-amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/start-amazon-cloudwatch-agent
 	$(LINUX_AMD64_BUILD)/config-translator github.com/aws/amazon-cloudwatch-agent/cmd/config-translator
+
+build-for-docker-arm64:
+	$(LINUX_ARM64_BUILD)/amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent
+	$(LINUX_ARM64_BUILD)/start-amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/start-amazon-cloudwatch-agent
+	$(LINUX_ARM64_BUILD)/config-translator github.com/aws/amazon-cloudwatch-agent/cmd/config-translator
 
 fmt:
 	go fmt ./...

--- a/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/README.md
+++ b/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/README.md
@@ -16,6 +16,8 @@ docker buildx create --name multi-builder
 docker buildx use multi-builder
 # Add proper tag and --push if you want to publish it
 docker buildx build --platform linux/amd64,linux/arm64 .
+# To build multi arch image from soruce code, run the following at project root
+docker buildx build --platform linux/amd64,linux/arm64 -f amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/Dockerfile .
 ```
 
 ### Build multi arch image manifest from single arch images

--- a/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
+++ b/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
@@ -3,6 +3,9 @@ ARG GO_IMAGE=golang:latest
 ARG CERT_IMAGE=ubuntu:latest
 FROM $GO_IMAGE as builder
 
+# NOTE: This arg will be populated by docker buildx
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
 RUN mkdir -p /go/src/github.com/aws/amazon-cloudwatch-agent/
 WORKDIR /go/src/github.com/aws/amazon-cloudwatch-agent/
 
@@ -10,19 +13,19 @@ ARG GO111MODULE="on"
 ENV GO111MODULE=${GO111MODULE}
 
 COPY . /go/src/github.com/aws/amazon-cloudwatch-agent/
-RUN make build && make package-deb
+RUN make build-for-docker-${TARGETARCH}
 
 # Install cert and binaries
 FROM $CERT_IMAGE as cert
 
-# NOTE: This arg will be populated by docker buildx
-# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+# Need to repeat the ARG after each FROM
 ARG TARGETARCH
+RUN mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+RUN mkdir -p /opt/aws/amazon-cloudwatch-agent/var
 RUN apt-get update &&  \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=builder /go/src/github.com/aws/amazon-cloudwatch-agent/build/bin/linux/ /tmp/deb
-RUN dpkg -i -E /tmp/deb/${TARGETARCH:-$(dpkg --print-architecture)}/amazon-cloudwatch-agent.deb
+COPY --from=builder /go/src/github.com/aws/amazon-cloudwatch-agent/build/bin/linux_${TARGETARCH}/ /opt/aws/amazon-cloudwatch-agent/bin
 
 FROM scratch
 


### PR DESCRIPTION
# Description of the issue

We were using deb when building image from source, i.e. source -> deb -> docker image. But we have composite agent, which is not used when running as image.

# Description of changes

- Add two new targets (x86_64 and arm64) to only build binary required for docker image
- Make amd64 the default target
- Use the new target in `Dockerfile`

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

Run the new commands (in a place that does not block go mod proxy)

```
docker buildx build --platform linux/amd64,linux/arm64 -f amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/Dockerfile .
```



