### PR TITLE
Export Task ARN resource via Prometheus

### DIFF
--- a/internal/ecsservicediscovery/decoratedtask.go
+++ b/internal/ecsservicediscovery/decoratedtask.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
@@ -22,6 +23,7 @@ const (
 	taskLaunchTypeLabel  = "LaunchType"
 	taskJobNameLabel     = "job"
 	taskMetricsPathLabel = "__metrics_path__"
+	taskArnResourceLabel = "TaskArnResource"
 	ec2InstanceTypeLabel = "InstanceType"
 	ec2VpcIdLabel        = "VpcId"
 	ec2SubnetIdLabel     = "SubnetId"
@@ -138,6 +140,9 @@ func (t *DecoratedTask) generatePrometheusTarget(
 	addExporterLabels(labels, taskGroupLabel, t.Task.Group)
 	addExporterLabels(labels, taskStartedbyLabel, t.Task.StartedBy)
 	addExporterLabels(labels, taskLaunchTypeLabel, t.Task.LaunchType)
+	if arn, err := arn.Parse(*t.Task.TaskArn); err == nil {
+		addExporterLabels(labels, taskArnResourceLabel, &arn.Resource)
+	}
 	if t.EC2Info != nil {
 		addExporterLabels(labels, ec2InstanceTypeLabel, &t.EC2Info.InstanceType)
 		addExporterLabels(labels, ec2VpcIdLabel, &t.EC2Info.VpcId)

--- a/internal/ecsservicediscovery/decoratedtask.go
+++ b/internal/ecsservicediscovery/decoratedtask.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -23,7 +24,8 @@ const (
 	taskLaunchTypeLabel  = "LaunchType"
 	taskJobNameLabel     = "job"
 	taskMetricsPathLabel = "__metrics_path__"
-	taskArnResourceLabel = "TaskArnResource"
+	taskClusterNameLabel = "TaskClusterName"
+	taskIdLabel          = "TaskId"
 	ec2InstanceTypeLabel = "InstanceType"
 	ec2VpcIdLabel        = "VpcId"
 	ec2SubnetIdLabel     = "SubnetId"
@@ -140,9 +142,23 @@ func (t *DecoratedTask) generatePrometheusTarget(
 	addExporterLabels(labels, taskGroupLabel, t.Task.Group)
 	addExporterLabels(labels, taskStartedbyLabel, t.Task.StartedBy)
 	addExporterLabels(labels, taskLaunchTypeLabel, t.Task.LaunchType)
+
 	if arn, err := arn.Parse(*t.Task.TaskArn); err == nil {
-		addExporterLabels(labels, taskArnResourceLabel, &arn.Resource)
+		// ARN formats: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
+		splitResource := strings.Split(arn.Resource, "/")[1:]
+		if len(splitResource) == 1 {
+			// Old ARN format
+			taskId := splitResource[0]
+			addExporterLabels(labels, taskIdLabel, &taskId)
+		} else if len(splitResource) == 2 {
+			// New ARN format
+			clusterName := splitResource[0]
+			taskId := splitResource[1]
+			addExporterLabels(labels, taskClusterNameLabel, &clusterName)
+			addExporterLabels(labels, taskIdLabel, &taskId)
+		}
 	}
+
 	if t.EC2Info != nil {
 		addExporterLabels(labels, ec2InstanceTypeLabel, &t.EC2Info.InstanceType)
 		addExporterLabels(labels, ec2VpcIdLabel, &t.EC2Info.VpcId)

--- a/internal/ecsservicediscovery/decoratedtask_test.go
+++ b/internal/ecsservicediscovery/decoratedtask_test.go
@@ -128,16 +128,18 @@ func Test_ExportDockerLabelBasedTarget_Fargate_AWSVPC(t *testing.T) {
 	target, ok := targets["10.0.0.129:9404/metrics"]
 	assert.True(t, ok, "Missing target: 10.0.0.129:9404/metrics")
 
-	assert.Equal(t, 5, len(target.Labels))
+	assert.Equal(t, 6, len(target.Labels))
 	assert.Equal(t, "java-tomcat-fargate-awsvpc", target.Labels["job"])
 	assert.Equal(t, "bugbash-tomcat-fargate-awsvpc-with-docker-label", target.Labels["container_name"])
 	assert.Equal(t, "4", target.Labels["TaskRevision"])
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 	assert.Equal(t, "9404", target.Labels["FARGATE_PROMETHEUS_EXPORTER_PORT"])
 	assert.Equal(t, "java-tomcat-fargate-awsvpc", target.Labels["FARGATE_PROMETHEUS_JOB_NAME"])
 
 	target, ok = targets["10.0.0.129:9406/metrics"]
 	assert.True(t, ok, "Missing target: 10.0.0.129:9406/metrics")
-	assert.Equal(t, 5, len(target.Labels))
+	assert.Equal(t, 6, len(target.Labels))
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 	assert.Equal(t, "4", target.Labels["TaskRevision"])
 	assert.Equal(t, "bugbash-jar-fargate-awsvpc-with-dockerlabel", target.Labels["container_name"])
 	assert.Equal(t, "9406", target.Labels["FARGATE_PROMETHEUS_EXPORTER_PORT"])
@@ -169,16 +171,18 @@ func Test_ExportTaskDefBasedTarget_Fargate_AWSVPC(t *testing.T) {
 	target, ok := targets["10.0.0.129:9404/stats/metrics"]
 	assert.True(t, ok, "Missing target: 10.0.0.129:9404/stats/metrics")
 
-	assert.Equal(t, 5, len(target.Labels))
+	assert.Equal(t, 6, len(target.Labels))
 	assert.Equal(t, "java-tomcat-fargate-awsvpc", target.Labels["FARGATE_PROMETHEUS_JOB_NAME"])
-	assert.Equal(t, "bugbash-tomcat-fargate-awsvpc-with-docker-label", target.Labels["container_name"])
 	assert.Equal(t, "4", target.Labels["TaskRevision"])
+	assert.Equal(t, "bugbash-tomcat-fargate-awsvpc-with-docker-label", target.Labels["container_name"])
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 	assert.Equal(t, "9404", target.Labels["FARGATE_PROMETHEUS_EXPORTER_PORT"])
 	assert.Equal(t, "/stats/metrics", target.Labels["__metrics_path__"])
 
 	target, ok = targets["10.0.0.129:9406/stats/metrics"]
 	assert.True(t, ok, "Missing target: 10.0.0.129:9406/stats/metrics")
-	assert.Equal(t, 5, len(target.Labels))
+	assert.Equal(t, 6, len(target.Labels))
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 	assert.Equal(t, "4", target.Labels["TaskRevision"])
 	assert.Equal(t, "bugbash-jar-fargate-awsvpc-with-dockerlabel", target.Labels["container_name"])
 	assert.Equal(t, "9406", target.Labels["FARGATE_PROMETHEUS_EXPORTER_PORT"])
@@ -213,16 +217,18 @@ func Test_exportServiceEndpointBasedTarget_Fargate_AWSVPC(t *testing.T) {
 	target, ok := targets["10.0.0.129:9404/stats/metrics"]
 	assert.True(t, ok, "Missing target: 10.0.0.129:9404/stats/metrics")
 
-	assert.Equal(t, 6, len(target.Labels))
+	assert.Equal(t, 7, len(target.Labels))
 	assert.Equal(t, "java-tomcat-fargate-awsvpc", target.Labels["FARGATE_PROMETHEUS_JOB_NAME"])
-	assert.Equal(t, "bugbash-tomcat-fargate-awsvpc-with-docker-label", target.Labels["container_name"])
 	assert.Equal(t, "4", target.Labels["TaskRevision"])
+	assert.Equal(t, "bugbash-tomcat-fargate-awsvpc-with-docker-label", target.Labels["container_name"])
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 	assert.Equal(t, "9404", target.Labels["FARGATE_PROMETHEUS_EXPORTER_PORT"])
 	assert.Equal(t, "/stats/metrics", target.Labels["__metrics_path__"])
 
 	target, ok = targets["10.0.0.129:9406/stats/metrics"]
 	assert.True(t, ok, "Missing target: 10.0.0.129:9406/stats/metrics")
-	assert.Equal(t, 6, len(target.Labels))
+	assert.Equal(t, 7, len(target.Labels))
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 	assert.Equal(t, "4", target.Labels["TaskRevision"])
 	assert.Equal(t, "bugbash-jar-fargate-awsvpc-with-dockerlabel", target.Labels["container_name"])
 	assert.Equal(t, "9406", target.Labels["FARGATE_PROMETHEUS_EXPORTER_PORT"])
@@ -411,7 +417,7 @@ func testExportMixedSDTarget_EC2_Bridge_DynamicPort(t *testing.T, networkMode st
 	target, ok := targets["10.4.0.205:32774/metrics"]
 	assert.True(t, ok, "Missing target: 10.4.0.205:32774/metrics")
 
-	assert.Equal(t, 8, len(target.Labels))
+	assert.Equal(t, 9, len(target.Labels))
 	assert.Equal(t, "/metrics", target.Labels["EC2_PROMETHEUS_METRICS_PATH"])
 	assert.Equal(t, "9406", target.Labels["EC2_PROMETHEUS_EXPORTER_PORT"])
 	assert.Equal(t, "t3.medium", target.Labels["InstanceType"])
@@ -420,10 +426,11 @@ func testExportMixedSDTarget_EC2_Bridge_DynamicPort(t *testing.T, networkMode st
 	assert.Equal(t, "vpc-03e9f55a92516a5e4", target.Labels["VpcId"])
 	assert.Equal(t, "/metrics", target.Labels["__metrics_path__"])
 	assert.Equal(t, "bugbash-jar-prometheus-workload-java-ec2-bridge", target.Labels["container_name"])
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 
 	target, ok = targets["10.4.0.205:9494/metrics"]
 	assert.True(t, ok, "Missing target: 10.4.0.205:9494/metrics")
-	assert.Equal(t, 8, len(target.Labels))
+	assert.Equal(t, 9, len(target.Labels))
 	assert.Equal(t, "9404", target.Labels["EC2_PROMETHEUS_EXPORTER_PORT"])
 	assert.Equal(t, "bugbash-tomcat-ec2-bridge-mapped-port", target.Labels["EC2_PROMETHEUS_JOB_NAME"])
 	assert.Equal(t, "t3.medium", target.Labels["InstanceType"])
@@ -431,6 +438,7 @@ func testExportMixedSDTarget_EC2_Bridge_DynamicPort(t *testing.T, networkMode st
 	assert.Equal(t, "5", target.Labels["TaskRevision"])
 	assert.Equal(t, "vpc-03e9f55a92516a5e4", target.Labels["VpcId"])
 	assert.Equal(t, "bugbash-tomcat-prometheus-workload-java-ec2-bridge-mapped-port", target.Labels["container_name"])
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 	assert.Equal(t, "bugbash-tomcat-ec2-bridge-mapped-port", target.Labels["job"])
 }
 
@@ -480,7 +488,7 @@ func testExportContainerNameSDTarget_EC2_Bridge_DynamicPort(t *testing.T, networ
 	target, ok := targets["10.4.0.205:9494/metrics"]
 	log.Print(target)
 	assert.True(t, ok, "Missing target: 10.4.0.205:9494/metrics")
-	assert.Equal(t, 8, len(target.Labels))
+	assert.Equal(t, 9, len(target.Labels))
 	assert.Equal(t, "9404", target.Labels["EC2_PROMETHEUS_EXPORTER_PORT"])
 	assert.Equal(t, "bugbash-tomcat-ec2-bridge-mapped-port", target.Labels["EC2_PROMETHEUS_JOB_NAME"])
 	assert.Equal(t, "t3.medium", target.Labels["InstanceType"])
@@ -489,4 +497,5 @@ func testExportContainerNameSDTarget_EC2_Bridge_DynamicPort(t *testing.T, networ
 	assert.Equal(t, "vpc-03e9f55a92516a5e4", target.Labels["VpcId"])
 	assert.Equal(t, "/metrics", target.Labels["__metrics_path__"])
 	assert.Equal(t, "bugbash-tomcat-prometheus-workload-java-ec2-bridge-mapped-port", target.Labels["container_name"])
+	assert.Equal(t, "task/ExampleCluster/1234567890123456789", target.Labels["TaskArnResource"])
 }

--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -321,7 +321,7 @@ func TestTailerSrcFiltersSingleLineLogs(t *testing.T) {
 	n := 100
 	matchedLog := "ERROR: this has an error in it."
 	unmatchedLog := "Some other log message"
-	publishLogsToFile(resources.file, matchedLog, unmatchedLog, n, 0)
+	publishLogsToFile(resources.file, matchedLog, unmatchedLog, n, 100)
 
 	// Removal of log file should stop tailersrc
 	if err := os.Remove(resources.file.Name()); err != nil {

--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -321,7 +321,7 @@ func TestTailerSrcFiltersSingleLineLogs(t *testing.T) {
 	n := 100
 	matchedLog := "ERROR: this has an error in it."
 	unmatchedLog := "Some other log message"
-	publishLogsToFile(resources.file, matchedLog, unmatchedLog, n, 100)
+	publishLogsToFile(resources.file, matchedLog, unmatchedLog, n, 0)
 
 	// Removal of log file should stop tailersrc
 	if err := os.Remove(resources.file.Name()); err != nil {

--- a/plugins/outputs/cloudwatch/aggregator_test.go
+++ b/plugins/outputs/cloudwatch/aggregator_test.go
@@ -73,8 +73,7 @@ func TestAggregator_ProperAggregationKey(t *testing.T) {
 
 	aggregator.AddMetric(m)
 	assertNoMetricsInChan(t, metricChan)
-	time.Sleep(2 * aggregationInterval)
-	assertMetricContent(t, metricChan, m, expectedFieldContent{"value", 1, 1, 1, 1, "",
+	assertMetricContent(t, metricChan, aggregationInterval * 2, m, expectedFieldContent{"value", 1, 1, 1, 1, "",
 		[]float64{1.0488088481701516}, []float64{1}})
 
 	assertNoMetricsInChan(t, metricChan)
@@ -110,14 +109,12 @@ func TestAggregator_MultipleAggregationPeriods(t *testing.T) {
 	aggregator.AddMetric(m)
 
 	assertNoMetricsInChan(t, metricChan)
-	time.Sleep(4 * aggregationInterval)
-	assertMetricContent(t, metricChan, m, expectedFieldContent{"value", 3, 1, 3, 6, "",
+	assertMetricContent(t, metricChan, aggregationInterval * 2, m, expectedFieldContent{"value", 3, 1, 3, 6, "",
 		[]float64{1.0488088481701516, 2.0438317370604793, 2.992374046230249}, []float64{1, 1, 1}})
 
 	assertNoMetricsInChan(t, metricChan)
 
-	time.Sleep(4 * aggregationInterval)
-	assertMetricContent(t, metricChan, m, expectedFieldContent{"value", 5, 4, 2, 9, "",
+	assertMetricContent(t, metricChan, aggregationInterval * 2, m, expectedFieldContent{"value", 5, 4, 2, 9, "",
 		[]float64{3.9828498555324616, 4.819248325194279}, []float64{1, 1}},
 		expectedFieldContent{"2nd value", 2, 1, 2, 3, "",
 			[]float64{1.0488088481701516, 2.0438317370604793}, []float64{1, 1}})
@@ -143,7 +140,7 @@ func TestAggregator_ShutdownBehavior(t *testing.T) {
 	close(shutdownChan)
 	wg.Wait()
 
-	assertMetricContent(t, metricChan, m, expectedFieldContent{"value", 1, 1, 1, 1, "", []float64{1.0488088481701516}, []float64{1}})
+	assertMetricContent(t, metricChan, 0 * time.Second, m, expectedFieldContent{"value", 1, 1, 1, 1, "", []float64{1.0488088481701516}, []float64{1}})
 	assertNoMetricsInChan(t, metricChan)
 }
 
@@ -208,48 +205,53 @@ func testPreparation() (chan telegraf.Metric, chan struct{}, Aggregator) {
 	return metricChan, shutdownChan, aggregator
 }
 
-func assertMetricContent(t *testing.T, metricChan <-chan telegraf.Metric, originalMetric telegraf.Metric, expectedFieldContent ...expectedFieldContent) {
-	log.Printf("The metric chan len is %v.", len(metricChan))
+func assertMetricContent(t *testing.T, metricChan <-chan telegraf.Metric, metricMaxWait time.Duration, originalMetric telegraf.Metric, expectedFieldContent ...expectedFieldContent) {
+	var aggregatedMetric telegraf.Metric
+
+	log.Printf("Waiting for metric.")
 	select {
-	case aggregatedMetric := <-metricChan:
-		assert.False(t, aggregatedMetric.HasTag(aggregationIntervalTagKey))
-		assert.Equal(t, "true", aggregatedMetric.Tags()[highResolutionTagKey])
-
-		for _, fieldContent := range expectedFieldContent {
-			dist, ok := aggregatedMetric.Fields()[fieldContent.fieldName].(distribution.Distribution)
-			assert.True(t, ok)
-
-			assert.Equal(t, fieldContent.max, dist.Maximum())
-			assert.Equal(t, fieldContent.sampleCount, dist.SampleCount())
-			assert.Equal(t, fieldContent.unit, dist.Unit())
-			assert.Equal(t, fieldContent.min, dist.Minimum())
-			assert.Equal(t, fieldContent.sum, dist.Sum())
-
-			values, counts := dist.ValuesAndCounts()
-			assert.Equal(t, len(fieldContent.expectedValues), len(values))
-			assert.Equal(t, len(fieldContent.expectedCounts), len(counts))
-
-			sort.Float64s(fieldContent.expectedValues)
-			sort.Float64s(values)
-			assert.Equal(t, fieldContent.expectedValues, values)
-
-			var expectedCountInts []int
-			for _, count := range fieldContent.expectedCounts {
-				expectedCountInts = append(expectedCountInts, int(count))
-			}
-			sort.Ints(expectedCountInts)
-			var countInts []int
-			for _, count := range counts {
-				countInts = append(countInts, int(count))
-			}
-			sort.Ints(countInts)
-			assert.Equal(t, expectedCountInts, countInts)
-		}
-
-		assert.NotEqual(t, originalMetric, aggregatedMetric, "The aggregatedMetric should not exactly equal to m since the field will be distribution.Distribution")
-	default:
-		assert.Fail(t, "We should got 1 metric now")
+	case aggregatedMetric = <-metricChan:
+	case <-time.After(metricMaxWait):
+		assert.FailNow(t, "We should've seen 1 metric by now")
 	}
+
+	log.Printf("Checking metric.")
+
+	assert.False(t, aggregatedMetric.HasTag(aggregationIntervalTagKey))
+	assert.Equal(t, "true", aggregatedMetric.Tags()[highResolutionTagKey])
+
+	for _, fieldContent := range expectedFieldContent {
+		dist, ok := aggregatedMetric.Fields()[fieldContent.fieldName].(distribution.Distribution)
+		assert.True(t, ok)
+
+		assert.Equal(t, fieldContent.max, dist.Maximum())
+		assert.Equal(t, fieldContent.sampleCount, dist.SampleCount())
+		assert.Equal(t, fieldContent.unit, dist.Unit())
+		assert.Equal(t, fieldContent.min, dist.Minimum())
+		assert.Equal(t, fieldContent.sum, dist.Sum())
+
+		values, counts := dist.ValuesAndCounts()
+		assert.Equal(t, len(fieldContent.expectedValues), len(values))
+		assert.Equal(t, len(fieldContent.expectedCounts), len(counts))
+
+		sort.Float64s(fieldContent.expectedValues)
+		sort.Float64s(values)
+		assert.Equal(t, fieldContent.expectedValues, values)
+
+		var expectedCountInts []int
+		for _, count := range fieldContent.expectedCounts {
+			expectedCountInts = append(expectedCountInts, int(count))
+		}
+		sort.Ints(expectedCountInts)
+		var countInts []int
+		for _, count := range counts {
+			countInts = append(countInts, int(count))
+		}
+		sort.Ints(countInts)
+		assert.Equal(t, expectedCountInts, countInts)
+	}
+
+	assert.NotEqual(t, originalMetric, aggregatedMetric, "The aggregatedMetric should not exactly equal to m since the field will be distribution.Distribution")
 }
 
 func assertNoMetricsInChan(t *testing.T, metricChan <-chan telegraf.Metric) {

--- a/plugins/outputs/cloudwatch/aggregator_test.go
+++ b/plugins/outputs/cloudwatch/aggregator_test.go
@@ -110,13 +110,13 @@ func TestAggregator_MultipleAggregationPeriods(t *testing.T) {
 	aggregator.AddMetric(m)
 
 	assertNoMetricsInChan(t, metricChan)
-	time.Sleep(2 * aggregationInterval)
+	time.Sleep(4 * aggregationInterval)
 	assertMetricContent(t, metricChan, m, expectedFieldContent{"value", 3, 1, 3, 6, "",
 		[]float64{1.0488088481701516, 2.0438317370604793, 2.992374046230249}, []float64{1, 1, 1}})
 
 	assertNoMetricsInChan(t, metricChan)
 
-	time.Sleep(2 * aggregationInterval)
+	time.Sleep(4 * aggregationInterval)
 	assertMetricContent(t, metricChan, m, expectedFieldContent{"value", 5, 4, 2, 9, "",
 		[]float64{3.9828498555324616, 4.819248325194279}, []float64{1, 1}},
 		expectedFieldContent{"2nd value", 2, 1, 2, 3, "",


### PR DESCRIPTION
# Description of the issue
Metrics exported to Prometheus don't include the cluster name or task ID, making it harder to map the metric back to the particular task that generated it using the AWS web UI.

# Description of changes
The task ID doesn't appear to be directly accessible, but the last part of the task's ARN (the resource) includes the cluster name and ID. This PR extracts this part of the ARN and exports it.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Automated tests have been updated and pass, and the changes have also been manually tested using a Fargate cluster.