### PR TITLE
Change to onPremise for all CWAgent component binaries and add executable path for Darwin

### DIFF
--- a/cmd/config-downloader/downloader.go
+++ b/cmd/config-downloader/downloader.go
@@ -113,7 +113,7 @@ func main() {
 
 	var region, mode, downloadLocation, outputDir, inputConfig, multiConfig string
 
-	flag.StringVar(&mode, "mode", "ec2", "The mode value, i.e. ec2 or onPrem")
+	flag.StringVar(&mode, "mode", "ec2", "Please provide the mode, i.e. ec2, onPremise, auto")
 	flag.StringVar(&downloadLocation, "download-source", "",
 		"Download source. Example: \"ssm:my-parameter-store-name\" for an EC2 SSM Parameter Store Name holding your CloudWatch Agent configuration.")
 	flag.StringVar(&outputDir, "output-dir", "", "Path of output json config directory.")

--- a/cmd/config-translator/translator.go
+++ b/cmd/config-translator/translator.go
@@ -29,7 +29,7 @@ func initFlags() {
 	var inputJsonFile = flag.String("input", "", "Please provide the path of input agent json config file")
 	var inputJsonDir = flag.String("input-dir", "", "Please provide the path of input agent json config directory.")
 	var inputTomlFile = flag.String("output", "", "Please provide the path of the output CWAgent config file")
-	var inputMode = flag.String("mode", "ec2", "Please provide the mode, i.e. ec2, onPrem")
+	var inputMode = flag.String("mode", "ec2", "Please provide the mode, i.e. ec2, onPremise, auto")
 	var inputConfig = flag.String("config", "", "Please provide the common-config file")
 	var multiConfig = flag.String("multi-config", "remove", "valid values: default, append, remove")
 	flag.Parse()

--- a/packaging/darwin/amazon-cloudwatch-agent-ctl
+++ b/packaging/darwin/amazon-cloudwatch-agent-ctl
@@ -167,23 +167,6 @@ cwa_config() {
 
      mkdir -p "${CONFDIR}"
 
-     param_mode="ec2"
-     case "${mode}" in
-     ec2)
-          param_mode="ec2"
-          ;;
-     onPremise)
-          param_mode="onPrem"
-          ;;
-     auto)
-          param_mode="auto"
-          ;;
-     *)
-          echo "Invalid mode: ${mode}" >&2
-          exit 1
-          ;;
-     esac
-
      if [ "${config_location}" = "${ALL_CONFIG}" ] && [ "${multi_config}" != 'remove' ]; then
           echo "ignore cwa configuration \"${ALL_CONFIG}\" as it is only supported by action \"remove-config\""
           return
