### PR TITLE
Delete runner cache and test cache if success

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -15,7 +15,7 @@ jobs:
         id: build-test
         uses: actions/cache@v2
         with:
-          path: AOC_GIT_SHA
+          path: LICENSE
           key: ${{ github.workflow }}-${{ github.run_id }}
 
       - name: Checkout Repo

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -17,15 +17,19 @@ jobs:
         with:
           path: AOC_GIT_SHA
           key: ${{ github.workflow }}-${{ github.run_id }}
+
       - name: Checkout Repo
+        if: steps.build-test.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
 
       - name: Setup Go
+        if: steps.build-test.outputs.cache-hit != 'true'
         uses: actions/setup-go@v2
         with:
           go-version: ~1.15.15
 
       - name: Cache Go
+        if: steps.build-test.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           path: |
@@ -36,4 +40,5 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run Unit tests
+        if: steps.build-test.outputs.cache-hit != 'true'
         run: go test ./...

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -36,8 +36,6 @@ jobs:
             %LocalAppData%\go-build
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Run Unit tests
         if: steps.build-test.outputs.cache-hit != 'true'

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -11,6 +11,12 @@ jobs:
   windows-unittest:
     runs-on: windows-latest
     steps:
+      - name: Cache if success
+        id: build-test
+        uses: actions/cache@v2
+        with:
+          path: AOC_GIT_SHA
+          key: ${{ github.workflow }}-${{ github.run_id }}
       - name: Checkout Repo
         uses: actions/checkout@v2
 
@@ -25,7 +31,6 @@ jobs:
           path: |
             %LocalAppData%\go-build
             ~/go/pkg/mod
-            C:\Users\runneradmin\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       id: build-test
       uses: actions/cache@v2
       with:
-        path: AOC_GIT_SHA
+        path: LICENSE
         key: ${{ github.workflow }}-${{ github.run_id }}-${{ matrix.os }}
     
     - name: Set up Go 1.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,6 @@ jobs:
       with:
         path: ${{ matrix.cachepath }}
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Test
       if: steps.build-test.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,24 +34,29 @@ jobs:
         key: ${{ github.workflow }}-${{ github.run_id }}-${{ matrix.os }}
     
     - name: Set up Go 1.x
+      if: steps.build-test.outputs.cache-hit != 'true'
       uses: actions/setup-go@v2
       with:
         go-version: ~1.15.15
-      id: go
+      
 
     - name: Configure git with longpath enabled (for windows)
+      if: steps.build-test.outputs.cache-hit != 'true'
       run: git config --global core.longpaths true
 
     - name: Check out code
+      if: steps.build-test.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
         submodules: 'true'
 
     - name: Debug go.mod
+      if: steps.build-test.outputs.cache-hit != 'true'
       run: cat go.mod
 
     - name: Cache build output
+      if: steps.build-test.outputs.cache-hit != 'true'
       uses: actions/cache@v2
       with:
         path: ${{ matrix.cachepath }}
@@ -60,12 +65,15 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Test
+      if: steps.build-test.outputs.cache-hit != 'true'
       run: make test
 
     - name: Upload coverage to Codecov
+      if: steps.build-test.outputs.cache-hit != 'true'
       uses: codecov/codecov-action@v2
       with:
         verbose: true
 
     - name: Build
+      if: steps.build-test.outputs.cache-hit != 'true'
       run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,18 @@ jobs:
             cachepath: |
               ~/.cache/go-build
               ~/go/pkg/mod
-              /home/runner/.cache/go-build
           - os: macos-latest
             cachepath: |
               ~/Library/Caches/go-build
               ~/go/pkg/mod
-              /Users/runner/Library/Caches/go-build
     steps:  
-
+    - name: Cache if success
+      id: build-test
+      uses: actions/cache@v2
+      with:
+        path: AOC_GIT_SHA
+        key: ${{ github.workflow }}-${{ github.run_id }}-${{ matrix.os }}
+    
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
# Description of the issue
Currently, there are two issues with time we got with:
* Should we build again even though the first retry has success? 
* The time for build is exactly the same without cache and with cache

# Description of changes
By changing these two,
* Adding cache to avoid building again for the second retry would reduce time and increase more resources spending on the remaining jobs
* Delete this path ```runner/Library/Caches/go-build``` when cache to reduce the time (testing it out with the PR) 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test with a PR and found unexpected results without caching this path ```runner/Library/Caches/go-build```:
https://github.com/aws/amazon-cloudwatch-agent/runs/4990690788?check_suite_focus=true
https://github.com/aws/amazon-cloudwatch-agent/runs/4990745483?check_suite_focus=true

Compared when cached this path ```runner/Library/Caches/go-build```:
https://github.com/aws/amazon-cloudwatch-agent/runs/4990443776?check_suite_focus=true


