### PR TITLE
Removed runc dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/influxdata/wlog v0.0.0-20160411224016-7c63b0a71ef8
 	github.com/kardianos/service v1.0.0
 	github.com/oklog/run v1.1.0
-	github.com/opencontainers/runc v1.0.0-rc10
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
@@ -64,8 +63,8 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
-	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
-	golang.org/x/text v0.3.2
+	golang.org/x/sys v0.0.0-20200316230553-a7d97aace0b0
+	golang.org/x/text v0.3.3
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7

--- a/go.sum
+++ b/go.sum
@@ -1235,6 +1235,8 @@ golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200316230553-a7d97aace0b0 h1:4Khi5GeNOkZS5DqSBRn4Sy7BE6GuxwOqARPqfurkdNk=
+golang.org/x/sys v0.0.0-20200316230553-a7d97aace0b0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1242,6 +1244,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -139,8 +139,8 @@ func (c *CloudWatch) Connect() error {
 	svc := cloudwatch.New(
 		configProvider,
 		&aws.Config{
-			Endpoint:   aws.String(c.EndpointOverride),
-			Retryer:    logThrottleRetryer,
+			Endpoint: aws.String(c.EndpointOverride),
+			Retryer:  logThrottleRetryer,
 		})
 
 	svc.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{opPutLogEvents, opPutMetricData}))

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -113,8 +113,8 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 	client := cloudwatchlogs.New(
 		credentialConfig.Credentials(),
 		&aws.Config{
-			Endpoint:   aws.String(c.EndpointOverride),
-			Retryer:    logThrottleRetryer,
+			Endpoint: aws.String(c.EndpointOverride),
+			Retryer:  logThrottleRetryer,
 		},
 	)
 	client.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{"PutLogEvents"}))

--- a/translator/cmdutil/set_uid_gid.go
+++ b/translator/cmdutil/set_uid_gid.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// +build linux
+// +build go1.16
+
+package cmdutil
+
+import "syscall"
+
+// go1.16 and later: use Setgid/Setuid implemented in go syscall (https://golang.org/doc/go1.16#syscall).
+
+func setUid(uid int) (err error) {
+	return syscall.Setuid(uid)
+}
+
+func setGid(gid int) (err error) {
+	return syscall.Setgid(gid)
+}

--- a/translator/cmdutil/set_uid_gid_1_15_x32.go
+++ b/translator/cmdutil/set_uid_gid_1_15_x32.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// +build linux
+// +build 386 arm
+// +build !go1.16
+
+package cmdutil
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// go1.15 and before: use unix raw syscall. Can be removed once minimum go version has been bumped.
+
+func setUid(uid int) (err error) {
+	_, _, e1 := unix.RawSyscall(unix.SYS_SETUID32, uintptr(uid), 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func setGid(gid int) (err error) {
+	_, _, e1 := unix.RawSyscall(unix.SYS_SETGID32, uintptr(gid), 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}

--- a/translator/cmdutil/set_uid_gid_1_15_x64.go
+++ b/translator/cmdutil/set_uid_gid_1_15_x64.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// +build linux
+// +build arm64 amd64 mips mipsle mips64 mips64le ppc ppc64 ppc64le riscv64 s390x
+// +build !go1.16
+
+package cmdutil
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// go1.15 and before: use unix raw syscall. Can be removed once minimum go version has been bumped.
+
+func setUid(uid int) (err error) {
+	_, _, e1 := unix.RawSyscall(unix.SYS_SETUID, uintptr(uid), 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func setGid(gid int) (err error) {
+	_, _, e1 := unix.RawSyscall(unix.SYS_SETUID, uintptr(gid), 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}

--- a/translator/cmdutil/userutil_linux_test.go
+++ b/translator/cmdutil/userutil_linux_test.go
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// +build linux
+
+package cmdutil
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestGetGroupIds(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "group-file-test")
+	require.Nil(t, err, "Failed to create temp file")
+
+	defer os.Remove(tmpfile.Name())
+	fmt.Fprintln(tmpfile, "root:x:0:")
+	fmt.Fprintln(tmpfile, "bin:x:1:")
+	fmt.Fprintln(tmpfile, "adm:x:4:root,other,test-user")
+	fmt.Fprintln(tmpfile, "wheel:x:10:test-user")
+	fmt.Fprintln(tmpfile, "tst:x:50:root,test-user,test")
+	fmt.Fprintln(tmpfile, "test:x:100:other,test-user-2")
+
+	gids, err := getGroupIds("test-user", tmpfile.Name())
+	require.Nil(t, err, "Failed to retrieve group IDs for user: test-user")
+	assert.Equal(t, []int{4, 10, 50}, gids)
+	gids, err = getGroupIds("not-in-file", tmpfile.Name())
+	require.Nil(t, err, "Failed to retrieve group IDs for user: not-in-file")
+	assert.Len(t, gids, 0)
+}


### PR DESCRIPTION
# Description of the issue
The agent has a dependency on `github.com/opencontainers/runc v1.0.0-rc10`, which requires an upgrade. While the version could be bumped up to `v1.0.0-rc95`, that would affect the dependency on `github.com/google/cadvisor v0.36.0`, which depends on `v1.0.0-rc10`. Without updating the cadvisor dependency, which would require more evaluation and incremental changes, the next best step would be to remove the local dependency.

See https://github.com/aws/amazon-cloudwatch-agent/pull/254 for more details.

# Description of changes
Removed dependency on runc in userutil_linux.

Replaced with golang os/user lookup and version/arch specific setUid/setGid.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested on EC2 linux instance. Added unit test for `getGroupIds`.




