### PR TITLE
Fix auto_removal feature so log lines are NOT dropped from old file

### DIFF
--- a/cmd/config-translator/translator_test.go
+++ b/cmd/config-translator/translator_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"regexp"
 	"testing"
@@ -34,13 +33,13 @@ func checkIfSchemaValidateAsExpected(t *testing.T, jsonInputPath string, shouldS
 	} else {
 		errorDetails := result.Errors()
 		for _, errorDetail := range errorDetails {
-			fmt.Printf("String: %v \n", errorDetail.String())
-			fmt.Printf("Context: %v \n", errorDetail.Context().String())
-			fmt.Printf("Description: %v \n", errorDetail.Description())
-			fmt.Printf("Details: %v \n", errorDetail.Details())
-			fmt.Printf("Field: %v \n", errorDetail.Field())
-			fmt.Printf("Type: %v \n", errorDetail.Type())
-			fmt.Printf("Value: %v \n", errorDetail.Value())
+			t.Logf("String: %v \n", errorDetail.String())
+			t.Logf("Context: %v \n", errorDetail.Context().String())
+			t.Logf("Description: %v \n", errorDetail.Description())
+			t.Logf("Details: %v \n", errorDetail.Details())
+			t.Logf("Field: %v \n", errorDetail.Field())
+			t.Logf("Type: %v \n", errorDetail.Type())
+			t.Logf("Value: %v \n", errorDetail.Value())
 			if _, ok := actualErrorMap[errorDetail.Type()]; ok {
 				actualErrorMap[errorDetail.Type()] += 1
 			} else {
@@ -185,9 +184,9 @@ func TestSampleConfigSchema(t *testing.T) {
 		re := regexp.MustCompile(".json")
 		for _, file := range files {
 			if re.MatchString(file.Name()) {
-				fmt.Printf("Validating ../../translator/totomlconfig/sampleConfig/%s\n", file.Name())
+				t.Logf("Validating ../../translator/totomlconfig/sampleConfig/%s\n", file.Name())
 				checkIfSchemaValidateAsExpected(t, "../../translator/totomlconfig/sampleConfig/"+file.Name(), true, map[string]int{})
-				fmt.Printf("Validated ../../translator/totomlconfig/sampleConfig/%s\n", file.Name())
+				t.Logf("Validated ../../translator/totomlconfig/sampleConfig/%s\n", file.Name())
 			}
 		}
 	} else {

--- a/logger/lumberjack_logger_test.go
+++ b/logger/lumberjack_logger_test.go
@@ -4,7 +4,6 @@
 package logger
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -141,7 +140,7 @@ func TestWriteToFileInRotation(t *testing.T) {
 
 	files, _ = ioutil.ReadDir(tempDir)
 	for _, file := range files {
-		fmt.Printf("%v/%v, size:%v\n", tempDir, file.Name(), file.Size())
+		t.Logf("%v/%v, size:%v\n", tempDir, file.Name(), file.Size())
 	}
 
 	assert.Equal(t, 4, len(files))

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -167,9 +167,11 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 
 			if _, ok := dests[filename]; ok {
 				continue
-			} else if fileconfig.AutoRemoval { // This logic means auto_removal does not work with publish_multi_logs
+			} else if fileconfig.AutoRemoval {
+				// This logic means auto_removal does not work with publish_multi_logs
 				for _, dst := range dests {
-					dst.tailer.StopAtEOF() // Stop all other tailers in favor of the newly found file
+					// Stop all other tailers in favor of the newly found file
+					dst.tailer.StopAtEOF()
 				}
 			}
 

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -417,7 +417,9 @@ func createWriteRead(t *testing.T, prefix string, logFile *LogFile, done chan bo
 	logSrc, evts := getLogSrc(t, logFile)
 	defer (*logSrc).Stop()
 	defer close(evts)
-	const numLines int = 1000
+	// Choose a large enough number of lines so that even high-spec hosts will not
+	// complete receiving logEvents before the 2nd createWriteRead() goroutine begins.
+	const numLines int = 100000
 	const msg string = "this is the best log line ever written to a file"
 	writeLines(t, file, numLines, msg)
 	file.Close()

--- a/plugins/inputs/logfile/tail/tail.go
+++ b/plugins/inputs/logfile/tail/tail.go
@@ -158,6 +158,7 @@ func (tail *Tail) Stop() error {
 }
 
 // StopAtEOF stops tailing as soon as the end of the file is reached.
+// Blocks until tailer is dead and returns reason for death.
 func (tail *Tail) StopAtEOF() error {
 	tail.Kill(errStopAtEOF)
 	return tail.Wait()
@@ -390,7 +391,7 @@ func (tail *Tail) tailFileSync() {
 						if errReadLine == nil {
 							tail.sendLine(line, tail.curOffset)
 						} else {
-							break
+							return
 						}
 					}
 				} else if err != ErrStop {
@@ -465,7 +466,6 @@ func (tail *Tail) waitForChanges() error {
 	case <-tail.Dying():
 		return ErrStop
 	}
-
 }
 
 func (tail *Tail) openReader() {
@@ -510,8 +510,13 @@ func (tail *Tail) sendLine(line string, offset int64) bool {
 		select {
 		case tail.Lines <- &Line{line, now, nil, offset}:
 		case <-tail.Dying():
-			tail.dropCnt += len(lines) - i
-			return true
+			if tail.Err() == errStopAtEOF {
+				// Try sending, even if it blocks.
+				tail.Lines <- &Line{line, now, nil, offset}
+			} else {
+				tail.dropCnt += len(lines) - i
+				return true
+			}
 		}
 	}
 

--- a/plugins/inputs/logfile/tail/tail_test.go
+++ b/plugins/inputs/logfile/tail/tail_test.go
@@ -93,7 +93,7 @@ func TestStopAtEOF(t *testing.T) {
 	case <-done:
 		t.Fatalf("StopAtEOF() completed unexpectedly")
 	case <-time.After(time.Second * 1):
-		fmt.Println("timeout waiting for StopAtEOF() (as expected)")
+		t.Log("timeout waiting for StopAtEOF() (as expected)")
 	}
 
 	assert.Equal(t, errStopAtEOF, tail.Err())

--- a/plugins/inputs/logfile/tail/tail_test.go
+++ b/plugins/inputs/logfile/tail/tail_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
-var linesWrittenToFile int = 10
+const linesWrittenToFile int = 10
 
 type testLogger struct {
 	debugs, infos, warns, errors []string

--- a/plugins/inputs/logfile/tail/tail_test.go
+++ b/plugins/inputs/logfile/tail/tail_test.go
@@ -106,7 +106,7 @@ func TestStopAtEOF(t *testing.T) {
 	// Verify StopAtEOF() has completed.
 	select {
 	case <-done:
-		fmt.Println("StopAtEOF() completed (as expected)")
+		t.Log("StopAtEOF() completed (as expected)")
 	case <- time.After(time.Second * 1):
 		t.Fatalf("StopAtEOF() has not completed")
 	}

--- a/plugins/inputs/logfile/tail/tail_test.go
+++ b/plugins/inputs/logfile/tail/tail_test.go
@@ -60,7 +60,6 @@ func (l *testLogger) Info(args ...interface{}) {
 
 func TestNotTailedCompeletlyLogging(t *testing.T) {
 	tmpfile, tail, tlog := setup(t)
-	tmpfile.Close()
 	defer tearDown(tmpfile)
 
 	readThreelines(t, tail)

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -76,6 +76,8 @@ type tailerSrc struct {
 	startTailerOnce sync.Once
 	cleanUpFns      []func()
 }
+// Verify tailerSrc implements LogSrc
+var _ logs.LogSrc = (*tailerSrc)(nil)
 
 func NewTailerSrc(
 	group, stream, destination, stateFilePath string,
@@ -119,26 +121,26 @@ func (ts *tailerSrc) SetOutput(fn func(logs.LogEvent)) {
 	ts.startTailerOnce.Do(func() { go ts.runTail() })
 }
 
-func (ts tailerSrc) Group() string {
+func (ts *tailerSrc) Group() string {
 	return ts.group
 }
 
-func (ts tailerSrc) Stream() string {
+func (ts *tailerSrc) Stream() string {
 	return ts.stream
 }
 
-func (ts tailerSrc) Description() string {
+func (ts *tailerSrc) Description() string {
 	return ts.tailer.Filename
 }
 
-func (ts tailerSrc) Destination() string {
+func (ts *tailerSrc) Destination() string {
 	return ts.destination
 }
 
-func (ts tailerSrc) Retention() int {
+func (ts *tailerSrc) Retention() int {
 	return ts.retentionInDays
 }
-func (ts tailerSrc) Done(offset fileOffset) {
+func (ts *tailerSrc) Done(offset fileOffset) {
 	// ts.offsetCh will only be blocked when the runSaveState func has exited,
 	// which only happens when the original file has been removed, thus making
 	// Keeping its offset useless

--- a/plugins/inputs/windows_event_log/windows_event_log_test.go
+++ b/plugins/inputs/windows_event_log/windows_event_log_test.go
@@ -7,7 +7,6 @@
 package windows_event_log
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"

--- a/plugins/inputs/windows_event_log/windows_event_log_test.go
+++ b/plugins/inputs/windows_event_log/windows_event_log_test.go
@@ -27,7 +27,7 @@ func TestGetStateFilePathGood(t *testing.T) {
 		Name:          "SystemEventLog",
 	}
 	pathname, err := getStateFilePath(&plugin, &ec)
-	fmt.Println(pathname)
+	t.Log(pathname)
 	if err != nil {
 		t.Errorf("expected nil, actual %v", err)
 	}
@@ -55,7 +55,7 @@ func TestGetStateFilePathEscape(t *testing.T) {
 		Name:          "System  Event//Log::",
 	}
 	pathname, err := getStateFilePath(&plugin, &ec)
-	fmt.Println(pathname)
+	t.Log(pathname)
 	if err != nil {
 		t.Errorf("expected nil, actual %v", err)
 	}
@@ -78,7 +78,7 @@ func TestGetStateFilePathEmpty(t *testing.T) {
 		Name:          "SystemEventLog",
 	}
 	pathname, err := getStateFilePath(&plugin, &ec)
-	fmt.Println(pathname)
+	t.Log(pathname)
 	if err == nil {
 		t.Errorf("expected non-nil")
 	}
@@ -97,7 +97,7 @@ func TestGetStateFilePathSpecialChars(t *testing.T) {
 		Name:          "SystemEventLog",
 	}
 	pathname, err := getStateFilePath(&plugin, &ec)
-	fmt.Println(pathname)
+	t.Log(pathname)
 	if err == nil {
 		t.Errorf("expected non-nil")
 	}

--- a/plugins/outputs/awscsm/metametrics/listener_test.go
+++ b/plugins/outputs/awscsm/metametrics/listener_test.go
@@ -87,7 +87,7 @@ func TestMetricWriter(t *testing.T) {
 			for i := 0; i < innerMetricCount; i++ {
 				eventTime := now.Add(time.Duration(j) * time.Minute)
 				bin := i % innerMetricBins
-				fmt.Printf("%d", bin)
+				t.Logf("%d", bin)
 				listener.Count(fmt.Sprintf("%d", bin), float64(bin), eventTime, testEndpoints[k])
 			}
 		}

--- a/translator/toenvconfig/toEnvConfig_test.go
+++ b/translator/toenvconfig/toEnvConfig_test.go
@@ -6,7 +6,6 @@ package toenvconfig
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -37,13 +36,13 @@ func checkIfTranslateSucceed(t *testing.T, jsonStr string, targetOs string, expe
 	err := json.Unmarshal([]byte(jsonStr), &input)
 	if err == nil {
 		envVarsBytes := ToEnvConfig(input)
-		fmt.Println(string(envVarsBytes))
+		t.Log(string(envVarsBytes))
 		var actualEnvVars = make(map[string]string)
 		err := json.Unmarshal(envVarsBytes, &actualEnvVars)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedEnvVars, actualEnvVars, "Expect to be equal")
 	} else {
-		fmt.Printf("Got error %v", err)
+		t.Logf("Got error %v", err)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
# Description of the issue
Fix #381 

# Description of changes
Fix Tail.sendLine() to NOT drop log lines when the tailer is dying because of errStopAtEOF.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated existing unit tests.
Ran all tests and verified they pass.

```
go test ./plugins/inputs/logfile -run TestLogsFileAutoRemoval -count=100 -v

=== RUN   TestLogsFileAutoRemoval
    logfile_test.go:376: Created temp file, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/file_auto_removal2801393868
2022/05/16 08:41:34 The state file  for /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/file_auto_removal2801393868 does not exist: stat : no such file or directory
    logfile_test.go:397: Fill temp file with sufficient lines to be read.
2022/05/16 08:41:34 W! [inputs.tail] Stopping tail as file no longer exists: /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/file_auto_removal668799011
    logfile_test.go:430: Verify every line written to the temp file is received.
    logfile_test.go:376: Created temp file, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/file_auto_removal2014352509
    logfile_test.go:444: Verify child completed.
2022/05/16 08:41:34 The state file  for /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/file_auto_removal2014352509 does not exist: stat : no such file or directory
    logfile_test.go:397: Fill temp file with sufficient lines to be read.
    logfile_test.go:430: Verify every line written to the temp file is received.
    logfile_test.go:447: Completed before timeout (as expected)
    logfile_test.go:451: Verify 1st temp file was auto deleted.
2022/05/16 08:41:35 W! [logfile] Failed to auto remove file /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/file_auto_removal2014352509: remove /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/file_auto_removal2014352509: no such file or directory
    logfile_test.go:466: Verify 1st tmp file created and discovered.
    logfile_test.go:469: Completed before timeout (as expected)
--- PASS: TestLogsFileAutoRemoval (1.40s)
```

```
go test ./plugins/inputs/logfile/tail -v

=== RUN   TestNotTailedCompeletlyLogging
--- PASS: TestNotTailedCompeletlyLogging (1.60s)
=== RUN   TestStopAtEOF
timeout waiting for StopAtEOF() (as expected)
StopAtEOF() completed (as expected)
--- PASS: TestStopAtEOF (1.00s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail	2.744s
```


