### PR TITLE
update runner to use windows server 2019

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   windows-unittest:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description of the issue
Part of #351, to clear up issues with unrelated tests in GitHub workflows

# Description of changes
Proposed in the linked issue, this changes the Windows runner to use `windows-2019`, which is recommended in https://github.com/actions/virtual-environments/issues/4856 if there is an issue with our actions after they migrate our workflow to the Window Server 2022 image.

Separately from this, will need to figure out the issue with the tests on Windows Server 2022.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Will find out if it works in the PR, but have high confidence based on the fact that the related code was not changed recently, and the only update was the image they're running on.




