### PR TITLE
Support SSM SecureString parameters.

### DIFF
--- a/cmd/config-downloader/downloader.go
+++ b/cmd/config-downloader/downloader.go
@@ -66,9 +66,9 @@ func downloadFromSSM(region, parameterStoreName, mode string, credsConfig map[st
 
 	ssmClient := ssm.New(ses)
 	input := ssm.GetParameterInput{
+		Name:           aws.String(parameterStoreName),
 		WithDecryption: aws.Bool(true),
 	}
-	input.SetName(parameterStoreName)
 	output, err := ssmClient.GetParameter(&input)
 	if err != nil {
 		fmt.Printf("Error in retrieving parameter store content: %v\n", err)

--- a/cmd/config-downloader/downloader.go
+++ b/cmd/config-downloader/downloader.go
@@ -65,7 +65,9 @@ func downloadFromSSM(region, parameterStoreName, mode string, credsConfig map[st
 	}
 
 	ssmClient := ssm.New(ses)
-	input := ssm.GetParameterInput{}
+	input := ssm.GetParameterInput{
+		WithDecryption: aws.Bool(true),
+	}
 	input.SetName(parameterStoreName)
 	output, err := ssmClient.GetParameter(&input)
 	if err != nil {


### PR DESCRIPTION
# Description of the issue
Currently, if the configuration file is stored in a `ParameterStore` as a `SecureString`, the `config-downloader` will successfully retrieve the file, but will not decrypt it, so the translator is unable to successfully parse it.
```
Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/ssm_SecureStringConfig.tmp ...
unable to scan config dir /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d with error: unable to parse json, error: invalid character 'A' looking for beginning of value
```

# Description of changes
Updated `ssm.GetParameter` to include the `WithDecryption` flag to support `SecureString` parameters. According to the SSM API (https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameter.html), the flag is ignored for `String` and `StringList` parameter types, so it can always be set to true.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Created a `SecureString` parameter in SSM along with a `String` parameter and tested both against the existing setup to confirm the issue. Built and replaced `config-downloader` on the EC2 instance and tested the download/translation again to validate the fix.




