### PR TITLE
Address flaky tests in GitHub CI

### DIFF
--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -470,7 +470,7 @@ func publishLogsToFile(file *os.File, matchedLog, unmatchedLog string, n, multiL
 	var sleepDuration time.Duration
 	if multiLineWaitMs > 0 {
 		multilineWaitPeriod = time.Duration(multiLineWaitMs) * time.Millisecond
-		sleepDuration = time.Duration(multiLineWaitMs * 2) * time.Millisecond
+		sleepDuration = time.Duration(multiLineWaitMs * 5) * time.Millisecond
 	}
 
 	for i := 0; i < n; i++ {

--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -470,7 +470,7 @@ func publishLogsToFile(file *os.File, matchedLog, unmatchedLog string, n, multiL
 	var sleepDuration time.Duration
 	if multiLineWaitMs > 0 {
 		multilineWaitPeriod = time.Duration(multiLineWaitMs) * time.Millisecond
-		sleepDuration = time.Duration(multiLineWaitMs * 6) * time.Millisecond
+		sleepDuration = time.Duration(multiLineWaitMs * 2) * time.Millisecond
 	}
 
 	for i := 0; i < n; i++ {
@@ -482,6 +482,8 @@ func publishLogsToFile(file *os.File, matchedLog, unmatchedLog string, n, multiL
 		}
 		if multiLineWaitMs > 0 {
 			time.Sleep(sleepDuration)
+		} else {
+			time.Sleep(multilineWaitPeriod)
 		}
 	}
 }

--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -470,7 +470,7 @@ func publishLogsToFile(file *os.File, matchedLog, unmatchedLog string, n, multiL
 	var sleepDuration time.Duration
 	if multiLineWaitMs > 0 {
 		multilineWaitPeriod = time.Duration(multiLineWaitMs) * time.Millisecond
-		sleepDuration = time.Duration(multiLineWaitMs * 5) * time.Millisecond
+		sleepDuration = time.Duration(multiLineWaitMs * 10) * time.Millisecond
 	}
 
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
# Description of the issue
`tailersrc_test` tests for log filtering added in #327 are flaky in GitHub.

# Description of changes
1. Noticed that older tailer tests had a 10x difference between the multilineWaitPeriod and the sleep timer (100ms vs 1s), so tweaked the sleep time in the log filter tests to match that. 
2. The single line log filter test sometimes would fail and not consume any logs. Added a sleep to allow the tailer to keep up with the log publication to (hopefully) keep it consistent

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Kept PR in draft mode and reran the GitHub Actions to manually test several times to see if the tests passed more consistently. 



