### PR TITLE
Nvidia windows

### DIFF
--- a/translator/totomlconfig/sampleConfig/complete_windows_config.conf
+++ b/translator/totomlconfig/sampleConfig/complete_windows_config.conf
@@ -16,6 +16,14 @@
 
 [inputs]
 
+  [[inputs.nvidia_smi]]
+    bin_path = "C:\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe"
+    fieldpass = ["utilization_gpu", "utilization_memory", "power_draw", "temperature_gpu"]
+    interval = "60s"
+    tagexclude = ["compute_mode", "pstate", "uuid"]
+    [inputs.nvidia_smi.tags]
+      metricPath = "metrics"
+
   [[inputs.logfile]]
     destination = "cloudwatchlogs"
     file_state_folder = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\state"

--- a/translator/totomlconfig/sampleConfig/complete_windows_config.json
+++ b/translator/totomlconfig/sampleConfig/complete_windows_config.json
@@ -12,6 +12,15 @@
   },
   "metrics": {
     "metrics_collected": {
+      "nvidia_gpu" : {
+        "measurement": [
+          "utilization_gpu",
+          "utilization_memory",
+          "power_draw",
+          "temperature_gpu"
+        ],
+        "metrics_collection_interval": 60
+      },
       "Processor": {
         "measurement": [
           {

--- a/translator/translate/metrics/config/registered_metrics.go
+++ b/translator/translate/metrics/config/registered_metrics.go
@@ -56,4 +56,5 @@ var Registered_Metrics_Windows = map[string][]string{
 var DisableWinPerfCounters = map[string]bool{
 	"statsd":   true,
 	"procstat": true,
+	"nvidia_smi": true,
 }

--- a/translator/translate/metrics/config/registered_metrics.go
+++ b/translator/translate/metrics/config/registered_metrics.go
@@ -54,7 +54,7 @@ var Registered_Metrics_Windows = map[string][]string{
 }
 
 var DisableWinPerfCounters = map[string]bool{
-	"statsd":   true,
-	"procstat": true,
+	"statsd":     true,
+	"procstat":   true,
 	"nvidia_smi": true,
 }

--- a/translator/translate/metrics/metrics_collect/gpu/nvidiaSmi.go
+++ b/translator/translate/metrics/metrics_collect/gpu/nvidiaSmi.go
@@ -69,6 +69,5 @@ func init() {
 	n := new(NvidiaSmi)
 	parent.RegisterLinuxRule(SectionKey_Nvidia_GPU, n)
 	parent.RegisterDarwinRule(SectionKey_Nvidia_GPU, n)
-	// Windows is not supported for customer build due to security concern
-	// 	parent.RegisterWindowsRule(SectionKey_Nvidia, n)
+	parent.RegisterWindowsRule(SectionKey_Nvidia_GPU, n)
 }

--- a/translator/translate/metrics/util/commonconfigutil.go
+++ b/translator/translate/metrics/util/commonconfigutil.go
@@ -31,7 +31,7 @@ func ProcessLinuxCommonConfig(input interface{}, pluginName string, path string,
 	inputMap := input.(map[string]interface{})
 	// Generate allowlisted metric list, process only if Measurement_Key exist
 	if translator.IsValid(inputMap, Measurement_Key, path) {
-		// NOTE: the logic here is a bit tricky, even windows uses linux config for metric like procstat.
+		// NOTE: the logic here is a bit tricky, even windows uses linux config for metric like procstat, NvidiaGPU.
 		os := config.OS_TYPE_LINUX
 		if translator.GetTargetPlatform() == config.OS_TYPE_DARWIN {
 			os = config.OS_TYPE_DARWIN
@@ -104,7 +104,7 @@ func ProcessWindowsCommonConfig(input interface{}, pluginName string, path strin
 		}
 	}
 
-	// Add common field ObkectName
+	// Add common field ObjectName
 	objectConfig[Windows_Object_Name_Key] = pluginName
 
 	// Output the message about the missing perf counter metrics

--- a/translator/translate/metrics/util/measurementutil.go
+++ b/translator/translate/metrics/util/measurementutil.go
@@ -22,6 +22,8 @@ const measurement_rename = "rename"
 const measurement_unit = "unit"
 const nvidia_smi_plugin_name = "nvidia_smi"
 const tag_exclude_key = "tagexclude"
+const smi_bin_path = "bin_path"
+const default_windows_smi_path = "C:\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe"
 
 func ApplyMeasurementRule(inputs interface{}, pluginName string, targetOs string, path string) (returnKey string, returnVal []string) {
 	inputList := inputs.([]interface{})
@@ -173,10 +175,17 @@ func GetMeasurementName(input interface{}) (measurementNames []string) {
 
 // ApplyPluginSpecificRules returns a map contains all the rules for tagpass, tagdrop, namepass, namedrop,
 //fieldpass, fielddrop, taginclude, tagexclude specifically for certain plugin.
-func ApplyPluginSpecificRules(pluginName string) (map[string][]string, bool) {
+func ApplyPluginSpecificRules(pluginName string) (map[string]interface{}, bool) {
 	switch pluginName {
 	case nvidia_smi_plugin_name:
-		return map[string][]string{tag_exclude_key: GetExcludingTags(pluginName)}, true
+		result := map[string]interface{} {tag_exclude_key: GetExcludingTags(pluginName)}
+		// if on windows, will look for smi in a windows style path
+		if translator.GetTargetPlatform() == translatorConfig.OS_TYPE_WINDOWS {
+			// default path for Nvidia_smi.exe is C:\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe
+			// Todo: for windows 10 the path should default to C:\\Windows\\System32\\nvidia-smi.exe will support in the future
+			result[smi_bin_path] = default_windows_smi_path
+		}
+		return result, true
 	default:
 		return nil, false
 	}

--- a/translator/translate/metrics/util/measurementutil.go
+++ b/translator/translate/metrics/util/measurementutil.go
@@ -178,7 +178,7 @@ func GetMeasurementName(input interface{}) (measurementNames []string) {
 func ApplyPluginSpecificRules(pluginName string) (map[string]interface{}, bool) {
 	switch pluginName {
 	case nvidia_smi_plugin_name:
-		result := map[string]interface{} {tag_exclude_key: GetExcludingTags(pluginName)}
+		result := map[string]interface{}{tag_exclude_key: GetExcludingTags(pluginName)}
 		// if on windows, will look for smi in a windows style path
 		if translator.GetTargetPlatform() == translatorConfig.OS_TYPE_WINDOWS {
 			// default path for Nvidia_smi.exe is C:\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe


### PR DESCRIPTION
# Description of the issue
Current Nvidia GPU metrics plugin only works on Linux

# Description of changes
Adding a config translation rule for Windows so that with proper configuration, Nvidia GPU metrics will be collected on Windows instances.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manually tested the feature, unit test the config translation, will add integration test in another PR





