### PR TITLE
The statsd plugin cannot be configured because the current JSON schema ignores some of the options

### DIFF
--- a/cmd/config-translator/translator_test.go
+++ b/cmd/config-translator/translator_test.go
@@ -163,6 +163,10 @@ func TestEthtoolConfig(t *testing.T) {
 	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validEthtoolConfig.json", true, map[string]int{})
 }
 
+func TestStatsdConfig(t *testing.T) {
+	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validstatsdConfig.json", true, map[string]int{})
+}
+
 func TestNvidiaGpuConfig(t *testing.T) {
 	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validNvidiaGpuConfig.json", true, map[string]int{})
 }

--- a/translator/config/sampleSchema/validStatsdConfig.json
+++ b/translator/config/sampleSchema/validStatsdConfig.json
@@ -1,0 +1,20 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "statsd": {
+        "metrics_aggregation_interval": 60,
+        "metrics_collection_interval": 10,
+        "service_address": ":8125",
+        "parse_data_dog_tags": true,
+        "delete_gauges": true,
+        "delete_counters": true,
+        "delete_sets": true,
+        "metric_separator": "_",
+        "allowed_pending_messages": 10000,
+        "templates": [
+          "cpu.* measurement*"
+        ]
+      }
+    }
+  }
+}

--- a/translator/config/schema.go
+++ b/translator/config/schema.go
@@ -365,6 +365,24 @@ var schema = `{
               "type": "string",
               "minLength": 1,
               "maxLength": 255
+            },
+            "parse_data_dog_tags": {
+              "type": "boolean"
+            },
+            "delete_gauges": {
+              "type": "boolean"
+            },
+            "delete_counters": {
+              "type": "boolean"
+            },
+            "delete_sets": {
+              "type": "boolean"
+            },
+            "templates": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -353,6 +353,24 @@
               "type": "string",
               "minLength": 1,
               "maxLength": 255
+            },
+            "parse_data_dog_tags": {
+              "type": "boolean"
+            },
+            "delete_gauges": {
+              "type": "boolean"
+            },
+            "delete_counters": {
+              "type": "boolean"
+            },
+            "delete_sets": {
+              "type": "boolean"
+            },
+            "templates": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
# Description of the issue
The statsd plugin cannot be configured because the current JSON schema ignores some of the options (#329)

# Description of changes
* New sample configuration.
* Changes in schema.json
* Test to validate sample config against schema.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Test to validate sample config against schema.




