### PR TITLE
Fix TestLogsFileRecreate() which has infinite loop on Windows.

### DIFF
--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -763,7 +763,9 @@ func TestLogsFileRecreate(t *testing.T) {
 	require.NoError(t, tmpfile.Close())
 	require.NoError(t, os.Remove(tmpfile.Name()))
 	_, err = os.Stat(tmpfile.Name())
-	require.NoError(t, err)
+	if err == nil {
+		t.Errorf("%s, should have been deleted", tmpfile.Name())
+	}
 	// Remove does not seem to be removing the file on Windows, because os.OpenFile() fails with ACCESS_DENIED
 	time.Sleep(time.Millisecond * 100)
 	tmpfile, err = os.OpenFile(tmpfile.Name(), os.O_WRONLY|os.O_CREATE, 0600)

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -760,9 +760,8 @@ func TestLogsFileRecreate(t *testing.T) {
 
 	t.Logf("Deleting the monitored temp file, and then creating it again with the same content...")
 	// recreate file
-	err = os.Remove(tmpfile.Name())
-	require.NoError(t, err)
 	require.NoError(t, tmpfile.Close())
+	require.NoError(t, os.Remove(tmpfile.Name()))
 	time.Sleep(time.Millisecond * 100)
 	tmpfile, err = os.OpenFile(tmpfile.Name(), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 	require.NoError(t, err)

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -744,10 +744,10 @@ func TestLogsFileRecreate(t *testing.T) {
 		t.Fatalf("%v log src was returned when 1 should be available", len(lsrcs))
 	}
 
-	lsrc := lsrcs[0]
-	defer lsrc.Stop()
+	lsrc1 := lsrcs[0]
+	defer lsrc1.Stop()
 	evts := make(chan logs.LogEvent)
-	lsrc.SetOutput(func(e logs.LogEvent) {
+	lsrc1.SetOutput(func(e logs.LogEvent) {
 		if e != nil {
 			evts <- e
 		}
@@ -775,16 +775,17 @@ func TestLogsFileRecreate(t *testing.T) {
 
 	tlog.Infof("I! Wait until LogFile object can find the LogSrc again...")
 	for start := time.Now(); time.Since(start) < 10 * time.Second; {
-		time.Sleep(1 * time.Second)
+		// Sleep before checking so there is a change for delete and recreate to be detected.
+		time.Sleep(time.Second * 1)
 		lsrcs = tt.FindLogSrc()
 		if len(lsrcs) > 0 {
 			break
 		}
 	}
 
-	lsrc = lsrcs[0]
-	defer lsrc.Stop()
-	lsrc.SetOutput(func(e logs.LogEvent) {
+	lsrc2 := lsrcs[0]
+	defer lsrc2.Stop()
+	lsrc2.SetOutput(func(e logs.LogEvent) {
 		if e != nil {
 			evts <- e
 		}

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -709,7 +709,7 @@ func TestLogsFileRecreate(t *testing.T) {
 
 	tlog.Infof("I! Creating temp log file for test...")
 	tmpfile, err := createTempFile("", "")
-	//defer os.Remove(tmpfile.Name())
+	defer os.Remove(tmpfile.Name())
 	require.NoError(t, err)
 	_, err = tmpfile.WriteString(logEntryString + "\n")
 	require.NoError(t, err)

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -762,8 +762,11 @@ func TestLogsFileRecreate(t *testing.T) {
 	// recreate file
 	require.NoError(t, tmpfile.Close())
 	require.NoError(t, os.Remove(tmpfile.Name()))
+	_, err = os.Stat(tmpfile.Name())
+	require.NoError(t, err)
+	// Remove does not seem to be removing the file on Windows, because os.OpenFile() fails with ACCESS_DENIED
 	time.Sleep(time.Millisecond * 100)
-	tmpfile, err = os.OpenFile(tmpfile.Name(), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+	tmpfile, err = os.OpenFile(tmpfile.Name(), os.O_WRONLY|os.O_CREATE, 0600)
 	require.NoError(t, err)
 
 	_, err = tmpfile.WriteString(logEntryString + "\n")


### PR DESCRIPTION
# Description of the issue
`TestLogsFileRecreate()` intermittently fails on Windows OS.
example: https://github.com/aws/amazon-cloudwatch-agent/runs/4156147013?check_suite_focus=true

There are actually 2 issues.
First is that there is a `for` loop that will does not end until Go does a `panic`.
Second, the delay between deleting the monitored temp file and recreating it is a fixed 100 ms.
These 2 changes are minimally required.

# Description of changes
The loop will timeout after 10 seconds if the LogSrc is not found, instead of `Panic` after 10 minutes.
The fixed delay between deleting and recreating the temp file has been increased from 100ms to 1 second.

I added some info messages to describe what the test is doing.
I was just going to add code comments, but logging what the test is doing makes it easier to correlate with what the functions being tested are doing and correlate with if/when errors occur.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested on a windows server 2019 EC2 instance (running as non Admin user):
```
PS C:\Users\adam\go\src\github.com\aws\amazon-cloudwatch-agent\plugins\inputs\logfile> go test -v -run TestLogsFileRecreate
=== RUN   TestLogsFileRecreate
2021/11/10 03:49:38 I! Creating temp log file for test...
2021/11/10 03:49:38 I! Created temp file C:\Users\adam\AppData\Local\Temp\2999914585, with some initial content.
2021/11/10 03:49:38 I! Creating state file with a position in the middle of the temp file...
2021/11/10 03:49:38 I! Creating LogFile object and verifying we find the 1 matching LogSrc...
2021/11/10 03:49:38 Reading from offset 10 in C:\Users\adam\AppData\Local\Temp\2999914585
2021/11/10 03:49:38 I! Receive an event (aka new content in file), expect only content from the position in the statefile and onward.
2021/11/10 03:49:38 D! [inputs.tail] Seeked C:\Users\adam\AppData\Local\Temp\2999914585 - &{Offset:10 Whence:0}
2021/11/10 03:49:38 I! Deleting the monitored temp file, and then creating it again with the same content...
2021/11/10 03:49:38 W! [inputs.tail] Stopping tail as file no longer exists: C:\Users\adam\AppData\Local\Temp\2999914585
2021/11/10 03:49:39 I! Wait until LogFile object can find the LogSrc again...
2021/11/10 03:49:41 Reading from offset 10 in C:\Users\adam\AppData\Local\Temp\2999914585
2021/11/10 03:49:41 I! Receive an event (aka new content in file), expect only content from the position in the statefile and onward.
2021/11/10 03:49:41 D! [inputs.tail] Seeked C:\Users\adam\AppData\Local\Temp\2999914585 - &{Offset:10 Whence:0}
--- PASS: TestLogsFileRecreate (3.21s)
PASS
ok      github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile   3.352s
```

Tested on MacOS (macbook):
```
adamym@88665a370425 logfile % go test -v -run TestLogsFileRecreate
=== RUN   TestLogsFileRecreate
2021/11/09 21:46:07 I! Creating temp log file for test...
2021/11/09 21:46:07 I! Created temp file /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/1522790960, with some initial content.
2021/11/09 21:46:07 I! Creating state file with a position in the middle of the temp file...
2021/11/09 21:46:07 I! Creating LogFile object and verifying we find the 1 matching LogSrc...
2021/11/09 21:46:07 Reading from offset 10 in /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/1522790960
2021/11/09 21:46:07 I! Receive an event (aka new content in file), expect only content from the position in the statefile and onward.
2021/11/09 21:46:07 D! [inputs.tail] Seeked /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/1522790960 - &{Offset:10 Whence:0}
2021/11/09 21:46:07 I! Deleting the monitored temp file, and then creating it again with the same content...
2021/11/09 21:46:08 W! [inputs.tail] Stopping tail as file no longer exists: /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/1522790960
2021/11/09 21:46:08 I! Wait until LogFile object can find the LogSrc again...
2021/11/09 21:46:10 Reading from offset 10 in /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/1522790960
2021/11/09 21:46:10 I! Receive an event (aka new content in file), expect only content from the position in the statefile and onward.
2021/11/09 21:46:10 D! [inputs.tail] Seeked /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/1522790960 - &{Offset:10 Whence:0}
--- PASS: TestLogsFileRecreate (3.11s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile	3.285s
```

I ran the tests >4 times each.
I ran `git clean -testcache` between test runs.

