### PR TITLE
Add a feature flag to user agent for container insights

### DIFF
--- a/cfg/agentinfo/info.go
+++ b/cfg/agentinfo/info.go
@@ -50,8 +50,8 @@ func Build() string {
 	return BuildStr
 }
 
-func Plugins() string {
-	outputs := strings.Join(OutputPlugins, " ")
+func Plugins(extraOutputs ...string) string {
+	outputs := strings.Join(append(OutputPlugins, extraOutputs...), " ")
 	inputs := strings.Join(InputPlugins, " ")
 
 	if !isRunningAsRoot() {
@@ -61,11 +61,11 @@ func Plugins() string {
 	return fmt.Sprintf("inputs:(%s) outputs:(%s)", inputs, outputs)
 }
 
-func UserAgent() string {
+func UserAgent(extraOutputs ...string) string {
 	if userAgent == "" {
 		ua := os.Getenv(envconfig.CWAGENT_USER_AGENT)
 		if ua == "" {
-			ua = fmt.Sprintf("%s %s", FullVersion(), Plugins())
+			ua = fmt.Sprintf("%s %s", FullVersion(), Plugins(extraOutputs))
 		}
 		userAgent = ua
 	}

--- a/cfg/agentinfo/info.go
+++ b/cfg/agentinfo/info.go
@@ -8,16 +8,19 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 )
 
-const versionFilename = "CWAGENT_VERSION"
-
-// We will fall back to a major version if no valid version file is found
-const fallbackVersion = "1"
+const (
+	containerInsightRegexp = "^/aws/.*containerinsights/.*/(performance|prometheus)$"
+	versionFilename        = "CWAGENT_VERSION"
+	// We will fall back to a major version if no valid version file is found
+	fallbackVersion = "1"
+)
 
 var isRunningAsRoot = func() bool {
 	return os.Getuid() == 0
@@ -29,7 +32,8 @@ var (
 	InputPlugins  []string
 	OutputPlugins []string
 
-	userAgent string
+	userAgentMap        = make(map[string]string)
+	ciCompiledRegexp, _ = regexp.Compile(containerInsightRegexp)
 )
 
 func Version() string {
@@ -50,30 +54,30 @@ func Build() string {
 	return BuildStr
 }
 
-func Plugins() string {
+func Plugins(groupName string) string {
 	outputs := strings.Join(OutputPlugins, " ")
 	inputs := strings.Join(InputPlugins, " ")
 
 	if !isRunningAsRoot() {
 		inputs += " run_as_user" // `inputs` is never empty, or agent will not start
 	}
+	if ciCompiledRegexp.MatchString(groupName) && !strings.Contains(outputs, "container_insights") {
+		outputs += "container_insights"
+	}
 
 	return fmt.Sprintf("inputs:(%s) outputs:(%s)", inputs, outputs)
 }
 
-func UserAgent() string {
-	if userAgent == "" {
-		ua := os.Getenv(envconfig.CWAGENT_USER_AGENT)
+func UserAgent(groupName string) string {
+	ua, found := userAgentMap[groupName]
+	if !found {
+		ua = os.Getenv(envconfig.CWAGENT_USER_AGENT)
 		if ua == "" {
-			ua = fmt.Sprintf("%s %s", FullVersion(), Plugins())
+			ua = fmt.Sprintf("%s %s", FullVersion(), Plugins(groupName))
 		}
-		userAgent = ua
+		userAgentMap[groupName] = ua
 	}
-	return userAgent
-}
-
-func ResetUserAgent() {
-	userAgent = ""
+	return ua
 }
 
 func FullVersion() string {

--- a/cfg/agentinfo/info.go
+++ b/cfg/agentinfo/info.go
@@ -50,8 +50,8 @@ func Build() string {
 	return BuildStr
 }
 
-func Plugins(extraOutputs ...string) string {
-	outputs := strings.Join(append(OutputPlugins, extraOutputs...), " ")
+func Plugins() string {
+	outputs := strings.Join(OutputPlugins, " ")
 	inputs := strings.Join(InputPlugins, " ")
 
 	if !isRunningAsRoot() {
@@ -61,11 +61,11 @@ func Plugins(extraOutputs ...string) string {
 	return fmt.Sprintf("inputs:(%s) outputs:(%s)", inputs, outputs)
 }
 
-func UserAgent(extraOutputs ...string) string {
+func UserAgent() string {
 	if userAgent == "" {
 		ua := os.Getenv(envconfig.CWAGENT_USER_AGENT)
 		if ua == "" {
-			ua = fmt.Sprintf("%s %s", FullVersion(), Plugins(extraOutputs))
+			ua = fmt.Sprintf("%s %s", FullVersion(), Plugins())
 		}
 		userAgent = ua
 	}

--- a/cfg/agentinfo/info.go
+++ b/cfg/agentinfo/info.go
@@ -72,6 +72,10 @@ func UserAgent() string {
 	return userAgent
 }
 
+func ResetUserAgent() {
+	userAgent = ""
+}
+
 func FullVersion() string {
 	return fmt.Sprintf("CWAgent/%s (%s; %s; %s) %s", Version(), runtime.Version(), runtime.GOOS, runtime.GOARCH, Build())
 }

--- a/cfg/agentinfo/info.go
+++ b/cfg/agentinfo/info.go
@@ -62,7 +62,7 @@ func Plugins(groupName string) string {
 		inputs += " run_as_user" // `inputs` is never empty, or agent will not start
 	}
 	if ciCompiledRegexp.MatchString(groupName) && !strings.Contains(outputs, "container_insights") {
-		outputs += "container_insights"
+		outputs += " container_insights"
 	}
 
 	return fmt.Sprintf("inputs:(%s) outputs:(%s)", inputs, outputs)

--- a/cfg/agentinfo/info_test.go
+++ b/cfg/agentinfo/info_test.go
@@ -82,20 +82,20 @@ func TestPlugins(t *testing.T) {
 
 	isRunningAsRoot = func() bool { return true }
 	plugins := Plugins("")
-	expected := fmt.Sprintf("inputs:(a b c) outputs:(x y z)")
+	expected := "inputs:(a b c) outputs:(x y z)"
+	if plugins != expected {
+		t.Errorf("wrong plugins string constructed '%v', expecting '%v'", plugins, expected)
+	}
+
+	plugins = Plugins("/aws/ecs/containerinsights/ecs-cluster-name/performance")
+	expected = "inputs:(a b c) outputs:(x y z container_insights)"
 	if plugins != expected {
 		t.Errorf("wrong plugins string constructed '%v', expecting '%v'", plugins, expected)
 	}
 
 	isRunningAsRoot = func() bool { return false }
 	plugins = Plugins("")
-	expected = fmt.Sprintf("inputs:(a b c run_as_user) outputs:(x y z)")
-	if plugins != expected {
-		t.Errorf("wrong plugins string constructed '%v', expecting '%v'", plugins, expected)
-	}
-
-	plugins = Plugins("/aws/ecs/containerinsights/ecs-cluster-name/performance")
-	expected = fmt.Sprintf("inputs:(a b c run_as_user) outputs:(x y z container_insights)")
+	expected = "inputs:(a b c run_as_user) outputs:(x y z)"
 	if plugins != expected {
 		t.Errorf("wrong plugins string constructed '%v', expecting '%v'", plugins, expected)
 	}
@@ -144,7 +144,6 @@ func TestUserAgent(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, UserAgent(tc.logGroupName), tc.errorMessage)
-
 		})
 	}
 }

--- a/cfg/agentinfo/info_test.go
+++ b/cfg/agentinfo/info_test.go
@@ -120,3 +120,10 @@ func TestUserAgentEnvOverride(t *testing.T) {
 		t.Errorf("UserAgent should use value configured in environment variable CWAGENT_USER_AGENT, but '%v' found, expecting '%v'", ua, expected)
 	}
 }
+func TestResetUserAgent(t *testing.T) {
+	userAgent = "TEST_USER_AGENT"
+	ResetUserAgent()
+	if userAgent != "" {
+		t.Errorf("userAgent string did not reset.")
+	}
+}

--- a/cfg/agentinfo/info_test.go
+++ b/cfg/agentinfo/info_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionUseInjectedIfAvailable(t *testing.T) {
@@ -80,22 +81,27 @@ func TestPlugins(t *testing.T) {
 	OutputPlugins = []string{"x", "y", "z"}
 
 	isRunningAsRoot = func() bool { return true }
-	plugins := Plugins()
+	plugins := Plugins("")
 	expected := fmt.Sprintf("inputs:(a b c) outputs:(x y z)")
 	if plugins != expected {
 		t.Errorf("wrong plugins string constructed '%v', expecting '%v'", plugins, expected)
 	}
 
 	isRunningAsRoot = func() bool { return false }
-	plugins = Plugins()
+	plugins = Plugins("")
 	expected = fmt.Sprintf("inputs:(a b c run_as_user) outputs:(x y z)")
+	if plugins != expected {
+		t.Errorf("wrong plugins string constructed '%v', expecting '%v'", plugins, expected)
+	}
+
+	plugins = Plugins("/aws/ecs/containerinsights/ecs-cluster-name/performance")
+	expected = fmt.Sprintf("inputs:(a b c run_as_user) outputs:(x y z container_insights)")
 	if plugins != expected {
 		t.Errorf("wrong plugins string constructed '%v', expecting '%v'", plugins, expected)
 	}
 }
 
 func TestUserAgent(t *testing.T) {
-	userAgent = ""
 	VersionStr = "VSTR"
 	BuildStr = "BSTR"
 	InputPlugins = []string{"a", "b", "c"}
@@ -103,27 +109,52 @@ func TestUserAgent(t *testing.T) {
 
 	isRunningAsRoot = func() bool { return true }
 
-	ua := UserAgent()
-	expected := fmt.Sprintf("CWAgent/VSTR (%v; %v; %v) BSTR inputs:(a b c) outputs:(x y z)", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-	if ua != expected {
-		t.Errorf("wrong UserAgent string constructed '%v', expecting '%v'", ua, expected)
+	tests := []struct {
+		name         string
+		logGroupName string
+		expected     string
+		errorMessage string
+	}{
+		{
+			"non container insights",
+			"test-group",
+			fmt.Sprintf("CWAgent/VSTR (%v; %v; %v) BSTR inputs:(a b c) outputs:(x y z)", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+			"wrong UserAgent string constructed",
+		},
+		{
+			"container insights EKS",
+			"/aws/containerinsights/eks-cluster-name/performance",
+			fmt.Sprintf("CWAgent/VSTR (%v; %v; %v) BSTR inputs:(a b c) outputs:(x y z container_insights)", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+			"\"container_insights\" flag shoould be in the outputs plugin list in container insights mode",
+		},
+		{
+			"container insights ECS",
+			"/aws/ecs/containerinsights/ecs-cluster-name/performance",
+			fmt.Sprintf("CWAgent/VSTR (%v; %v; %v) BSTR inputs:(a b c) outputs:(x y z container_insights)", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+			"\"container_insights\" flag shoould be in the outputs plugin list in container insights mode",
+		},
+		{
+			"container insights prometheus",
+			"/aws/containerinsights/cluster-name/prometheus",
+			fmt.Sprintf("CWAgent/VSTR (%v; %v; %v) BSTR inputs:(a b c) outputs:(x y z container_insights)", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+			"\"container_insights\" flag shoould be in the outputs plugin list in container insights mode",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, UserAgent(tc.logGroupName), tc.errorMessage)
+
+		})
 	}
 }
 
 func TestUserAgentEnvOverride(t *testing.T) {
-	userAgent = ""
 	os.Setenv(envconfig.CWAGENT_USER_AGENT, "CUSTOM CWAGENT USER AGENT")
 	expected := "CUSTOM CWAGENT USER AGENT"
 
-	ua := UserAgent()
+	ua := UserAgent("TestUserAgentEnvOverride")
 	if ua != expected {
 		t.Errorf("UserAgent should use value configured in environment variable CWAGENT_USER_AGENT, but '%v' found, expecting '%v'", ua, expected)
-	}
-}
-func TestResetUserAgent(t *testing.T) {
-	userAgent = "TEST_USER_AGENT"
-	ResetUserAgent()
-	if userAgent != "" {
-		t.Errorf("userAgent string did not reset.")
 	}
 }

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -145,7 +145,7 @@ func (c *CloudWatch) Connect() error {
 		})
 
 	svc.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{opPutLogEvents, opPutMetricData}))
-	svc.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentinfo.UserAgent()))
+	svc.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentinfo.UserAgent("")))
 
 	//Format unique roll up list
 	c.RollupDimensions = GetUniqueRollupList(c.RollupDimensions)

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -132,7 +132,17 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 	containerInsightRegexp := "^/aws/.*containerinsights/.*/(performance|prometheus)$"
 	r, _ := regexp.Compile(containerInsightRegexp)
 	if r.MatchString(t.Group) {
-		agentinfo.OutputPlugins = append(agentinfo.OutputPlugins, "container_insights")
+		hasCIFlag := false
+		for _, plugin := range agentinfo.OutputPlugins {
+			if plugin == "container_insights" {
+				hasCIFlag = true
+				break
+			}
+		}
+		if !hasCIFlag {
+			agentinfo.OutputPlugins = append(agentinfo.OutputPlugins, "container_insights")
+		}
+		agentinfo.ResetUserAgent()
 	}
 	client.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentinfo.UserAgent()))
 

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -132,7 +132,7 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 	containerInsightRegexp := "^/aws/.*containerinsights/.*/(performance|prometheus)$"
 	r, _ := regexp.Compile(containerInsightRegexp)
 	if r.MatchString(t.Group) {
-		append(agentinfo.OutputPlugins, "container_insights")
+		agentinfo.OutputPlugins = append(agentinfo.OutputPlugins, "container_insights")
 	}
 	client.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentinfo.UserAgent()))
 

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -132,10 +132,9 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 	containerInsightRegexp := "^/aws/.*containerinsights/.*/(performance|prometheus)$"
 	r, _ := regexp.Compile(containerInsightRegexp)
 	if r.MatchString(t.Group) {
-		client.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentinfo.UserAgent("container_insights")))
-	} else {
-		client.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentinfo.UserAgent()))
+		append(agentinfo.OutputPlugins, "container_insights")
 	}
+	client.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentinfo.UserAgent()))
 
 	pusher := NewPusher(t, client, c.ForceFlushInterval.Duration, maxRetryTimeout, c.Log)
 	cwd := &cwDest{pusher: pusher, retryer: logThrottleRetryer}

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -39,7 +39,10 @@ const (
 	metricRetryTimeout = 2 * time.Minute
 
 	attributesInFields = "attributesInFields"
+	containerInsightRegexp = "^/aws/.*containerinsights/.*/(performance|prometheus)$"
 )
