### PR TITLE
Increase Timeout, Sometimes CA Bundle Test Needs More Time To Run

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -431,7 +431,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 15
+          timeout_minutes: 30
           retry_wait_seconds: 5
           command: |
             cd integration/terraform/ec2/linux


### PR DESCRIPTION
# Description of the issue
CA Bundle Time out 
https://github.com/aws/amazon-cloudwatch-agent/runs/6919650158?check_suite_focus=true

# Description of changes
Increase timeout

# Tests
N/A

Possible better solution would be to download the go mod on instances during the instance builder phase so this is cached in the ami. Since the go mod download took 10 minutes in this test.  




