### PR TITLE
Delete statefile when tailer terminates due to an error

### DIFF
--- a/integration/terraform/ec2/linux/README.md
+++ b/integration/terraform/ec2/linux/README.md
@@ -313,3 +313,5 @@ terraform destroy --auto-approve
 7. aws-cli
 8. CloudWatchAgentServerRole is attached
 9. crontab
+10. gcc
+11. python3

--- a/integration/test/agent_util.go
+++ b/integration/test/agent_util.go
@@ -90,6 +90,14 @@ func RunShellScript(path string, args ...string) {
 	}
 }
 
+func RunCommand(cmd string) {
+	out, err := exec.Command("bash", "-c", cmd).Output()
+
+	if err != nil {
+		log.Fatalf("Error occurred when executing %s: %s | %s", cmd, err.Error(), string(out))
+	}
+}
+
 func ReplaceLocalStackHostName(pathIn string) {
 	out, err := exec.Command("bash", "-c", "sed -i 's/localhost.localstack.cloud/'\"$LOCAL_STACK_HOST_NAME\"'/g' "+pathIn).Output()
 

--- a/integration/test/cloudwatchlogs/publish_logs_test.go
+++ b/integration/test/cloudwatchlogs/publish_logs_test.go
@@ -49,6 +49,8 @@ var testParameters = []input{
 	},
 }
 
+// TestWriteLogsToCloudWatch writes N number of logs, and then validates that N logs
+// are queryable from CloudWatch Logs
 func TestWriteLogsToCloudWatch(t *testing.T) {
 	// this uses the {instance_id} placeholder in the agent configuration,
 	// so we need to determine the host's instance ID for validation
@@ -78,7 +80,12 @@ func TestWriteLogsToCloudWatch(t *testing.T) {
 	}
 }
 
