### PR TITLE
Adding support for Drop original dimensions when aggregating

### DIFF
--- a/translator/config/sampleSchema/validLinuxMetrics.json
+++ b/translator/config/sampleSchema/validLinuxMetrics.json
@@ -2,6 +2,7 @@
   "metrics": {
     "metrics_collected": {
       "cpu": {
+        "drop_original_metrics": ["cpu_usage_idle"],
         "resources": [
           "*"
         ],

--- a/translator/defaultKeyCase.go
+++ b/translator/defaultKeyCase.go
@@ -9,7 +9,17 @@ import (
 
 //DefaultCase check if current input overrides the default value for the given config entry key.
 func DefaultCase(key string, defaultVal, input interface{}) (returnKey string, returnVal interface{}) {
-	m := input.(map[string]interface{})
+	m, ok := input.(map[string]interface{})
+	if !ok {
+		// bypassing special formats like:
+		//		"procstat": [
+		//			{
+		//				"pid_file": "/var/run/example1.pid",
+		// 				...
+		returnKey = ""
+		returnVal = ""
+	}
+
 	if val, ok := m[key]; ok {
 		//The key is in current input instance, use the value in JSON.
 		returnVal = val

--- a/translator/totomlconfig/sampleConfig/drop_origin_linux.conf
+++ b/translator/totomlconfig/sampleConfig/drop_origin_linux.conf
@@ -1,0 +1,81 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.cpu]]
+    collect_cpu_time = true
+    fieldpass = ["usage_idle", "usage_nice", "usage_guest", "time_active", "usage_active"]
+    interval = "10s"
+    percpu = true
+    report_active = true
+    totalcpu = false
+    [inputs.cpu.tags]
+      "aws:StorageResolution" = "true"
+      d1 = "foo"
+      d2 = "bar"
+      metricPath = "metrics"
+
+  [[inputs.disk]]
+    fieldpass = ["free", "total", "used"]
+    ignore_fs = ["sysfs", "devtmpfs"]
+    interval = "60s"
+    mount_points = ["/", "/dev", "/sys"]
+    tagexclude = ["mode"]
+    [inputs.disk.tags]
+      d3 = "foo3"
+      d4 = "bar4"
+      metricPath = "metrics"
+
+  [[inputs.nvidia_smi]]
+    fieldpass = ["utilization_gpu", "utilization_memory", "power_draw", "temperature_gpu"]
+    interval = "60s"
+    tagexclude = ["compute_mode", "pstate", "uuid"]
+    [inputs.nvidia_smi.tags]
+      metricPath = "metrics"
+
+[outputs]
+
+  [[outputs.cloudwatch]]
+    force_flush_interval = "60s"
+    namespace = "CWAgent"
+    region = "us-west-2"
+    tagexclude = ["host", "metricPath"]
+    [outputs.cloudwatch.drop_original_metrics]
+      cpu = ["cpu_usage_idle", "time_active"]
+      nvidia_smi = ["temperature_gpu", "utilization_gpu"]
+
+    [[outputs.cloudwatch.metric_decoration]]
+      category = "cpu"
+      name = "usage_idle"
+      rename = "CPU_USAGE_IDLE"
+      unit = "unit"
+
+    [[outputs.cloudwatch.metric_decoration]]
+      category = "cpu"
+      name = "usage_nice"
+      unit = "unit"
+    [outputs.cloudwatch.tagpass]
+      metricPath = ["metrics"]
+
+[processors]
+
+  [[processors.ec2tagger]]
+    ec2_instance_tag_keys = ["aws:autoscaling:groupName"]
+    ec2_metadata_tags = ["ImageId", "InstanceId", "InstanceType"]
+    refresh_interval_seconds = "0s"
+    [processors.ec2tagger.tagpass]
+      metricPath = ["metrics"]

--- a/translator/totomlconfig/sampleConfig/drop_origin_linux.json
+++ b/translator/totomlconfig/sampleConfig/drop_origin_linux.json
@@ -1,0 +1,61 @@
+{
+  "metrics": {
+    "append_dimensions": {
+      "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+      "ImageId": "${aws:ImageId}",
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}"
+    },
+    "metrics_collected": {
+      "cpu": {
+        "drop_original_metrics": ["cpu_usage_idle", "time_active"],
+        "resources": [
+          "*"
+        ],
+        "measurement": [
+          {"name": "cpu_usage_idle", "rename": "CPU_USAGE_IDLE", "unit": "unit"},
+          {"name": "cpu_usage_nice", "unit": "unit"},
+          "cpu_usage_guest",
+          "time_active",
+          "usage_active"
+        ],
+        "totalcpu": false,
+        "metrics_collection_interval": 10,
+        "append_dimensions": {
+          "d1": "foo",
+          "d2": "bar"
+        }
+      },
+      "disk": {
+        "resources": [
+          "/",
+          "/dev",
+          "/sys"
+        ],
+        "measurement": [
+          "free",
+          "total",
+          "used"
+        ],
+        "metrics_collection_interval": 60,
+        "append_dimensions": {
+          "d3": "foo3",
+          "d4": "bar4"
+        },
+        "ignore_file_system_types": [
+          "sysfs", "devtmpfs"
+        ]
+      },
+      "nvidia_gpu": {
+        "drop_original_metrics": ["utilization_gpu", "temperature_gpu"],
+        "measurement": [
+          "utilization_gpu",
+          "utilization_memory",
+          "power_draw",
+          "temperature_gpu"
+        ],
+        "metrics_collection_interval": 60
+      }
+    }
+  }
+}

--- a/translator/totomlconfig/toTomlConfig.go
+++ b/translator/totomlconfig/toTomlConfig.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus/ecsservicediscovery/taskdefinition"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus/emfprocessor"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/append_dimensions"
+	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/drop_origin"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metric_decoration"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/agentInternal"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect/collectd"

--- a/translator/totomlconfig/toTomlConfig_test.go
+++ b/translator/totomlconfig/toTomlConfig_test.go
@@ -125,6 +125,11 @@ func TestAdvancedConfig(t *testing.T) {
 	checkIfTranslateSucceed(t, ReadFromFile("./sampleConfig/advanced_config_windows.json"), "./sampleConfig/advanced_config_windows.conf", "windows")
 }
 
+func TestDropOriginConfig(t *testing.T) {
+	resetContext()
+	checkIfTranslateSucceed(t, ReadFromFile("./sampleConfig/drop_origin_linux.json"), "./sampleConfig/drop_origin_linux.conf", "linux")
+}
+
 func TestLogOnlyConfig(t *testing.T) {
 	resetContext()
 	checkIfTranslateSucceed(t, ReadFromFile("./sampleConfig/log_only_config_windows.json"), "./sampleConfig/log_only_config_windows.conf", "windows")

--- a/translator/translate/metrics/config/cloudwatch_output_plugin_config_keys.go
+++ b/translator/translate/metrics/config/cloudwatch_output_plugin_config_keys.go
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package config
+
+// CloudWatchOutputPluginKeys This served as a set that contains the supported CloudWatch output plugin keys
+var CloudWatchOutputPluginKeys = map[string]struct{}{
+	"metric_decoration": {},
+	"drop_original_metrics":       {},
+}
+
+func ContainsKey(key string) bool {
+	_, ok := CloudWatchOutputPluginKeys[key]
+	return ok
+}

--- a/translator/translate/metrics/drop_origin/drop_origin.go
+++ b/translator/translate/metrics/drop_origin/drop_origin.go
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package drop_origin
+
+import (
+	parent "github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/metrics_collect"
+	"log"
+	"reflect"
+)
+
+type dropOrigin struct {
+}
+
+const SectionKey = "drop_original_metrics"
+
+func (do *dropOrigin) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	im := input.(map[string]interface{})
+
+	returnKey = ""
+	returnVal = ""
+	if _, ok := im[metrics_collect.SectionKey]; !ok {
+		return
+	} else {
+		pluginMap := im[metrics_collect.SectionKey].(map[string]interface{})
+		result := make(map[string][]string)
+
+		for key, val := range pluginMap {
+			if entries, isMap := val.(map[string]interface{}); isMap {
+				if values, isSlice := entries[SectionKey].([]interface{}); isSlice && len(values) > 0 {
+					droppingDimensions := make([]string, 0)
+					for _, value := range values {
+						if reflect.TypeOf(value).String() == "string" {
+							droppingDimensions = append(droppingDimensions, value.(string))
+						} else {
+							log.Panic("Fail to translate the JSON config, invalid format of dropping dimensions.")
+						}
+					}
+
+					returnKey = SectionKey
+					result[config.GetRealPluginName(key)] = droppingDimensions
+					returnVal = result
+				}
+			}
+		}
+	}
+	return
+}
+
+func init() {
+	do := new(dropOrigin)
+	parent.RegisterRule(SectionKey, do)
+}

--- a/translator/translate/metrics/drop_origin/drop_origin_test.go
+++ b/translator/translate/metrics/drop_origin/drop_origin_test.go
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package drop_origin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDropOriginal(t *testing.T) {
+	e := new(dropOrigin)
+	//Check whether override default config
+	var input interface{}
+	err := json.Unmarshal([]byte(`{
+	 			"metrics_collected": {
+	 				"cpu": {
+	 					"drop_original_metrics": ["cpu_usage_guest", "cpu_usage_idle"],
+	 					"measurement": [
+	 						"cpu_usage_guest",
+							"cpu_usage_system",
+							"cpu_usage_idle"
+	 					]
+	 				}
+	 			}}`), &input)
+	assert.NoError(t, err)
+	actualKey, actualVal := e.ApplyRule(input)
+	expectedKey := "drop_original_metrics"
+	expectedVal := map[string][]string{
+		"cpu": {"cpu_usage_guest", "cpu_usage_idle"},
+	}
+
+	assert.Equal(t, expectedKey, actualKey)
+	assert.Equal(t, expectedVal, actualVal)
+
+}
+
+func TestDropMultipleOriginal(t *testing.T) {
+	e := new(dropOrigin)
+	//Check whether override default config
+	var input interface{}
+	err := json.Unmarshal([]byte(`{
+	 			"metrics_collected": {
+	 				"cpu": {
+	 					"drop_original_metrics": ["cpu_usage_guest", "cpu_usage_idle"],
+	 					"measurement": [
+	 						"cpu_usage_guest",
+							"cpu_usage_system",
+							"cpu_usage_idle"
+	 					]
+	 				},
+					"nvidia_gpu": {
+	 					"drop_original_metrics": ["utilization_gpu", "temperature_gpu"],
+						"measurement": [
+							"utilization_gpu", 
+							"temperature_gpu", 
+							"power_draw", 
+							"utilization_memory", 
+							"fan_speed", 
+							"memory_total", 
+							"memory_used", 
+							"memory_free", 
+							"temperature_gpu"
+						]
+					}
+	 			}}`), &input)
+	assert.NoError(t, err)
+	actualKey, actualVal := e.ApplyRule(input)
+	expectedKey := "drop_original_metrics"
+	expectedVal := map[string][]string{
+		"cpu": {"cpu_usage_guest", "cpu_usage_idle"},
+		"nvidia_smi": {"utilization_gpu", "temperature_gpu"},
+	}
+
+	assert.Equal(t, expectedKey, actualKey)
+	assert.Equal(t, expectedVal, actualVal)
+
+}
+
+func TestNotDropOriginal(t *testing.T) {
+	e := new(dropOrigin)
+	//Check whether override default config
+	var input interface{}
+	err := json.Unmarshal([]byte(`{
+	 			"metrics_collected": {
+	 				"cpu": {
+	 					"drop_original_metrics": [],
+	 					"measurement": [
+	 						"cpu_usage_guest"
+	 					]
+	 				},
+					"nvidia_gpu": {
+						"measurement": [
+							"memory_used"
+						]
+					}
+	 			}}`), &input)
+	assert.NoError(t, err)
+	actualKey, actualVal := e.ApplyRule(input)
+
+	assert.Equal(t, "", actualKey)
+	assert.Equal(t, "", actualVal)
+}
+
+func TestDefaultDropOriginal(t *testing.T) {
+	e := new(dropOrigin)
+	//Check whether override default config
+	var input interface{}
+	err := json.Unmarshal([]byte(`{
+	 			"metrics_collected": {
+	 				"cpu": {
+	 					"measurement": [
+	 						"cpu_usage_guest"
+	 					]
+	 				}
+	 			}}`), &input)
+	assert.NoError(t, err)
+	actualKey, actualVal := e.ApplyRule(input)
+
+	assert.Equal(t, "", actualKey)
+	assert.Equal(t, "", actualVal)
+}

--- a/translator/translate/metrics/metric_decoration/metric_decoration_test.go
+++ b/translator/translate/metrics/metric_decoration/metric_decoration_test.go
@@ -27,7 +27,7 @@ func TestMetricDecoration_ApplyRule(t *testing.T) {
 			}}`), &input)
 
 	require.Nil(t, err)
-	_, val := c.ApplyRule(input)
+	key, val := c.ApplyRule(input)
 	expected := []interface{}{
 		map[string]string{
 			"rename":   "CPU",
@@ -42,10 +42,11 @@ func TestMetricDecoration_ApplyRule(t *testing.T) {
 		},
 		// cpu_usage_guest will not translated into anything since there is no metric decoration configured for it.
 	}
+	assert.Equal(t, "metric_decoration", key)
 	assert.Equal(t, expected, val)
 }
 
-//Check the case when the input is in "cpu":{//specific configuration}
+//Check the case when the input is in "nvidia_gpu":{//specific configuration}
 func TestMetricDecoration_plugin_with_alias_ApplyRule(t *testing.T) {
 	c := new(MetricDecoration)
 	//Check whether override default config

--- a/translator/translate/metrics/metrics.go
+++ b/translator/translate/metrics/metrics.go
@@ -8,7 +8,9 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/jsonconfig/mergeJsonRule"
 	"github.com/aws/amazon-cloudwatch-agent/translator/jsonconfig/mergeJsonUtil"
 	parent "github.com/aws/amazon-cloudwatch-agent/translator/translate"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/util"
+	"sort"
 )
 
 type Rule translator.Rule
@@ -25,8 +27,8 @@ func GetCurPath() string {
 	return curPath
 }
 
-func RegisterRule(fieldname string, r Rule) {
-	ChildRule[fieldname] = r
+func RegisterRule(fieldName string, r Rule) {
+	ChildRule[fieldName] = r
 }
 
 type Metrics struct {
@@ -51,8 +53,8 @@ func (m *Metrics) ApplyRule(input interface{}) (returnKey string, returnVal inte
 			if key != "" {
 				if key == OutputsKey {
 					outputPlugInfo = translator.MergeTwoUniqueMaps(outputPlugInfo, val.(map[string]interface{}))
-				} else if key == "metric_decoration" {
-					addDecorations(key, val, outputPlugInfo)
+				} else if config.ContainsKey(key) {
+					addCloudWatchOutputConfig(key, val, outputPlugInfo)
 				} else {
 					result[key] = val
 				}
@@ -69,16 +71,27 @@ func (m *Metrics) ApplyRule(input interface{}) (returnKey string, returnVal inte
 	return
 }
 
-func addDecorations(key string, val interface{}, outputPlugInfo map[string]interface{}) {
-	if len(val.([]interface{})) > 0 {
+func addCloudWatchOutputConfig(key string, val interface{}, outputPlugInfo map[string]interface{}) {
+	if val1, isSlice := val.([]interface{}); isSlice && len(val1) > 0 {
 		outputPlugInfo[key] = val
+	} else if val2, isMap := val.(map[string][]string); isMap && len(val2) > 0 {
+		sortItems(val2)
+		outputPlugInfo[key] = val2
 	}
+
 }
 
 var MergeRuleMap = map[string]mergeJsonRule.MergeRule{}
 
 func (m *Metrics) Merge(source map[string]interface{}, result map[string]interface{}) {
 	mergeJsonUtil.MergeMap(source, result, SectionKey, MergeRuleMap, GetCurPath())
+}
+
+// Sort items in map alphabetically to temporarily avoid unstable tests before introduce Toml-to-Toml comparison.
+func sortItems(vals map[string][]string) {
+	for _,val := range vals {
+		sort.Strings(val)
+	}
 }
 
 func init() {


### PR DESCRIPTION
1. Transalte drop original flags config at metrics level
2. Drop metrics based on the metric names when the output plugin is configured
3. Unit tests for config translation and config reading

# Description of the issue
_Describe the problem or feature in addition to a link to the issues._

# Description of changes
_How does this change address the problem?_

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._




