### PR TITLE
Change to us-west-2 for ECS Integration Test

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -575,7 +575,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.TERRAFORM_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TERRAFORM_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+          aws-region: us-west-2
 
       - name: Cache if success
         id: ecs-fargate-integration-test


### PR DESCRIPTION
# Description of the issue
Change to `us-west-2` for ECS Integration Test since creating docker image step publishes image in private us-west-2 ECR Repo

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test on my fork




