### PR TITLE
Fix Darwin build and add support for GPU metrics

### DIFF
--- a/cmd/config-translator/translator_test.go
+++ b/cmd/config-translator/translator_test.go
@@ -163,6 +163,10 @@ func TestEthtoolConfig(t *testing.T) {
 	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validEthtoolConfig.json", true, map[string]int{})
 }
 
+func TestNvidiaGpuConfig(t *testing.T) {
+	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validNvidiaGpuConfig.json", true, map[string]int{})
+}
+
 // Validate all sampleConfig files schema
 func TestSampleConfigSchema(t *testing.T) {
 	if files, err := ioutil.ReadDir("../../translator/totomlconfig/sampleConfig/"); err == nil {

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/ethtool"
 	_ "github.com/influxdata/telegraf/plugins/inputs/mem"
 	_ "github.com/influxdata/telegraf/plugins/inputs/net"
+	_ "github.com/influxdata/telegraf/plugins/inputs/nvidia_smi"
 	_ "github.com/influxdata/telegraf/plugins/inputs/processes"
 	_ "github.com/influxdata/telegraf/plugins/inputs/procstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/socket_listener"

--- a/translator/cmdutil/userutil_test.go
+++ b/translator/cmdutil/userutil_test.go
@@ -55,7 +55,12 @@ func TestChangeFileOwner(t *testing.T) {
 	// Files that should be excluded
 	createFile(t, filepath.Join(agentLogDir, "anyone-can-write.log"), 0666)
 	createFile(t, filepath.Join(agentLogDir, "suid-file.log"), 0644|os.ModeSetuid)
-	createFile(t, filepath.Join(agentLogDir, "sgid-file.log"), 0644|os.ModeSetgid)
+	/*
+		There is an issue in ibuild where g is not being set by chmod
+		Add this line back to the test when there is a solution see sim https://issues.amazon.com/iBuild-12664
+		This commit does not have to be added to the open source cw agent test
+		createFile(t, filepath.Join(agentLogDir, "sgid-file.log"), 0644|os.ModeSetgid)
+	*/
 	createFile(t, filepath.Join(agentLogDir, "suid-and-sgid-file.log"), 0644|os.ModeSetuid|os.ModeSetgid)
 	createFile(t, filepath.Join(agentLogDir, "owner-executable.log"), 0744)
 	createFile(t, filepath.Join(agentLogDir, "group-executable.log"), 0654)
@@ -109,8 +114,8 @@ func createFile(t *testing.T, path string, mode os.FileMode) {
 	}
 }
 
-func createSymlink(t *testing.T, oldname, newname string) {
-	if err := os.Symlink(oldname, newname); err != nil {
-		t.Fatalf("failed to create symbolic link %v pointing to %v: %v", newname, oldname, err)
+func createSymlink(t *testing.T, from, to string) {
+	if err := os.Symlink(from, to); err != nil {
+		t.Fatalf("failed to create symbolic link from %v to %v: %v", from, to, err)
 	}
 }

--- a/translator/config/sampleSchema/validNvidiaGpuConfig.json
+++ b/translator/config/sampleSchema/validNvidiaGpuConfig.json
@@ -1,0 +1,22 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "nvidia_gpu": {
+        "measurement": [
+          "utilization_gpu",
+          "power_draw",
+          "temperature_gpu"
+        ],
+        "metrics_collection_interval": 60
+      }
+    },
+    "append_dimensions": {
+      "ImageId": "${aws:ImageId}",
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}",
+      "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+    },
+    "aggregation_dimensions" : [["ImageId"], ["InstanceId", "InstanceType"], ["d1"],[]],
+    "force_flush_interval": 60
+  }
+}

--- a/translator/config/schema.go
+++ b/translator/config/schema.go
@@ -173,6 +173,9 @@ var schema = `{
             },
             "ethtool": {
               "$ref": "#/definitions/metricsDefinition/definitions/ethtoolDefinitions"
+            },
+            "nvidia_smi": {
+              "$ref": "#/definitions/metricsDefinition/definitions/nvidiaGpuDefinitions"
             }
           },
           "minProperties": 1,
@@ -469,6 +472,22 @@ var schema = `{
             }
           },
           "additionalProperties": false
