### PR TITLE
Because of security reason symlinks shouldn't be always allowed.

### DIFF
--- a/plugins/inputs/logfile/fileconfig.go
+++ b/plugins/inputs/logfile/fileconfig.go
@@ -75,6 +75,10 @@ type FileConfig struct {
 
 	//Indicate retention in days for log group
 	RetentionInDays int `toml:"retention_in_days"`
+
+	//Indicate if symbolic links are ignored
+	IgnoreSymLinks bool `toml:"ignore_symlinks"`
+
 	//Time *time.Location Go type timezone info.
 	TimezoneLoc *time.Location
 	//Regexp go type timestampFromLogLine regex

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -85,6 +85,7 @@ const sampleConfig = `
       max_event_size = 262144
       ## Suffix to be added to truncated logline to indicate its truncation, defaults to "[Truncated...]"
       truncate_suffix = "[Truncated...]"
+      ignore_symlinks = false
 
 `
 
@@ -190,14 +191,15 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 
 			tailer, err := tail.TailFile(filename,
 				tail.Config{
-					ReOpen:      false,
-					Follow:      true,
-					Location:    seekFile,
-					MustExist:   true,
-					Pipe:        fileconfig.Pipe,
-					Poll:        true,
-					MaxLineSize: fileconfig.MaxEventSize,
-					IsUTF16:     isutf16,
+					ReOpen:          false,
+					Follow:          true,
+					Location:        seekFile,
+					MustExist:       true,
+					Pipe:            fileconfig.Pipe,
+					IgnoreSymLinks:    fileconfig.IgnoreSymLinks,
+					Poll:            true,
+					MaxLineSize:     fileconfig.MaxEventSize,
+					IsUTF16:         isutf16,
 				})
 
 			if err != nil {

--- a/translator/config/sampleSchema/validLogFiles.json
+++ b/translator/config/sampleSchema/validLogFiles.json
@@ -15,13 +15,15 @@
             "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/test.log",
             "log_group_name": "test.log",
             "log_stream_name": "test.log",
-            "timezone": "Local"
+            "timezone": "Local",
+            "ignore_symlinks": false
           },
           {
             "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/*",
             "blacklist": "agent.log*|env.log|profiler.log|\\.\\d$",
             "publish_multi_logs": true,
-            "timezone": "UTC"
+            "timezone": "UTC",
+            "ignore_symlinks": true
           }
         ]
       }

