### PR TITLE
fix duplicate retention check

### DIFF
--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -403,7 +403,7 @@ func (t *LogFile) checkForDuplicateRetentionSettings() {
 
 	for i := range t.FileConfig {
 		fileconfig := &t.FileConfig[i]
-		if fileconfig.LogGroupName != "" {
+		if fileconfig.LogGroupName != "" && fileconfig.RetentionInDays !=-1 {
 			logGroup := strings.ToLower(fileconfig.LogGroupName)
 			configMap[logGroup] += 1
 		}

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -149,7 +149,7 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 
 	t.cleanUpStoppedTailerSrc()
 
-	// If a log group has retention settings defined in more than one place, stop the agent
+	// If a log group has differing retentionInDays values defined in multiple places, stop the agent
 	t.checkForDuplicateRetentionSettings()
 	// Create a "tailer" for each file
 	for i := range t.FileConfig {
@@ -410,11 +410,11 @@ func (t *LogFile) checkForDuplicateRetentionSettings() {
 		}
 		// if the configMap[logGroup] exists, retention has been set for the same logGroup somewhere
 		if configMap[logGroup] != 0 {
-			// 2 different retentions has been set for the same log group, panic and stop the agent
+			// different retentions has been set for the same log group, panic and stop the agent
 			if configMap[logGroup] != fileConfig.RetentionInDays {
-				panic(fmt.Sprintf("error: retention for the same log group set in multiple places. Log Group Name: %v", fileConfig.LogGroupName))
+				panic(fmt.Sprintf("error: The Log Group has differing retentionInDays values defined in two or more places. Log Group Name: %v", fileConfig.LogGroupName))
 			}
-			// The same retention for a log group has been configured in multiple places, so unset it so that the retention api is only called once
+			// The same retention for a log group has been configured in multiple places. Unset it so that the retention api is only called once
 			fileConfig.RetentionInDays = -1
 		} else {
 			configMap[logGroup] = fileConfig.RetentionInDays

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -398,17 +398,26 @@ func (t *LogFile) cleanUpStoppedTailerSrc() {
 	}
 }
 
-// checkForDuplicateRetentionSettings: Checks if a log group has retention set in multiple places and stops the agent if found
+// checkForDuplicateRetentionSettings: Checks if a log group has retention set differently in multiple places and stops the agent if found
 func (t *LogFile) checkForDuplicateRetentionSettings() {
 	configMap := make(map[string]int)
 	for i := range t.FileConfig {
 		fileConfig := &t.FileConfig[i]
-		if fileConfig.LogGroupName != "" && fileConfig.RetentionInDays !=-1 {
-			logGroup := strings.ToLower(fileConfig.LogGroupName)
-			configMap[logGroup] += 1
+		logGroup := strings.ToLower(fileConfig.LogGroupName)
+		// if retention is 0, -1 or less it's either invalid or default
+		if fileConfig.RetentionInDays < 1 {
+			continue
 		}
-		if fileConfig.LogGroupName != "" && configMap[strings.ToLower(fileConfig.LogGroupName)] > 1 {
-			panic(fmt.Sprintf("error: retention for the same log group set in multiple places. Log Group Name: %v", fileConfig.LogGroupName))
+		// if the configMap[logGroup] exists, retention has been set for the same logGroup somewhere
+		if configMap[logGroup] != 0 {
+			// 2 different retentions has been set for the same log group, panic and stop the agent
+			if configMap[logGroup] != fileConfig.RetentionInDays {
+				panic(fmt.Sprintf("error: retention for the same log group set in multiple places. Log Group Name: %v", fileConfig.LogGroupName))
+			}
+			// The same retention for a log group has been configured in multiple places, so unset it so that the retention api is only called once
+			fileConfig.RetentionInDays = -1
+		} else {
+			configMap[logGroup] = fileConfig.RetentionInDays
 		}
 	}
 }

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -412,11 +412,6 @@ func (t *LogFile) checkForDuplicateRetentionSettings() {
 		}
 
 	}
-	//for i := range t.FileConfig {
-	//	fileconfig := &t.FileConfig[i]
-	//	// log group has Retention settings in multiple places: throw an error
-	//
-	//}
 }
 
 // Compressed file should be skipped.

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -407,15 +407,16 @@ func (t *LogFile) checkForDuplicateRetentionSettings() {
 			logGroup := strings.ToLower(fileconfig.LogGroupName)
 			configMap[logGroup] += 1
 		}
-
-	}
-	for i := range t.FileConfig {
-		fileconfig := &t.FileConfig[i]
-		// log group has Retention settings in multiple places: throw an error
 		if fileconfig.LogGroupName != "" && configMap[strings.ToLower(fileconfig.LogGroupName)] > 1 {
 			panic(fmt.Sprintf("error: retention for the same log group set in multiple places. Log Group Name: %v", fileconfig.LogGroupName))
 		}
+
 	}
+	//for i := range t.FileConfig {
+	//	fileconfig := &t.FileConfig[i]
+	//	// log group has Retention settings in multiple places: throw an error
+	//
+	//}
 }
 
 // Compressed file should be skipped.

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -398,19 +398,18 @@ func (t *LogFile) cleanUpStoppedTailerSrc() {
 	}
 }
 
+// checkForDuplicateRetentionSettings: Checks if a log group has retention set in multiple places and stops the agent if found
 func (t *LogFile) checkForDuplicateRetentionSettings() {
 	configMap := make(map[string]int)
-
 	for i := range t.FileConfig {
-		fileconfig := &t.FileConfig[i]
-		if fileconfig.LogGroupName != "" && fileconfig.RetentionInDays !=-1 {
-			logGroup := strings.ToLower(fileconfig.LogGroupName)
+		fileConfig := &t.FileConfig[i]
+		if fileConfig.LogGroupName != "" && fileConfig.RetentionInDays !=-1 {
+			logGroup := strings.ToLower(fileConfig.LogGroupName)
 			configMap[logGroup] += 1
 		}
-		if fileconfig.LogGroupName != "" && configMap[strings.ToLower(fileconfig.LogGroupName)] > 1 {
-			panic(fmt.Sprintf("error: retention for the same log group set in multiple places. Log Group Name: %v", fileconfig.LogGroupName))
+		if fileConfig.LogGroupName != "" && configMap[strings.ToLower(fileConfig.LogGroupName)] > 1 {
+			panic(fmt.Sprintf("error: retention for the same log group set in multiple places. Log Group Name: %v", fileConfig.LogGroupName))
 		}
-
 	}
 }
 

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -774,7 +774,7 @@ func TestLogsFileRecreate(t *testing.T) {
 	defer lsrc.Stop()
 
 	// Waiting 10 seconds for the recreated temp file to be detected is plenty sufficient on any OS.
-	for start := time.Now(); time.Since(start) < 10*time.Second; {
+	for start := time.Now(); time.Since(start) < 10 * time.Second; {
 		lsrcs = tt.FindLogSrc()
 		if len(lsrcs) > 0 {
 			break

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -774,7 +774,7 @@ func TestLogsFileRecreate(t *testing.T) {
 	defer lsrc.Stop()
 
 	// Waiting 10 seconds for the recreated temp file to be detected is plenty sufficient on any OS.
-	for start := time.Now(); time.Since(start) < 10 * time.Second; {
+	for start := time.Now(); time.Since(start) < 10*time.Second; {
 		lsrcs = tt.FindLogSrc()
 		if len(lsrcs) > 0 {
 			break
@@ -1086,6 +1086,68 @@ func TestCheckForDuplicateRetentionSettingsPanics(t *testing.T) {
 			FromBeginning:   true,
 			LogGroupName:    logGroupName,
 			RetentionInDays: 3,
+		},
+	}
+	assert.Panics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Did not panic after finding duplicate log group")
+}
+
+func TestCheckForDuplicateRetentionSettingsWithDefaultRetention(t *testing.T) {
+	tt := NewLogFile()
+	logGroupName := "DuplicateLogGroupName"
+	tt.FileConfig = []FileConfig{{
+		FilePath:        "SampleFilePath",
+		FromBeginning:   true,
+		LogGroupName:    logGroupName,
+		RetentionInDays: -1,
+	},
+		{
+			FilePath:        "SampleFilePath",
+			FromBeginning:   true,
+			LogGroupName:    logGroupName,
+			RetentionInDays: -1,
+		},
+	}
+	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Did not panic after finding duplicate log group")
+}
+
+func TestCheckForDuplicateRetentionSettings(t *testing.T) {
+	tt := NewLogFile()
+	tt.FileConfig = []FileConfig{{
+		FilePath:        "SampleFilePath",
+		FromBeginning:   true,
+		LogGroupName:    "logGroupName1",
+		RetentionInDays: 5,
+	},
+		{
+			FilePath:        "SampleFilePath",
+			FromBeginning:   true,
+			LogGroupName:    "logGroupName2",
+			RetentionInDays: 3,
+		},
+	}
+	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Did not panic after finding duplicate log group")
+}
+
+func TestCheckDuplicateRetentionWithDefaultAndSetLogGroups(t *testing.T) {
+	tt := NewLogFile()
+	logGroupName := "DuplicateLogGroupName"
+	tt.FileConfig = []FileConfig{{
+		FilePath:        "SampleFilePath",
+		FromBeginning:   true,
+		LogGroupName:    logGroupName,
+		RetentionInDays: 3,
+	},
+		{
+			FilePath:        "SampleFilePath",
+			FromBeginning:   true,
+			LogGroupName:    logGroupName,
+			RetentionInDays: 5,
+		},
+		{
+			FilePath:        "SampleFilePath",
+			FromBeginning:   true,
+			LogGroupName:    logGroupName,
+			RetentionInDays: -1,
 		},
 	}
 	assert.Panics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Did not panic after finding duplicate log group")

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -1107,7 +1107,7 @@ func TestCheckForDuplicateRetentionSettingsWithDefaultRetention(t *testing.T) {
 			RetentionInDays: -1,
 		},
 	}
-	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Did not panic after finding duplicate log group")
+	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Panicked when no duplicate retention settings exists")
 }
 
 func TestCheckForDuplicateRetentionSettings(t *testing.T) {
@@ -1125,7 +1125,7 @@ func TestCheckForDuplicateRetentionSettings(t *testing.T) {
 			RetentionInDays: 3,
 		},
 	}
-	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Did not panic after finding duplicate log group")
+	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Panicked when no duplicate retention settings exists")
 }
 
 func TestCheckDuplicateRetentionWithDefaultAndSetLogGroups(t *testing.T) {

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -1116,7 +1116,26 @@ func TestCheckForDuplicateRetentionSettingsWithDefaultRetention(t *testing.T) {
 	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Panicked when no duplicate retention settings exists")
 }
 
-func TestCheckForDuplicateRetentionSettings(t *testing.T) {
+func TestCheckForDuplicateRetentionWithDefaultAndNonDefaultValue(t *testing.T) {
+	tt := NewLogFile()
+	logGroupName := "DuplicateLogGroupName"
+	tt.FileConfig = []FileConfig{{
+		FilePath:        "SampleFilePath",
+		FromBeginning:   true,
+		LogGroupName:    logGroupName,
+		RetentionInDays: -1,
+	},
+		{
+			FilePath:        "SampleFilePath",
+			FromBeginning:   true,
+			LogGroupName:    logGroupName,
+			RetentionInDays: 3,
+		},
+	}
+	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Panicked when no duplicate retention settings exists")
+}
+
+func TestCheckForDuplicateRetentionSettingsDifferentLogGroups(t *testing.T) {
 	tt := NewLogFile()
 	tt.FileConfig = []FileConfig{{
 		FilePath:        "SampleFilePath",
@@ -1181,11 +1200,10 @@ func TestCheckForDuplicateRetentionSettingsWithDefault(t *testing.T) {
 			RetentionInDays: 5,
 		},
 	}
-	tt.checkForDuplicateRetentionSettings()
+	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Panicked when no duplicate retention settings exists")
 	assert.Equal(t, tt.FileConfig[0].RetentionInDays, 5)
 	assert.Equal(t, tt.FileConfig[1].RetentionInDays, -1)
-	assert.Equal(t, tt.FileConfig[1].RetentionInDays, -1)
-	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Panicked when no duplicate retention settings exists")
+	assert.Equal(t, tt.FileConfig[2].RetentionInDays, -1)
 }
 
 

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -1087,6 +1087,12 @@ func TestCheckForDuplicateRetentionSettingsPanics(t *testing.T) {
 			LogGroupName:    logGroupName,
 			RetentionInDays: 3,
 		},
+		{
+			FilePath:        "SampleFilePath",
+			FromBeginning:   true,
+			LogGroupName:    logGroupName,
+			RetentionInDays: 3,
+		},
 	}
 	assert.Panics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Did not panic after finding duplicate log group")
 }
@@ -1152,3 +1158,34 @@ func TestCheckDuplicateRetentionWithDefaultAndSetLogGroups(t *testing.T) {
 	}
 	assert.Panics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Did not panic after finding duplicate log group")
 }
+
+func TestCheckForDuplicateRetentionSettingsWithDefault(t *testing.T) {
+	tt := NewLogFile()
+	logGroupName := "DuplicateLogGroupName"
+	tt.FileConfig = []FileConfig{{
+		FilePath:        "SampleFilePath",
+		FromBeginning:   true,
+		LogGroupName:    logGroupName,
+		RetentionInDays: 5,
+	},
+		{
+			FilePath:        "SampleFilePath",
+			FromBeginning:   true,
+			LogGroupName:    logGroupName,
+			RetentionInDays: 5,
+		},
+		{
+			FilePath:        "SampleFilePath",
+			FromBeginning:   true,
+			LogGroupName:    logGroupName,
+			RetentionInDays: 5,
+		},
+	}
+	tt.checkForDuplicateRetentionSettings()
+	assert.Equal(t, tt.FileConfig[0].RetentionInDays, 5)
+	assert.Equal(t, tt.FileConfig[1].RetentionInDays, -1)
+	assert.Equal(t, tt.FileConfig[1].RetentionInDays, -1)
+	assert.NotPanics(t, func() { tt.checkForDuplicateRetentionSettings() }, "Panicked when no duplicate retention settings exists")
+}
+
+

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -774,7 +774,7 @@ func TestLogsFileRecreate(t *testing.T) {
 	defer lsrc.Stop()
 
 	// Waiting 10 seconds for the recreated temp file to be detected is plenty sufficient on any OS.
-	for start := time.Now(); time.Since(start) < 10 * time.Second; {
+	for start := time.Now(); time.Since(start) < 10*time.Second; {
 		lsrcs = tt.FindLogSrc()
 		if len(lsrcs) > 0 {
 			break
@@ -1205,5 +1205,3 @@ func TestCheckForDuplicateRetentionSettingsWithDefault(t *testing.T) {
 	assert.Equal(t, tt.FileConfig[1].RetentionInDays, -1)
 	assert.Equal(t, tt.FileConfig[2].RetentionInDays, -1)
 }
-
-


### PR DESCRIPTION
# Description of the issue
There was a customer issue where when retention in unset (and automatically set to -1), checkForDuplicateRetention would assume that there was multiple retention sets
https://github.com/aws/amazon-cloudwatch-agent/issues/315

# Description of changes
Add a check that if retention is set to -1, do not assume that retention is considered duplicate since its a default value and considered unset

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added additonal Unit tests `checkForDuplicateRetention`




