### PR TITLE
Bring back -help output

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -356,11 +356,6 @@ func runAgent(ctx context.Context,
 	return ag.Run(ctx)
 }
 
-func usageExit(rc int) {
-	//fmt.Println(internal.Usage)
-	os.Exit(rc)
-}
-
 type program struct {
 	inputFilters      []string
 	outputFilters     []string
@@ -388,7 +383,6 @@ func (p *program) Stop(_ service.Service) error {
 }
 
 func main() {
-	// flag.Usage = func() { usageExit(0) }
 	flag.Parse()
 	args := flag.Args()
 

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -388,7 +388,7 @@ func (p *program) Stop(_ service.Service) error {
 }
 
 func main() {
-	flag.Usage = func() { usageExit(0) }
+	// flag.Usage = func() { usageExit(0) }
 	flag.Parse()
 	args := flag.Args()
 


### PR DESCRIPTION
# Description of the issue

As reported in #393, currently `--help`, `-help`, `-h` produces no output / empty output

# Description of changes

Brings back the default `flag.Usage` implementation (currently it's overridden with a function that just exits without printing anything). 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

Manual test on the cli

Closes #393


