### PR TITLE
Fix typo in setGid function.

### DIFF
--- a/translator/cmdutil/set_uid_gid_1_15_x64.go
+++ b/translator/cmdutil/set_uid_gid_1_15_x64.go
@@ -22,7 +22,7 @@ func setUid(uid int) (err error) {
 }
 
 func setGid(gid int) (err error) {
-	_, _, e1 := unix.RawSyscall(unix.SYS_SETUID, uintptr(gid), 0, 0)
+	_, _, e1 := unix.RawSyscall(unix.SYS_SETGID, uintptr(gid), 0, 0)
 	if e1 != 0 {
 		err = e1
 	}


### PR DESCRIPTION
# Description of the issue
The `setGid` function was using the `SYS_SETUID` syscall, which was causing the user to be changed to the gid and preventing the actual user from being set.

# Description of changes
Fixed syscall name.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._