-// Validate https://github.com/aws/amazon-cloudwatch-agent/issues/447
+// TestRotatingLogsDoesNotSkipLines validates https://github.com/aws/amazon-cloudwatch-agent/issues/447
+// The following should happen in the test:
+// 1. A log line of size N should be written
+// 2. The file should be rotated, and a new log line of size N should be written
+// 3. The file should be rotated again, and a new log line of size GREATER THAN N should be written
+// 4. All three log lines, in full, should be visible in CloudWatch Logs
 func TestRotatingLogsDoesNotSkipLines(t *testing.T) {
 	cfgFilePath := "resources/config_log_rotated.json"
 

--- a/integration/test/cloudwatchlogs/publish_logs_test.go
+++ b/integration/test/cloudwatchlogs/publish_logs_test.go
@@ -110,6 +110,11 @@ func TestRotatingLogsDoesNotSkipLines(t *testing.T) {
 	time.Sleep(agentRuntime)
 	test.StopAgent()
 
+	// These expected log lines are created using resources/write_and_rotate_logs.py,
+	// which are taken directly from the repro case in https://github.com/aws/amazon-cloudwatch-agent/issues/447
+	// logging.info(json.dumps({"Metric": "12345"*10}))
+	// logging.info(json.dumps({"Metric": "09876"*10}))
+	// logging.info({"Metric": "1234567890"*10})
 	lines := []string{
 		fmt.Sprintf("{\"Metric\": \"%s\"}", strings.Repeat("12345", 10)),
 		fmt.Sprintf("{\"Metric\": \"%s\"}", strings.Repeat("09876", 10)),

--- a/integration/test/cloudwatchlogs/resources/config_log_rotated.json
+++ b/integration/test/cloudwatchlogs/resources/config_log_rotated.json
@@ -1,0 +1,19 @@
+{
+  "agent": {
+    "run_as_user": "root"
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/tmp/rotate_me.log*",
+            "log_group_name": "{instance_id}",
+            "log_stream_name": "{instance_id}Rotated",
+            "timezone": "UTC"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/integration/test/cloudwatchlogs/resources/write_and_rotate_logs.py
+++ b/integration/test/cloudwatchlogs/resources/write_and_rotate_logs.py
@@ -1,0 +1,28 @@
+"""
+Lifted this from https://github.com/aws/amazon-cloudwatch-agent/issues/447
+because I was not able to adequately reproduce the issue natively in Go,
+directly in the integration test code.
+"""
+import json
+import logging
+import time
+from logging.handlers import TimedRotatingFileHandler
+
+# get root logger
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# rotate our log file every 10 seconds
+handler = TimedRotatingFileHandler("/tmp/rotate_me.log", when="S", interval=10)
+logger.addHandler(handler)
+
+# log a message
+logging.info(json.dumps({"Metric": "12345"*10}))
+# sleep so that file will rotate upon next log message
+time.sleep(15)
+# log another message (this one will not appear since byte length of message == byte length of old log file)
+logging.info(json.dumps({"Metric": "09876"*10}))
+# sleep again so that file will rotate upon next log message
+time.sleep(15)
+# this message will be partially written
+logging.info({"Metric": "1234567890"*10})

--- a/integration/test/cwl_util.go
+++ b/integration/test/cwl_util.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,6 +102,65 @@ func DeleteLogGroupAndStream(logGroupName, logStreamName string) {
 	})
 	if err != nil && !errors.As(err, &rnf) {
 		log.Printf("Error occurred while deleting log group %s: %v", logGroupName, err)
+	}
+}
+
+// ValidateLogsInOrder takes a log group, log stream, a list of specific log lines and a timestamp.
+// It should query the given log stream for log events, and then confirm that the log lines that are
+// returned match the expected log lines. This also sanitizes the log lines from both the output and
+// the expected lines input to ensure that they don't diverge in JSON representation (" vs ')
+func ValidateLogsInOrder(t *testing.T, logGroup, logStream string, logLines []string, since time.Time) {
+	log.Printf("Checking %s/%s since %s for %d expected logs", logGroup, logStream, since.UTC().Format(time.RFC3339), len(logLines))
+	cwlClient, clientContext, err := getCloudWatchLogsClient()
+	if err != nil {
+		t.Fatalf("Error occurred while creating CloudWatch Logs SDK client: %v", err.Error())
+	}
+
+	sinceMs := since.UnixNano() / 1e6 // convert to millisecond timestamp
+
+	// https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html
+	// GetLogEvents can return an empty result while still having more log events on a subsequent page,
+	// so rather than expecting all the events to show up in one GetLogEvents API call, we need to paginate.
+	params := &cloudwatchlogs.GetLogEventsInput{
+		LogGroupName:  aws.String(logGroup),
+		LogStreamName: aws.String(logStream),
+		StartTime:     aws.Int64(sinceMs),
+		StartFromHead: aws.Bool(true), // read from the beginning
+	}
+
+	foundLogs := make([]string, 0)
+	var output *cloudwatchlogs.GetLogEventsOutput
+	var nextToken *string
+
+	for {
+		if nextToken != nil {
+			params.NextToken = nextToken
+		}
+		output, err = cwlClient.GetLogEvents(*clientContext, params)
+
+		if err != nil {
+			t.Fatalf("Error occurred while getting log events: %v", err.Error())
+		}
+
+		for _, e := range output.Events {
+			foundLogs = append(foundLogs, *e.Message)
+		}
+
+		if nextToken != nil && output.NextForwardToken != nil && *output.NextForwardToken == *nextToken {
+			// From the docs: If you have reached the end of the stream, it returns the same token you passed in.
+			log.Printf("Done paginating log events for %s/%s and found %d logs", logGroup, logStream, len(foundLogs))
+			break
+		}
+
+		nextToken = output.NextForwardToken
+	}
+
+	// Validate that each of the logs are found, in order and in full.
+	assert.Len(t, foundLogs, len(logLines))
+	for i := 0; i < len(logLines); i++ {
+		expected := strings.ReplaceAll(logLines[i], "'", "\"")
+		actual := strings.ReplaceAll(foundLogs[i], "'", "\"")
+		assert.Equal(t, expected, actual)
 	}
 }
 

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -22,8 +22,6 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-var offsetThreshold int64 = 1024 * 1024 // PutLogEvents API maxes out at 1mb for a payload
-
 type LogFile struct {
 	//array of file config for file to be monitored.
 	FileConfig []FileConfig `toml:"file_config"`
@@ -344,13 +342,6 @@ func (t *LogFile) restoreState(filename string) (int64, error) {
 		t.Log.Warnf("Issue encountered when parsing offset value %v: %v", byteArray, err)
 		return 0, err
 	}
-
-	// https://github.com/aws/amazon-cloudwatch-agent/issues/447
-	// try to not drop the first log in a log file when rotated by reasoning that if the
-	//if offset < offsetThreshold {
-	//	t.Log.Debugf("Offset %d is less than allowed %d for publishing logs. Reset to zero offset", offset, offsetThreshold)
-	//	offset = 0
-	//}
 
 	t.Log.Infof("Reading from offset %v in %s", offset, filename)
 

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -252,6 +252,17 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 
 				}
 			}(src))
+			//src.AddCleanUpFn(func(ts *tailerSrc) func() {
+			//	return func() {
+			//		select {
+			//		case closed := <-ts.tailer.FileDeletedCh:
+			//			if closed {
+			//				os.Remove(ts.stateFilePath)
+			//			}
+			//		default:
+			//		}
+			//	}
+			//}(src))
 
 			srcs = append(srcs, src)
 
@@ -334,10 +345,12 @@ func (t *LogFile) restoreState(filename string) (int64, error) {
 		return 0, err
 	}
 
-	if offset < offsetThreshold {
-		t.Log.Debugf("Offset %d is less than allowed %d for publishing logs. Reset to zero offset", offset, offsetThreshold)
-		offset = 0
-	}
+	// https://github.com/aws/amazon-cloudwatch-agent/issues/447
+	// try to not drop the first log in a log file when rotated by reasoning that if the
+	//if offset < offsetThreshold {
+	//	t.Log.Debugf("Offset %d is less than allowed %d for publishing logs. Reset to zero offset", offset, offsetThreshold)
+	//	offset = 0
+	//}
 
 	t.Log.Infof("Reading from offset %v in %s", offset, filename)
 

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -250,17 +250,6 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 
 				}
 			}(src))
