### PR TITLE
Fix missing Windows events by changing getRecords().

### DIFF
--- a/plugins/inputs/windows_event_log/wineventlog/sys_call.go
+++ b/plugins/inputs/windows_event_log/wineventlog/sys_call.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Portions Licensed under the Apache License, Version 2.0, Copyright (c) 2012–2017 Elastic <http://www.elastic.co>

--- a/plugins/inputs/windows_event_log/wineventlog/utils.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils.go
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
+//go:build windows
 // +build windows
 
 package wineventlog

--- a/plugins/inputs/windows_event_log/wineventlog/utils_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils_test.go
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
+//go:build windows
 // +build windows
 
 package wineventlog

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -159,7 +159,7 @@ func (l *windowsEventLog) Open() error {
 	// Subscribe for events
 	eventHandle, err := EvtSubscribe(0, uintptr(signalEvent), channelPath, query, bookmark, 0, 0, EvtSubscribeStartAfterBookmark)
 	if err != nil {
-		fmt.Errorf("EvtSubscribe(), name %v, err %v", l.name, err)
+		log.Printf("EvtSubscribe(), name %v, err %v", l.name, err)
 		return err
 	}
 

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -152,7 +152,10 @@ func (w *windowsEventLog) Open() error {
 	if err != nil {
 		return err
 	}
-	// Subscribe for events
+	// Subscribe for events.
+	// This will fail if the eventlog name has not been registered.
+	// However returning an error would mean the the plugin won't monitor other
+	// eventlogs.
 	eventHandle, err := EvtSubscribe(0, uintptr(signalEvent), channelPath, query, bookmark, 0, 0, EvtSubscribeStartAfterBookmark)
 	if err != nil {
 		log.Printf("W! [wineventlog] EvtSubscribe(), name %v, err %v", w.name, err)

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -346,7 +346,7 @@ func (l *windowsEventLog) getRecords(handles []EvtHandle) (records []*windowsEve
 			//old SSM agent Windows format
 			var recordMessage eventMessage
 			if err = xml.Unmarshal(descriptionBytes, &recordMessage); err != nil {
-				log.Printf("I! [wineventlog] UTF16ToUTF8Bytes() err %v", err)
+				log.Printf("I! [wineventlog] Unmarshal() err %v", err)
 				continue
 			}
 

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog_notwindows.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog_notwindows.go
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
+//go:build !windows
 // +build !windows
 
 package wineventlog

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// common inputs for creating an EventLog.
-	NAME            = "Application"
+	NAME = "Application"
 	// 2 is ERROR
 	LEVELS          = []string{"2"}
 	GROUP_NAME      = "fake"
@@ -121,7 +121,7 @@ func seekToEnd(t *testing.T, elog *windowsEventLog) {
 func writeEvents(t *testing.T, msgCount int, doRegister bool, logSrc string, eventId uint32) {
 	if doRegister {
 		// Expected to fail if unit test previously ran and installed the event src.
-		_ = eventlog.InstallAsEventCreate(logSrc, eventlog.Info | eventlog.Warning | eventlog.Error)
+		_ = eventlog.InstallAsEventCreate(logSrc, eventlog.Info|eventlog.Warning|eventlog.Error)
 	}
 	wlog, err := eventlog.Open(logSrc)
 	assert.NoError(t, err)

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
@@ -65,9 +65,6 @@ func TestReadGoodSource(t *testing.T) {
 	assert.Equal(t, nil, elog.Open())
 	seekToEnd(t, elog)
 	writeEvents(t, 10, true, "CWA_UnitTest111", 777)
-	// Without a sleep we do not read any events!!!
-	// To work around the bad behavior of writeEvents() we must sleep.
-	time.Sleep(1 * time.Second)
 	checkEvents(t, elog, 10, "[Application] [ERROR] [777] [CWA_UnitTest111] ")
 	assert.Equal(t, nil, elog.Close())
 }
@@ -80,7 +77,6 @@ func TestReadBadSource(t *testing.T) {
 	assert.Equal(t, nil, elog.Open())
 	seekToEnd(t, elog)
 	writeEvents(t, 10, false, "CWA_UnitTest222", 888)
-	time.Sleep(1 * time.Second)
 	checkEvents(t, elog, 0, "[Application] [ERROR] [888] [CWA_UnitTest222] ")
 	assert.Equal(t, nil, elog.Close())
 }
@@ -95,7 +91,6 @@ func TestReadWithBothSources(t *testing.T) {
 	seekToEnd(t, elog)
 	writeEvents(t, 10, true, "CWA_UnitTest111", 777)
 	writeEvents(t, 10, false, "CWA_UnitTest222", 888)
-	time.Sleep(1 * time.Second)
 	checkEvents(t, elog, 10, "[Application] [ERROR] [777] [CWA_UnitTest111] ")
 	assert.Equal(t, nil, elog.Close())
 }
@@ -131,6 +126,8 @@ func writeEvents(t *testing.T, msgCount int, doRegister bool, logSrc string, eve
 	}
 	err = wlog.Close()
 	assert.NoError(t, err)
+	// Must sleep after wlog.Error() otherwise elog.read() will not see results.
+	time.Sleep(1 * time.Second)
 }
 
 // checkEvents reads all events (since last read) then checks each one for the

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
@@ -105,7 +105,6 @@ func seekToEnd(t *testing.T, elog *windowsEventLog) {
 	numRetrieved := 0
 	for {
 		records := elog.read()
-		//assert.Equal(t, nil, err)
 		t.Logf("seekToEnd() current count %v", len(records))
 		numRetrieved += len(records)
 		if len(records) == 0 {
@@ -142,7 +141,6 @@ func checkEvents(t *testing.T, elog *windowsEventLog, msgCount int, substr strin
 		// In the old code read() would return an error if there were events
 		// from an unregistered provider.
 		currentRecords := elog.read()
-		//assert.Equal(t, nil, err)
 		t.Logf("checkEvents() current count %v", len(currentRecords))
 		if len(currentRecords) == 0 {
 			break

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
@@ -46,7 +46,7 @@ func TestOpen(t *testing.T) {
 	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
 		STATE_FILE_PATH, BATCH_SIZE, RETENTION)
 	assert.NoError(t, elog.Open())
-	assert.NotNil(t, elog.eventHandle)
+	assert.NotZero(t, elog.eventHandle)
 	assert.NoError(t, elog.Close())
 	// bad name
 	elog = NewEventLog("FakeBadElogName", LEVELS, GROUP_NAME, STREAM_NAME,

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
@@ -1,0 +1,163 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+// +build windows
+
+package wineventlog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+var (
+	// common inputs for creating an EventLog.
+	NAME            = "Application"
+	// 2 is ERROR
+	LEVELS          = []string{"2"}
+	GROUP_NAME      = "fake"
+	STREAM_NAME     = "fake"
+	RENDER_FMT      = FormatPlainText
+	DEST            = "fake"
+	STATE_FILE_PATH = "fake"
+	BATCH_SIZE      = 99
+	RETENTION       = 42
+)
+
+// TestNewEventLog verifies constructor's default values.
+func TestNewEventLog(t *testing.T) {
+	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
+		STATE_FILE_PATH, BATCH_SIZE, RETENTION)
+	assert.Equal(t, NAME, elog.name)
+	assert.Equal(t, uint64(0), elog.eventOffset)
+	assert.Zero(t, elog.eventHandle)
+}
+
+// TestOpen verifies Open() succeeds with valid inputs.
+// And fails with invalid inputs.
+func TestOpen(t *testing.T) {
+	// happy
+	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
+		STATE_FILE_PATH, BATCH_SIZE, RETENTION)
+	assert.NoError(t, elog.Open())
+	assert.NotNil(t, elog.eventHandle)
+	assert.NoError(t, elog.Close())
+	// bad name
+	elog = NewEventLog("FakeBadElogName", LEVELS, GROUP_NAME, STREAM_NAME,
+		RENDER_FMT, DEST, STATE_FILE_PATH, BATCH_SIZE, RETENTION)
+	assert.Error(t, elog.Open())
+	assert.Zero(t, elog.eventHandle)
+	// bad LEVELS does not cause Open() to fail.
+	// bad wlog.eventOffset does not cause Open() to fail.
+}
+
+// TestReadGoodSource will verify we can read events written by a registered
+// event log source.
+func TestReadGoodSource(t *testing.T) {
+	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
+		STATE_FILE_PATH, BATCH_SIZE, RETENTION)
+	assert.Equal(t, nil, elog.Open())
+	seekToEnd(t, elog)
+	writeEvents(t, 10, true, "CWA_UnitTest111", 777)
+	// Without a sleep we do not read any events!!!
+	time.Sleep(1 * time.Second)
+	checkEvents(t, elog, 10, "[Application] [ERROR] [777] [CWA_UnitTest111] ")
+	assert.Equal(t, nil, elog.Close())
+}
+
+// TestReadBadSource will verify that we cannot read events written by an
+// unregistered event log source.
+func TestReadBadSource(t *testing.T) {
+	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
+		STATE_FILE_PATH, BATCH_SIZE, RETENTION)
+	assert.Equal(t, nil, elog.Open())
+	seekToEnd(t, elog)
+	writeEvents(t, 10, false, "CWA_UnitTest222", 888)
+	time.Sleep(1 * time.Second)
+	checkEvents(t, elog, 0, "[Application] [ERROR] [888] [CWA_UnitTest222] ")
+	assert.Equal(t, nil, elog.Close())
+}
+
+// TestReadWithBothSources will verify we can read events written by a
+// registered event log source, even if the batch contains events from an
+// unregistered source too.
+func TestReadWithBothSources(t *testing.T) {
+	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
+		STATE_FILE_PATH, BATCH_SIZE, RETENTION)
+	assert.Equal(t, nil, elog.Open())
+	seekToEnd(t, elog)
+	writeEvents(t, 10, true, "CWA_UnitTest111", 777)
+	writeEvents(t, 10, false, "CWA_UnitTest222", 888)
+	time.Sleep(1 * time.Second)
+	checkEvents(t, elog, 10, "[Application] [ERROR] [777] [CWA_UnitTest111] ")
+	assert.Equal(t, nil, elog.Close())
+}
+
+// seekToEnd skips past all current events in the event log.
+func seekToEnd(t *testing.T, elog *windowsEventLog) {
+	// loop until we stop getting records.
+	numRetrieved := 0
+	for {
+		records := elog.read()
+		//assert.Equal(t, nil, err)
+		t.Logf("seekToEnd() current count %v", len(records))
+		numRetrieved += len(records)
+		if len(records) == 0 {
+			break
+		}
+	}
+	t.Logf("seekToEnd() total %v", numRetrieved)
+}
+
+// writeEvents writes msgCount number of events to the Application event log.
+// Optionally register the given logSrc.
+// Fail the test if an error occurs.
+func writeEvents(t *testing.T, msgCount int, doRegister bool, logSrc string, eventId uint32) {
+	if doRegister {
+		// Expected to fail if unit test previously ran and installed the event src.
+		_ = eventlog.InstallAsEventCreate(logSrc, eventlog.Info | eventlog.Warning | eventlog.Error)
+	}
+	wlog, err := eventlog.Open(logSrc)
+	assert.NoError(t, err)
+	for i := 0; i < msgCount; i++ {
+		msg := fmt.Sprintf("CWA_UnitTest event msg %v", i)
+		wlog.Error(eventId, msg)
+	}
+	err = wlog.Close()
+	assert.NoError(t, err)
+}
+
+// checkEvents reads all events (since last read) then checks each one for the
+// given substr. Verify count == msgCount.
+func checkEvents(t *testing.T, elog *windowsEventLog, msgCount int, substr string) {
+	// Get all new records.
+	var records []*windowsEventLogRecord
+	for {
+		// In the old code read() would return an error if there were events
+		// from an unregistered provider.
+		currentRecords := elog.read()
+		//assert.Equal(t, nil, err)
+		t.Logf("checkEvents() current count %v", len(currentRecords))
+		if len(currentRecords) == 0 {
+			break
+		}
+		records = append(records, currentRecords...)
+	}
+	t.Logf("checkEvents() total count %v", len(records))
+	// Check all new records.
+	found := 0
+	for _, r := range records {
+		eventMsg, err := r.Value()
+		assert.NoError(t, err)
+		if strings.Contains(eventMsg, substr) {
+			found += 1
+		}
+	}
+	assert.Equal(t, msgCount, found)
+}

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord.go
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
+//go:build windows
 // +build windows
 
 package wineventlog

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -355,7 +355,7 @@ func (c *CloudWatch) WriteToCloudWatch(req interface{}) {
 			}
 			switch awsErr.Code() {
 			case cloudwatch.ErrCodeLimitExceededFault, cloudwatch.ErrCodeInternalServiceFault:
-				log.Printf("W! cloudwatch putmetricdate met issue: %s, message: %s",
+				log.Printf("W! cloudwatch PutMetricData, error: %s, message: %s",
 					awsErr.Code(),
 					awsErr.Message())
 				c.backoffSleep()

--- a/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist.go
+++ b/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist.go
@@ -21,7 +21,7 @@ const (
 	BatchReadSizeKey   = "batch_read_size"
 	EventLevelsKey     = "event_levels"
 	//TODO: Performance test to confirm the proper value here - https://github.com/aws/amazon-cloudwatch-agent/issues/231
-	BatchReadSizeValue = 170
+	BatchReadSizeValue = 100
 )
 
 var ChildRule = map[string]Rule{}

--- a/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist.go
+++ b/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist.go
@@ -21,7 +21,7 @@ const (
 	BatchReadSizeKey   = "batch_read_size"
 	EventLevelsKey     = "event_levels"
 	//TODO: Performance test to confirm the proper value here - https://github.com/aws/amazon-cloudwatch-agent/issues/231
-	BatchReadSizeValue = 100
+	BatchReadSizeValue = 170
 )
 
 var ChildRule = map[string]Rule{}


### PR DESCRIPTION
# Description of the issue
Closes https://github.com/aws/amazon-cloudwatch-agent/issues/199
CloudWatch Agent reads from the Windows event logs in batches.
Currently, if the Agent has issues reading or rendering _any_ event in the batch, it will drop all the events in the batch.
In this specific case there was an event related to the install of Google Chrome for which `EvtOpenPublisherMetadata()` failed.

# Description of changes
Change `getRecords()` to `continue` when an error is encountered, instead of `return`.
Added unit tests.
Fixed another bug in `windowsEventLog.Open()` so it returns an error when `EvtSubscribe()` fails.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manual test:
1. Start an EC2 instance running Windows Server 2019 with the latest CloudWatch Agent installed and configured to monitor the Application Event log for ERROR, INFO, VERBOSE.
2. Run a PowerShell script which repeatedly writes an ERROR level event to the Application event log with a specific message and an increasing counter.
3. Install and uninstall Google Chrome.
4. Expect CloudWatch console to show all events from the PowerShell script, but actual result shows missing events.

Added unit test:
```
PS C:\Users\Administrator\go\src\amazon-cloudwatch-agent> go test  .\plugins\inputs\windows_event_log\wineventlog\...
ok      github.com/aws/amazon-cloudwatch-agent/plugins/inputs/windows_event_log/wineventlog     6.594s
```



