### PR TITLE
Default config metrics exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+build
 vendor
 release
 .DS_Store

--- a/plugins/inputs/logfile/fileconfig_test.go
+++ b/plugins/inputs/logfile/fileconfig_test.go
@@ -122,13 +122,13 @@ func TestTimestampParserWithPadding(t *testing.T) {
 
 	logEntry := fmt.Sprintf(" 2 1 07:10:06 instance-id: i-02fce21a425a2efb3")
 	timestamp := fileConfig.timestampFromLogLine(logEntry)
-	assert.Equal(t, 7, timestamp.Hour(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "7", timestamp.Hour() ))
-	assert.Equal(t, 10, timestamp.Minute(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "10", timestamp.Minute() ))
+	assert.Equal(t, 7, timestamp.Hour(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "7", timestamp.Hour()))
+	assert.Equal(t, 10, timestamp.Minute(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "10", timestamp.Minute()))
 
 	logEntry = fmt.Sprintf("2 1 07:10:06 instance-id: i-02fce21a425a2efb3")
 	timestamp = fileConfig.timestampFromLogLine(logEntry)
-	assert.Equal(t, 7, timestamp.Hour(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "7", timestamp.Hour() ))
-	assert.Equal(t, 10, timestamp.Minute(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "10", timestamp.Minute() ))
+	assert.Equal(t, 7, timestamp.Hour(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "7", timestamp.Hour()))
+	assert.Equal(t, 10, timestamp.Minute(), fmt.Sprintf("Timestamp does not match: %v, act: %v", "10", timestamp.Minute()))
 }
 
 func TestTimestampParserWithFracSeconds(t *testing.T) {

--- a/tool/data/config/metric/aggregationDimensions.go
+++ b/tool/data/config/metric/aggregationDimensions.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package metric
+
+import "github.com/aws/amazon-cloudwatch-agent/tool/runtime"
+
+type AggregationDimensions struct {
+	Dimensions [][]string
+}
+
+func (config *AggregationDimensions) ToMap(ctx *runtime.Context) (string, [][]string) {
+	config.SetDefaultDimensions()
+	return "aggregation_dimensions", config.Dimensions
+}
+
+func (config *AggregationDimensions) SetDefaultDimensions() {
+	config.Dimensions = [][]string{{"InstanceId"}}
+}

--- a/tool/data/config/metric/aggregationDimensions_test.go
+++ b/tool/data/config/metric/aggregationDimensions_test.go
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package metric
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-cloudwatch-agent/tool/runtime"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAggregationDimension_ToMap(t *testing.T) {
+	expectedKey := "aggregation_dimensions"
+	expectedValue := [][]string{{"InstanceId"}}
+	ctx := &runtime.Context{}
+	conf := new(AggregationDimensions)
+	key, value := conf.ToMap(ctx)
+	assert.Equal(t, expectedKey, key)
+	assert.Equal(t, expectedValue, value)
+}

