### PR TITLE
Use aptdcon Ubuntu Fixes (#426)

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -221,7 +221,8 @@ jobs:
       matrix:
         arrays: [
           { os: "ubuntu", username: "ubuntu",
-            installAgentCommand: "dpkg -i -E ./amazon-cloudwatch-agent.deb",
+            # ubuntu needs to have dpkg lock cleared before installing cw agent
+            installAgentCommand: "aptdcon --safe-upgrade && sudo dpkg -i -E ./amazon-cloudwatch-agent.deb",
             ami: "cloudwatch-agent-integration-test-ubuntu*", caCertPath: "/etc/ssl/certs/ca-certificates.crt",
             arc: "amd64", binaryName: "amazon-cloudwatch-agent.deb" },
           { os: "al2", username: "ec2-user",


### PR DESCRIPTION
# Description of the issue
Ubuntu has a non null chance of not install cw agent

# Description of changes
Wait until apt lock is opened to install agent. 

# Tests
Ran on my fork




