### PR TITLE
use json comparison for windows migration tests

### DIFF
--- a/tool/processors/migration/windows/windows_migration_core_test.go
+++ b/tool/processors/migration/windows/windows_migration_core_test.go
@@ -4,7 +4,9 @@
 package windows
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,19 +37,22 @@ func TestMapOldWindowsConfigToNewConfig(t *testing.T) {
 
 			// Get actual output
 			newConfig := MapOldWindowsConfigToNewConfig(oldConfig)
-
+			confBytes, err := json.Marshal(newConfig)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			actualJson := string(confBytes)
 			// Get the expected
 			absPath, _ = filepath.Abs(tc.outputFile)
-			expectedConfig, err := ReadNewConfigFromPath(absPath)
+			expectedJson, err := ReadConfigFromPathAsString(absPath)
 			if err != nil {
 				t.Error(err)
 				return
 			}
 
-			// Assert
-			if !AreTwoConfigurationsEqual(newConfig, expectedConfig) {
-				t.Errorf("The generated new config is incorrect, got:\n %v\n, want:\n %v.\n", newConfig, expectedConfig)
-			}
+			// strict compare JSON strings
+			assert.JSONEq(t, expectedJson, actualJson)
 		})
 	}
 }

--- a/tool/processors/migration/windows/windows_util.go
+++ b/tool/processors/migration/windows/windows_util.go
@@ -42,3 +42,12 @@ func ReadOldConfigFromPath(path string) (config OldSsmCwConfig, err error) {
 	fmt.Println(err)
 	return config, errors.New("failed to parse the expected config")
 }
+
+func ReadConfigFromPathAsString(path string) (str string, err error) {
+	var file []byte
+	if file, err = ioutil.ReadFile(path); err == nil {
+		return string(file), nil
+	}
+	fmt.Println(err)
+	return str, errors.New("failed to parse the expected config")
+}


### PR DESCRIPTION
Closes #285 

# Description of the issue
#285 describes how the test json included an empty `files` object when there shouldn't be one. This was observed in #283. 
Debugging the issue showed that because the struct included the files object, even though the JSON blob itself did not contain it, when unmarshalling in Go, the files key was included in the test struct, which still passed assertions because both the input and output had an empty files object.

# Description of changes
Changed the testing logic for the `windows_migration_core_test.go` that specifically target the matrix of input and output files to perform JSON string assertions instead of unmarshalling the JSON files as typed Go structs and comparing those, to avoid injecting an unintended, empty files object into the interface.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added logs to print out the resulting JSON strings, and confirmed that `files` does not show up in the output when running the test suite. See my comment [here](https://github.com/aws/amazon-cloudwatch-agent/issues/285#issuecomment-943464393) for the output of my findings.



