### PR TITLE
Performance fix for interaction of Container Insights code with Kubernetes API server.

### DIFF
--- a/internal/k8sCommon/k8sclient/endpoint.go
+++ b/internal/k8sCommon/k8sclient/endpoint.go
@@ -185,6 +185,7 @@ func transformFuncEndpoint(obj interface{}) (interface{}, error) {
 func createEndpointListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.ResourceVersion = ""
 			return client.CoreV1().Endpoints(ns).List(opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {

--- a/internal/k8sCommon/k8sclient/job.go
+++ b/internal/k8sCommon/k8sclient/job.go
@@ -150,6 +150,7 @@ func transformFuncJob(obj interface{}) (interface{}, error) {
 func createJobListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.ResourceVersion = ""
 			return client.BatchV1().Jobs(ns).List(opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {

--- a/internal/k8sCommon/k8sclient/node.go
+++ b/internal/k8sCommon/k8sclient/node.go
@@ -163,6 +163,7 @@ func transformFuncNode(obj interface{}) (interface{}, error) {
 func createNodeListWatch(client kubernetes.Interface) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.ResourceVersion = ""
 			return client.CoreV1().Nodes().List(opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {

--- a/internal/k8sCommon/k8sclient/pod.go
+++ b/internal/k8sCommon/k8sclient/pod.go
@@ -118,6 +118,7 @@ func transformFuncPod(obj interface{}) (interface{}, error) {
 func createPodListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.ResourceVersion = ""
 			return client.CoreV1().Pods(ns).List(opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {

--- a/internal/k8sCommon/k8sclient/replicaset.go
+++ b/internal/k8sCommon/k8sclient/replicaset.go
@@ -149,6 +149,7 @@ func transformFuncReplicaSet(obj interface{}) (interface{}, error) {
 func createReplicaSetListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.ResourceVersion = ""
 			return client.AppsV1().ReplicaSets(ns).List(opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {


### PR DESCRIPTION
Performance fix for interaction of Container Insights code with Kubernetes API server.

When running in a Kubernetes cluster, one leader-elected instance of the agent stays up to date with metadata such as
the full list of pods and nodes in the cluster, in order to post metrics for Container Insights.  It does this using a
Go client called the Reflector which performs API calls against the Kubernetes API server for each resource type.  The
Reflector works in two phases:
1. Perform an initial List call to receive the current set of resources (e.g., pods), at whatever version the API server
   happens to return.  The List call is paginated in case there are a large number of resources, so this phase might
   entail several API calls.
2. Thereafter, perform long-lived Watch calls to receive updates from the server whenever the set of resources changes,
   e.g. if a new pod is launched or one is deleted.

More information about the behavior of API calls here: https://kubernetes.io/docs/reference/using-api/api-concepts/

The K8S API server can serve List calls either from its cache or from etcd, its underlying data store, depending on the
consistency of results requested.  In the specific scenario where the request is paginated but resourceVersion is set to
0, the API server will serve from cache but ignore the pagination parameter, and thus return all resources in one huge
response.  For a customer with a large number of resources, the large response was causing the agent to exceed its
memory limit and restart, thus starting the List phase again on a new pod which would do the same expensive List API
call over again.  This would repeat until one pod managed to process the response.  In the meantime, the expensive calls
would drive up the CPU load on the API server nodes and starve out other requests.

This change forces the Reflector to set resourceVersion to empty instead of 0.  This causes the API server to send the
call to etcd instead of serving from cache, which respects pagination.  It does introduce more load on etcd, which the
Reflector was explicitly trying to avoid, but these calls should be infrequent - once the initial List call succeeds,
the Reflector will Watch until the pod it's running on is killed.

# Description of the issue
_Describe the problem or feature in addition to a link to the issues._

# Description of changes
_How does this change address the problem?_

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._