--- a/translator/config/schema.go
+++ b/translator/config/schema.go
@@ -685,6 +685,9 @@ var schema = `{
                   },
                   "retention_in_days": {
                     "$ref": "#/definitions/logsDefinition/definitions/retentionInDaysDefinition"
+                  },
+                  "ignore_symlinks": {
+                    "type": "boolean"
                   }
                 },
                 "required": [

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -673,6 +673,9 @@
                   },
                   "retention_in_days": {
                     "$ref": "#/definitions/logsDefinition/definitions/retentionInDaysDefinition"
+                  },
+                  "ignore_symlinks": {
+                    "type": "boolean"
                   }
                 },
                 "required": [

--- a/translator/totomlconfig/sampleConfig/complete_darwin_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_darwin_config.conf
@@ -54,6 +54,7 @@
     [[inputs.logfile.file_config]]
       file_path = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "amazon-cloudwatch-agent.log"
       log_stream_name = "amazon-cloudwatch-agent.log"
       pipe = false
@@ -64,6 +65,7 @@
       auto_removal = true
       file_path = "/opt/aws/amazon-cloudwatch-agent/logs/test.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "test.log"
       log_stream_name = "test.log"
       pipe = false

--- a/translator/totomlconfig/sampleConfig/complete_linux_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_linux_config.conf
@@ -54,6 +54,7 @@
     [[inputs.logfile.file_config]]
       file_path = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "amazon-cloudwatch-agent.log"
       log_stream_name = "amazon-cloudwatch-agent.log"
       pipe = false
@@ -64,6 +65,7 @@
       auto_removal = true
       file_path = "/opt/aws/amazon-cloudwatch-agent/logs/test.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "test.log"
       log_stream_name = "test.log"
       pipe = false

--- a/translator/totomlconfig/sampleConfig/complete_windows_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_windows_config.conf
@@ -23,6 +23,7 @@
     [[inputs.logfile.file_config]]
       file_path = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "amazon-cloudwatch-agent.log"
       pipe = false
       retention_in_days = 5
@@ -32,6 +33,7 @@
       auto_removal = true
       file_path = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\test.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "test.log"
       pipe = false
       retention_in_days = -1

--- a/translator/totomlconfig/sampleConfig/log_metric_and_log.conf
+++ b/translator/totomlconfig/sampleConfig/log_metric_and_log.conf
@@ -36,6 +36,7 @@
     [[inputs.logfile.file_config]]
       file_path = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "amazon-cloudwatch-agent.log"
       log_stream_name = "amazon-cloudwatch-agent.log"
       multi_line_start_pattern = "{timestamp_regex}"
@@ -48,6 +49,7 @@
     [[inputs.logfile.file_config]]
       file_path = "/opt/aws/amazon-cloudwatch-agent/logs/test.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "test.log"
       log_stream_name = "test.log"
       pipe = false

--- a/translator/totomlconfig/sampleConfig/log_only_config_windows.conf
+++ b/translator/totomlconfig/sampleConfig/log_only_config_windows.conf
@@ -23,6 +23,7 @@
     [[inputs.logfile.file_config]]
       file_path = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "amazon-cloudwatch-agent.log"
       pipe = false
       retention_in_days = -1
@@ -30,6 +31,7 @@
     [[inputs.logfile.file_config]]
       file_path = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\test.log"
       from_beginning = true
+      ignore_symlinks = false
       log_group_name = "test.log"
       pipe = false
       retention_in_days = -1

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
@@ -36,6 +36,7 @@ func TestFileConfig(t *testing.T) {
 		"log_stream_name":   "LOG_STREAM_NAME",
 		"pipe":              false,
 		"retention_in_days": -1,
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -55,6 +56,7 @@ func TestFileConfigOverride(t *testing.T) {
 		"log_group_name":    "group1",
 		"pipe":              false,
 		"retention_in_days": -1,
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -83,6 +85,7 @@ func TestTimestampFormat(t *testing.T) {
 		"timestamp_regex":   "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2})",
 		"timezone":          "UTC",
 		"retention_in_days": -1,
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -108,6 +111,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  "15:04:05 06 Jan 2",
 				"timestamp_regex":   "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2})",
+				"ignore_symlinks":   false,
 			}},
 		},
 		{
@@ -126,6 +130,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  "1 2 15:04:05",
 				"timestamp_regex":   "(\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
+				"ignore_symlinks":   false,
 			}},
 		},
 		{
@@ -144,6 +149,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  "2 1 15:04:05",
 				"timestamp_regex":   "(\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
+				"ignore_symlinks":   false,
 			}},
 		},
 		{
@@ -162,6 +168,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  "5 2 1 15:04:05",
 				"timestamp_regex":   "(\\d{1,2} \\s{0,1}\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
+				"ignore_symlinks":   false,
 			}},
 		},
 	}
@@ -212,6 +219,7 @@ func TestTimestampFormat_NonZeroPadding(t *testing.T) {
 		"timestamp_layout":  expectedLayout,
 		"timestamp_regex":   expectedRegex,
 		"timezone":          "UTC",
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -258,6 +266,7 @@ func TestTimestampFormat_SpecialCharacters(t *testing.T) {
 		"timestamp_layout":  expectedLayout,
 		"timestamp_regex":   expectedRegex,
 		"timezone":          "UTC",
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -296,6 +305,7 @@ func TestTimestampFormat_Template(t *testing.T) {
 		"retention_in_days": -1,
 		"timestamp_layout":  expectedLayout,
 		"timestamp_regex":   expectedRegex,
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -336,6 +346,7 @@ func TestMultiLineStartPattern(t *testing.T) {
 		"timestamp_regex":          "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\d{2})",
 		"timezone":                 "UTC",
 		"multi_line_start_pattern": "{timestamp_regex}",
+		"ignore_symlinks":          false,
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -366,6 +377,7 @@ func TestEncoding(t *testing.T) {
 		"timestamp_regex":   "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\d{2})",
 		"timezone":          "UTC",
 		"encoding":          "gbk",
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -390,6 +402,7 @@ func TestEncoding_Invalid(t *testing.T) {
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 	assert.False(t, translator.IsTranslateSuccess())
@@ -418,6 +431,7 @@ func TestAutoRemoval(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": -1,
 		"auto_removal":      true,
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -439,6 +453,7 @@ func TestAutoRemoval(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": -1,
 		"auto_removal":      false,
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -458,6 +473,7 @@ func TestAutoRemoval(t *testing.T) {
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
+		"ignore_symlinks":   false,
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -533,6 +549,7 @@ func TestPublishMultiLogs_WithBlackList(t *testing.T) {
 		"blacklist":          "^agent.log",
 		"publish_multi_logs": true,
 		"timezone":           "UTC",
+		"ignore_symlinks":    false,
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -556,6 +573,7 @@ func TestPublishMultiLogs_WithBlackList(t *testing.T) {
 		"retention_in_days":  -1,
 		"publish_multi_logs": false,
 		"timezone":           "UTC",
+		"ignore_symlinks":    false,
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -575,6 +593,73 @@ func TestPublishMultiLogs_WithBlackList(t *testing.T) {
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
+		"ignore_symlinks":   false,
+	}}
+	assert.Equal(t, expectVal, val)
+}
+
+func TestIgnoreSymLinks(t *testing.T) {
+	f := new(FileConfig)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{
+		"collect_list":[
+			{
+				"file_path":"path1"
+			}
+		]
+	}`), &input)
+	if e != nil {
+		assert.Fail(t, e.Error())
+	}
+	_, val := f.ApplyRule(input)
+	expectVal := []interface{}{map[string]interface{}{
+		"file_path":      "path1",
+		"from_beginning": true,
+		"pipe":           false,
+    "retention_in_days": -1,
+		"ignore_symlinks": false,
+	}}
+	assert.Equal(t, expectVal, val)
+
+	e = json.Unmarshal([]byte(`{
+		"collect_list":[
+			{
+				"file_path":"path1",
+				"ignore_symlinks": true
+			}
+		]
+	}`), &input)
+	if e != nil {
+		assert.Fail(t, e.Error())
+	}
+	_, val = f.ApplyRule(input)
+	expectVal = []interface{}{map[string]interface{}{
+		"file_path":      "path1",
+		"from_beginning": true,
+		"pipe":           false,
+    "retention_in_days": -1,
+		"ignore_symlinks": true,
+	}}
+	assert.Equal(t, expectVal, val)
+
+	e = json.Unmarshal([]byte(`{
+		"collect_list":[
+			{
+				"file_path":"path1",
+				"ignore_symlinks": false
+			}
+		]
+	}`), &input)
+	if e != nil {
+		assert.Fail(t, e.Error())
+	}
+	_, val = f.ApplyRule(input)
+	expectVal = []interface{}{map[string]interface{}{
+		"file_path":      "path1",
+		"from_beginning": true,
+		"pipe":           false,
+    "retention_in_days": -1,
+		"ignore_symlinks": false,
 	}}
 	assert.Equal(t, expectVal, val)
 }

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleIgnoreSymLinks.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleIgnoreSymLinks.go
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package collect_list
+
+import (
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+)
+
+type IgnoreSymLinks struct {
+}
+
+func (f *IgnoreSymLinks) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	returnKey, returnVal = translator.DefaultCase("ignore_symlinks", false, input)
+	return
+}
+
+func init() {
+	f := new(IgnoreSymLinks)
+	r := []Rule{f}
+	RegisterRule("ignore_symlinks", r)
+}


### PR DESCRIPTION
# Description of the issue
We are using CloudWatch Agent on the device, which will be later managed by customers. We encountered a security issue with the way it handles log files symbolic links. In our use case we would like the agent to skip symbolic links and only tail real files.

# Description of changes
In this PR I suggest adding a new optional parameter (ignore_symlinks), so the user could decide if the agent should skip symbolic links. If the parameter is not provided, we keep the default behavior. Possible values for the parameter:

 * **false**: default behavior, resolve target file
 * **true**: ignore symbolic links
 
# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added the required unit test.


