### PR TITLE
Fixed windows event log plugin to use proper StateFile path.

### DIFF
--- a/plugins/inputs/windows_event_log/windows_event_log.go
+++ b/plugins/inputs/windows_event_log/windows_event_log.go
@@ -6,9 +6,10 @@
 package windows_event_log
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
-
 	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/logscommon"
@@ -33,9 +34,10 @@ type EventConfig struct {
 }
 
 type Plugin struct {
-	FileStateFolder string        `toml:"file_state_folder"`
-	Events          []EventConfig `toml:"event_config"`
-	Destination     string        `toml:"destination"`
+	FileStateFolder string          `toml:"file_state_folder"`
+	Events          []EventConfig   `toml:"event_config"`
+	Destination     string          `toml:"destination"`
+	Log             telegraf.Logger `toml:"-"`
 
 	newEvents []logs.LogSrc
 }
@@ -73,7 +75,12 @@ func (s *Plugin) FindLogSrc() []logs.LogSrc {
  */
 func (s *Plugin) Start(acc telegraf.Accumulator) error {
 	for _, eventConfig := range s.Events {
-		stateFilePath := logscommon.WindowsEventLogPrefix + escapeFilePath(eventConfig.LogGroupName)
+		// Assume no 2 EventConfigs have the same combination of:
+		// LogGroupName, LogStreamName, Name.
+		stateFilePath, err := getStateFilePath(s, &eventConfig)
+		if err != nil {
+			return err
+		}
 		destination := eventConfig.Destination
 		if destination == "" {
 			destination = s.Destination
@@ -88,7 +95,7 @@ func (s *Plugin) Start(acc telegraf.Accumulator) error {
 			stateFilePath,
 			eventConfig.BatchReadSize,
 		)
-		err := eventLog.Init()
+		err = eventLog.Init()
 		if err != nil {
 			return err
 		}
@@ -97,7 +104,22 @@ func (s *Plugin) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func escapeFilePath(filePath string) string {
+// getStateFilePath returns a unique file pathname for a given EventConfig.
+func getStateFilePath(plugin *Plugin, ec *EventConfig) (string, error) {
+	if plugin.FileStateFolder == "" {
+		return "", errors.New("empty FileStateFolder")
+	}
+	err := os.MkdirAll(plugin.FileStateFolder, 0755)
+	if err != nil {
+		return "", err
+	}
+	stateFileName := logscommon.WindowsEventLogPrefix +
+		escapeFileName(ec.LogGroupName+"_"+ec.LogStreamName+"_"+ec.Name)
+	return filepath.Join(plugin.FileStateFolder, stateFileName), nil
+}
+
+// escapeFileName returns a valid filename string.
+func escapeFileName(filePath string) string {
 	escapedFilePath := filepath.ToSlash(filePath)
 	escapedFilePath = strings.Replace(escapedFilePath, "/", "_", -1)
 	escapedFilePath = strings.Replace(escapedFilePath, " ", "_", -1)

--- a/plugins/inputs/windows_event_log/windows_event_log_test.go
+++ b/plugins/inputs/windows_event_log/windows_event_log_test.go
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// +build windows
+
+package windows_event_log
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetStateFilePathGood tests getStateFilePath with good input.
+func TestGetStateFilePathGood(t *testing.T) {
+	fileStateFolder := filepath.Join(os.TempDir(), "CloudWatchAgentTest")
+	// cleanup
+	defer os.RemoveAll(fileStateFolder)
+	plugin := Plugin{
+		FileStateFolder: fileStateFolder,
+	}
+	ec := EventConfig{
+		LogGroupName:  "MyGroup",
+		LogStreamName: "MyStream",
+		Name:          "SystemEventLog",
+	}
+	pathname, err := getStateFilePath(&plugin, &ec)
+	fmt.Println(pathname)
+	if err != nil {
+		t.Errorf("expected nil, actual %v", err)
+	}
+	expected := filepath.Join(fileStateFolder,
+		"Amazon_CloudWatch_WindowsEventLog_MyGroup_MyStream_SystemEventLog")
+	if pathname != expected {
+		t.Errorf("expected %s, actual %s", expected, pathname)
+	}
+	if _, err := os.Stat(fileStateFolder); os.IsNotExist(err) {
+		t.Errorf("expected %s, to exist", fileStateFolder)
+	}
+}
+
+// TestGetStateFilePathEscape tests getStateFilePath() with special characters.
+func TestGetStateFilePathEscape(t *testing.T) {
+	fileStateFolder := filepath.Join(os.TempDir(), "CloudWatchAgentTest")
+	// cleanup
+	defer os.RemoveAll(fileStateFolder)
+	plugin := Plugin{
+		FileStateFolder: fileStateFolder,
+	}
+	ec := EventConfig{
+		LogGroupName:  "My  Group/:::",
+		LogStreamName: "My::Stream//  ",
+		Name:          "System  Event//Log::",
+	}
+	pathname, err := getStateFilePath(&plugin, &ec)
+	fmt.Println(pathname)
+	if err != nil {
+		t.Errorf("expected nil, actual %v", err)
+	}
+	expected := filepath.Join(fileStateFolder,
+		"Amazon_CloudWatch_WindowsEventLog_My__Group_____My__Stream_____System__Event__Log__")
+	if pathname != expected {
+		t.Errorf("expected %s, actual %s", expected, pathname)
+	}
+}
+
+// TestGetStateFilePathEmpty tests getStateFilePath() with empty folder.
+func TestGetStateFilePathEmpty(t *testing.T) {
+	fileStateFolder := ""
+	plugin := Plugin{
+		FileStateFolder: fileStateFolder,
+	}
+	ec := EventConfig{
+		LogGroupName:  "MyGroup",
+		LogStreamName: "MyStream",
+		Name:          "SystemEventLog",
+	}
+	pathname, err := getStateFilePath(&plugin, &ec)
+	fmt.Println(pathname)
+	if err == nil {
+		t.Errorf("expected non-nil")
+	}
+}
+
+// TestGetStateFilePathSpecialChars tests getStateFilePath() with bad folder.
+func TestGetStateFilePathSpecialChars(t *testing.T) {
+	fileStateFolder := "F:\\\\bin!@#$%^&*)(\\CloudWatchAgentTest"
+	// cleanup
+	plugin := Plugin{
+		FileStateFolder: fileStateFolder,
+	}
+	ec := EventConfig{
+		LogGroupName:  "MyGroup",
+		LogStreamName: "MyStream",
+		Name:          "SystemEventLog",
+	}
+	pathname, err := getStateFilePath(&plugin, &ec)
+	fmt.Println(pathname)
+	if err == nil {
+		t.Errorf("expected non-nil")
+	}
+}


### PR DESCRIPTION
Also changed the filename to be more unique and allow LogGroup to be used more than once.

# Description of the issue
https://github.com/aws/amazon-cloudwatch-agent/issues/266
Currently cannot monitor the Windows "Application" and "System" event logs using the same "LogGroup" value.

# Description of changes
"StateFile" name is now a combination of the "event_config"'s values for "event_name", "log_group_name", and "log_stream_name".

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manual testing.
Before change:
```
2021-09-24T16:09:16Z I! [windows_event_log] The state file for Amazon_CloudWatch_WindowsEventLog_Application does not exist: CreateFile Amazon_CloudWatch_WindowsEventLog_Application: The system cannot find the file specified.
2021-09-24T16:09:16Z I! [processors.ec2tagger] ec2tagger: Initial retrieval of tags succeded
```
This was creating the statefile in `C:\windows\system32\`
As seen in this image:
![cwa_statefile_before](https://user-images.githubusercontent.com/90734270/134724651-79281b06-badc-4076-8a39-631daec20473.png)

After change:
```
2021-09-24T18:03:03Z I! [windows_event_log] The state file for C:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\state\Amazon_CloudWatch_WindowsEventLog_Systemi-068404f568da63dc8System does not exist: CreateFile C:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\state\Amazon_CloudWatch_WindowsEventLog_Systemi-068404f568da63dc8System: The system cannot find the file specified.
2021-09-24T18:03:03Z I! [windows_event_log] The state file for C:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\state\Amazon_CloudWatch_WindowsEventLog_Applicationi-068404f568da63dc8Application does not exist: CreateFile C:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\state\Amazon_CloudWatch_WindowsEventLog_Applicationi-068404f568da63dc8Application: The system cannot find the file specified.
2021-09-24T18:03:03Z I! [processors.ec2tagger] ec2tagger: Initial retrieval of tags succeded
```
This is creating the statefile in the proper location:

![cwa_statefile_after](https://user-images.githubusercontent.com/90734270/134725135-bbca88fc-d693-42de-8993-8d6786be4e04.png)


