### PR TITLE
Fix request drop on max retries

### DIFF
--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -287,6 +287,7 @@ func (p *pusher) send() {
 		wait := retryWait(retryCount)
 		if time.Since(startTime)+wait > p.RetryDuration {
 			p.Log.Errorf("All %v retries to %v/%v failed for PutLogEvents, request dropped.", retryCount, p.Group, p.Stream)
+			p.reset()
 			return
 		}
 

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -287,6 +287,7 @@ func (p *pusher) send() {
 		wait := retryWait(retryCount)
 		if time.Since(startTime)+wait > p.RetryDuration {
 			p.Log.Errorf("All %v retries to %v/%v failed for PutLogEvents, request dropped.", retryCount, p.Group, p.Stream)
+			return
 		}
 
 		p.Log.Warnf("Retried %v time, going to sleep %v before retrying.", retryCount, wait)

--- a/plugins/outputs/cloudwatchlogs/pusher_test.go
+++ b/plugins/outputs/cloudwatchlogs/pusher_test.go
@@ -672,3 +672,31 @@ func TestAddEventNonBlocking(t *testing.T) {
 	}
 	p.Stop()
 }
+
+func TestResendWouldStopAfterExhaustedRetries(t *testing.T) {
+	var s svcMock
+
+	cnt := 0
+	s.ple = func(in *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		cnt++
+		return nil, &cloudwatchlogs.ServiceUnavailableException{}
+	}
+
+	var logbuf bytes.Buffer
+	log.SetOutput(io.MultiWriter(&logbuf, os.Stdout))
+
+	p := NewPusher(Target{"G", "S"}, &s, 10*time.Millisecond, time.Second, models.NewLogger("cloudwatchlogs", "test", ""))
+	p.AddEvent(evtMock{"msg", time.Now(), nil})
+	time.Sleep(2 * time.Second)
+
+	loglines := strings.Split(strings.TrimSpace(logbuf.String()), "\n")
+	lastline := loglines[len(loglines)-1]
+	expected := fmt.Sprintf("All %v retries to G/S failed for PutLogEvents, request dropped.", cnt-1)
+	if !strings.HasSuffix(lastline, expected) {
+		t.Errorf("Expecting error log to end with request dropped, but received '%s' in the log", logbuf.String())
+	}
+	log.SetOutput(os.Stderr)
+
+	p.Stop()
+	time.Sleep(10 * time.Millisecond)
+}


### PR DESCRIPTION
# Description of the issue
Currently, the pusher resend will not exit the loop even after the maximum allowable time for retries has been reached.

# Description of changes
Added resetting and returning after the logging the error to drop the request.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added a unit test.


