### PR TITLE
update systemd network target

### DIFF
--- a/packaging/dependencies/amazon-cloudwatch-agent.service
+++ b/packaging/dependencies/amazon-cloudwatch-agent.service
@@ -9,7 +9,7 @@
 
 [Unit]
 Description=Amazon CloudWatch Agent
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
Closes #298 

# Description of the issue
Using the `After=network.target` only indicates that the device is available but not configured (see [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/systemd-network-targets-and-services_configuring-and-managing-networking)).

# Description of changes
Changing the systemd configuration to use `After=network-online.target` puts a delay on activation until the device designates itself as "up" (see [here](https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/)).

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.