### PR TITLE
force consistent log stream name

### DIFF
--- a/translator/totomlconfig/sampleConfig/log_filter.conf
+++ b/translator/totomlconfig/sampleConfig/log_filter.conf
@@ -52,7 +52,7 @@
 
   [[outputs.cloudwatchlogs]]
     force_flush_interval = "5s"
-    log_stream_name = "i-UNKNOWN"
+    log_stream_name = "LOG_STREAM_NAME"
     region = "us-east-1"
     tagexclude = ["metricPath"]
     [outputs.cloudwatchlogs.tagpass]

--- a/translator/totomlconfig/sampleConfig/log_filter.json
+++ b/translator/totomlconfig/sampleConfig/log_filter.json
@@ -30,6 +30,7 @@
           }
         ]
       }
-    }
+    },
+    "log_stream_name": "LOG_STREAM_NAME"
   }
 }


### PR DESCRIPTION
# Description of the issue
Depending on the environment that is running tests, the log stream name for this test can change, because of env vars on the test runner that could be picked up by the test and injected into the translation output.

Reading from the environment is a design choice of the agent, so rather than trying to refactor/modify that, I'm opting to just specify a log stream name so that it remains consistent in this test without causing a breaking change in existing functionality.

# Description of changes
Supplied a `log_stream_name` value in the test config json so that it consistently uses that in the test, regardless of the environment that the test is run.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the test locally to verify it worked, and also ran the test with differing log stream names just to confirm it fails as expected then. 




