### PR TITLE
Fix YAML for terraform destroy

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -610,7 +610,7 @@ jobs:
             fi
       
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
+        if: ${{ cancelled() && steps.ecs-fargate-integration-test.outputs.cache-hit != 'true' }}
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3


### PR DESCRIPTION
# Description of the issue
Typo in the integration test YAML file causes the integration tests to not run. 

# Description of changes
Fix typo

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran integration test on my fork and made sure that it actually executed instead of failing immediately.
![Screen Shot 2022-05-09 at 3 03 16 PM](https://user-images.githubusercontent.com/17056456/167479540-d5235775-4522-4a51-9e34-676d8b9bd994.png)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




