### PR TITLE
update error handling to account for ResourceAlreadyExists gracefully

### DIFF
--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -344,9 +344,14 @@ func (p *pusher) createLogGroupAndStream() error {
 					LogStreamName: &p.Stream,
 				})
 			} else {
-				p.Log.Errorf("creating group fail due to : %v \n", err)
+				p.Log.Debugf("creating group fail due to : %v \n", err)
 			}
 		}
+	}
+
+	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cloudwatchlogs.ErrCodeResourceAlreadyExistsException {
+		p.Log.Debugf("Resource was already created. %v\n", err)
+		return nil // if the log group or log stream already exist, this is not worth returning an error for
 	}
 
 	return err

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -374,7 +374,7 @@ func (p *pusher) putRetentionPolicy() {
 			// to push a log to a non-existent log group, we don't want to dirty the log with an error
 			// if the error is that the log group doesn't exist (yet).
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
-				p.Log.Debugf("Log group %v not created yet: %v", &p.Group, err)
+				p.Log.Debugf("Log group %v not created yet: %v", p.Group, err)
 			} else {
 				p.Log.Errorf("Unable to put retention policy for log group %v: %v ", p.Group, err)
 			}

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -339,13 +339,13 @@ func (p *pusher) createLogGroupAndStream() error {
 
 			// create stream again if group created successfully.
 			if err == nil {
-				p.Log.Debugf("successfully created log group %v. Retrying log stream", &p.Group)
+				p.Log.Debugf("successfully created log group %v. Retrying log stream %v", p.Group, p.Stream)
 				_, err = p.Service.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
 					LogGroupName:  &p.Group,
 					LogStreamName: &p.Stream,
 				})
 				if err == nil {
-					p.Log.Debugf("successfully created log stream %v", &p.Stream)
+					p.Log.Debugf("successfully created log stream %v", p.Stream)
 				}
 			} else {
 				p.Log.Debugf("creating group fail due to : %v", err)


### PR DESCRIPTION
# Description of the issue
Closes #415 

Currently, when we try to create a log stream and log group (typically when the agent first starts up and sends its first log), there is a potential race condition that can occur when two different instances of the agent attempt to create the same log group. In `pusher.go`, we reuse the same `error` variable, so in the scenario where:
1. Agent A tries to push to CWL and log group doesn't exist
2. Agent B tries to push to CWL and log group doesn't exist
3. Agent B creates log group
4. Agent A fails to create log group because it already exists

The agent log will be confusing, because there will be an instance where the log says the log group does not exist yet, and simultaneously there will be an error that says the log group already exists.

# Description of changes
1. Moved all of the log statements in the `createLogGroupAndStream()` function to debug level, so we don't parrot the same error information twice at error level
2. Added a check before returning, such that if the error we are about to return is due to `ResourceAlreadyExistsException`, we return nil instead, indicating no issue
3. Added debug log when attempting to update the log retention policy
4. Captures the error when failing to put the log retention policy when the log group doesn't exist yet, because that shouldn't be considered a failure state (error level log).
5. Added debug logs to show that the log group or stream was created successfully when no err was returned, or that the retention policy was updated successfully

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Wasn't able to 100% reproduce the issue, but I think the logging updates are sufficient.
1. Set up a CloudFormation template that spawns a bunch of independent EC2 instances
2. Each EC2 instance downloads the RPM and config, and starts the agent
6. Each agent attempts to publish to the same log groups but different log streams

The relevant agent logs from the instance that started publishing first. Note that the other agent logs don't enter the race condition posited in the original issue, but I don't want to spend a lot of time trying to reproduce that exact scenario since this change is more overarching than that one situation.
```
2022-03-29T20:59:54Z D! [outputs.cloudwatchlogs] Log group MyTestLogGroup11111a not created yet: ResourceNotFoundException: The specified log group does not exist.
2022-03-29T20:59:54Z D! [outputs.cloudwatchlogs] Log group MyTestLogGroup22222a not created yet: ResourceNotFoundException: The specified log group does not exist.
2022-03-29T20:59:59Z D! [outputs.cloudwatchlogs] creating stream fail due to : ResourceNotFoundException: The specified log group does not exist.
2022-03-29T20:59:59Z D! [outputs.cloudwatchlogs] creating stream fail due to : ResourceNotFoundException: The specified log group does not exist.
2022-03-29T20:59:59Z D! [outputs.cloudwatchlogs] successfully created log group MyTestLogGroup11111a. Retrying log stream MyTestLogStream11111a
2022-03-29T20:59:59Z D! [outputs.cloudwatchlogs] successfully created log group MyTestLogGroup22222a. Retrying log stream i-0d30e8222e219283d-agent-log22222a
2022-03-29T20:59:59Z D! [outputs.cloudwatchlogs] successfully created log stream MyTestLogStream11111a
2022-03-29T20:59:59Z D! [outputs.cloudwatchlogs] successfully created log stream i-0d30e8222e219283d-agent-log22222a
2022-03-29T20:59:59Z D! [outputs.cloudwatchlogs] successfully updated log retention policy for log group MyTestLogGroup11111a
2022-03-29T20:59:59Z D! [outputs.cloudwatchlogs] successfully updated log retention policy for log group MyTestLogGroup22222a
```
The config file used:
```
{
    "agent": {
        "debug": true,
        "metrics_collection_interval": 60,
        "run_as_user": "root"
    },
    "logs": {
        "logs_collected": {
            "files": {
                "collect_list": [
                    {
                        "file_path": "/tmp/logfile.txt",
                        "log_group_name": "MyTestLogGroup11111a",
                        "log_stream_name": "MyTestLogStream11111a",
                        "retention_in_days": 1
                    },
                    {
                        "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
                        "log_group_name": "MyTestLogGroup22222a",
                        "log_stream_name": "{instance_id}-agent-log22222a",
                        "retention_in_days": 1,
                        "filters": [
                            {
                                "type": "include",
                                "expression": "D!"
                            },
                            {
                                "type": "include",
                                "expression": "cloudwatchlogs"
                            },
                            {
                                "type": "exclude",
                                "expression": "Buffer fullness"
                            },
                            {
                                "type": "exclude",
                                "expression": "Retried"
                            },
                            {
                                "type": "exclude",
                                "expression": "Pusher published"
                            }
                        ]
                    }
                ]
            }
        }
    }
}
```
