### PR TITLE
Using different cache key for different test case

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -417,7 +417,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: go.mod
-          key: ec2-linux-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}
+          key: ec2-linux-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
 
       - name: Echo Test Info
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} test dir ${{ matrix.arrays.test_dir }}
@@ -582,7 +582,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: go.mod
-          key: ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}
+          key: ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
 
       - name: Login ECR
         id: login-ecr


### PR DESCRIPTION
# Description of the issue
Each time we merge a PR, the GitHub workflow will spin up an [integration test](https://github.com/aws/amazon-cloudwatch-agent/blob/master/.github/workflows/integrationTest.yml) to validate our integration test. However, in the EC2 Linux and ECS Fargate, similar OS with different test cases are using the same key cache `ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}`. This would cause the workflow to always return success after a second retry even though the test failed (e.g Linux RHEL Test has two different tests such as: Check Dimension, Rotating Log; if one of them succeeds, it would submit the same key cache and it would make the second retry return successful for the other test case even though that other test case failed originally).
Therefore, I propose: 
* **Short term:** Utilize the `{{ matrix.arrays.test_dir }}` and add it to the key in order to differentiate between different test cases
* **Long term:** Only test the features within the main OS (same with internal integration test does) and other OS are only test json configuration (sanity check with runnable confirmation)

# Descriptions of changes
Adding `${{ matrix.arrays.test_dir }}` to the key in cache-action as a short term strategies.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




