### PR TITLE
Fix failing windows event log unit test.

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2019 ]
+        os: [ windows-2019, windows-latest ]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -320,7 +320,7 @@ func (w *windowsEventLog) getRecord(evtHandle EvtHandle) (*windowsEventLogRecord
 	var bufferUsed uint32
 	err = EvtFormatMessage(publisherMetadataEvtHandle, evtHandle, 0, 0, 0, EvtFormatMessageXml, uint32(bufferSize), &renderBuf[0], &bufferUsed)
 	EvtClose(publisherMetadataEvtHandle)
-	if err != nil {
+	if err != nil && bufferUsed == 0 {
 		return nil, fmt.Errorf("EvtFormatMessage() publisher %v, err %v", newRecord.System.Provider.Name, err)
 	}
 	descriptionBytes, err := UTF16ToUTF8BytesForWindowsEventBuffer(renderBuf, bufferUsed)


### PR DESCRIPTION
# Description of the issue
Fixes #351 
Fix failing windows event log unit test.
Ignore EvtFormatMessage() errors if data is returned.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran `go test` on Windows server 2022 host:
```
PS C:\Users\Administrator\go\src\github.com\aws\amazon-cloudwatch-agent\plugins\inputs\windows_event_log> go test
C:\Users\ADMINI~1\AppData\Local\Temp\2\CloudWatchAgentTest\Amazon_CloudWatch_WindowsEventLog_MyGroup_MyStream_SystemEventLog
C:\Users\ADMINI~1\AppData\Local\Temp\2\CloudWatchAgentTest\Amazon_CloudWatch_WindowsEventLog_My__Group_____My__Stream_____System__Event__Log__


PASS
ok      github.com/aws/amazon-cloudwatch-agent/plugins/inputs/windows_event_log 0.032s
```
and
```
PS C:\Users\Administrator\go\src\github.com\aws\amazon-cloudwatch-agent\plugins\inputs\windows_event_log> cd .\wineventlog\
PS C:\Users\Administrator\go\src\github.com\aws\amazon-cloudwatch-agent\plugins\inputs\windows_event_log\wineventlog> go test
2022/04/05 20:41:44 I! Buffer used: 2872 is returning as single byte character count
2022/04/05 20:41:44 I! Buffer used: 1436 is returning as double byte character count, doubling it to get the whole buffer content.
2022/04/05 20:41:44 I! Buffer used: 512 is returning as double byte character count, doubling it to get the whole buffer content.
2022/04/05 20:41:44 W! [wineventlog] EvtSubscribe(), name FakeBadElogName, err The specified channel could not be found.
2022/04/05 20:41:44 I! [wineventlog] EvtOpenPublisherMetadata() publisher CWA_UnitTest222, err The system cannot find the file specified.
.
.
.
2022/04/05 20:41:49 I! [wineventlog] EvtOpenPublisherMetadata() publisher CWA_UnitTest222, err The system cannot find the file specified.
2022/04/05 20:41:49 I! [wineventlog] EvtOpenPublisherMetadata() publisher CWA_UnitTest222, err The system cannot find the file specified.
PASS
ok      github.com/aws/amazon-cloudwatch-agent/plugins/inputs/windows_event_log/wineventlog     4.679s
PS C:\Users\Administrator\go\src\github.com\aws\amazon-cloudwatch-agent\plugins\inputs\windows_event_log\wineventlog>
```

Here is the failiure just for reference:
```
PS C:\Users\Administrator\go\src\github.com\aws\amazon-cloudwatch-agent\plugins\inputs\windows_event_log\wineventlog> go test
2022/04/05 23:18:50 I! Buffer used: 2872 is returning as single byte character count
2022/04/05 23:18:50 I! Buffer used: 1436 is returning as double byte character count, doubling it to get the whole buffer content.
2022/04/05 23:18:50 I! Buffer used: 512 is returning as double byte character count, doubling it to get the whole buffer content.
2022/04/05 23:18:50 W! [wineventlog] EvtSubscribe(), name FakeBadElogName, err The specified channel could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
2022/04/05 23:18:50 I! [wineventlog] EvtFormatMessage() publisher CWA_UnitTest111, err The message ID for the desired message could not be found.
.
.
.
--- FAIL: TestReadWithBothSources (2.24s)
    wineventlog_test.go:122: seekToEnd() current count 0
    wineventlog_test.go:128: seekToEnd() total 0
    wineventlog_test.go:175:
                Error Trace:    wineventlog_test.go:175
                                                        wineventlog_test.go:110
                Error:          Not equal:
                                expected: 10
                                actual  : 0
                Test:           TestReadWithBothSources
                Messages:       expected [Application] [ERROR] [777] [CWA_UnitTest111] , 10, actual 0
FAIL
exit status 1
FAIL    github.com/aws/amazon-cloudwatch-agent/plugins/inputs/windows_event_log/wineventlog     5.219s
```


