### PR TITLE
Breakout unit testing per OS. Issue: #353

### DIFF
--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -30,9 +30,6 @@ jobs:
         go-version: ~1.15.15
       id: go
 
-    - name: Configure git with longpath enabled (for windows)
-      run: git config --global core.longpaths true
-
     - name: Check out code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -19,8 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-linux:
-    name: Build-linux
+  linux-unittest:
     runs-on: ubuntu-latest
     steps:  
 

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -43,7 +43,6 @@ jobs:
         path: |
               ~/.cache/go-build
               ~/go/pkg/mod
-              /home/runner/.cache/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
     - name: Test

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -1,9 +1,10 @@
-name: build-and-test-linux
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
 
+name: build-and-test-linux
 on:
   push:
     branches: [master, main]
-
     paths-ignore:
       - '**.md'
       - '.github/**'

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -28,7 +28,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ~1.15.15
-      id: go
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -1,0 +1,68 @@
+name: build-and-test-linux
+
+on:
+  push:
+    branches:
+      - master
+
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
+      - '!.github/workflows/build-*'
+      
+
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-linux:
+    name: Build-linux
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:  
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ~1.15.15
+      id: go
+
+    - name: Configure git with longpath enabled (for windows)
+      run: git config --global core.longpaths true
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: 'true'
+
+    - name: Debug go.mod
+      run: cat go.mod
+
+    - name: Cache build output
+      uses: actions/cache@v2
+      with:
+        path: |
+              ~/.cache/go-build
+              ~/go/pkg/mod
+              /home/runner/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Test
+      run: make test
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        verbose: true
+
+    - name: Build
+      run: make build

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -35,9 +35,6 @@ jobs:
         fetch-depth: 0
         submodules: 'true'
 
-    - name: Debug go.mod
-      run: cat go.mod
-
     - name: Cache build output
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -47,8 +47,6 @@ jobs:
               ~/go/pkg/mod
               /home/runner/.cache/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Test
       run: make test

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -2,8 +2,7 @@ name: build-and-test-linux
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, main]
 
     paths-ignore:
       - '**.md'

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -22,8 +22,6 @@ jobs:
   build-linux:
     name: Build-linux
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:  
 
     - name: Set up Go 1.x

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -1,9 +1,10 @@
-name: build-and-test-macos
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
 
+name: build-and-test-macos
 on:
   push:
     branches: [master, main]
-
     paths-ignore:
       - '**.md'
       - '.github/**'

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -30,9 +30,6 @@ jobs:
         go-version: ~1.15.15
       id: go
 
-    - name: Configure git with longpath enabled (for windows)
-      run: git config --global core.longpaths true
-
     - name: Check out code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -47,8 +47,6 @@ jobs:
               ~/go/pkg/mod
               /Users/runner/Library/Caches/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Test
       run: make test

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -59,10 +59,5 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        verbose: true
-
     - name: Build
       run: make build

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -22,8 +22,6 @@ jobs:
   build-macos:
     name: Build-macos
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
     steps:  
 
     - name: Set up Go 1.x

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -51,5 +51,10 @@ jobs:
     - name: Test
       run: make test
 
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        verbose: true
+
     - name: Build
       run: make build

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -28,7 +28,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ~1.15.15
-      id: go
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -2,8 +2,7 @@ name: build-and-test-macos
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, main]
 
     paths-ignore:
       - '**.md'

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -35,9 +35,6 @@ jobs:
         fetch-depth: 0
         submodules: 'true'
 
-    - name: Debug go.mod
-      run: cat go.mod
-
     - name: Cache build output
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: build-and-test-macos
 
 on:
   push:
@@ -20,24 +20,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: ${{ matrix.os }}
+  build-macos:
+    name: Build-macos
+    runs-on: macos-latest
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        include:
-          - os: ubuntu-latest
-            cachepath: |
-              ~/.cache/go-build
-              ~/go/pkg/mod
-              /home/runner/.cache/go-build
-          - os: macos-latest
-            cachepath: |
-              ~/Library/Caches/go-build
-              ~/go/pkg/mod
-              /Users/runner/Library/Caches/go-build
     steps:  
 
     - name: Set up Go 1.x
@@ -61,7 +48,10 @@ jobs:
     - name: Cache build output
       uses: actions/cache@v2
       with:
-        path: ${{ matrix.cachepath }}
+        path: |
+              ~/Library/Caches/go-build
+              ~/go/pkg/mod
+              /Users/runner/Library/Caches/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -19,8 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-macos:
-    name: Build-macos
+  macos-unittest:
     runs-on: macos-latest
     steps:  
 

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -43,7 +43,6 @@ jobs:
         path: |
               ~/Library/Caches/go-build
               ~/go/pkg/mod
-              /Users/runner/Library/Caches/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
     - name: Test

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -38,8 +38,17 @@ jobs:
             ~/go/pkg/mod
             C:\Users\runneradmin\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+
+      - name: Install make
+        run: choco install make
 
       - name: Run Unit tests
-        run: go test ./...
+        run: make test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          verbose: true
+
+      - name: Run build
+        run: make build

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -36,7 +36,6 @@ jobs:
           path: |
             %LocalAppData%\go-build
             ~/go/pkg/mod
-            C:\Users\runneradmin\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Install make

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -1,10 +1,10 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
 
 name: build-and-test-windows
 on:
   push:
-    branches:
-      - master
-
+    branches: [master, main]
     paths-ignore:
       - '**.md'
       - '.github/**'


### PR DESCRIPTION
# Description of the issue
The "build.yml" workflow does both linux and macos build and test. This could lead to the failure of both of them if one of them fails and then require to rerun everything all over again for both OS, which is both costly and time consuming.
Link to the issue: https://github.com/aws/amazon-cloudwatch-agent/issues/353

# Description of changes
Split the "build.yml" workflow into "build-test-linux.yml" and "build-test-macos.yml".

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Pushed the same code in another fork and have run both of these workflow successfully .



