### PR TITLE
Allow account ID as placeholder value for log configuration

### DIFF
--- a/translator/translate/csm/rulePort.go
+++ b/translator/translate/csm/rulePort.go
@@ -19,7 +19,7 @@ func applyServiceAddressesRule(input interface{}) (returnKey string, returnVal i
 	stringAddresses := inputAddresses.([]string)
 	addresses := []string{}
 
-	metadata := util.GetMetadataInfo()
+	metadata := util.GetMetadataInfo(util.Ec2MetadataInfoProvider)
 
 	for _, addr := range stringAddresses {
 		resolvedAddr := util.ResolvePlaceholder(addr, metadata)

--- a/translator/translate/logs/logs.go
+++ b/translator/translate/logs/logs.go
@@ -42,7 +42,7 @@ func (l *Logs) ApplyRule(input interface{}) (returnKey string, returnVal interfa
 	inputs := map[string]interface{}{}
 	processors := map[string]interface{}{}
 	cloudwatchConfig := map[string]interface{}{}
-	GlobalLogConfig.MetadataInfo = util.GetMetadataInfo()
+	GlobalLogConfig.MetadataInfo = util.GetMetadataInfo(util.Ec2MetadataInfoProvider)
 
 	//Check if this plugin exist in the input instance
 	//If not, not process

--- a/translator/translate/util/placeholderUtil.go
+++ b/translator/translate/util/placeholderUtil.go
@@ -21,11 +21,13 @@ const (
 	ipAddressPlaceholder     = "{ip_address}"
 	awsRegionPlaceholder     = "{aws_region}"
 	datePlaceholder          = "{date}"
+	accountIdPlaceholder     = "{account_id}"
 
 	unknownInstanceId = "i-UNKNOWN"
 	unknownHostname   = "UNKNOWN-HOST"
 	unknownIpAddress  = "UNKNOWN-IP"
 	unknownAwsRegion  = "UNKNOWN-REGION"
+	unknownAccountId  = "UNKNOWN-ACCOUNT"
 )
 
 //resolve place holder for log group and log stream.
@@ -64,8 +66,15 @@ func GetMetadataInfo() map[string]string {
 		awsRegion = unknownAwsRegion
 	}
 
+	accountID := ec2util.GetEC2UtilSingleton().AccountID
+	if accountID == "" {
+		accountID = unknownAccountId
+	}
+
 	return map[string]string{instanceIdPlaceholder: instanceID, hostnamePlaceholder: hostname,
-		localHostnamePlaceholder: localHostname, ipAddressPlaceholder: ipAddress, awsRegionPlaceholder: awsRegion}
+		localHostnamePlaceholder: localHostname, ipAddressPlaceholder: ipAddress, awsRegionPlaceholder: awsRegion,
+		accountIdPlaceholder: accountID,
+	}
 }
 
 func getHostName() string {

--- a/translator/translate/util/placeholderUtil.go
+++ b/translator/translate/util/placeholderUtil.go
@@ -24,11 +24,12 @@ type Metadata struct {
 type MetadataInfoProvider func() *Metadata
 
 var Ec2MetadataInfoProvider = func() *Metadata {
+	ec2 := ec2util.GetEC2UtilSingleton()
 	return &Metadata{
-		InstanceID: ec2util.GetEC2UtilSingleton().InstanceID,
-		Hostname: ec2util.GetEC2UtilSingleton().Hostname,
-		PrivateIP: ec2util.GetEC2UtilSingleton().PrivateIP,
-		AccountID: ec2util.GetEC2UtilSingleton().AccountID,
+		InstanceID: ec2.InstanceID,
+		Hostname: ec2.Hostname,
+		PrivateIP: ec2.PrivateIP,
+		AccountID: ec2.AccountID,
 	}
 }
 

--- a/translator/translate/util/placeholderUtil_test.go
+++ b/translator/translate/util/placeholderUtil_test.go
@@ -9,10 +9,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	dummyInstanceId = "some_instance_id"
+	dummyHostName = "some_hostname"
+	dummyPrivateIp = "some_private_ip"
+	dummyAccountId = "some_account_id"
+)
+
 func TestHostName(t *testing.T) {
 	assert.True(t, getHostName() != unknownHostname)
 }
 
 func TestIpAddress(t *testing.T) {
 	assert.True(t, getIpAddress() != unknownIpAddress)
+}
+
+func TestGetMetadataInfo(t *testing.T) {
+	m := GetMetadataInfo(mockMetadataProvider(dummyInstanceId, dummyHostName, dummyPrivateIp, dummyAccountId))
+	assert.Equal(t, dummyInstanceId, m[instanceIdPlaceholder])
+	assert.Equal(t, dummyHostName, m[hostnamePlaceholder])
+	assert.Equal(t, dummyPrivateIp, m[ipAddressPlaceholder])
+	assert.Equal(t, dummyAccountId, m[accountIdPlaceholder])
+}
+
+func TestGetMetadataInfoEmptyInstanceId(t *testing.T) {
+	m := GetMetadataInfo(mockMetadataProvider("", dummyHostName, dummyPrivateIp, dummyAccountId))
+	assert.Equal(t, unknownInstanceId, m[instanceIdPlaceholder])
+}
+
+func TestGetMetadataInfoUsesLocalHostname(t *testing.T) {
+	m := GetMetadataInfo(mockMetadataProvider(dummyInstanceId, "", dummyPrivateIp, dummyAccountId))
+	assert.Equal(t, getHostName(), m[hostnamePlaceholder])
+}
+
+func TestGetMetadataInfoDerivesIpAddress(t *testing.T) {
+	m := GetMetadataInfo(mockMetadataProvider(dummyInstanceId, dummyHostName, "", dummyAccountId))
+	assert.Equal(t, getIpAddress(), m[ipAddressPlaceholder])
+}
+
+func TestGetMetadataInfoEmptyAccountId(t *testing.T) {
+	m := GetMetadataInfo(mockMetadataProvider(dummyInstanceId, dummyHostName, dummyPrivateIp, ""))
+	assert.Equal(t, unknownAccountId, m[accountIdPlaceholder])
+}
+
+func mockMetadataProvider(instanceId, hostname, privateIp, accountId string) func() *Metadata {
+	return func() *Metadata {
+		return &Metadata{
+			InstanceID: instanceId,
+			Hostname: hostname,
+			PrivateIP: privateIp,
+			AccountID: accountId,
+		}
+	}
 }

--- a/translator/util/ec2util/ec2util.go
+++ b/translator/util/ec2util/ec2util.go
@@ -20,6 +20,7 @@ type ec2Util struct {
 	PrivateIP  string
 	InstanceID string
 	Hostname   string
+	AccountID string
 }
 
 const allowedRetries = 5
@@ -101,8 +102,9 @@ func initEC2UtilSingleton() (newInstance *ec2Util) {
 
 	if info, err := md.GetInstanceIdentityDocument(); err == nil {
 		newInstance.Region = info.Region
+		newInstance.AccountID = info.AccountID
 	} else {
-		log.Println("E! getting region from EC2 metadata fail: ", err)
+		log.Println("E! fetching identity document from EC2 metadata fail: ", err)
 	}
 
 	return


### PR DESCRIPTION
# Description of the issue
Closes #371

# Description of changes
Uses the EC2 metadata to pull the account ID from the instance, and exposes it as a placeholder value that can be replaced as part of the log configuration, so that customers can use the account ID to identify where logs are coming from.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manually ran test on an EC2 and confirmed that the log group with my account ID was created, and logs were flowing to it.

Note that I tested this by using the account ID as a placeholder replacement for the log group, but it's the same logic for replacing the value in the log stream name, so I'm not super concerned about that. 
```
[ec2-user@ip-172-31-27-74 ~]$ sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json 
-s
****** processing amazon-cloudwatch-agent ******
/opt/aws/amazon-cloudwatch-agent/bin/config-downloader --output-dir /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d --download-source file:/opt/aws/amazon-clo
udwatch-agent/bin/config.json --mode ec2 --config /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml --multi-config default
Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp
Start configuration validation...
/opt/aws/amazon-cloudwatch-agent/bin/config-translator --input /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json --input-dir /opt/aws/amazon-cloudwatch-agent
/etc/amazon-cloudwatch-agent.d --output /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml --mode ec2 --config /opt/aws/amazon-cloudwatch-agent/etc/common-con
fig.toml --multi-config default
2022/03/09 20:56:29 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp ...
Valid Json input schema.
I! Detecting run_as_user...
2022/03/09 20:56:29 D! [EC2] Found active network interface
No csm configuration found.
No metric configuration found.
Configuration validation first phase succeeded
/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -schematest -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
Configuration validation second phase succeeded
Configuration validation succeeded
amazon-cloudwatch-agent has already been stopped
Redirecting to /bin/systemctl restart amazon-cloudwatch-agent.service
[ec2-user@ip-172-31-27-74 ~]$ cat /opt/aws/amazon-cloudwatch-agent/bin/config.json
{
  "agent": {
    "run_as_user": "root"
  },
  "logs": {
    "logs_collected": {
      "files": {
        "collect_list": [
          {
            "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
            "log_group_name": "{account_id}",
            "log_stream_name": "{instance_id}",
            "retention_in_days": -1
          }
        ]
      }
    }
  }
}
```