@@ -192,7 +175,7 @@ cwa_config() {
      if [ "${config_location}" = "${ALL_CONFIG}" ]; then
           rm -rf "${JSON_DIR}"/*
      else
-          runDownloaderCommand="${CMDDIR}/config-downloader --output-dir ${JSON_DIR} --download-source ${config_location} --mode ${param_mode} --config ${COMMON_CONIG} --multi-config ${multi_config}"
+          runDownloaderCommand="${CMDDIR}/config-downloader --output-dir ${JSON_DIR} --download-source ${config_location} --mode ${mode} --config ${COMMON_CONIG} --multi-config ${multi_config}"
           echo ${runDownloaderCommand}
           ${runDownloaderCommand}
      fi
@@ -201,7 +184,7 @@ cwa_config() {
           echo "all amazon-cloudwatch-agent configurations have been removed"
           rm -f "${TOML}"
      else
-          runTranslatorCommand="${CMDDIR}/config-translator --input ${JSON} --input-dir ${JSON_DIR} --output ${TOML} --mode ${param_mode} --config ${COMMON_CONIG} --multi-config ${multi_config}"
+          runTranslatorCommand="${CMDDIR}/config-translator --input ${JSON} --input-dir ${JSON_DIR} --output ${TOML} --mode ${mode} --config ${COMMON_CONIG} --multi-config ${multi_config}"
           echo ${runTranslatorCommand}
           ${runTranslatorCommand}
 
@@ -248,7 +231,7 @@ cwa_config() {
 
      if [ "${restart}" = 'true' ]; then
           cwa_stop
-          cwa_start "${param_mode}"
+          cwa_start "${mode}"
      fi
 }
 
@@ -282,11 +265,8 @@ main() {
 
      case "${mode}" in
      ec2) ;;
-
      onPremise) ;;
-
      auto) ;;
-
      *)
           echo "Invalid mode: ${mode} ${UsageString}" >&2
           exit 1

--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -305,27 +305,10 @@ config_all() {
 
      mkdir -p "${CONFDIR}"
 
-     param_mode="ec2"
-     case "${mode}" in
-     ec2)
-          param_mode="ec2"
-          ;;
-     onPremise)
-          param_mode="onPrem"
-          ;;
-     auto)
-          param_mode="auto"
-          ;;
-     *)
-          echo "Invalid mode: ${mode}" >&2
-          exit 1
-          ;;
-     esac
-
      if [ -n "${cwoc_config_location}" ]; then
           echo "****** processing cwagent-otel-collector ******"
           set +e
-          cwoc_config "${cwoc_config_location}" "${restart}" "${param_mode}" "${multi_config}"
+          cwoc_config "${cwoc_config_location}" "${restart}" "${mode}" "${multi_config}"
           set -e
           echo ""
      fi
@@ -334,7 +317,7 @@ config_all() {
      # default cwa config depends on the existence of cwoc config
      if [ -n "${cwa_config_location}" ]; then
           echo "****** processing amazon-cloudwatch-agent ******"
-          cwa_config "${cwa_config_location}" "${restart}" "${param_mode}" "${multi_config}"
+          cwa_config "${cwa_config_location}" "${restart}" "${mode}" "${multi_config}"
      fi
 }
 
@@ -536,11 +519,8 @@ main() {
 
      case "${mode}" in
      ec2) ;;
-
      onPremise) ;;
-
      auto) ;;
-
      *)
           echo "Invalid mode: ${mode} ${UsageString}" >&2
           exit 1

--- a/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
+++ b/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
@@ -352,7 +352,7 @@ Function CWAConfig() {
 
     $param_mode="ec2"
     if (!$EC2) {
-        $param_mode="onPrem"
+        $param_mode="onPremise"
     }
 
     if ($ConfigLocation -eq $AllConfig -And $multi_config -ne 'remove') {
@@ -435,7 +435,7 @@ Function CWOCConfig() {
 
     $param_mode="ec2"
     if (!$EC2) {
-        $param_mode="onPrem"
+        $param_mode="onPremise"
     }
 
     if ($OtelConfigLocation -eq $AllConfig -And $multi_config -ne 'remove') {

--- a/translator/cmdutil/translatorutil.go
+++ b/translator/cmdutil/translatorutil.go
@@ -72,10 +72,10 @@ func getJsonConfigMap(jsonConfigFilePath, osType string) (map[string]interface{}
 		curPath := getCurBinaryPath()
 		if osType == config.OS_TYPE_WINDOWS {
 			jsonConfigFilePath = filepath.Join(curPath, jsonTemplateName_Windows)
-		} else if osType == config.OS_TYPE_LINUX {
-			jsonConfigFilePath = filepath.Join(curPath, jsonTemplateName_Linux)
-		} else {
+		} else if osType == config.OS_TYPE_DARWIN {
 			jsonConfigFilePath = filepath.Join(curPath, jsonTemplateName_Darwin)
+		} else {
+			jsonConfigFilePath = filepath.Join(curPath, jsonTemplateName_Linux)
 		}
 	}
 	log.Printf("Reading json config file path: %v ...", jsonConfigFilePath)

--- a/translator/cmdutil/translatorutil.go
+++ b/translator/cmdutil/translatorutil.go
@@ -27,6 +27,7 @@ const (
 	tomlFileMode             = 0644
 	jsonTemplateName_Linux   = "default_linux_config.json"
 	jsonTemplateName_Windows = "default_windows_config.json"
+	jsonTemplateName_Darwin  = "default_darwin_config.json"
 	defaultTomlConfigName    = "CWAgent.conf"
 	exitSuccessMessage       = "Configuration validation first phase succeeded"
 )
@@ -71,8 +72,10 @@ func getJsonConfigMap(jsonConfigFilePath, osType string) (map[string]interface{}
 		curPath := getCurBinaryPath()
 		if osType == config.OS_TYPE_WINDOWS {
 			jsonConfigFilePath = filepath.Join(curPath, jsonTemplateName_Windows)
-		} else {
+		} else if osType == config.OS_TYPE_LINUX {
 			jsonConfigFilePath = filepath.Join(curPath, jsonTemplateName_Linux)
+		} else {
+			jsonConfigFilePath = filepath.Join(curPath, jsonTemplateName_Darwin)
 		}
 	}
 	log.Printf("Reading json config file path: %v ...", jsonConfigFilePath)

--- a/translator/config/mode.go
+++ b/translator/config/mode.go
@@ -5,5 +5,5 @@ package config
 
 const (
 	ModeEC2    = "ec2"
-	ModeOnPrem = "onPrem"
+	ModeOnPrem = "onPremise"
 )

--- a/translator/config/mode.go
+++ b/translator/config/mode.go
@@ -6,4 +6,5 @@ package config
 const (
 	ModeEC2    = "ec2"
 	ModeOnPrem = "onPremise"
+	ModeAuto   = "auto"
 )

--- a/translator/config/mode.go
+++ b/translator/config/mode.go
@@ -6,5 +6,4 @@ package config
 const (
 	ModeEC2    = "ec2"
 	ModeOnPrem = "onPremise"
-	ModeAuto   = "auto"
 )

--- a/translator/context/context.go
+++ b/translator/context/context.go
@@ -114,7 +114,7 @@ func (ctx *Context) SetMode(mode string) {
 	case config.ModeOnPrem:
 		ctx.mode = config.ModeOnPrem
 	default:
-		panic(fmt.Sprintf("Invalid mode %s. Valid mode values are %s, %s and %s.\n", mode, config.ModeEC2, config.ModeOnPrem,config.ModeAuto))
+		panic(fmt.Sprintf("Invalid mode %s. Valid mode values are %s, and %s.\n", mode, config.ModeEC2, config.ModeOnPrem))
 	}
 }
 

--- a/translator/context/context.go
+++ b/translator/context/context.go
@@ -114,7 +114,7 @@ func (ctx *Context) SetMode(mode string) {
 	case config.ModeOnPrem:
 		ctx.mode = config.ModeOnPrem
 	default:
-		panic(fmt.Sprintf("Invalid mode %s. Valid mode values are %s and %s.\n", mode, config.ModeEC2, config.ModeOnPrem))
+		panic(fmt.Sprintf("Invalid mode %s. Valid mode values are %s, %s and %s.\n", mode, config.ModeEC2, config.ModeOnPrem,config.ModeAuto))
 	}
 }
 

--- a/translator/util/sdkutil.go
+++ b/translator/util/sdkutil.go
@@ -46,7 +46,7 @@ func DetectAgentMode(configuredMode string) string {
 		fmt.Println("I! Detected the instance is ECS")
 		return config.ModeEC2
 	}
-	fmt.Println("I! Detected the instance is OnPrem")
+	fmt.Println("I! Detected the instance is OnPremise")
 	return config.ModeOnPrem
 }
 


### PR DESCRIPTION
# Description of the issue
There are two changes:
- Add executable path for Darwin since it confuses for the customer when using Darwin but [their executable config json for using is Linux as default for other OS.](https://github.com/aws/amazon-cloudwatch-agent/blob/master/translator/cmdutil/translatorutil.go#L74-L76)
- Change config-translator, config-downloader's `onPrem` mode to `onPremise` mode since it would consistent with [`amazon-cloudwatch-agent-ctl` binary](https://github.com/aws/amazon-cloudwatch-agent/blob/master/packaging/dependencies/amazon-cloudwatch-agent-ctl#L64) and aws-otel-collector is using [`onPremise` too](https://github.com/aws-observability/aws-otel-collector/blob/86d542ef6c9afbab2f5fc94d52a1a2e1f7b839c2/tools/ctl/linux/aws-otel-collector-ctl#L178-L189).


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- For the second changes, use `go run config-translator` with mode onPrem and mode onPremise; to be more sure, `make build` and test their binaries.


