### PR TITLE
Add support for an includePattern to filter log lines exported to CloudWatch

### DIFF
--- a/plugins/inputs/logfile/fileconfig.go
+++ b/plugins/inputs/logfile/fileconfig.go
@@ -28,6 +28,8 @@ type FileConfig struct {
 	FilePath string `toml:"file_path"`
 	//The blacklist used to filter out some files
 	Blacklist string `toml:"blacklist"`
+	//The include pattern to be used to filter log file lines
+	IncludePattern string `toml:"include_pattern"`
 
 	PublishMultiLogs bool `toml:"publish_multi_logs"`
 
@@ -72,6 +74,9 @@ type FileConfig struct {
 
 	//Suffix to be added to truncated logline to indicate its truncation
 	TruncateSuffix string `toml:"truncate_suffix"`
+
+	//Regexp go type includePattern regex
+	IncludePatternP *regexp.Regexp `toml:"include_pattern"`
 
 	//Time *time.Location Go type timezone info.
 	TimezoneLoc *time.Location
@@ -122,6 +127,12 @@ func (config *FileConfig) init() error {
 	} else {
 		if config.MultiLineStartPatternP, err = regexp.Compile(config.MultiLineStartPattern); err != nil {
 			return fmt.Errorf("multi_line_start_pattern has issue, regexp: Compile( %v ): %v", config.MultiLineStartPattern, err.Error())
+		}
+	}
+
+	if config.IncludePattern != "" {
+		if config.IncludePatternP, err = regexp.Compile(config.IncludePattern); err != nil {
+			return fmt.Errorf("include pattern regex has issue, regexp: Compile( %v ): %v", config.IncludePattern, err.Error())
 		}
 	}
 

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -237,6 +237,7 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 				fileconfig.Enc,
 				fileconfig.MaxEventSize,
 				fileconfig.TruncateSuffix,
+				fileconfig.IncludePatternP,
 			)
 
 			src.AddCleanUpFn(func(ts *tailerSrc) func() {

--- a/tool/data/config/logs.go
+++ b/tool/data/config/logs.go
@@ -33,12 +33,12 @@ func (config *Logs) ToMap(ctx *runtime.Context) (string, map[string]interface{})
 	return "logs", resultMap
 }
 
-func (config *Logs) AddLogFile(filePath, logGroupName string, logStream, timestampFormat, timezone, multiLineStartPattern, encoding string) {
+func (config *Logs) AddLogFile(filePath, logGroupName string, logStream, timestampFormat, timezone, multiLineStartPattern, encoding string, includePattern string) {
 	if config.LogsCollect == nil {
 		config.LogsCollect = &logs.Collection{}
 	}
 
-	config.LogsCollect.AddLogFile(filePath, logGroupName, logStream, timestampFormat, timezone, multiLineStartPattern, encoding)
+	config.LogsCollect.AddLogFile(filePath, logGroupName, logStream, timestampFormat, timezone, multiLineStartPattern, encoding, includePattern)
 }
 
 func (config *Logs) AddWindowsEvent(eventName, logGroupName, logStream, eventFormat string, eventLevels []string) {

--- a/tool/data/config/logs/collection.go
+++ b/tool/data/config/logs/collection.go
@@ -37,9 +37,9 @@ func (config *Collection) AddWindowsEvent(eventName, logGroupName, logStreamName
 	config.WinEvents.AddWindowsEvent(eventName, logGroupName, logStreamName, eventFormat, eventLevels)
 }
 
-func (config *Collection) AddLogFile(filePath, logGroupName, logStreamName string, timestampFormat, timezone, multiLineStartPattern, encoding string) {
+func (config *Collection) AddLogFile(filePath, logGroupName, logStreamName string, timestampFormat, timezone, multiLineStartPattern, encoding string, includePattern string) {
 	if config.Files == nil {
 		config.Files = &Files{}
 	}
-	config.Files.AddLogFile(filePath, logGroupName, logStreamName, timestampFormat, timezone, multiLineStartPattern, encoding)
+	config.Files.AddLogFile(filePath, logGroupName, logStreamName, timestampFormat, timezone, multiLineStartPattern, encoding, includePattern)
 }

--- a/tool/data/config/logs/config.go
+++ b/tool/data/config/logs/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Timezone              string `timezone`
 	MultiLineStartPattern string `multi_line_start_pattern`
 	Encoding              string `encoding`
+	IncludePattern        string `include_pattern`
 }
 
 func (config *Config) ToMap(ctx *runtime.Context) (string, map[string]interface{}) {
@@ -33,6 +34,9 @@ func (config *Config) ToMap(ctx *runtime.Context) (string, map[string]interface{
 	}
 	if config.Encoding != "" {
 		resultMap["encoding"] = config.Encoding
+	}
+	if config.IncludePattern != "" {
+		resultMap["include_pattern"] = config.IncludePattern
 	}
 	return "", resultMap
 }

--- a/tool/data/config/logs/files.go
+++ b/tool/data/config/logs/files.go
@@ -24,7 +24,7 @@ func (config *Files) ToMap(ctx *runtime.Context) (string, map[string]interface{}
 	return "files", resultMap
 }
 
-func (config *Files) AddLogFile(filePath, logGroupName, logStreamName string, timestampFormat, timezone, multiLineStartPattern, encoding string) {
+func (config *Files) AddLogFile(filePath, logGroupName, logStreamName string, timestampFormat, timezone, multiLineStartPattern, encoding string, includePattern string) {
 	if config.FileConfigs == nil {
 		config.FileConfigs = []*Config{}
 	}
@@ -46,6 +46,9 @@ func (config *Files) AddLogFile(filePath, logGroupName, logStreamName string, ti
 	}
 	if encoding != "" {
 		singleFile.Encoding = encoding
+	}
+	if includePattern != "" {
+		singleFile.IncludePattern = includePattern
 	}
 	config.FileConfigs = append(config.FileConfigs, singleFile)
 }

--- a/tool/data/config/logs/files_test.go
+++ b/tool/data/config/logs/files_test.go
@@ -4,16 +4,17 @@
 package logs
 
 import (
+	"testing"
+
 	"github.com/aws/amazon-cloudwatch-agent/tool/runtime"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestFiles_ToMap(t *testing.T) {
 	conf := new(Files)
 
-	conf.AddLogFile("/var/log", "lg1", "ls1", "timeStamp1", "utc", "p1", "utf-8")
-	conf.AddLogFile("/var/message", "lg2", "ls2", "timeStamp2", "pst", "p2", "")
+	conf.AddLogFile("/var/log", "lg1", "ls1", "timeStamp1", "utc", "p1", "utf-8", ".*")
+	conf.AddLogFile("/var/message", "lg2", "ls2", "timeStamp2", "pst", "p2", "", "")
 
 	expectedKey := "files"
 	expectedVal := map[string]interface{}{
@@ -26,6 +27,7 @@ func TestFiles_ToMap(t *testing.T) {
 				"timestamp_format":         "timeStamp1",
 				"timezone":                 "utc",
 				"encoding":                 "utf-8",
+				"include_pattern":          ".*",
 			},
 			{
 				"multi_line_start_pattern": "p2",

--- a/tool/data/config/logs_test.go
+++ b/tool/data/config/logs_test.go
@@ -30,14 +30,16 @@ func TestLogs_ToMap(t *testing.T) {
 						"timestamp_format":         "%H:%M:%S %y %b %d",
 						"timezone":                 "UTC",
 						"multi_line_start_pattern": "{timestamp_format}",
-						"log_stream_name":          "{hostname}"},
+						"log_stream_name":          "{hostname}",
+						"encoding":                 "utf-8",
+						"include_pattern":          ".*"},
 				},
 			},
 		},
 	}
 	conf := new(Logs)
-	conf.AddLogFile("file1", "log_group_1", "{hostname}", "%H:%M:%S %y %b %d", "UTC", "{timestamp_format}", "")
-	conf.AddLogFile("file2", "log_group_2", "{hostname}", "%H:%M:%S %y %b %d", "UTC", "{timestamp_format}", "")
+	conf.AddLogFile("file1", "log_group_1", "{hostname}", "%H:%M:%S %y %b %d", "UTC", "{timestamp_format}", "", "")
+	conf.AddLogFile("file2", "log_group_2", "{hostname}", "%H:%M:%S %y %b %d", "UTC", "{timestamp_format}", "utf-8", ".*")
 	ctx := &runtime.Context{}
 	key, value := conf.ToMap(ctx)
 	assert.Equal(t, expectedKey, key)

--- a/tool/processors/migration/linux/knownConfigKeys.go
+++ b/tool/processors/migration/linux/knownConfigKeys.go
@@ -81,5 +81,6 @@ func addLogConfig(logsConfig *config.Logs, filePath, section string, p *configpa
 			}
 		}
 	}
-	logsConfig.AddLogFile(logFilePath, logGroupName, logStreamName, timestampFormat, timezone, multiLineStartPattern, encoding)
+	includePattern, _ := p.Get(section, "include_pattern")
+	logsConfig.AddLogFile(logFilePath, logGroupName, logStreamName, timestampFormat, timezone, multiLineStartPattern, encoding, includePattern)
 }

--- a/tool/processors/question/logs/logs.go
+++ b/tool/processors/question/logs/logs.go
@@ -4,14 +4,15 @@
 package logs
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/aws/amazon-cloudwatch-agent/tool/data"
 	"github.com/aws/amazon-cloudwatch-agent/tool/processors"
 	"github.com/aws/amazon-cloudwatch-agent/tool/processors/question/events"
 	"github.com/aws/amazon-cloudwatch-agent/tool/processors/serialization"
 	"github.com/aws/amazon-cloudwatch-agent/tool/runtime"
 	"github.com/aws/amazon-cloudwatch-agent/tool/util"
-	"path/filepath"
-	"strings"
 )
 
 var Processor processors.Processor = &processor{}
@@ -51,7 +52,7 @@ func monitorLogs(ctx *runtime.Context, config *data.Config) {
 			logStreamNameHint = "{hostname}"
 		}
 		logStreamName := util.AskWithDefault("Log stream name:", logStreamNameHint)
-		logsConf.AddLogFile(logFilePath, logGroupName, logStreamName, "", "", "", "")
+		logsConf.AddLogFile(logFilePath, logGroupName, logStreamName, "", "", "", "", "")
 		yes = util.Yes("Do you want to specify any additional log files to monitor?")
 		if !yes {
 			return


### PR DESCRIPTION
# Description of the issue

As discussed in #257 all log lines in a log file are exported to CloudWatch logs. Since log ingest can get expensive it can be useful to filter the log lines that are exported to CloudWatch

# Description of changes

This PR introduces an _include pattern_ that is used to filter the logs. Only lines that match the supplied regular expression are exported to CloudWatch. I have not included any support for an _exclude pattern_ though that could be added using the same implementation pattern without too much trouble.

I _think_ I have updated all of the places I need to to get this to work but please point out anything that I have missed. I couldn't find any documentation that needed updating but I am happy to contribute any docs that are required if you let me know where to look.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

* Tests have been added for the `tailersrc` changes that check that the include pattern is used correctly.
* There are smaller changes to some other test files.