-			//src.AddCleanUpFn(func(ts *tailerSrc) func() {
-			//	return func() {
-			//		select {
-			//		case closed := <-ts.tailer.FileDeletedCh:
-			//			if closed {
-			//				os.Remove(ts.stateFilePath)
-			//			}
-			//		default:
-			//		}
-			//	}
-			//}(src))
 
 			srcs = append(srcs, src)
 

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -335,7 +335,7 @@ func (t *LogFile) restoreState(filename string) (int64, error) {
 	}
 
 	if offset < offsetThreshold {
-		t.Log.Errorf("Offset %d is less than the max size of a batch of logs sent to PLE. Publish from the beginning", offset)
+		t.Log.Debugf("Offset %d is less than allowed %d for publishing logs. Reset to zero offset", offset, offsetThreshold)
 		offset = 0
 	}
 

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -735,9 +735,12 @@ func TestLogsFileRecreate(t *testing.T) {
 	defer os.Remove(stateDir)
 
 	stateFileName := filepath.Join(stateDir, escapeFilePath(tmpfile.Name()))
-	stateFile, err := os.OpenFile(stateFileName, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+	stateFile, err := os.OpenFile(stateFileName, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
 	require.NoError(t, err)
 	_, err = stateFile.WriteString("10")
+	require.NoError(t, err)
+	err = stateFile.Close()
+	require.NoError(t, err)
 	defer os.Remove(stateFileName)
 
 	tt := NewLogFile()

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -198,34 +198,7 @@ func TestRestoreState(t *testing.T) {
 	logFilePath := "/tmp/logfile.log"
 	logFileStateFileName := "_tmp_logfile.log"
 
-	offset := offsetThreshold + 1
-	err = ioutil.WriteFile(
-		tmpfolder+string(filepath.Separator)+logFileStateFileName,
-		[]byte(strconv.FormatInt(offset, 10)+"\n"+logFilePath),
-		os.ModePerm)
-	require.NoError(t, err)
-
-	tt := NewLogFile()
-	tt.Log = TestLogger{t}
-	tt.FileStateFolder = tmpfolder
-	roffset, err := tt.restoreState(logFilePath)
-	assert.Equal(t, offset, roffset, fmt.Sprintf("The actual offset is %d, different from the expected offset %d.", roffset, offset))
-	tt.Stop()
-}
-
-// TestRestoreStateReadFromBeginning ensures that if the offset stored in the state file
-// is less than the defined offsetThreshold, we read from the beginning instead of upholding
-// the stored offset. https://github.com/aws/amazon-cloudwatch-agent/issues/447
-func TestRestoreStateReadFromBeginning(t *testing.T) {
-	multilineWaitPeriod = 10 * time.Millisecond
-	tmpfolder, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpfolder)
-
-	logFilePath := "/tmp/logfile.log"
-	logFileStateFileName := "_tmp_logfile.log"
-
-	offset := offsetThreshold + 1
+	offset := int64(9323)
 	err = ioutil.WriteFile(
 		tmpfolder+string(filepath.Separator)+logFileStateFileName,
 		[]byte(strconv.FormatInt(offset, 10)+"\n"+logFilePath),
@@ -645,7 +618,6 @@ func TestLogsFileTruncate(t *testing.T) {
 
 func TestLogsFileWithOffset(t *testing.T) {
 	multilineWaitPeriod = 10 * time.Millisecond
-	offsetThreshold = 10
 	logEntryString := "xxxxxxxxxxContentAfterOffset"
 
 	tmpfile, err := createTempFile("", "")
@@ -696,7 +668,6 @@ func TestLogsFileWithOffset(t *testing.T) {
 
 func TestLogsFileWithInvalidOffset(t *testing.T) {
 	multilineWaitPeriod = 10 * time.Millisecond
-	offsetThreshold = 10
 	logEntryString := "xxxxxxxxxxContentAfterOffset"
 
 	tmpfile, err := createTempFile("", "")
@@ -745,11 +716,10 @@ func TestLogsFileWithInvalidOffset(t *testing.T) {
 
 // TestLogsFileRecreate verifies that if a LogSrc matching a LogConfig is detected,
 // We only receive log lines beginning at the offset specified in the corresponding state-file.
-// And if the file happens to get deleted and recreated we expect to receive log lines beginning
-// at that same offset in the state file.
+// And if the file happens to get deleted and recreated we expect to receive log lines
+// from the beginning of the file. See https://github.com/aws/amazon-cloudwatch-agent/issues/447
 func TestLogsFileRecreate(t *testing.T) {
 	multilineWaitPeriod = 10 * time.Millisecond
-	offsetThreshold = 10
 
 	logEntryString := "xxxxxxxxxxContentAfterOffset"
 	expectedContent := "ContentAfterOffset"

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -805,7 +805,7 @@ func TestLogsFileRecreate(t *testing.T) {
 	// the tailer should start from the beginning.
 	e = <-evts
 	if e.Message() != logEntryString {
-		t.Errorf("Wrong log found after file replacement: \n% x\nExpecting:\n% x\n", e.Message(), expectedContent)
+		t.Errorf("Wrong log found after file replacement: \n% x\nExpecting:\n% x\n", e.Message(), logEntryString)
 	}
 
 	lsrc.Stop()

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -735,7 +735,7 @@ func TestLogsFileRecreate(t *testing.T) {
 	defer os.Remove(stateDir)
 
 	stateFileName := filepath.Join(stateDir, escapeFilePath(tmpfile.Name()))
-	stateFile, err := os.OpenFile(stateFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	stateFile, err := os.OpenFile(stateFileName, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 	require.NoError(t, err)
 	_, err = stateFile.WriteString("10")
 	defer os.Remove(stateFileName)

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -735,7 +735,7 @@ func TestLogsFileRecreate(t *testing.T) {
 	defer os.Remove(stateDir)
 
 	stateFileName := filepath.Join(stateDir, escapeFilePath(tmpfile.Name()))
-	stateFile, err := os.OpenFile(stateFileName, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+	stateFile, err := os.OpenFile(stateFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	require.NoError(t, err)
 	_, err = stateFile.WriteString("10")
 	defer os.Remove(stateFileName)

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -831,8 +831,10 @@ func TestLogsFileRecreate(t *testing.T) {
 		}
 	})
 
+	// after the file gets deleted, the state file should be deleted too, so
+	// the tailer should start from the beginning.
 	e = <-evts
-	if e.Message() != expectedContent {
+	if e.Message() != logEntryString {
 		t.Errorf("Wrong log found after file replacement: \n% x\nExpecting:\n% x\n", e.Message(), expectedContent)
 	}
 

--- a/plugins/inputs/logfile/tail/tail.go
+++ b/plugins/inputs/logfile/tail/tail.go
@@ -172,9 +172,6 @@ func (tail *Tail) close() {
 	if tail.dropCnt > 0 {
 		tail.Logger.Errorf("Dropped %v lines for stopped tail for file %v", tail.dropCnt, tail.Filename)
 	}
-	if tail.isFileDeleted() {
-		close(tail.FileDeletedCh)
-	}
 	close(tail.Lines)
 	tail.closeFile()
 }
@@ -391,6 +388,7 @@ func (tail *Tail) tailFileSync() {
 			err := tail.waitForChanges()
 			if err != nil {
 				if err == ErrDeletedNotReOpen {
+					close(tail.FileDeletedCh)
 					for {
 						line, errReadLine := tail.readLine()
 						if errReadLine == nil {

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -281,13 +281,6 @@ func (ts *tailerSrc) cleanUp() {
 		clf()
 	}
 
-	//// delete state file if log file was closed
-	//select {
-	//case <-ts.tailer.FileDeletedCh:
-	//	os.Remove(ts.stateFilePath)
-	//default:
-	//}
-
 	if ts.outputFn != nil {
 		ts.outputFn(nil) // inform logs agent the tailer src's exit, to stop runSrcToDest
 	}

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -280,6 +280,14 @@ func (ts *tailerSrc) cleanUp() {
 	for _, clf := range ts.cleanUpFns {
 		clf()
 	}
+
+	// delete state file if log file was closed
+	select {
+	case <-ts.tailer.FileDeletedCh:
+		os.Remove(ts.stateFilePath)
+	default:
+	}
+
 	if ts.outputFn != nil {
 		ts.outputFn(nil) // inform logs agent the tailer src's exit, to stop runSrcToDest
 	}

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -292,7 +292,7 @@ func (ts *tailerSrc) runSaveState() {
 	t := time.NewTicker(100 * time.Millisecond)
 	defer t.Stop()
 
-	waitDuration := fileDeleteWaitPeriod
+	//waitDuration := fileDeleteWaitPeriod
 
 	var offset, lastSavedOffset fileOffset
 	for {
@@ -305,7 +305,6 @@ func (ts *tailerSrc) runSaveState() {
 			if offset == lastSavedOffset {
 				continue
 			}
-			log.Printf("E! [logfile] saving to state file because of ticker")
 			err := ts.saveState(offset.offset)
 			if err != nil {
 				log.Printf("E! [logfile] Error happened when saving file state %s to file state folder %s: %v", ts.tailer.Filename, ts.stateFilePath, err)
@@ -314,21 +313,21 @@ func (ts *tailerSrc) runSaveState() {
 			lastSavedOffset = offset
 		case <-ts.tailer.FileDeletedCh:
 			log.Printf("W! [logfile] deleting state file %s", ts.stateFilePath)
-			for i := 0; i < fileDeleteMaxRetries; i++ {
-				err := os.Remove(ts.stateFilePath)
-				if err == nil {
-					return
-				}
-				log.Printf("W! [logfile] error occurred deleting state file %s: %v", ts.stateFilePath, err)
-				time.Sleep(waitDuration)
-
-				waitDuration *= 2
-			}
-			// reaching here means we exhausted retries on deleting the state file
-			log.Printf("E! [logfile] failed to delete state file %s", ts.stateFilePath)
+			os.Remove(ts.stateFilePath)
+			//for i := 0; i < fileDeleteMaxRetries; i++ {
+			//	err := os.Remove(ts.stateFilePath)
+			//	if err == nil {
+			//		return
+			//	}
+			//	log.Printf("W! [logfile] error occurred deleting state file %s: %v", ts.stateFilePath, err)
+			//	time.Sleep(waitDuration)
+			//
+			//	waitDuration *= 2
+			//}
+			//// reaching here means we exhausted retries on deleting the state file
+			//log.Printf("E! [logfile] failed to delete state file %s", ts.stateFilePath)
 			return
 		case <-ts.done:
-			log.Printf("E! [logfile] saving to state file because channel closed")
 			err := ts.saveState(offset.offset)
 			if err != nil {
 				log.Printf("E! [logfile] Error happened during final file state saving of logfile %s to file state folder %s, duplicate log maybe sent at next start: %v", ts.tailer.Filename, ts.stateFilePath, err)

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -305,7 +305,6 @@ func (ts *tailerSrc) runSaveState() {
 			if offset == lastSavedOffset {
 				continue
 			}
-			log.Printf("E! [logfile] saving to state file because of ticker")
 			err := ts.saveState(offset.offset)
 			if err != nil {
 				log.Printf("E! [logfile] Error happened when saving file state %s to file state folder %s: %v", ts.tailer.Filename, ts.stateFilePath, err)
@@ -328,7 +327,6 @@ func (ts *tailerSrc) runSaveState() {
 			log.Printf("E! [logfile] failed to delete state file %s", ts.stateFilePath)
 			return
 		case <-ts.done:
-			log.Printf("E! [logfile] saving to state file because channel closed")
 			err := ts.saveState(offset.offset)
 			if err != nil {
 				log.Printf("E! [logfile] Error happened during final file state saving of logfile %s to file state folder %s, duplicate log maybe sent at next start: %v", ts.tailer.Filename, ts.stateFilePath, err)

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -305,6 +305,7 @@ func (ts *tailerSrc) runSaveState() {
 			if offset == lastSavedOffset {
 				continue
 			}
+			log.Printf("E! [logfile] saving to state file because of ticker")
 			err := ts.saveState(offset.offset)
 			if err != nil {
 				log.Printf("E! [logfile] Error happened when saving file state %s to file state folder %s: %v", ts.tailer.Filename, ts.stateFilePath, err)
@@ -327,6 +328,7 @@ func (ts *tailerSrc) runSaveState() {
 			log.Printf("E! [logfile] failed to delete state file %s", ts.stateFilePath)
 			return
 		case <-ts.done:
+			log.Printf("E! [logfile] saving to state file because channel closed")
 			err := ts.saveState(offset.offset)
 			if err != nil {
 				log.Printf("E! [logfile] Error happened during final file state saving of logfile %s to file state folder %s, duplicate log maybe sent at next start: %v", ts.tailer.Filename, ts.stateFilePath, err)

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -18,10 +18,8 @@ import (
 )
 
 const (
-	stateFileMode        = 0644
-	bufferLimit          = 50
-	fileDeleteMaxRetries = 5
-	fileDeleteWaitPeriod = 10 * time.Millisecond
+	stateFileMode = 0644
+	bufferLimit   = 50
 )
 
 var (
@@ -292,8 +290,6 @@ func (ts *tailerSrc) runSaveState() {
 	t := time.NewTicker(100 * time.Millisecond)
 	defer t.Stop()
 
-	//waitDuration := fileDeleteWaitPeriod
-
 	var offset, lastSavedOffset fileOffset
 	for {
 		select {
@@ -313,19 +309,10 @@ func (ts *tailerSrc) runSaveState() {
 			lastSavedOffset = offset
 		case <-ts.tailer.FileDeletedCh:
 			log.Printf("W! [logfile] deleting state file %s", ts.stateFilePath)
-			os.Remove(ts.stateFilePath)
-			//for i := 0; i < fileDeleteMaxRetries; i++ {
-			//	err := os.Remove(ts.stateFilePath)
-			//	if err == nil {
-			//		return
-			//	}
-			//	log.Printf("W! [logfile] error occurred deleting state file %s: %v", ts.stateFilePath, err)
-			//	time.Sleep(waitDuration)
-			//
-			//	waitDuration *= 2
-			//}
-			//// reaching here means we exhausted retries on deleting the state file
-			//log.Printf("E! [logfile] failed to delete state file %s", ts.stateFilePath)
+			err := os.Remove(ts.stateFilePath)
+			if err != nil {
+				log.Printf("E! [logfile] Error happened while deleting state file %s on cleanup", ts.stateFilePath)
+			}
 			return
 		case <-ts.done:
 			err := ts.saveState(offset.offset)

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -281,12 +281,12 @@ func (ts *tailerSrc) cleanUp() {
 		clf()
 	}
 
-	// delete state file if log file was closed
-	select {
-	case <-ts.tailer.FileDeletedCh:
-		os.Remove(ts.stateFilePath)
-	default:
-	}
+	//// delete state file if log file was closed
+	//select {
+	//case <-ts.tailer.FileDeletedCh:
+	//	os.Remove(ts.stateFilePath)
+	//default:
+	//}
 
 	if ts.outputFn != nil {
 		ts.outputFn(nil) // inform logs agent the tailer src's exit, to stop runSrcToDest
@@ -314,6 +314,8 @@ func (ts *tailerSrc) runSaveState() {
 				continue
 			}
 			lastSavedOffset = offset
+		case <-ts.tailer.FileDeletedCh:
+			os.Remove(ts.stateFilePath)
 		case <-ts.done:
 			err := ts.saveState(offset.offset)
 			if err != nil {

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -309,7 +309,10 @@ func (ts *tailerSrc) runSaveState() {
 			lastSavedOffset = offset
 		case <-ts.tailer.FileDeletedCh:
 			log.Printf("W! [logfile] deleting state file %s", ts.stateFilePath)
-			os.Remove(ts.stateFilePath)
+			err := os.Remove(ts.stateFilePath)
+			if err != nil {
+				log.Printf("E! [logfile] error occurred deleting state file %s: %v", ts.stateFilePath, err)
+			}
 			return
 		case <-ts.done:
 			err := ts.saveState(offset.offset)

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	stateFileMode = 0644
-	bufferLimit   = 50
+	stateFileMode        = 0644
+	bufferLimit          = 50
+	fileDeleteMaxRetries = 5
+	fileDeleteWaitPeriod = 10 * time.Millisecond
 )
 
 var (
@@ -290,6 +292,8 @@ func (ts *tailerSrc) runSaveState() {
 	t := time.NewTicker(100 * time.Millisecond)
 	defer t.Stop()
 
+	waitDuration := fileDeleteWaitPeriod
+
 	var offset, lastSavedOffset fileOffset
 	for {
 		select {
@@ -309,10 +313,18 @@ func (ts *tailerSrc) runSaveState() {
 			lastSavedOffset = offset
 		case <-ts.tailer.FileDeletedCh:
 			log.Printf("W! [logfile] deleting state file %s", ts.stateFilePath)
-			err := os.Remove(ts.stateFilePath)
-			if err != nil {
-				log.Printf("E! [logfile] error occurred deleting state file %s: %v", ts.stateFilePath, err)
+			for i := 0; i < fileDeleteMaxRetries; i++ {
+				err := os.Remove(ts.stateFilePath)
+				if err == nil {
+					return
+				}
+				log.Printf("W! [logfile] error occurred deleting state file %s: %v", ts.stateFilePath, err)
+				time.Sleep(waitDuration)
+
+				waitDuration *= 2
 			}
+			// reaching here means we exhausted retries on deleting the state file
+			log.Printf("E! [logfile] failed to delete state file %s", ts.stateFilePath)
 			return
 		case <-ts.done:
 			err := ts.saveState(offset.offset)

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -297,7 +297,6 @@ func (ts *tailerSrc) runSaveState() {
 	t := time.NewTicker(100 * time.Millisecond)
 	defer t.Stop()
 
-	var deletedStateFile bool
 	var offset, lastSavedOffset fileOffset
 	for {
 		select {
@@ -316,13 +315,9 @@ func (ts *tailerSrc) runSaveState() {
 			}
 			lastSavedOffset = offset
 		case <-ts.tailer.FileDeletedCh:
-			if !deletedStateFile {
-				log.Printf("W! [logfile] deleting state file %s", ts.stateFilePath)
-				err := os.Remove(ts.stateFilePath)
-				if err == nil {
-					deletedStateFile = true
-				}
-			}
+			log.Printf("W! [logfile] deleting state file %s", ts.stateFilePath)
+			os.Remove(ts.stateFilePath)
+			return
 		case <-ts.done:
 			err := ts.saveState(offset.offset)
 			if err != nil {


### PR DESCRIPTION
# Description of the issue
Closes #447 
Adapted from #455 

# Description of changes
1. Added an additional channel in the tailer to capture when the process encounters an error from the log file being deleted
2. Added a cleanup step to delete the state file if the FileDeleted channel is closed (- I was apprehensive about this, but found out that according to https://www.gopl.io/ it's fine to leave a channel unclosed because it will get garbage collected. 
3. Added integration test to validate repro case
4. Updated unit test to reflect new behavior after log file is deleted, to not read from the stored offset

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Same tests done in #455.

Integration test output:
```
aws_instance.integration-test (remote-exec): === RUN   TestRotatingLogsDoesNotSkipLines
aws_instance.integration-test (remote-exec): 2022/04/29 14:16:09 Found instance id i-0239bc2cee4077f66
aws_instance.integration-test (remote-exec): 2022/04/29 14:16:09 Copy File resources/config_log_rotated.json to /opt/aws/amazon-cloudwatch-agent/bin/config.json
aws_instance.integration-test (remote-exec): 2022/04/29 14:16:09 File resources/config_log_rotated.json abs path /home/ec2-user/amazon-cloudwatch-agent/integration/test/cloudwatchlogs/resources/config_log_rotated.json
aws_instance.integration-test (remote-exec): 2022/04/29 14:16:09 File : resources/config_log_rotated.json copied to : /opt/aws/amazon-cloudwatch-agent/bin/config.json
aws_instance.integration-test (remote-exec): 2022/04/29 14:16:09 Agent has started
aws_instance.integration-test: Still creating... [3m10s elapsed]
aws_instance.integration-test: Still creating... [3m20s elapsed]
aws_instance.integration-test (remote-exec):     publish_logs_test.go:100: Writing logs and rotating
aws_instance.integration-test: Still creating... [3m30s elapsed]
aws_instance.integration-test: Still creating... [3m40s elapsed]
aws_instance.integration-test: Still creating... [3m50s elapsed]
aws_instance.integration-test: Still creating... [4m0s elapsed]
aws_instance.integration-test: Still creating... [4m10s elapsed]
aws_instance.integration-test (remote-exec): 2022/04/29 14:17:19 Agent is stopped
aws_instance.integration-test (remote-exec): 2022/04/29 14:17:19 Checking i-0239bc2cee4077f66/i-0239bc2cee4077f66Rotated since 2022-04-29T14:16:09Z for 3 expected logs
aws_instance.integration-test (remote-exec): 2022/04/29 14:17:20 Done paginating log events for i-0239bc2cee4077f66/i-0239bc2cee4077f66Rotated and found 3 logs
aws_instance.integration-test (remote-exec): --- PASS: TestRotatingLogsDoesNotSkipLines (71.93s)
aws_instance.integration-test (remote-exec): PASS
aws_instance.integration-test (remote-exec): ok  	github.com/aws/amazon-cloudwatch-agent/integration/test/cloudwatchlogs	154.413s
```

#Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
1. Run `make linter`