### PR TITLE
Export Go Bin Path

### DIFF
--- a/integration/terraform/ec2/linux/main.tf
+++ b/integration/terraform/ec2/linux/main.tf
@@ -8,6 +8,7 @@ resource "aws_instance" "integration-test" {
     inline = [
       "cloud-init status --wait",
       "echo clone and install agent",
+      "export PATH=$PATH:/usr/local/go/bin",
       "git clone ${var.github_repo}",
       "cd amazon-cloudwatch-agent",
       "git reset --hard ${var.github_sha}",


### PR DESCRIPTION
# Description of the issue
Need to execute go in non interactive shell. 

# Description of changes
Export go path

# Tests
On my fork

https://github.com/sethAmazon/amazon-cloudwatch-agent/runs/7012889647?check_suite_focus=true




