### PR TITLE
Add concurrency for pr

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -6,9 +6,10 @@ on:
       - master
 
     paths-ignore:
+      - '**.md'
       - '.github/**'
       - '!.github/workflows/**'
-      - '**.md'
+
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -7,8 +7,7 @@ on:
 
     paths-ignore:
       - '.github/**'
-      - '!.github/workflows/build.yml'
-      - '!.github/workflows/build-test-windows.yml'
+      - '!.github/workflows/**'
       - '**.md'
 
   pull_request:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-and-test-windows-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-and-test-windows-${{ github.event.pull_request.number }}
+  group: build-and-test-windows-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -2,7 +2,15 @@
 name: build-and-test-windows
 on:
   push:
-    branches: [ main, master ]
+    branches:
+      - master
+
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/build.yml'
+      - '!.github/workflows/build-test-windows.yml'
+      - '**.md'
+
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -10,7 +10,6 @@ on:
       - '.github/**'
       - '!.github/workflows/**'
 
-
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -7,6 +7,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+concurrency:
+  group: build-and-test-windows-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   windows-unittest:
     runs-on: windows-latest

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-and-test-windows-${{ github.ref_name }}
+  group: build-and-test-windows-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**.md'
       - '.github/**'
-      - '!.github/workflows/**'
+      - '!.github/workflows/build-*'
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,7 @@ on:
 
     paths-ignore:
       - '.github/**'
-      - '!.github/workflows/build.yml'
-      - '!.github/workflows/build-test-windows.yml'
+      - '!.github/workflows/**'
       - '**.md'
 
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-and-test-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-and-test-${{ github.event.pull_request.number }}
+  group: build-and-test-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-and-test-${{ github.ref_name }}
+  group: build-and-test-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
     paths-ignore:
       - '.github/**'
-      - '!.github/workflows/**'
+      - '!.github/workflows/build-*'
       - '**.md'
 
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
-jobs:
+concurrency:
+  group: build-and-test-${{ github.ref_name }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,10 @@ on:
       - master
 
     paths-ignore:
+      - '**.md'
       - '.github/**'
       - '!.github/workflows/build-*'
-      - '**.md'
+      
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - master
+
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/build.yml'
+      - '!.github/workflows/build-test-windows.yml'
+      - '**.md'
+
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -10,6 +10,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: integration-tests-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   EC2LinuxIntegrationTest:
     name: 'EC2LinuxIntegrationTest'

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: integration-tests-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Description of the issue
Currently, there are two issues I want to address: 
- When we add changes to readme doc, create a PR out of it, merge into main; we would trigger the workflow build; however, that's not needed since relating to docs are not needed to trigger the build. 
- When creating a PR with multiple commits or merging into main, the Github Runners will scale based on the commits and the PRs have been merged into main. Therefore, to reduce the needed Github Runners, we can use [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to avoid running simultaneously.

# Description of changes
Add paths ignore when merging into master and add concurrency to reduce GitHub Runners running a PR for a single branch.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
**Concurrency:** https://github.com/khanhntd/aws-otel-collector/blob/main/.github/workflows/CI.yml#L47-L49
**Ignore:** https://github.com/khanhntd/aws-otel-collector/blob/main/.github/workflows/CI.yml#L22-L25