+
+var ciCompiledRegexp, _ = regexp.Compile(containerInsightRegexp)
 
 type CloudWatchLogs struct {
 	Region           string `toml:"region"`
@@ -129,9 +132,7 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 	)
 	client.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{"PutLogEvents"}))
 
-	containerInsightRegexp := "^/aws/.*containerinsights/.*/(performance|prometheus)$"
-	r, _ := regexp.Compile(containerInsightRegexp)
-	if r.MatchString(t.Group) {
+	if ciCompiledRegexp.MatchString(t.Group) {
 		hasCIFlag := false
 		for _, plugin := range agentinfo.OutputPlugins {
 			if plugin == "container_insights" {

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs_test.go
@@ -4,12 +4,9 @@
 package cloudwatchlogs
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/aws/amazon-cloudwatch-agent/cfg/agentinfo"
 	"github.com/influxdata/telegraf/plugins/outputs"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateDest(t *testing.T) {
@@ -45,53 +42,5 @@ func TestCreateDest(t *testing.T) {
 
 	if d.pusher.Group != "G1" || d.pusher.Stream != "S1" {
 		t.Errorf("Empty create dest should return dest to default group and stream, %v/%v found", d.pusher.Group, d.pusher.Stream)
-	}
-}
-
-func TestUserAgent(t *testing.T) {
-	c := outputs.Outputs["cloudwatchlogs"]().(*CloudWatchLogs)
-	tests := []struct {
-		name         string
-		logGroupName string
-		expectFlag   bool
-	}{
-		{
-			"emptyLogGroup",
-			"",
-			false,
-		},
-		{
-			"non container insights",
-			"test-group",
-			false,
-		},
-		{
-			"container insights EKS",
-			"/aws/containerinsights/eks-cluster-name/performance",
-			true,
-		},
-		{
-			"container insights ECS",
-			"/aws/ecs/containerinsights/ecs-cluster-name/performance",
-			true,
-		},
-		{
-			"container insights prometheus",
-			"/aws/containerinsights/cluster-name/prometheus",
-			true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			target := Target{
-				Group:     tc.logGroupName,
-				Stream:    "Stream",
-				Retention: -1,
-			}
-			c.getDest(target)
-			assert.Equal(t, strings.Contains(agentinfo.UserAgent(), "container_insights"), tc.expectFlag)
-
-		})
 	}
 }


### PR DESCRIPTION
# Description of the issue
We don't have the ability to see how much usage comes from `Container Insights` right now. Adding this so that we can have an idea what plugins/features are in use and potentially make users more willing to use these features.

# Description of changes
- As discussed, the outputs plugin name should be `container_insights`
- Update the output plugin list (in the user agent info) when the log group name matches the pattern of `Container Insights`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added a new unit test `TestUserAgent`



