### PR TITLE
fix: ca_bundle is not being used when calling cloudwatch sync from on…

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -6,7 +6,6 @@ package cloudwatch
 import (
 	"log"
 	"math"
-	"net/http"
 	"reflect"
 	"runtime"
 	"sort"
@@ -141,7 +140,6 @@ func (c *CloudWatch) Connect() error {
 		configProvider,
 		&aws.Config{
 			Endpoint:   aws.String(c.EndpointOverride),
-			HTTPClient: &http.Client{Timeout: 1 * time.Minute},
 			Retryer:    logThrottleRetryer,
 		})
 

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -6,7 +6,6 @@ package cloudwatchlogs
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -115,7 +114,6 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 		credentialConfig.Credentials(),
 		&aws.Config{
 			Endpoint:   aws.String(c.EndpointOverride),
-			HTTPClient: &http.Client{Timeout: 1 * time.Minute},
 			Retryer:    logThrottleRetryer,
 		},
 	)


### PR DESCRIPTION
… prem

# Description of the issue
CA bundle is being removed when calling metrics

# Description of changes
Use CA bundle when pushing metrics

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
This was tested by @haojhcwa by using a snake oil pem. 