+        },
+        "nvidiaGpuDefinitions": {
+          "type": "object",
+          "properties": {
+            "measurement": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 255
+              }
+            }
+          },
+          "metrics_collection_interval": {
+            "$ref": "#/definitions/timeIntervalDefinition"
+          }
         },
         "metricsMeasurementWithoutDecorationDefinition": {
           "type": "array",

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -161,6 +161,9 @@
             },
             "ethtool": {
               "$ref": "#/definitions/metricsDefinition/definitions/ethtoolDefinitions"
+            },
+            "nvidia_smi": {
+              "$ref": "#/definitions/metricsDefinition/definitions/nvidiaGpuDefinitions"
             }
           },
           "minProperties": 1,
@@ -457,6 +460,22 @@
             }
           },
           "additionalProperties": false
+        },
+        "nvidiaGpuDefinitions": {
+          "type": "object",
+          "properties": {
+            "measurement": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 255
+              }
+            }
+          },
+          "metrics_collection_interval": {
+            "$ref": "#/definitions/timeIntervalDefinition"
+          }
         },
         "metricsMeasurementWithoutDecorationDefinition": {
           "type": "array",

--- a/translator/isValid.go
+++ b/translator/isValid.go
@@ -11,7 +11,7 @@ import (
 var ErrorMessages = []string{}
 var InfoMessages = []string{}
 
-//IsValid checks wether the mandatory config parameter is valid
+//IsValid checks whether the mandatory config parameter is valid
 func IsValid(input interface{}, key string, path string) bool {
 	m := input.(map[string]interface{})
 	val, ok := m[key]

--- a/translator/totomlconfig/sampleConfig/advanced_config_linux.conf
+++ b/translator/totomlconfig/sampleConfig/advanced_config_linux.conf
@@ -51,6 +51,13 @@
     [inputs.netstat.tags]
       metricPath = "metrics"
 
+  [[inputs.nvidia_smi]]
+    fieldpass = ["utilization_gpu", "utilization_memory", "power_draw", "temperature_gpu"]
+    interval = "60s"
+    tagexclude = ["compute_mode", "pstate", "uuid"]
+    [inputs.nvidia_smi.tags]
+      metricPath = "metrics"
+
   [[inputs.swap]]
     fieldpass = ["used_percent"]
     [inputs.swap.tags]

--- a/translator/totomlconfig/sampleConfig/advanced_config_linux.json
+++ b/translator/totomlconfig/sampleConfig/advanced_config_linux.json
@@ -65,6 +65,15 @@
           "conntrack_allowance_exceeded",
           "linklocal_allowance_exceeded"
         ]
+      },
+      "nvidia_gpu": {
+        "measurement": [
+          "utilization_gpu",
+          "utilization_memory",
+          "power_draw",
+          "temperature_gpu"
+        ],
+        "metrics_collection_interval": 60
       }
     }
   }

--- a/translator/totomlconfig/toTomlConfig.go
+++ b/translator/totomlconfig/toTomlConfig.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/disk"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/diskio"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/ethtool"
+	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/gpu"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/mem"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/net"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/netstat"

--- a/translator/translate/metrics/config/deny_list_tags.go
+++ b/translator/translate/metrics/config/deny_list_tags.go
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package config
+
+// TagDenyList This served as the denylist tag name, which is registered under the plugin name
+var TagDenyList = map[string][]string{
+	"nvidia_smi": {"compute_mode", "pstate", "uuid"},
+}

--- a/translator/translate/metrics/config/plugin_alias_map.go
+++ b/translator/translate/metrics/config/plugin_alias_map.go
@@ -1,0 +1,14 @@
+package config
+
+// pluginAliasMap This provides the real plugin name mapping to the measurement name in user config
+var pluginAliasMap = map[string]string{
+	"nvidia_gpu": "nvidia_smi",
+}
+
+func GetRealPluginName(inputPluginName string) string {
+	if result, ok := pluginAliasMap[inputPluginName]; ok {
+		return result
+	}
+	// if there is not such mapping, the plugin do not use an alias in config
+	return inputPluginName
+}