--- a/tool/data/config/metrics.go
+++ b/tool/data/config/metrics.go
@@ -11,6 +11,8 @@ import (
 type Metrics struct {
 	AppendDimensions *metric.AppendDimensions
 
+	AggregationDimensions *metric.AggregationDimensions
+
 	MetricsCollect *metric.Collection
 }
 
@@ -24,6 +26,17 @@ func (config *Metrics) ToMap(ctx *runtime.Context) (string, map[string]interface
 
 	if config.AppendDimensions != nil {
 		mapKey, mapValue := config.AppendDimensions.ToMap(ctx)
+		if mapValue != nil {
+			resultMap[mapKey] = mapValue
+		}
+	}
+
+	if config.AggregationDimensions == nil && ctx.WantAggregateDimensions {
+		config.AggregationDimensions = new(metric.AggregationDimensions)
+	}
+
+	if config.AggregationDimensions != nil {
+		mapKey, mapValue := config.AggregationDimensions.ToMap(ctx)
 		if mapValue != nil {
 			resultMap[mapKey] = mapValue
 		}

--- a/tool/data/config/metrics_test.go
+++ b/tool/data/config/metrics_test.go
@@ -16,7 +16,8 @@ import (
 func TestMetrics_ToMap(t *testing.T) {
 	expectedKey := "metrics"
 	expectedValue := map[string]interface{}{
-		"append_dimensions": map[string]interface{}{"ImageId": "${aws:ImageId}", "InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}", "AutoScalingGroupName": "${aws:AutoScalingGroupName}"},
+		"aggregation_dimensions": [][]string{{"InstanceId"}},
+		"append_dimensions":      map[string]interface{}{"ImageId": "${aws:ImageId}", "InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}", "AutoScalingGroupName": "${aws:AutoScalingGroupName}"},
 		"metrics_collected": map[string]interface{}{
 			"diskio":   map[string]interface{}{"resources": []string{"*"}, "measurement": []string{"io_time", "write_bytes", "read_bytes", "writes", "reads"}},
 			"mem":      map[string]interface{}{"measurement": []string{"mem_used_percent"}},
@@ -31,10 +32,11 @@ func TestMetrics_ToMap(t *testing.T) {
 	}
 	conf := new(Metrics)
 	ctx := &runtime.Context{
-		OsParameter:            util.OsTypeLinux,
-		WantEC2TagDimensions:   true,
-		IsOnPrem:               true,
-		WantPerInstanceMetrics: true,
+		OsParameter:             util.OsTypeLinux,
+		WantEC2TagDimensions:    true,
+		WantAggregateDimensions: true,
+		IsOnPrem:                true,
+		WantPerInstanceMetrics:  true,
 	}
 	conf.CollectAllMetrics(ctx)
 	key, value := conf.ToMap(ctx)
@@ -43,10 +45,11 @@ func TestMetrics_ToMap(t *testing.T) {
 
 	conf = new(Metrics)
 	ctx = &runtime.Context{
-		OsParameter:            util.OsTypeDarwin,
-		WantEC2TagDimensions:   true,
-		IsOnPrem:               true,
-		WantPerInstanceMetrics: true,
+		OsParameter:             util.OsTypeDarwin,
+		WantEC2TagDimensions:    true,
+		WantAggregateDimensions: true,
+		IsOnPrem:                true,
+		WantPerInstanceMetrics:  true,
 	}
 	conf.CollectAllMetrics(ctx)
 	key, value = conf.ToMap(ctx)
@@ -54,7 +57,8 @@ func TestMetrics_ToMap(t *testing.T) {
 	assert.Equal(t, expectedValue, value)
 
 	expectedValue = map[string]interface{}{
-		"append_dimensions": map[string]interface{}{"InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}", "AutoScalingGroupName": "${aws:AutoScalingGroupName}", "ImageId": "${aws:ImageId}"},
+		"aggregation_dimensions": [][]string{{"InstanceId"}},
+		"append_dimensions":      map[string]interface{}{"InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}", "AutoScalingGroupName": "${aws:AutoScalingGroupName}", "ImageId": "${aws:ImageId}"},
 		"metrics_collected": map[string]interface{}{
 			"LogicalDisk":       map[string]interface{}{"resources": []string{"*"}, "measurement": []string{"% Free Space"}},
 			"Memory":            map[string]interface{}{"measurement": []string{"% Committed Bytes In Use"}},

--- a/tool/processors/basicInfo/basicInfo.go
+++ b/tool/processors/basicInfo/basicInfo.go
@@ -33,9 +33,13 @@ func ensurePermission() {
 }
 
 func welcome() {
-	fmt.Println("=============================================================")
-	fmt.Println("= Welcome to the AWS CloudWatch Agent Configuration Manager =")
-	fmt.Println("=============================================================")
+	fmt.Println("================================================================")
+	fmt.Println("= Welcome to the Amazon CloudWatch Agent Configuration Manager =")
+	fmt.Println("=                                                              =")
+	fmt.Println("= CloudWatch Agent allows you to collect metrics and logs from =")
+	fmt.Println("= your host and send them to CloudWatch. Additional CloudWatch =")
+	fmt.Println("= charges may apply.                                           =")
+	fmt.Println("================================================================")
 }
 
 func whichOS(ctx *runtime.Context) {

--- a/tool/processors/defaultConfig/defaultConfig.go
+++ b/tool/processors/defaultConfig/defaultConfig.go
@@ -97,7 +97,7 @@ func wantMonitorAnyHostMetrics() bool {
 }
 
 func wantPerInstanceMetrics(ctx *runtime.Context) {
-	ctx.WantPerInstanceMetrics = util.Yes("Do you want to monitor cpu metrics per core? Additional CloudWatch charges may apply.")
+	ctx.WantPerInstanceMetrics = util.Yes("Do you want to monitor cpu metrics per core?")
 }
 
 func wantEC2TagDimensions(ctx *runtime.Context) {

--- a/tool/processors/defaultConfig/defaultConfig.go
+++ b/tool/processors/defaultConfig/defaultConfig.go
@@ -32,6 +32,7 @@ func (p *processor) NextProcessor(ctx *runtime.Context, config *data.Config) int
 	if wantMonitorAnyHostMetrics() {
 		wantPerInstanceMetrics(ctx)
 		wantEC2TagDimensions(ctx)
+		wantEC2AggregateDimensions(ctx)
 		metricsCollectInterval(ctx)
 	} else {
 		if ctx.OsParameter == util.OsTypeWindows {
@@ -104,6 +105,13 @@ func wantEC2TagDimensions(ctx *runtime.Context) {
 		return
 	}
 	ctx.WantEC2TagDimensions = util.Yes("Do you want to add ec2 dimensions (ImageId, InstanceId, InstanceType, AutoScalingGroupName) into all of your metrics if the info is available?")
+}
+
+func wantEC2AggregateDimensions(ctx *runtime.Context) {
+	if ctx.IsOnPrem {
+		return
+	}
+	ctx.WantAggregateDimensions = util.Yes("Do you want to aggregate ec2 dimensions (InstanceId)?")
 }
 
 func metricsCollectInterval(ctx *runtime.Context) {

--- a/tool/processors/defaultConfig/defaultConfig_test.go
+++ b/tool/processors/defaultConfig/defaultConfig_test.go
@@ -31,7 +31,8 @@ func TestProcessor_Process(t *testing.T) {
 //basic metrics config
 var basicMetricsConf = map[string]interface{}{
 	"metrics": map[string]interface{}{
-		"append_dimensions": map[string]interface{}{"AutoScalingGroupName": "${aws:AutoScalingGroupName}", "ImageId": "${aws:ImageId}", "InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}"},
+		"aggregation_dimensions": [][]string{{"InstanceId"}},
+		"append_dimensions":      map[string]interface{}{"AutoScalingGroupName": "${aws:AutoScalingGroupName}", "ImageId": "${aws:ImageId}", "InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}"},
 		"metrics_collected": map[string]interface{}{
 			"disk": map[string]interface{}{"resources": []string{"*"}, "metrics_collection_interval": 60, "measurement": []string{"used_percent"}},
 			"mem":  map[string]interface{}{"metrics_collection_interval": 60, "measurement": []string{"mem_used_percent"}}}}}
@@ -39,7 +40,8 @@ var basicMetricsConf = map[string]interface{}{
 //standard metrics config
 var standardMetricsConf = map[string]interface{}{
 	"metrics": map[string]interface{}{
-		"append_dimensions": map[string]interface{}{"ImageId": "${aws:ImageId}", "InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}", "AutoScalingGroupName": "${aws:AutoScalingGroupName}"},
+		"aggregation_dimensions": [][]string{{"InstanceId"}},
+		"append_dimensions":      map[string]interface{}{"ImageId": "${aws:ImageId}", "InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}", "AutoScalingGroupName": "${aws:AutoScalingGroupName}"},
 		"metrics_collected": map[string]interface{}{
 			"cpu":    map[string]interface{}{"resources": []string{"*"}, "totalcpu": false, "metrics_collection_interval": 60, "measurement": []string{"cpu_usage_idle", "cpu_usage_iowait", "cpu_usage_user", "cpu_usage_system"}},
 			"disk":   map[string]interface{}{"resources": []string{"*"}, "metrics_collection_interval": 60, "measurement": []string{"used_percent", "inodes_free"}},
@@ -50,7 +52,8 @@ var standardMetricsConf = map[string]interface{}{
 //advanced metrics config
 var advancedMetricsConf = map[string]interface{}{
 	"metrics": map[string]interface{}{
-		"append_dimensions": map[string]interface{}{"ImageId": "${aws:ImageId}", "InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}", "AutoScalingGroupName": "${aws:AutoScalingGroupName}"},
+		"aggregation_dimensions": [][]string{{"InstanceId"}},
+		"append_dimensions":      map[string]interface{}{"ImageId": "${aws:ImageId}", "InstanceId": "${aws:InstanceId}", "InstanceType": "${aws:InstanceType}", "AutoScalingGroupName": "${aws:AutoScalingGroupName}"},
 		"metrics_collected": map[string]interface{}{
 			"swap":    map[string]interface{}{"metrics_collection_interval": 60, "measurement": []string{"swap_used_percent"}},
 			"cpu":     map[string]interface{}{"metrics_collection_interval": 60, "measurement": []string{"cpu_usage_idle", "cpu_usage_iowait", "cpu_usage_user", "cpu_usage_system"}, "resources": []string{"*"}, "totalcpu": false},
@@ -75,19 +78,21 @@ func TestProcessor_NextProcessor(t *testing.T) {
 	// wantMonitorAnyHostMetrics?
 	// wantPerInstanceMetrics?
 	// wantEC2TagDimensions?
+	// wantEC2AggregateDimensions?
 	// metricsCollectInterval?
 	// whichDefaultConfig?
-	testutil.Type(inputChan, "", "1", "", "", "4")
+	testutil.Type(inputChan, "", "1", "", "", "", "4")
 	nextProcessor = Processor.NextProcessor(ctx, conf)
 	assert.Equal(t, question.Processor, nextProcessor)
 	assert.Equal(t, true, ctx.WantPerInstanceMetrics)
 	assert.Equal(t, true, ctx.WantEC2TagDimensions)
+	assert.Equal(t, true, ctx.WantAggregateDimensions)
 	assert.Equal(t, new(data.Config), conf)
 
 	//basic metrics config
 	ctx = new(runtime.Context)
 	conf = new(data.Config)
-	testutil.Type(inputChan, "", "1", "", "", "", "")
+	testutil.Type(inputChan, "", "1", "", "", "", "", "")
 	nextProcessor = Processor.NextProcessor(ctx, conf)
 	assert.Equal(t, linux.Processor, nextProcessor)
 
@@ -97,7 +102,7 @@ func TestProcessor_NextProcessor(t *testing.T) {
 	//standard metrics config
 	ctx = new(runtime.Context)
 	conf = new(data.Config)
-	testutil.Type(inputChan, "", "1", "", "", "2", "")
+	testutil.Type(inputChan, "", "1", "", "", "", "2", "")
 	nextProcessor = Processor.NextProcessor(ctx, conf)
 	assert.Equal(t, linux.Processor, nextProcessor)
 
@@ -107,7 +112,7 @@ func TestProcessor_NextProcessor(t *testing.T) {
 	//advanced metrics config
 	ctx = new(runtime.Context)
 	conf = new(data.Config)
-	testutil.Type(inputChan, "", "1", "", "", "3", "")
+	testutil.Type(inputChan, "", "1", "", "", "", "3", "")
 	nextProcessor = Processor.NextProcessor(ctx, conf)
 	assert.Equal(t, linux.Processor, nextProcessor)
 
@@ -117,7 +122,7 @@ func TestProcessor_NextProcessor(t *testing.T) {
 	//not satisfied with advanced config and restart with basic config
 	ctx = new(runtime.Context)
 	conf = new(data.Config)
-	testutil.Type(inputChan, "", "1", "", "", "3", "2", "", "")
+	testutil.Type(inputChan, "", "1", "", "", "", "3", "2", "", "")
 	nextProcessor = Processor.NextProcessor(ctx, conf)
 	assert.Equal(t, linux.Processor, nextProcessor)
 

--- a/tool/runtime/context.go
+++ b/tool/runtime/context.go
@@ -8,6 +8,7 @@ type Context struct {
 	IsOnPrem                  bool
 	WantPerInstanceMetrics    bool //CPU per core
 	WantEC2TagDimensions      bool
+	WantAggregateDimensions   bool
 	MetricsCollectionInterval int //sub minute, high resolution, metric collect interval, unit as sec.
 
 	//linux migration

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
@@ -86,7 +86,7 @@ func TestTimestampFormat(t *testing.T) {
 
 func TestTimestampFormatAll(t *testing.T) {
 	tests := []struct {
-		input string
+		input    string
 		expected interface{}
 	}{
 		{
@@ -98,13 +98,13 @@ func TestTimestampFormatAll(t *testing.T) {
 						}
 					]
 				}`,
-			expected:  []interface{}{map[string]interface{}{
-				"file_path":"path1",
+			expected: []interface{}{map[string]interface{}{
+				"file_path":        "path1",
 				"from_beginning":   true,
 				"pipe":             false,
 				"timestamp_layout": "15:04:05 06 Jan 2",
 				"timestamp_regex":  "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2})",
-				}},
+			}},
 		},
 		{
 			input: `{
@@ -115,8 +115,8 @@ func TestTimestampFormatAll(t *testing.T) {
 						}
 					]
 				}`,
-			expected:  []interface{}{map[string]interface{}{
-				"file_path":"path1",
+			expected: []interface{}{map[string]interface{}{
+				"file_path":        "path1",
 				"from_beginning":   true,
 				"pipe":             false,
 				"timestamp_layout": "1 2 15:04:05",
@@ -132,8 +132,8 @@ func TestTimestampFormatAll(t *testing.T) {
 						}
 					]
 				}`,
-			expected:  []interface{}{map[string]interface{}{
-				"file_path":"path1",
+			expected: []interface{}{map[string]interface{}{
+				"file_path":        "path1",
 				"from_beginning":   true,
 				"pipe":             false,
 				"timestamp_layout": "2 1 15:04:05",
@@ -149,8 +149,8 @@ func TestTimestampFormatAll(t *testing.T) {
 						}
 					]
 				}`,
-			expected:  []interface{}{map[string]interface{}{
-				"file_path":"path1",
+			expected: []interface{}{map[string]interface{}{
+				"file_path":        "path1",
 				"from_beginning":   true,
 				"pipe":             false,
 				"timestamp_layout": "5 2 1 15:04:05",


### PR DESCRIPTION
# Description of the issue
In order to support EC2 metrics published by the CW Agent on Metrics Explorer, the dimensions of the metrics should be set as "Instance Id". This is something we achieve for the existing customers using some guideline docs. But for new customers who will onboard for the first time, we would like to offer this support by default by arranging these settings in the CW Agent config file.

# Description of changes
Added a yes/no prompt in `defaultConfig.go` as part of the config wizard to add the `aggregation_dimensions` field to the `metrics` config. By default, the `aggregation_dimensions` will have a single dimension of "Instance Id". Moved pricing disclaimer from prompt to welcome message.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated `defaultConfig_test.go` to account for the additional prompt and added the `aggregation_dimensions` field to the expected.
Tested the validity of the generated config and performed end-to-end test.



