### PR TITLE
Delete log file after done writing in CWL integ test

### DIFF
--- a/integration/test/cloudwatchlogs/publish_logs_test.go
+++ b/integration/test/cloudwatchlogs/publish_logs_test.go
@@ -74,7 +74,7 @@ func TestWriteLogsToCloudWatch(t *testing.T) {
 			writeLogs(t, logFilePath, param.iterations)
 			time.Sleep(agentRuntime)
 			test.StopAgent()
-			time.sleep(agentRuntime)
+			time.Sleep(agentRuntime)
 
 			// check CWL to ensure we got the expected number of logs in the log stream
 			test.ValidateLogs(t, instanceId, instanceId, param.numExpectedLogs, start)

--- a/integration/test/cloudwatchlogs/publish_logs_test.go
+++ b/integration/test/cloudwatchlogs/publish_logs_test.go
@@ -23,7 +23,7 @@ const (
 	logLineId1       = "foo"
 	logLineId2       = "bar"
 	logFilePath      = "/tmp/test.log"  // TODO: not sure how well this will work on Windows
-	agentRuntime     = 15 * time.Second // default flush interval is 5 seconds
+	agentRuntime     = 20 * time.Second // default flush interval is 5 seconds
 )
 
 var logLineIds = []string{logLineId1, logLineId2}
@@ -74,7 +74,6 @@ func TestWriteLogsToCloudWatch(t *testing.T) {
 			writeLogs(t, logFilePath, param.iterations)
 			time.Sleep(agentRuntime)
 			test.StopAgent()
-			time.Sleep(agentRuntime)
 
 			// check CWL to ensure we got the expected number of logs in the log stream
 			test.ValidateLogs(t, instanceId, instanceId, param.numExpectedLogs, start)
@@ -131,6 +130,7 @@ func writeLogs(t *testing.T, filePath string, iterations int) {
 		t.Fatalf("Error occurred creating log file for writing: %v", err)
 	}
 	defer f.Close()
+	defer os.Remove(filePath)
 
 	log.Printf("Writing %d lines to %s", iterations*len(logLineIds), filePath)
 

--- a/integration/test/cloudwatchlogs/publish_logs_test.go
+++ b/integration/test/cloudwatchlogs/publish_logs_test.go
@@ -23,7 +23,7 @@ const (
 	logLineId1       = "foo"
 	logLineId2       = "bar"
 	logFilePath      = "/tmp/test.log"  // TODO: not sure how well this will work on Windows
-	agentRuntime     = 20 * time.Second // default flush interval is 5 seconds
+	agentRuntime     = 15 * time.Second // default flush interval is 5 seconds
 )
 
 var logLineIds = []string{logLineId1, logLineId2}
@@ -74,6 +74,7 @@ func TestWriteLogsToCloudWatch(t *testing.T) {
 			writeLogs(t, logFilePath, param.iterations)
 			time.Sleep(agentRuntime)
 			test.StopAgent()
+			time.sleep(agentRuntime)
 
 			// check CWL to ensure we got the expected number of logs in the log stream
 			test.ValidateLogs(t, instanceId, instanceId, param.numExpectedLogs, start)


### PR DESCRIPTION
# Description of the issue
CloudWatch Logs integration tests on GitHub have been flaky, specifically only on the log filter tests.

# Description of changes
Deleting the log file after writing forces the agent to flush everything before stopping, so that ensures that everything is published before the next test. It also cleans up any statefile on the test host. I think an obfuscated issue could be that since I'm publishing the same logs in both tests and just applying a filter the second time, is that when the agent starts up it sees there's no new data to read since the offset is the same - this correlates with the fact that just sleeping longer after running the test does not resolve the flakiness so it is not likely that it is a problem or delay in publishing the logs. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran on my fork https://github.com/SaxyPandaBear/amazon-cloudwatch-agent/runs/6945050639?check_suite_focus=true there seems to be an issue that's unrelated on Amazon Linux 2 with the `go.mod` that can be addressed separately. Might need to just update the version of Go that gets installed in the AMIs.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