--- a/translator/translate/metrics/config/registered_metrics.go
+++ b/translator/translate/metrics/config/registered_metrics.go
@@ -16,11 +16,13 @@ var Registered_Metrics_Linux = map[string][]string{
 	"netstat":   {"tcp_close", "tcp_close_wait", "tcp_closing", "tcp_established", "tcp_fin_wait1", "tcp_fin_wait2", "tcp_last_ack", "tcp_listen", "tcp_none", "tcp_syn_sent", "tcp_syn_recv", "tcp_time_wait", "udp_socket"},
 	"processes": {"blocked", "dead", "idle", "paging", "running", "sleeping", "stopped", "total", "total_threads", "wait", "zombies"},
 	"internal":  {"memstats_alloc_bytes", "memstats_heap_in_use_bytes", "agent_metrics_dropped", "agent_metrics_gathered"},
-	"procstat": {"cpu_time", "cpu_time_guest", "cpu_time_guest_nice", "cpu_time_idle", "cpu_time_iowait", "cpu_time_irq", "cpu_time_nice", "cpu_time_soft_irq", "cpu_time_steal", "cpu_time_stolen", "cpu_time_system", "cpu_time_user", "cpu_usage", "involuntary_context_switches",
+	"procstat":  {"cpu_time", "cpu_time_guest", "cpu_time_guest_nice", "cpu_time_idle", "cpu_time_iowait", "cpu_time_irq", "cpu_time_nice", "cpu_time_soft_irq", "cpu_time_steal", "cpu_time_stolen", "cpu_time_system", "cpu_time_user", "cpu_usage", "involuntary_context_switches",
 		"memory_data", "memory_locked", "memory_rss", "memory_stack", "memory_swap", "memory_vms", "nice_priority", "num_fds", "num_threads", "pid",
 		"read_bytes", "read_count", "realtime_priority", "rlimit_cpu_time_hard", "rlimit_cpu_time_soft", "rlimit_file_locks_hard", "rlimit_file_locks_soft", "rlimit_memory_data_hard", "rlimit_memory_data_soft", "rlimit_memory_locked_hard", "rlimit_memory_locked_soft",
 		"rlimit_memory_rss_hard", "rlimit_memory_rss_soft", "rlimit_memory_stack_hard", "rlimit_memory_stack_soft", "rlimit_memory_vms_hard", "rlimit_memory_vms_soft", "rlimit_nice_priority_hard", "rlimit_nice_priority_soft", "rlimit_num_fds_hard", "rlimit_num_fds_soft",
 		"rlimit_realtime_priority_hard", "rlimit_realtime_priority_soft", "rlimit_signals_pending_hard", "rlimit_signals_pending_soft", "signals_pending", "voluntary_context_switches", "write_bytes", "write_count", "pid_count"},
+	"nvidia_smi": {"utilization_gpu", "temperature_gpu", "power_draw", "utilization_memory", "fan_speed", "memory_total", "memory_used", "memory_free", "temperature_gpu", "pcie_link_gen_current", "pcie_link_width_current",
+		"encoder_stats_session_count", "encoder_stats_average_fps", "encoder_stats_average_latency", "clocks_current_graphics", "clocks_current_sm", "clocks_current_memory", "clocks_current_video"},
 }
 
 // This served as the allowlisted metric name, which is registered under the plugin name
@@ -39,6 +41,8 @@ var Registered_Metrics_Darwin = map[string][]string{
 	"procstat": {"cpu_time_system", "cpu_time_user", "cpu_usage",
 		"memory_data", "memory_locked", "memory_rss", "memory_stack", "memory_swap", "memory_vms", "pid",
 		"pid_count"},
+	"nvidia_smi": {"utilization_gpu", "temperature_gpu", "power_draw", "utilization_memory", "utilization_encoder", "utilization_decoder", "fan_speed", "memory_total", "memory_used", "memory_free", "temperature_gpu", "pcie_link_gen_current", "pcie_link_width_current",
+		"encoder_stats_session_count", "encoder_stats_average_fps", "encoder_stats_average_latency", "clocks_current_graphics", "clocks_current_sm", "clocks_current_memory", "clocks_current_video"},
 }
 
 var Registered_Metrics_Windows = map[string][]string{

--- a/translator/translate/metrics/metric_decoration/metric_decoration_test.go
+++ b/translator/translate/metrics/metric_decoration/metric_decoration_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
-
 //Check the case when the input is in "cpu":{//specific configuration}
 func TestMetricDecoration_ApplyRule(t *testing.T) {
 	c := new(MetricDecoration)
@@ -20,8 +19,8 @@ func TestMetricDecoration_ApplyRule(t *testing.T) {
 			"metrics_collected": {
 				"cpu": {
 					"measurement": [
-						{"name": "cpu_usage_idle", "rename": "CPU", "unit": "unit"},
-						{"name": "cpu_usage_nice", "unit": "unit"},
+						{"name": "cpu_usage_idle", "rename": "CPU", "unit": "Percent"},
+						{"name": "cpu_usage_nice", "unit": "Percent"},
 						"cpu_usage_guest"
 					]
 				}
@@ -32,15 +31,51 @@ func TestMetricDecoration_ApplyRule(t *testing.T) {
 	expected := []interface{}{
 		map[string]string{
 			"rename":   "CPU",
-			"unit":     "unit",
+			"unit":     "Percent",
 			"category": "cpu",
 			"name":     "usage_idle",
 		},
 		map[string]string{
 			"category": "cpu",
 			"name":     "usage_nice",
-			"unit":     "unit",
+			"unit":     "Percent",
 		},
+		// cpu_usage_guest will not translated into anything since there is no metric decoration configured for it.
+	}
+	assert.Equal(t, expected, val)
+}
+
+//Check the case when the input is in "cpu":{//specific configuration}
+func TestMetricDecoration_plugin_with_alias_ApplyRule(t *testing.T) {
+	c := new(MetricDecoration)
+	//Check whether override default config
+	var input interface{}
+	err := json.Unmarshal([]byte(`{
+			"metrics_collected": {
+				"nvidia_gpu": {
+					"measurement": [
+				  		{"name": "utilization_gpu", "rename": "gpu_usage", "unit": "Percent"},
+						"temperature_gpu",
+						{"name":"memory_total", "unit": "Bytes"}
+					]
+				}
+			}}`), &input)
+
+	require.Nil(t, err)
+	_, val := c.ApplyRule(input)
+	expected := []interface{}{
+		map[string]string{
+			"rename":   "gpu_usage",
+			"unit":     "Percent",
+			"category": "nvidia_smi",
+			"name":     "utilization_gpu",
+		},
+		map[string]string{
+			"category": "nvidia_smi",
+			"name":     "memory_total",
+			"unit":     "Bytes",
+		},
+		// temperature_gpu will not translated into anything since there is no metric decoration configured for it.
 	}
 	assert.Equal(t, expected, val)
 }

--- a/translator/translate/metrics/metrics_collect/gpu/nvidiaSmi.go
+++ b/translator/translate/metrics/metrics_collect/gpu/nvidiaSmi.go
@@ -1,0 +1,74 @@
+package gpu
+
+import (
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/config"
+	parent "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/util"
+)
+
+var ChildRule = map[string]translator.Rule{}
+
+//
+//	"nvidia_gpu": {
+//		"measurement": [
+//			"utilization_gpu",
+//			"temperature_gpu"
+//		],
+//      "metrics_collection_interval": 60
+//	}
+//
+
+// SectionKey_Nvidia_GPU metrics name in user config to opt in Nvidia GPU metrics
+const SectionKey_Nvidia_GPU = "nvidia_gpu"
+
+func GetCurPath() string {
+	curPath := parent.GetCurPath() + SectionKey_Nvidia_GPU + "/"
+	return curPath
+}
+
+func RegisterRule(fieldname string, r translator.Rule) {
+	ChildRule[fieldname] = r
+}
+
+type NvidiaSmi struct {
+}
+
+func (n *NvidiaSmi) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	m := input.(map[string]interface{})
+	resArr := []interface{}{}
+	result := map[string]interface{}{}
+	// nvidia_gpu is not the real telegraf plugin's name, need to register the real plugin name to enable it.
+	telegrafPluginName := config.GetRealPluginName(SectionKey_Nvidia_GPU)
+	//Check if this plugin exist in the input instance
+	//If not, not process
+	if _, ok := m[SectionKey_Nvidia_GPU]; !ok {
+		returnKey = ""
+		returnVal = ""
+	} else {
+		/*
+		  In JSON config file, it represent as "nvidia_gpu" : {//specification config information}
+		  To check the specification config entry
+		*/
+		//Check if there are any config entry with rules applied
+		result = translator.ProcessRuleToApply(m[SectionKey_Nvidia_GPU], ChildRule, result)
+		//Process common config, like measurement
+		hasValidMetric := util.ProcessLinuxCommonConfig(m[SectionKey_Nvidia_GPU], telegrafPluginName, GetCurPath(), result)
+		if hasValidMetric {
+			resArr = append(resArr, result)
+			returnKey = telegrafPluginName
+			returnVal = resArr
+		} else {
+			returnKey = ""
+		}
+	}
+	return
+}
+
+func init() {
+	n := new(NvidiaSmi)
+	parent.RegisterLinuxRule(SectionKey_Nvidia_GPU, n)
+	parent.RegisterDarwinRule(SectionKey_Nvidia_GPU, n)
+	// Windows is not supported for customer build due to security concern
+	// 	parent.RegisterWindowsRule(SectionKey_Nvidia, n)
+}

--- a/translator/translate/metrics/metrics_collect/gpu/nvidiaSmi_test.go
+++ b/translator/translate/metrics/metrics_collect/gpu/nvidiaSmi_test.go
@@ -1,0 +1,115 @@
+package gpu
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+//Check the case when the input is in "nvidia_gpu":{//specific configuration}
+func TestSpecificConfig(t *testing.T) {
+	n := new(NvidiaSmi)
+	var input interface{}
+	err := json.Unmarshal([]byte(`{"nvidia_gpu":{"measurement": [
+						"utilization_gpu",
+						"temperature_gpu"
+					]}}`), &input)
+	if err == nil {
+		_, actualVal := n.ApplyRule(input)
+		expectedVal := []interface{}{map[string]interface{}{
+			"fieldpass": []string{"utilization_gpu", "temperature_gpu"},
+			"tagexclude": []string{"compute_mode", "pstate", "uuid"},
+		},
+		}
+		assert.Equal(t, expectedVal, actualVal, "Expect to be equal")
+	} else {
+		panic(err)
+	}
+}
+
+func TestNoFieldConfig(t *testing.T) {
+	n := new(NvidiaSmi)
+	var input interface{}
+	var e = json.Unmarshal([]byte(`{"nvidia_gpu":{"metrics_collection_interval":"60s"}}`), &input)
+	if e == nil {
+		actualReturnKey, _ := n.ApplyRule(input)
+		assert.Equal(t, "", actualReturnKey, "return key should be empty")
+	} else {
+		panic(e)
+	}
+}
+
+func TestFullConfig(t *testing.T) {
+	n := new(NvidiaSmi)
+	var input interface{}
+	err := json.Unmarshal([]byte(`{"nvidia_gpu":{"measurement": [
+						"utilization_gpu", 
+						"temperature_gpu", 
+						"power_draw", 
+						"utilization_memory", 
+						"fan_speed", 
+						"memory_total", 
+						"memory_used", 
+						"memory_free", 
+						"temperature_gpu", 
+						"pcie_link_gen_current", 
+						"pcie_link_width_current",
+						"encoder_stats_session_count", 
+						"encoder_stats_average_fps", 
+						"encoder_stats_average_latency",
+						"clocks_current_graphics", 
+						"clocks_current_sm", 
+						"clocks_current_memory", 
+						"clocks_current_video"
+					]}}`), &input)
+	if err == nil {
+		_, actualVal := n.ApplyRule(input)
+		expectedVal := []interface{}{map[string]interface{}{
+			"fieldpass": []string{"utilization_gpu", "temperature_gpu", "power_draw", "utilization_memory",
+				"fan_speed", "memory_total", "memory_used", "memory_free", "temperature_gpu", "pcie_link_gen_current",
+				"pcie_link_width_current", "encoder_stats_session_count", "encoder_stats_average_fps",
+				"encoder_stats_average_latency", "clocks_current_graphics", "clocks_current_sm",
+				"clocks_current_memory", "clocks_current_video"},
+			"tagexclude": []string{"compute_mode", "pstate", "uuid"},
+		},
+		}
+		assert.Equal(t, expectedVal, actualVal, "Expect to be equal")
+	} else {
+		panic(err)
+	}
+}
+
+func TestInvalidMetrics(t *testing.T) {
+	c := new(NvidiaSmi)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{"nvidia_gpu": {
+					"measurement": [
+						"invalid_utilization_gpu",
+						"invalid_temperature_gpu",
+						"dummy_invalid_field_name"
+					],
+					"metrics_collection_interval": "1s"
+				}}`), &input)
+	if e == nil {
+		actualKey, _ := c.ApplyRule(input)
+		assert.Equal(t, "", actualKey, "return key should be empty")
+	} else {
+		panic(e)
+	}
+}
+
+func TestNonGpuConfig(t *testing.T) {
+	c := new(NvidiaSmi)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{"nvidia_smi":{"foo":"bar"}}`), &input)
+
+	if e == nil {
+		actualKey, actualVal := c.ApplyRule(input)
+		expectedKey := ""
+		expectedVal := ""
+		assert.Equal(t, expectedKey, actualKey, "ReturnKey should be empty")
+		assert.Equal(t, expectedVal, actualVal, "ReturnVal should be empty")
+	} else {
+		panic(e)
+	}
+}

--- a/translator/translate/metrics/util/commonconfigutil.go
+++ b/translator/translate/metrics/util/commonconfigutil.go
@@ -26,7 +26,7 @@ const (
 
 // ProcessLinuxCommonConfig is used by both Linux and Darwin.
 func ProcessLinuxCommonConfig(input interface{}, pluginName string, path string, result map[string]interface{}) bool {
-	isHighRsolution := IsHighResolution(agent.Global_Config.Interval)
+	isHighResolution := IsHighResolution(agent.Global_Config.Interval)
 	inputMap := input.(map[string]interface{})
 	// Generate allowlisted metric list, process only if Measurement_Key exist
 	if translator.IsValid(inputMap, Measurement_Key, path) {
@@ -47,7 +47,7 @@ func ProcessLinuxCommonConfig(input interface{}, pluginName string, path string,
 	}
 
 	// Set input plugin specific interval
-	isHighRsolution = setTimeInterval(inputMap, result, isHighRsolution, pluginName)
+	isHighResolution = setTimeInterval(inputMap, result, isHighResolution, pluginName)
 
 	//Set append_dimensions as tags
 	if val, ok := inputMap[Append_Dimensions_Key]; ok {
@@ -55,8 +55,15 @@ func ProcessLinuxCommonConfig(input interface{}, pluginName string, path string,
 		util.Cleanup(val)
 	}
 
+	// apply any specific rules for the plugin
+	if m, ok := ApplyPluginSpecificRules(pluginName); ok {
+		for key, val := range m {
+			result[key] = val
+		}
+	}
+
 	// Add HighResolution tags
-	if isHighRsolution {
+	if isHighResolution {
 		if result[Append_Dimensions_Mapped_Key] != nil {
 			util.AddHighResolutionTag(result[Append_Dimensions_Mapped_Key])
 		} else {


### PR DESCRIPTION
# Description of the issue
Fix Darwin build and add support for GPU metrics.
GPU metrics feature not usable yet.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests.




