### PR TITLE
sync Go version used in GitHub actions to 1.15.15

### DIFF
--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -41,7 +41,7 @@ jobs:
 
     - uses: zencargo/github-action-go-mod-tidy@v1
       with:
-        go-version: ~1.15.15
+        go-version: 1.15
 
     - name: Cache build output
       uses: actions/cache@v2

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -41,7 +41,7 @@ jobs:
 
     - uses: zencargo/github-action-go-mod-tidy@v1
       with:
-        go-version: 1.15
+        go-version: ~1.15.15
 
     - name: Cache build output
       uses: actions/cache@v2

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ~1.15.15
         id: go
 
       #Need to install rpm so ubuntu can make rpm by default ubuntu can make deb


### PR DESCRIPTION
# Description of the issue
A change in the GitHub runner to allow using go1.18 breaks releasing because of a dependency in golang/sys/unix. Using the `^1.15` made the runner pick up go1.18 but all of the other build workflows are pinned to `~1.15.15`, so just updating this to match

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.




