### PR TITLE
Add set of requirements for PR and add go linter tools for checking security, format, simplify...

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,11 @@ By submitting this pull request, I confirm that you can use, modify, copy, and r
 # Tests
 _Describe what tests you have done._
 
+#Requirements
+_Before commit the code, please do the following steps._
+1. Run `make fmt` and `make fmt-sh`
+2. Run [golangci-lint run](https://golangci-lint.run/usage/install/)
+
 
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ _Describe what tests you have done._
 #Requirements
 _Before commit the code, please do the following steps._
 1. Run `make fmt` and `make fmt-sh`
-2. Run [golangci-lint run](https://golangci-lint.run/usage/install/)
+2. Run `make linter`
 
 
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,60 @@
+run:
+  # The default concurrency value is the number of available CPU.
+  concurrency: 4
+
+  # Timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 20m
+
+  # Exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # Include test files or not, default is true
+  tests: true
+
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  modules-download-mode: readonly
+
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+# All available settings of specific linters
+linters-settings:
+  revive:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.7
+  gofmt:
+    # Simplify code: gofmt with `-s` option, true by default
+    simplify: true
+  goimports:
+    # Put imports beginning with prefix after 3rd-party packages.
+    # It's a comma-separated list of prefixes.
+    local-prefixes: github.com/aws/amazon-cloudwatch-agent
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    locale: US
+    
+linters:
+  disable:
+    - errcheck
+  enable:
+    - gofmt
+    - goimports
+    - gosimple
+    - deadcode
+    - gosec
+    - unused
+    - structcheck
+    - misspell
+    - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,3 +58,4 @@ linters:
     - structcheck
     - misspell
     - revive
+    - golint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,9 +48,9 @@ linters-settings:
 linters:
   disable:
     - errcheck
-  enable:
     - gofmt
     - goimports
+  enable:
     - gosimple
     - deadcode
     - gosec

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ fmt: install-tools
 fmt-sh: install-tools
 	${SHFMT} -w -d -i 5 .
 
-linter: install-tools
+lint: install-tools
 	${LINTER} run ./...
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,8 @@ build-for-docker-arm64:
 	$(LINUX_ARM64_BUILD)/start-amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/start-amazon-cloudwatch-agent
 	$(LINUX_ARM64_BUILD)/config-translator github.com/aws/amazon-cloudwatch-agent/cmd/config-translator
 
-#Install from source is not recommended based on https://golangci-lint.run/usage/install/#install-from-source
+#Install from source for golangci-lint is not recommended based on https://golangci-lint.run/usage/install/#install-from-source so using binary
+#installation
 install-tools:
 	GOBIN=$(TOOLS_BIN_DIR) go install golang.org/x/tools/cmd/goimports
 	GOBIN=$(TOOLS_BIN_DIR) go install mvdan.cc/sh/v3/cmd/shfmt@latest


### PR DESCRIPTION
# Description of the issue
By using [`golangci-lint`](https://golangci-lint.run/usage/install/) with appropriate tools such as `gosec, golint, govet, simplify`, we can confirm that every code is up-to-standards and able to identify security errors, before merging it. One thing to note for is that this `golangci-lint` is only for development level instead of pipelines level (i.e when we deploy a hot-fix but simplify does not pass)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Run `golangci-lint run` with my branch.




