### PR TITLE
add tools for fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,12 @@ build-for-docker-arm64:
 	$(LINUX_ARM64_BUILD)/start-amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/start-amazon-cloudwatch-agent
 	$(LINUX_ARM64_BUILD)/config-translator github.com/aws/amazon-cloudwatch-agent/cmd/config-translator
 
-fmt:
+fmt: install-tools
 	go fmt ./...
+	echo $(ALL_SRC) | xargs -n 10 $(GOIMPORTS) $(GOIMPORTS_OPT)
+
+fmt-sh:
+	shfmt -w -d -i 5 .
 
 test:
 	CGO_ENABLED=0 go test -coverprofile coverage.txt -failfast ./awscsm/... ./cfg/... ./cmd/... ./handlers/... ./internal/... ./logger/... ./logs/... ./metric/... ./plugins/... ./profiler/... ./tool/... ./translator/...
@@ -258,7 +262,7 @@ package-win: package-prepare-win-zip
 package-darwin: package-prepare-darwin-tar
 	ARCH=amd64 TARGET_SUPPORTED_ARCH=x86_64 PREPKGPATH="$(BUILD_SPACE)/private/darwin/amd64/tar/amazon-cloudwatch-agent-pre-pkg" $(BUILD_SPACE)/Tools/src/create_darwin.sh
 
-.PHONY: fmt build test clean
+.PHONY: fmt fmt-sh build test clean
 
 .PHONY: dockerized-build dockerized-build-vendor
 dockerized-build:


### PR DESCRIPTION
# Description of the issue
Force to format sh file with one template by using shfmt and format go files.

# Description of changes
_How does this change address the problem?_
Add shfmt for formatting sh files and goimports to formating go packages.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
There are two tests have been done:
* GoImports: By using ```make fmt``` to format all the go files. Ensure the builds still working by using ```make build```
* shfmt: By using ```make fmt-sh``` to format all the sh files. Ensure the builds still working by using ```make build```. Even though the shfmt returns error during the first time, it still return effective results and return non-error during the second attempt.

# Documents
Goimports: https://goinbigdata.com/goimports-vs-gofmt/
Shfmt: https://ostechnix.com/how-to-format-shell-programs-using-shfmt-in-linux/





