### PR TITLE
Chore/collectd install prompt

### DIFF
--- a/tool/processors/collectd/collectd.go
+++ b/tool/processors/collectd/collectd.go
@@ -21,7 +21,7 @@ func (p *processor) Process(ctx *runtime.Context, config *data.Config) {
 	if ctx.OsParameter == util.OsTypeWindows {
 		return
 	}
-	yes := util.Yes("Do you want to monitor metrics from CollectD? Note that enabling this requires the collectd software to be installed on your server")
+	yes := util.Yes("Do you want to monitor metrics from CollectD? Note that depending on the system, some require the CollectD software to be installed on your server (e.g. Amazon Linux 2) or the /usr/share/collectd/types.db file to be created.")
 	if yes {
 		collection := config.MetricsConf().Collection()
 		collection.CollectD = new(collectd.CollectD)

--- a/tool/processors/collectd/collectd.go
+++ b/tool/processors/collectd/collectd.go
@@ -21,7 +21,7 @@ func (p *processor) Process(ctx *runtime.Context, config *data.Config) {
 	if ctx.OsParameter == util.OsTypeWindows {
 		return
 	}
-	yes := util.Yes("Do you want to monitor metrics from CollectD?")
+	yes := util.Yes("Do you want to monitor metrics from CollectD? Note that enabling this requires the collectd software to be installed on your server")
 	if yes {
 		collection := config.MetricsConf().Collection()
 		collection.CollectD = new(collectd.CollectD)


### PR DESCRIPTION
# Description of the issue

#274 

Following the wizard, there is a prompt to `monitor metrics from CollectD`. If this is enabled, there will be errors downstream when configuring the agent with the created JSON template.

The error:`Error running agent: Error parsing /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml, open /usr/share/collectd/types.db: no such file or directory`

This is error is also mentioned in an [issue](https://github.com/awsdocs/amazon-cloudwatch-user-guide/issues/54) in the [amazon-cloudwatch-user-guide](https://github.com/awsdocs/amazon-cloudwatch-user-guide).

The cause of this is because some systems don't have CollectD installed as explained in [AWS documentation for retrieving custom metrics with collectd](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-collectd.html)

# Description of changes

Add a **note** in the wizard when users are prompted to enable CollectD from the wizard. This note informs users that they need to have CollectD installed (I tested this fix on Amazon Linux 2) or have the `/usr/share/collectd/types.db file` file created (I tested this fix on RHEL8). Credit to these fixes can be found in the [issue](https://github.com/awsdocs/amazon-cloudwatch-user-guide/issues/54) in the [amazon-cloudwatch-user-guide](https://github.com/awsdocs/amazon-cloudwatch-user-guide).


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

## Amazon Linux 2

1. Install CollectD:
    ```
    sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
    sudo yum install -y collectd
    ```
2. Assuming the configuration is stored in SSM parameters as mentioned in the associated issue, use the Systems Manager `Run Command`
    - Command document: `AmazonCloudWatch-ManageAgent`
    - Configure the location to the SSM parameter store with the JSON config from point 2
    - Run the command
3. This fixes the issue
    ![image](https://user-images.githubusercontent.com/31919569/135197453-998a22a9-1345-4b8f-8406-b7e3b42b89d3.png)

## RHEL8

1. I encountered some issues with CollectD install and went for the solution to create the `/usr/share/collectd/types.db file` file. Run the following:
    ```bash
    mkdir -p /usr/share/collectd/
    touch /usr/share/collectd/types.db
    ```
2. Assuming the configuration is stored in SSM parameters as mentioned in the associated issue, use the Systems Manager `Run Command`
    - Command document: `AmazonCloudWatch-ManageAgent`
    - Configure the location to the SSM parameter store with the JSON config from point 2
    - Run the command
3. This fixes the issue
    ![image](https://user-images.githubusercontent.com/31919569/135197628-aaffe48b-020d-4f4f-a422-2abf19cc9e91.png)



