### PR TITLE
add cache step to build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            cachepath: |
+              ~/.cache/go-build
+              ~/go/pkg/mod
+          - os: macos-latest
+            cachepath: |
+              ~/Library/Caches/go-build
+              ~/go/pkg/mod
+          - os: windows-latest
+            cachepath: |
+              %LocalAppData%\go-build
+              ~/go/pkg/mod
     steps:
 
     - name: Set up Go 1.x
@@ -37,6 +50,14 @@ jobs:
     - name: Debug go.mod
       run: cat go.mod
       working-directory: amazon-cloudwatch-agent
+
+    - name: Cache build output
+      uses: actions/cache@v2
+      with:
+        path: ${{ matrix.cachepath }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Build
       run: make test build


### PR DESCRIPTION
# Description of the issue
GitHub CI build times are long because we always have to download dependencies for each build, fresh.

# Description of changes
Uses the [cache](https://github.com/actions/cache/blob/main/examples.md#go---modules) action to cache build output from Go. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Pushed this to my fork and confirmed that (1), the new step ran, and (2) that the matrix picked the correct paths for the different OS types. See [my build](https://github.com/SaxyPandaBear/amazon-cloudwatch-agent/runs/4041624140?check_suite_focus=true).




