### PR TITLE
Avoid exit immediately when ADOT Collector fails

### DIFF
--- a/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
+++ b/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
@@ -452,6 +452,7 @@ Function CWOCConfig() {
         Write-Output "Successfully fetched the config and saved in ${YAML_DIR}\default.tmp"
     } else {
         & cmd /c "`"$CWAProgramFiles\config-downloader.exe`" --output-dir ${YAML_DIR} --download-source ${OtelConfigLocation} --mode ${param_mode} --config ${COMMON_CONIG} --multi-config ${multi_config} 2>&1"
+        # Use return instead of exit since CWAgent and ADOT Collector should be two independent agents as much as possible
         if ($LASTEXITCODE -ne 0) {
            return
         }

--- a/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
+++ b/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
@@ -452,7 +452,9 @@ Function CWOCConfig() {
         Write-Output "Successfully fetched the config and saved in ${YAML_DIR}\default.tmp"
     } else {
         & cmd /c "`"$CWAProgramFiles\config-downloader.exe`" --output-dir ${YAML_DIR} --download-source ${OtelConfigLocation} --mode ${param_mode} --config ${COMMON_CONIG} --multi-config ${multi_config} 2>&1"
-        CheckCMDResult # Exit immediately if config-downloader outputs any error
+        if ($LASTEXITCODE -ne 0) {
+           return
+        }
     }
 
     $yamlDirContent = Get-ChildItem "${YAML_DIR}" | Measure-Object


### PR DESCRIPTION
# Description of the issue
After the introducing of using`cmd /c` for PowerShell ISE and Windows 2022, I accidentally make ADOT Collector exit immediately during CloudWatch Agent execution script. However, CWAgent and Adot Collector should be two independent agents as much as possible (not affecting each other). Therefore, revert the change for exit immediately for Windows CTL Script.

# Description of changes
Revert the change for exit immediately with ADOT Collector for Windows CTL Script.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Running the new Windows Script on Windows Server and running our `verify-windows-script` which are in our internal integration test.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




