### PR TITLE
retry on network failure for detecting EC2

### DIFF
--- a/packaging/dependencies/amazon-cloudwatch-agent.service
+++ b/packaging/dependencies/amazon-cloudwatch-agent.service
@@ -9,7 +9,7 @@
 
 [Unit]
 Description=Amazon CloudWatch Agent
-After=network-online.target
+After=network.target
 
 [Service]
 Type=simple

--- a/translator/util/ec2util/ec2util.go
+++ b/translator/util/ec2util/ec2util.go
@@ -4,14 +4,13 @@
 package ec2util
 
 import (
-	"log"
-	"sync"
-	"time"
-
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"log"
+	"sync"
+	"time"
 )
 
 // this is a singleton struct
@@ -40,15 +39,15 @@ func initEC2UtilSingleton() (newInstance *ec2Util) {
 		return
 	}
 
-	ses, e := session.NewSession()
-	if e != nil {
-		log.Println("E! [EC2] getting new session info: ", e)
+	ses, err := session.NewSession()
+	if err != nil {
+		log.Println("E! [EC2] getting new session info: ", err)
 		return
 	}
 	md := ec2metadata.New(ses)
 	for i := 0; i < allowedRetries; i++ {
 		if md.Available() {
-			continue
+			break
 		}
 		log.Println("W! [EC2] network not available yet. Sleeping for 1 second")
 		time.Sleep(1 * time.Second)
@@ -59,28 +58,28 @@ func initEC2UtilSingleton() (newInstance *ec2Util) {
 		return
 	}
 
-	if info, e := md.GetMetadata("instance-id"); e == nil {
+	if info, err := md.GetMetadata("instance-id"); err == nil {
 		newInstance.InstanceID = info
 	} else {
-		log.Println("E! getting instance-id from EC2 metadata fail: ", e)
+		log.Println("E! getting instance-id from EC2 metadata fail: ", err)
 	}
 
-	if info, e := md.GetMetadata("hostname"); e == nil {
+	if info, err := md.GetMetadata("hostname"); err == nil {
 		newInstance.Hostname = info
 	} else {
-		log.Println("E! getting hostname from EC2 metadata fail: ", e)
+		log.Println("E! getting hostname from EC2 metadata fail: ", err)
 	}
 
-	if info, e := md.GetMetadata("local-ipv4"); e == nil {
+	if info, err := md.GetMetadata("local-ipv4"); err == nil {
 		newInstance.PrivateIP = info
 	} else {
-		log.Println("E! getting local-ipv4 from EC2 metadata fail: ", e)
+		log.Println("E! getting local-ipv4 from EC2 metadata fail: ", err)
 	}
 
-	if info, e := md.GetInstanceIdentityDocument(); e == nil {
+	if info, err := md.GetInstanceIdentityDocument(); err == nil {
 		newInstance.Region = info.Region
 	} else {
-		log.Println("E! getting region from EC2 metadata fail: ", e)
+		log.Println("E! getting region from EC2 metadata fail: ", err)
 	}
 
 	return


### PR DESCRIPTION
# Description of the issue
Closes #395 

# Description of changes
Add a simple retry in the EC2 util so that if the network is not immediately available, it can recover gracefully once network is available.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. Reproduced issue on a CentOS 8 EC2 instance with the 349 version of the agent
2. Confirmed that the network target change in #344 with v350 fixes the issue
3. Ran locally built agent and config-translator binary on the host, after reverting the systemd configuration change
4. Output below shows that at initial startup, the host could not connect to EC2 metadata after the reboot, but recovered after one retry: `2022/03/08 17:51:05 I! 2022/03/08 17:51:04 E! [EC2] network not available yet. Sleeping for 1 second`
```
[centos@ip-172-31-59-92 ~]$ cat /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log 
2022/03/08 17:50:08 I! I! Detected the instance is EC2
2022/03/08 17:50:08 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json ...
/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json does not exist or cannot read. Skipping it.
2022/03/08 17:50:08 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/default ...
Valid Json input schema.
I! Detecting run_as_user...
No csm configuration found.
No log configuration found.
Configuration validation first phase succeeded
 
2022/03/08 17:50:08 I! Config has been translated into TOML /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml 
2022/03/08 17:50:08 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json ...
2022/03/08 17:50:08 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/default ...
2022/03/08 17:50:08 I! Detected runAsUser: cwagent
2022/03/08 17:50:08 I! Changing ownership of [/opt/aws/amazon-cloudwatch-agent/logs /opt/aws/amazon-cloudwatch-agent/etc /opt/aws/amazon-cloudwatch-agent/var] to 990:987
2022/03/08 17:50:08 I! Set HOME: /home/cwagent
2022-03-08T17:50:08Z I! Starting AmazonCloudWatchAgent 1.247350.0-15-g98cf13bb-dirty
2022-03-08T17:50:08Z I! AWS SDK log level not set
2022-03-08T17:50:08Z I! Loaded inputs: disk mem
2022-03-08T17:50:08Z I! Loaded aggregators: 
2022-03-08T17:50:08Z I! Loaded processors: ec2tagger
2022-03-08T17:50:08Z I! Loaded outputs: cloudwatch
2022-03-08T17:50:08Z I! Tags enabled: host=ip-172-31-59-92.us-west-2.compute.internal
2022-03-08T17:50:08Z I! [agent] Config: Interval:1m0s, Quiet:false, Hostname:"ip-172-31-59-92.us-west-2.compute.internal", Flush Interval:1s
2022-03-08T17:50:08Z I! [logagent] starting
2022-03-08T17:50:08Z I! [processors.ec2tagger] ec2tagger: EC2 tagger has started initialization.
2022-03-08T17:50:08Z I! cloudwatch: get unique roll up list []
2022-03-08T17:50:08Z I! cloudwatch: publish with ForceFlushInterval: 1m0s, Publish Jitter: 41s
2022-03-08T17:50:08Z I! [processors.ec2tagger] ec2tagger: Initial retrieval of tags succeded
2022-03-08T17:50:08Z I! [processors.ec2tagger] ec2tagger: EC2 tagger has started, finished initial retrieval of tags and Volumes
2022-03-08T17:50:41Z I! Profiler is stopped during shutdown
2022-03-08T17:50:41Z I! [agent] Hang on, flushing any cached metrics before shutdown
2022/03/08 17:51:05 I! 2022/03/08 17:51:04 E! [EC2] network not available yet. Sleeping for 1 second
I! Detected the instance is EC2
2022/03/08 17:51:05 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json ...
/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json does not exist or cannot read. Skipping it.
2022/03/08 17:51:05 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/default ...
Valid Json input schema.
I! Detecting run_as_user...
No csm configuration found.
No log configuration found.
Configuration validation first phase succeeded
 
2022/03/08 17:51:05 I! Config has been translated into TOML /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml 
2022/03/08 17:51:05 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json ...
2022/03/08 17:51:05 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/default ...
2022/03/08 17:51:05 I! Detected runAsUser: cwagent
2022/03/08 17:51:05 I! Changing ownership of [/opt/aws/amazon-cloudwatch-agent/logs /opt/aws/amazon-cloudwatch-agent/etc /opt/aws/amazon-cloudwatch-agent/var] to 990:987
2022/03/08 17:51:05 I! Set HOME: /home/cwagent
2022-03-08T17:51:08Z I! Starting AmazonCloudWatchAgent 1.247350.0-15-g98cf13bb-dirty
2022-03-08T17:51:08Z I! AWS SDK log level not set
2022-03-08T17:51:08Z I! Loaded inputs: disk mem
2022-03-08T17:51:08Z I! Loaded aggregators: 
2022-03-08T17:51:08Z I! Loaded processors: ec2tagger
2022-03-08T17:51:08Z I! Loaded outputs: cloudwatch
2022-03-08T17:51:08Z I! Tags enabled: host=ip-172-31-59-92.us-west-2.compute.internal
2022-03-08T17:51:08Z I! [agent] Config: Interval:1m0s, Quiet:false, Hostname:"ip-172-31-59-92.us-west-2.compute.internal", Flush Interval:1s
2022-03-08T17:51:08Z I! [logagent] starting
2022-03-08T17:51:08Z I! [processors.ec2tagger] ec2tagger: EC2 tagger has started initialization.
2022-03-08T17:51:08Z I! cloudwatch: get unique roll up list []
2022-03-08T17:51:08Z I! cloudwatch: publish with ForceFlushInterval: 1m0s, Publish Jitter: 42s
2022-03-08T17:51:08Z I! [processors.ec2tagger] ec2tagger: Initial retrieval of tags succeded
2022-03-08T17:51:08Z I! [processors.ec2tagger] ec2tagger: EC2 tagger has started, finished initial retrieval of tags and Volumes
```



