### PR TITLE
Fix TestLogsFileRecreate.

### DIFF
--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -781,7 +781,9 @@ func TestLogsFileRecreate(t *testing.T) {
 		}
 		time.Sleep(1 * time.Second)
 	}
-
+	if len(lsrcs) != 1 {
+		t.Fatalf("%v log src was returned when 1 should be available", len(lsrcs))
+	}
 	lsrc = lsrcs[0]
 	lsrc.SetOutput(func(e logs.LogEvent) {
 		if e != nil {

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -705,6 +705,10 @@ func TestLogsFileWithInvalidOffset(t *testing.T) {
 	tt.Stop()
 }
 
+// TestLogsFileRecreate verifies that if a LogSrc matching a LogConfig is detected,
+// We only receive log lines beginning at the offset specified in the corresponding state-file.
+// And if the file happens to get deleted and recreated we expect to receive log lines beginning
+// at that same offset in the state file.
 func TestLogsFileRecreate(t *testing.T) {
 	multilineWaitPeriod = 10 * time.Millisecond
 	logEntryString := "xxxxxxxxxxContentAfterOffset"

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -753,7 +753,8 @@ func TestLogsFileRecreate(t *testing.T) {
 		err = os.Remove(tmpfile.Name())
 		require.NoError(t, err)
 		require.NoError(t, tmpfile.Close())
-		time.Sleep(time.Millisecond * 100)
+		// 100 ms between deleting and recreating is enough on Linux and MacOS, but not Windows.
+		time.Sleep(time.Second * 1)
 		tmpfile, err = os.OpenFile(tmpfile.Name(), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 		require.NoError(t, err)
 
@@ -768,7 +769,8 @@ func TestLogsFileRecreate(t *testing.T) {
 	}
 	defer lsrc.Stop()
 
-	for {
+	// Waiting 10 seconds for the recreated temp file to be detected is plenty sufficient on any OS.
+	for start := time.Now(); time.Since(start) < 10 * time.Second; {
 		lsrcs = tt.FindLogSrc()
 		if len(lsrcs) > 0 {
 			break


### PR DESCRIPTION
# Description of the issue
`TestLogsFileRecreate()` intermittently fails on Windows OS.
example: https://github.com/aws/amazon-cloudwatch-agent/runs/4156147013?check_suite_focus=true

There are actually 2 issues.
First is that there is a `for` loop that will does not end until Go does a `panic`.
Second, the delay between deleting the monitored temp file and recreating it is a fixed 100 ms.
These 2 changes are minimally required.

# Description of changes
The loop will timeout after 10 seconds if the LogSrc is not found, instead of `Panic` after 10 minutes.
The fixed delay between deleting and recreating the temp file has been increased from 100ms to 1 second.

I added some info messages to describe what the test is doing.
I was just going to add code comments, but logging what the test is doing makes it easier to correlate with what the functions being tested are doing and correlate with if/when errors occur.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
```
make release
```