### PR TITLE
Grammer and spelling touch up for translator tests

### DIFF
--- a/cmd/config-translator/translator_test.go
+++ b/cmd/config-translator/translator_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func checkIfSchemaValidationAsExpected(t *testing.T, jsonInputPath string, shouldSucess bool, expectedErrorMap map[string]int) {
+func checkIfSchemaValidateAsExpected(t *testing.T, jsonInputPath string, shouldSuccess bool, expectedErrorMap map[string]int) {
 	actualErrorMap := make(map[string]int)
 
 	jsonInputMap, err := util.GetJsonMapFromFile(jsonInputPath)
@@ -30,7 +30,7 @@ func checkIfSchemaValidationAsExpected(t *testing.T, jsonInputPath string, shoul
 	}
 
 	if result.Valid() {
-		assert.True(t, shouldSucess, "It should fail the schemaValidation!")
+		assert.True(t, shouldSuccess, "It should fail the schemaValidation!")
 	} else {
 		errorDetails := result.Errors()
 		for _, errorDetail := range errorDetails {
@@ -48,56 +48,56 @@ func checkIfSchemaValidationAsExpected(t *testing.T, jsonInputPath string, shoul
 			}
 		}
 		assert.Equal(t, expectedErrorMap, actualErrorMap, "Unexpected error set!")
-		assert.False(t, shouldSucess, "It should pass the schemaValidation!")
+		assert.False(t, shouldSuccess, "It should pass the schemaValidation!")
 	}
 
 }
 
 func TestAgentConfig(t *testing.T) {
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validAgent.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validAgent.json", true, map[string]int{})
 	expectedErrorMap := map[string]int{}
 	expectedErrorMap["invalid_type"] = 5
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidAgent.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidAgent.json", false, expectedErrorMap)
 }
 
 func TestLogFilesConfig(t *testing.T) {
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validLogFiles.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validLogFiles.json", true, map[string]int{})
 	expectedErrorMap := map[string]int{}
 	expectedErrorMap["array_min_items"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidLogFilesWithNoFileConfigured.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidLogFilesWithNoFileConfigured.json", false, expectedErrorMap)
 	expectedErrorMap1 := map[string]int{}
 	expectedErrorMap1["required"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidLogFilesWithMissingFilePath.json", false, expectedErrorMap1)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidLogFilesWithMissingFilePath.json", false, expectedErrorMap1)
 	expectedErrorMap2 := map[string]int{}
 	expectedErrorMap2["unique"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidLogFilesWithDuplicateEntry.json", false, expectedErrorMap2)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidLogFilesWithDuplicateEntry.json", false, expectedErrorMap2)
 }
 
 func TestLogWindowsEventConfig(t *testing.T) {
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validLogWindowsEvents.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validLogWindowsEvents.json", true, map[string]int{})
 	expectedErrorMap := map[string]int{}
 	expectedErrorMap["number_not"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidLogWindowsEventsWithInvalidEventName.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidLogWindowsEventsWithInvalidEventName.json", false, expectedErrorMap)
 	expectedErrorMap1 := map[string]int{}
 	expectedErrorMap1["required"] = 2
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidLogWindowsEventsWithMissingEventNameAndLevel.json", false, expectedErrorMap1)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidLogWindowsEventsWithMissingEventNameAndLevel.json", false, expectedErrorMap1)
 	expectedErrorMap2 := map[string]int{}
 	expectedErrorMap2["invalid_type"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidLogWindowsEventsWithInvalidEventLevelType.json", false, expectedErrorMap2)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidLogWindowsEventsWithInvalidEventLevelType.json", false, expectedErrorMap2)
 	expectedErrorMap3 := map[string]int{}
 	expectedErrorMap3["enum"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidLogWindowsEventsWithInvalidEventFormatType.json", false, expectedErrorMap3)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidLogWindowsEventsWithInvalidEventFormatType.json", false, expectedErrorMap3)
 }
 
 func TestMetricsConfig(t *testing.T) {
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validLinuxMetrics.json", true, map[string]int{})
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validWindowsMetrics.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validLinuxMetrics.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validWindowsMetrics.json", true, map[string]int{})
 	expectedErrorMap := map[string]int{}
 	expectedErrorMap["invalid_type"] = 2
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithInvalidAggregationDimensions.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithInvalidAggregationDimensions.json", false, expectedErrorMap)
 	expectedErrorMap1 := map[string]int{}
 	expectedErrorMap1["array_min_properties"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithNoMetricsDefined.json", false, expectedErrorMap1)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithNoMetricsDefined.json", false, expectedErrorMap1)
 	expectedErrorMap2 := map[string]int{}
 	expectedErrorMap2["required"] = 1
 	expectedErrorMap2["invalid_type"] = 2
@@ -106,46 +106,46 @@ func TestMetricsConfig(t *testing.T) {
 	expectedErrorMap2["unique"] = 1
 	expectedErrorMap2["number_gte"] = 1
 	expectedErrorMap2["string_gte"] = 2
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithInvalidMeasurement.json", false, expectedErrorMap2)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithInvalidMeasurement.json", false, expectedErrorMap2)
 	expectedErrorMap3 := map[string]int{}
 	expectedErrorMap3["invalid_type"] = 2
 	expectedErrorMap3["number_all_of"] = 2
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithInvalidAppendDimensions.json", false, expectedErrorMap3)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithInvalidAppendDimensions.json", false, expectedErrorMap3)
 	expectedErrorMap4 := map[string]int{}
 	expectedErrorMap4["enum"] = 1
 	expectedErrorMap4["array_max_items"] = 1
 	expectedErrorMap4["invalid_type"] = 1
 	expectedErrorMap4["number_all_of"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithinvalidMetricsCollected.json", false, expectedErrorMap4)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithinvalidMetricsCollected.json", false, expectedErrorMap4)
 	expectedErrorMap5 := map[string]int{}
 	expectedErrorMap5["additional_property_not_allowed"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithAdditionalProperties.json", false, expectedErrorMap5)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithAdditionalProperties.json", false, expectedErrorMap5)
 	expectedErrorMap6 := map[string]int{}
 	expectedErrorMap6["required"] = 1
 	expectedErrorMap6["invalid_type"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithInvalidMetrics_Collected.json", false, expectedErrorMap6)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidMetricsWithInvalidMetrics_Collected.json", false, expectedErrorMap6)
 }
 
 func TestCsmConfig_Valid(t *testing.T) {
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validCsm.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validCsm.json", true, map[string]int{})
 }
 
 func TestCsmConfig_InvalidKey(t *testing.T) {
 	expectedErrorMap := map[string]int{}
 	expectedErrorMap["additional_property_not_allowed"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidCsmKey.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidCsmKey.json", false, expectedErrorMap)
 }
 
 func TestCsmConfig_InvalidPort(t *testing.T) {
 	expectedErrorMap := map[string]int{}
 	expectedErrorMap["number_gte"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidCsmPort.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidCsmPort.json", false, expectedErrorMap)
 }
 
 func TestCsmConfig_InvalidMemoryLimitInMb(t *testing.T) {
 	expectedErrorMap := map[string]int{}
 	expectedErrorMap["invalid_type"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidCsmMemoryLimitInMb.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidCsmMemoryLimitInMb.json", false, expectedErrorMap)
 }
 
 func TestProcstatConfig(t *testing.T) {
@@ -154,21 +154,21 @@ func TestProcstatConfig(t *testing.T) {
 	expectedErrorMap["number_all_of"] = 1
 	expectedErrorMap["number_any_of"] = 1
 	expectedErrorMap["required"] = 1
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidProcstatMeasurement.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidProcstatMeasurement.json", false, expectedErrorMap)
 
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validProcstatConfig.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validProcstatConfig.json", true, map[string]int{})
 }
 
 func TestEthtoolConfig(t *testing.T) {
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validEthtoolConfig.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validEthtoolConfig.json", true, map[string]int{})
 }
 
 func TestNvidiaGpuConfig(t *testing.T) {
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validNvidiaGpuConfig.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validNvidiaGpuConfig.json", true, map[string]int{})
 }
 
 func TestValidLogFilterConfig(t *testing.T) {
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/validLogFilesWithFilters.json", true, map[string]int{})
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validLogFilesWithFilters.json", true, map[string]int{})
 }
 
 func TestInvalidLogFilterConfig(t *testing.T) {
@@ -176,7 +176,7 @@ func TestInvalidLogFilterConfig(t *testing.T) {
 		"additional_property_not_allowed": 1,
 		"enum": 1,
 	}
-	checkIfSchemaValidationAsExpected(t, "../../translator/config/sampleSchema/invalidLogFilesWithFilters.json", false, expectedErrorMap)
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidLogFilesWithFilters.json", false, expectedErrorMap)
 }
 
 // Validate all sampleConfig files schema
@@ -186,7 +186,7 @@ func TestSampleConfigSchema(t *testing.T) {
 		for _, file := range files {
 			if re.MatchString(file.Name()) {
 				fmt.Printf("Validating ../../translator/totomlconfig/sampleConfig/%s\n", file.Name())
-				checkIfSchemaValidationAsExpected(t, "../../translator/totomlconfig/sampleConfig/"+file.Name(), true, map[string]int{})
+				checkIfSchemaValidateAsExpected(t, "../../translator/totomlconfig/sampleConfig/"+file.Name(), true, map[string]int{})
 				fmt.Printf("Validated ../../translator/totomlconfig/sampleConfig/%s\n", file.Name())
 			}
 		}


### PR DESCRIPTION
Fixing spelling and grammer in Translator test naming. 



