### PR TITLE
Add wait group for avoiding checking file exists before removing file

### DIFF
--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -408,8 +408,6 @@ func TestLogsFileAutoRemoval(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		time.Sleep(1 * time.Second)
-
 		// create a new file matching configured pattern
 		tmpfile2, err = createTempFile("", filePrefix)
 		require.NoError(t, err)

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -360,6 +360,8 @@ func TestLogsFileRemove(t *testing.T) {
 
 //When another file is created for the same file config and the file config has auto_removal as true, the old files will stop at EOF and removed afterwards
 func TestLogsFileAutoRemoval(t *testing.T) {
+	var wg sync.WaitGroup
+
 	multilineWaitPeriod = 10 * time.Millisecond
 	logEntryString := "anything"
 	filePrefix := "file_auto_removal"
@@ -400,7 +402,12 @@ func TestLogsFileAutoRemoval(t *testing.T) {
 			os.Remove(tmpfile2.Name())
 		}
 	}()
+
+	wg.Add(1)
+	
 	go func() {
+		defer wg.Done()
+
 		time.Sleep(1 * time.Second)
 
 		// create a new file matching configured pattern
@@ -437,6 +444,10 @@ func TestLogsFileAutoRemoval(t *testing.T) {
 	if e.Message() != logEntryString {
 		t.Errorf("Wrong log found from 2nd file: \n% x\nExpecting:\n% x\n", e.Message(), logEntryString)
 	}
+
+	//Use Wait Group to avoid race condition between opening tmpfile2 to delete tmpfile1 with auto_removal and opening tmpfile1
+	//to check it exist
+	wg.Wait()
 
 	_, err = os.Open(tmpfile1.Name())
 	assert.True(t, os.IsNotExist(err))


### PR DESCRIPTION
# Description of the issue
The `TestLogsFileAutoRemoval` has been in a race condition of removing the first file by using `auto_removal`; however, in some case, the first file has not been removed by the time the [check first file exists](https://github.com/aws/amazon-cloudwatch-agent/blob/master/plugins/inputs/logfile/logfile_test.go#L441-L442) occurs. Therefore, adding `WaitGroup` to wait for the second file to be completely created, then it would delete the first file and the [check first file exists](https://github.com/aws/amazon-cloudwatch-agent/blob/master/plugins/inputs/logfile/logfile_test.go#L441-L442) will be able to pass. 

# Description of changes
Add [WaitGroup](https://www.golangprograms.com/goroutines.html) for `TestLogsFileAutoRemoval`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
By using `make test` over 10 times, I have confidence that the credibility of this change has worked.




