### PR TITLE
cut scan length to 20 bytes

### DIFF
--- a/plugins/inputs/windows_event_log/wineventlog/utils.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils.go
@@ -23,6 +23,7 @@ const (
 	eventLogQueryTemplate = `<QueryList><Query Id="0"><Select Path="%s">%s</Select></Query></QueryList>`
 	eventLogLevelFilter   = "Level='%s'"
 	eventIgnoreOldFilter  = "TimeCreated[timediff(@SystemTime) &lt;= %d]"
+	emptySpaceScanLength  = 20
 
 	CRITICAL    = "CRITICAL"
 	ERROR       = "ERROR"
@@ -112,15 +113,15 @@ func UTF16ToUTF8Bytes(in []byte, length uint32) ([]byte, error) {
 }
 
 func isTheEndOfContent(in []byte, length uint32) bool {
-	// scan next 100 characters, if any of them is none '0', return false
+	// scan next 20 bytes, if any of them is none '0', return false
 	i := int(length)
 
 	if i%2 != 0 {
 		i -= 1
 	}
 	max := len(in)
-	if i+100 < max {
-		max = i+100
+	if i+emptySpaceScanLength < max {
+		max = i+emptySpaceScanLength
 	}
 
 	for ; i < max - 2; i += 2 {


### PR DESCRIPTION
# Description of the issue
Performance degrade when high log throughput 

# Description of changes
reduce the number of bytes scanning when determine the buffer used returned by Microsoft windows event log api should be doubled.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manually test new build on soaking host and observe the usage of CPU and mem back to good stat.



