### PR TITLE
Restart agent on RPM upgrade

### DIFF
--- a/packaging/debian/preinst
+++ b/packaging/debian/preinst
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 if [ "$1" = "upgrade" ]; then
+    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a prep-restart
     /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop
 fi
 
@@ -14,4 +15,14 @@ fi
 if ! id cwagent >/dev/null 2>&1; then
     useradd -r -M cwagent -d /home/cwagent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh))) >/dev/null 2>&1
     echo "create user cwagent, result: $?"
+fi
+
+if ! grep "^aoc:" /etc/group >/dev/null 2>&1; then
+    groupadd -r aoc >/dev/null 2>&1
+    echo "create group aoc, result: $?"
+fi
+
+if ! id aoc >/dev/null 2>&1; then
+    useradd -r -M aoc -d /home/aoc -g aoc >/dev/null 2>&1
+    echo "create user aoc, result: $?"
 fi

--- a/packaging/linux/amazon-cloudwatch-agent.spec
+++ b/packaging/linux/amazon-cloudwatch-agent.spec
@@ -100,6 +100,16 @@ if ! id cwagent >/dev/null 2>&1; then
     echo "create user cwagent, result: $?"
 fi
 
+if ! grep "^aoc:" /etc/group >/dev/null 2>&1; then
+    groupadd -r aoc >/dev/null 2>&1
+    echo "create group aoc, result: $?"
+fi
+
+if ! id aoc >/dev/null 2>&1; then
+    useradd -r -M aoc -d /home/aoc -g aoc >/dev/null 2>&1
+    echo "create user aoc, result: $?"
+fi
+
 %preun
 # Stop the agent after uninstall
 if [ $1 -eq 0 ] ; then

--- a/packaging/linux/amazon-cloudwatch-agent.spec
+++ b/packaging/linux/amazon-cloudwatch-agent.spec
@@ -112,5 +112,6 @@ fi
 # restart agent after upgrade
 if [ -x /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl ]; then
     /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a cond-restart
+fi
 
 %clean

--- a/packaging/linux/amazon-cloudwatch-agent.spec
+++ b/packaging/linux/amazon-cloudwatch-agent.spec
@@ -85,6 +85,7 @@ ln -f -s /opt/aws/amazon-cloudwatch-agent/cwagent-otel-collector/var ${RPM_BUILD
 # Stop the agent before upgrades.
 if [ $1 -ge 2 ]; then
     if [ -x /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl ]; then
+        /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a prep-restart
         /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop
     fi
 fi
@@ -106,5 +107,10 @@ if [ $1 -eq 0 ] ; then
         /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a preun
     fi
 fi
+
+%posttrans
+# restart agent after upgrade
+if [ -x /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl ]; then
+    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a cond-restart
 
 %clean


### PR DESCRIPTION
# Description of the issue
Currently, if you perform the following:
1. Install older version of CloudWatch agent
2. Configure/start agent
3. Install a newer version of CloudWatch agent (I did it via `sudo rpm -U amazon-cloudwatch-agent.rpm`)

The result is that the agent will be upgraded, but **stopped**. The agent should be able to gracefully restart after an upgrade. This would coincide with an existing AWS SSM integration which automatically installs and attempts to update the CloudWatch agent on managed fleets every 30 days. 

# Description of changes
1. Add `%posttrans%` scriptlet to the spec file when building the RPM in order to conditionally restart
2. Add `prep-restart` call pre-upgrade in order to correctly perform the conditional restart after the upgrade action
3. Create the `aoc` user/group that is required for the bundled OTEL collector, which appears to have been missing from RPM builds thus far. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. Built the RPM locally: `make clean build package-rpm`
2. `scp` the built RPM to a clean EC2 instance
3. `sudo yum install amazon-cloudwatch-agent -y` to install an older version of CWA
5. Started the agent
6. Manually updated to a newer release (but not the dirty build I made)
7. Verified that the agent is **stopped** (the current, bugged behavior)
8. Restart the agent
9. Manually update to locally built RPM
10. Verified that the agent is still running after upgrade
Snippet of output - doesn't include initial install and upgrades/restarts, but has the most relevant portion that pertains to this feature:
```
[ec2-user@ip-172-31-61-207 ~]$ sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
{
  "status": "running",
  "starttime": "2022-03-01T19:33:57+0000",
  "configstatus": "configured",
  "cwoc_status": "running",
  "cwoc_starttime": "2022-03-01T19:33:57+0000",
  "cwoc_configstatus": "configured",
  "version": "1.247349.0b251399"
}
[ec2-user@ip-172-31-61-207 ~]$ ps -ef | grep cloudwatch
cwagent   1050     1  0 19:33 ?        00:00:00 /opt/aws/amazon-cloudwatch-agent/bin/cwagent-otel-collector --config /opt/aws/amazon-cloudwatch-agent/cwagent-otel-collector/etc/cwagent-otel-collector.yaml
cwagent   1149     1  0 19:33 ?        00:00:00 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml -envconfig /opt/aws/amazon-cloudwatch-agent/etc/env-config.json -pidfile /opt/aws/amazon-cloudwatch-agent/var/amazon-cloudwatch-agent.pid
ec2-user  1232   314  0 19:34 pts/0    00:00:00 grep --color=auto cloudwatch
[ec2-user@ip-172-31-61-207 ~]$ sudo rpm -U ./amazon-cloudwatch-agent.rpm 
****** processing cwagent-otel-collector ******
Redirecting to /bin/systemctl stop cwagent-otel-collector.service
Removed symlink /etc/systemd/system/multi-user.target.wants/cwagent-otel-collector.service.

****** processing amazon-cloudwatch-agent ******
Redirecting to /bin/systemctl stop amazon-cloudwatch-agent.service
create group aoc, result: 0
create user aoc, result: 0
Created symlink from /etc/systemd/system/multi-user.target.wants/cwagent-otel-collector.service to /etc/systemd/system/cwagent-otel-collector.service.
Redirecting to /bin/systemctl restart cwagent-otel-collector.service
Redirecting to /bin/systemctl restart amazon-cloudwatch-agent.service
[ec2-user@ip-172-31-61-207 ~]$ ps -ef | grep cloudwatch
aoc       1395     1  0 19:34 ?        00:00:00 /opt/aws/amazon-cloudwatch-agent/bin/cwagent-otel-collector --config /opt/aws/amazon-cloudwatch-agent/cwagent-otel-collector/etc/cwagent-otel-collector.yaml
cwagent   1464     1  0 19:34 ?        00:00:00 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml -envconfig /opt/aws/amazon-cloudwatch-agent/etc/env-config.json -pidfile /opt/aws/amazon-cloudwatch-agent/var/amazon-cloudwatch-agent.pid
ec2-user  1483   314  0 19:35 pts/0    00:00:00 grep --color=auto cloudwatch
[ec2-user@ip-172-31-61-207 ~]$ sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
{
  "status": "running",
  "starttime": "2022-03-01T19:34:48+0000",
  "configstatus": "configured",
  "cwoc_status": "running",
  "cwoc_starttime": "2022-03-01T19:34:47+0000",
  "cwoc_configstatus": "configured",
  "version": "1.247350.0-20-g95068d3-dirty"
}

```




