### PR TITLE
Fix CloudWatch.publish() sometimes not jittering.

### DIFF
--- a/plugins/outputs/cloudwatch/aggregator_test.go
+++ b/plugins/outputs/cloudwatch/aggregator_test.go
@@ -39,6 +39,8 @@ func TestAggregator_NoAggregationKeyFound(t *testing.T) {
 
 	assertNoMetricsInChan(t, metricChan)
 	close(shutdownChan)
+	// Cleanup
+	wg.Wait()
 }
 
 func TestAggregator_NotDurationType(t *testing.T) {
@@ -60,6 +62,8 @@ func TestAggregator_NotDurationType(t *testing.T) {
 
 	assertNoMetricsInChan(t, metricChan)
 	close(shutdownChan)
+	// Cleanup
+	wg.Wait()
 }
 
 func TestAggregator_ProperAggregationKey(t *testing.T) {
@@ -78,6 +82,8 @@ func TestAggregator_ProperAggregationKey(t *testing.T) {
 
 	assertNoMetricsInChan(t, metricChan)
 	close(shutdownChan)
+	// Cleanup
+	wg.Wait()
 }
 
 func TestAggregator_MultipleAggregationPeriods(t *testing.T) {
@@ -121,6 +127,8 @@ func TestAggregator_MultipleAggregationPeriods(t *testing.T) {
 
 	assertNoMetricsInChan(t, metricChan)
 	close(shutdownChan)
+	// Cleanup
+	wg.Wait()
 }
 
 func TestAggregator_ShutdownBehavior(t *testing.T) {

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -638,7 +638,9 @@ func (c *CloudWatch) ProcessRollup(rawDimension []*cloudwatch.Dimension) [][]*cl
 		}
 
 	}
-	log.Printf("D! cloudwatch: Get Full dimensionList %v", fullDimensionsList)
+	if len(fullDimensionsList) > 0 && len(fullDimensionsList[0]) > 0 {
+		log.Printf("D! cloudwatch: Get Full dimensionList %v", fullDimensionsList)
+	}
 	return fullDimensionsList
 }
 

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -377,7 +377,7 @@ func (c *CloudWatch) backoffSleep() {
 	if c.retries <= defaultRetryCount {
 		backoffInMillis = int64(backoffRetryBase * 1 << c.retries)
 		// Adding at most 1 second on each retry for the sake of jitter.
-		backoffInMillis += publisJitterInt(1000)
+		backoffInMillis += getJitter(1000)
 	}
 	sleepDuration := time.Millisecond * time.Duration(backoffInMillis)
 	log.Printf("W! %v retries, going to sleep %v before retrying.", c.retries,

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -397,8 +397,8 @@ func TestPublish(t *testing.T) {
 	svc.On("PutMetricData", mock.Anything).Return(
 		&res,
 		nil)
-	interval := 30 * time.Second
-	numMetrics := 5000
+	interval := 60 * time.Second
+	numMetrics := 10000
 	expectedCalls := numMetrics / defaultMaxDatumsPerCall
 	cloudWatchOutput := newCloudWatchClient(svc, interval)
 	cloudWatchOutput.publisher, _ = publisher.NewPublisher(

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -545,7 +545,7 @@ func TestBackoffRetries(t *testing.T) {
 	sleeps := []time.Duration{time.Millisecond * 200, time.Millisecond * 400, time.Millisecond * 800,
 		time.Millisecond * 1600, time.Millisecond * 3200, time.Millisecond * 6400}
 	assert := assert.New(t)
-	leniency := 100 * time.Millisecond
+	leniency := 200 * time.Millisecond
 	for i := 0; i <= defaultRetryCount; i++ {
 		start := time.Now()
 		c.backoffSleep()

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -536,21 +536,22 @@ func TestBackoffRetries(t *testing.T) {
 	c := &CloudWatch{}
 	sleeps := []time.Duration{time.Millisecond * 200, time.Millisecond * 400, time.Millisecond * 800,
 		time.Millisecond * 1600, time.Millisecond * 3200, time.Millisecond * 6400}
+	assert := assert.New(t)
 	for i := 0; i <= defaultRetryCount; i++ {
 		now := time.Now()
 		c.backoffSleep()
 		// Allow up 2 seconds difference due to 1 second random jitter, and 1
 		// second for Sleep() accuracy.
-		assert.True(t, math.Abs((time.Since(now)-sleeps[i]).Seconds()) < 2)
+		assert.True(math.Abs((time.Since(now)-sleeps[i]).Seconds()) < 2)
 	}
 	now := time.Now()
 	c.backoffSleep()
-	assert.Greater(t, 2, math.Abs((time.Since(now)-time.Minute).Seconds()))
+	assert.Greater(2, math.Abs((time.Since(now)-time.Minute).Seconds()))
 
 	c.retries = 0
 	now = time.Now()
 	c.backoffSleep()
-	assert.True(t, math.Abs((time.Since(now)-sleeps[0]).Seconds()) < 2)
+	assert.True(math.Abs((time.Since(now)-sleeps[0]).Seconds()) < 2)
 }
 
 // Fill up the channel and verify it is full.

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -110,6 +110,9 @@ func TestBuildMetricDatums(t *testing.T) {
 func TestProcessRollup(t *testing.T) {
 	svc := new(mockCloudWatchClient)
 	cloudWatchOutput := newCloudWatchClient(svc, time.Second)
+	cloudWatchOutput.publisher, _ = publisher.NewPublisher(
+		publisher.NewNonBlockingFifoQueue(10), 10, 2*time.Second,
+		cloudWatchOutput.WriteToCloudWatch)
 	cloudWatchOutput.RollupDimensions = [][]string{{"d1", "d2"}, {"d1"}, {}, {"d4"}}
 
 	rawDimension := []*cloudwatch.Dimension{
@@ -274,7 +277,9 @@ func TestIsFlushable(t *testing.T) {
 		&res,
 		nil)
 	cloudWatchOutput := newCloudWatchClient(svc, time.Second)
-
+	cloudWatchOutput.publisher, _ = publisher.NewPublisher(
+		publisher.NewNonBlockingFifoQueue(10), 10, 2*time.Second,
+		cloudWatchOutput.WriteToCloudWatch)
 	assert := assert.New(t)
 	perRequestConstSize := overallConstPerRequestSize + len("CWAgent") + namespaceOverheads
 	batch := newMetricDatumBatch(defaultMaxDatumsPerCall, perRequestConstSize)

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -545,13 +545,14 @@ func TestBackoffRetries(t *testing.T) {
 	sleeps := []time.Duration{time.Millisecond * 200, time.Millisecond * 400, time.Millisecond * 800,
 		time.Millisecond * 1600, time.Millisecond * 3200, time.Millisecond * 6400}
 	assert := assert.New(t)
+	leniency := 100 * time.Millisecond
 	for i := 0; i <= defaultRetryCount; i++ {
 		start := time.Now()
 		c.backoffSleep()
 		// Expect time since start is between sleeps[i]/2 and sleeps[i].
 		// Except that github automation fails on this for MacOs, so allow leniency.
 		assert.Less(sleeps[i] / 2, time.Since(start))
-		assert.Greater(sleeps[i], time.Since(start))
+		assert.Greater(sleeps[i] + leniency, time.Since(start))
 	}
 	start := time.Now()
 	c.backoffSleep()
@@ -561,7 +562,7 @@ func TestBackoffRetries(t *testing.T) {
 	c.retries = 0
 	start = time.Now()
 	c.backoffSleep()
-	assert.Greater(200 * time.Millisecond, time.Since(start))
+	assert.Greater(200 * time.Millisecond + leniency, time.Since(start))
 }
 
 // Fill up the channel and verify it is full.

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -545,7 +545,7 @@ func TestBackoffRetries(t *testing.T) {
 	}
 	now := time.Now()
 	c.backoffSleep()
-	assert.True(t, math.Abs((time.Since(now)-time.Minute).Seconds()) < 2)
+	assert.Greater(t, 2, math.Abs((time.Since(now)-time.Minute).Seconds()))
 
 	c.retries = 0
 	now = time.Now()

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -546,7 +546,7 @@ func TestBackoffRetries(t *testing.T) {
 	}
 	now := time.Now()
 	c.backoffSleep()
-	assert.Greater(2, math.Abs((time.Since(now)-time.Minute).Seconds()))
+	assert.Greater(2.0, math.Abs((time.Since(now)-time.Minute).Seconds()))
 
 	c.retries = 0
 	now = time.Now()

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -380,12 +380,12 @@ func TestWriteError(t *testing.T) {
 	metrics := makeMetrics(20)
 	cloudWatchOutput.Write(metrics)
 
-	var sum float64
+	var sum int
 	for i := 0; i < defaultRetryCount; i++ {
 		// Allow up to 1 second of random jitter and some exponential jitter.
-		sum += 1 + math.Pow(2, float64(i))
+		sum += 1 + (1 << i)
 	}
-	time.Sleep(time.Duration(backoffRetryBase*int64(sum)) * time.Millisecond)
+	time.Sleep(time.Duration(backoffRetryBase * sum) * time.Millisecond)
 	assert.True(t, svc.AssertNumberOfCalls(t, "PutMetricData", 5))
 }
 
@@ -397,8 +397,8 @@ func TestPublish(t *testing.T) {
 	svc.On("PutMetricData", mock.Anything).Return(
 		&res,
 		nil)
-	interval := 60 * time.Second
-	numMetrics := 10000
+	interval := 30 * time.Second
+	numMetrics := 5000
 	expectedCalls := numMetrics / defaultMaxDatumsPerCall
 	cloudWatchOutput := newCloudWatchClient(svc, interval)
 	cloudWatchOutput.publisher, _ = publisher.NewPublisher(

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -542,7 +542,7 @@ func TestBackoffRetries(t *testing.T) {
 		c.backoffSleep()
 		// Allow up 2 seconds difference due to 1 second random jitter, and 1
 		// second for Sleep() accuracy.
-		assert.True(math.Abs((time.Since(now)-sleeps[i]).Seconds()) < 2)
+		assert.Greater(2.0, math.Abs((time.Since(now)-sleeps[i]).Seconds()))
 	}
 	now := time.Now()
 	c.backoffSleep()
@@ -551,7 +551,7 @@ func TestBackoffRetries(t *testing.T) {
 	c.retries = 0
 	now = time.Now()
 	c.backoffSleep()
-	assert.True(math.Abs((time.Since(now)-sleeps[0]).Seconds()) < 2)
+	assert.Greater(2.0, math.Abs((time.Since(now)-sleeps[0]).Seconds()))
 }
 
 // Fill up the channel and verify it is full.

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -240,7 +240,9 @@ func TestProcessRollup(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualValues(t, expectedDimensionList, actualDimensionList, "Unexpected dimension roll up list with duplicate roll up")
+	assert.EqualValues(t, expectedDimensionList, actualDimensionList,
+		"Unexpected dimension roll up list with duplicate roll up")
+	cloudWatchOutput.Close()
 }
 
 func TestGetUniqueRollupList(t *testing.T) {
@@ -287,6 +289,7 @@ func TestIsFlushable(t *testing.T) {
 	assert.False(cloudWatchOutput.timeToPublish(batch))
 	time.Sleep(time.Second + cloudWatchOutput.ForceFlushInterval.Duration)
 	assert.True(cloudWatchOutput.timeToPublish(batch))
+	cloudWatchOutput.Close()
 }
 
 func TestIsFull(t *testing.T) {
@@ -361,8 +364,8 @@ func TestWrite(t *testing.T) {
 	metrics := makeMetrics(30)
 	cloudWatchOutput.Write(metrics)
 	time.Sleep(time.Second + 2*cloudWatchOutput.ForceFlushInterval.Duration)
-	cloudWatchOutput.Close()
 	assert.True(t, svc.AssertNumberOfCalls(t, "PutMetricData", 2))
+	cloudWatchOutput.Close()
 }
 
 func TestWriteError(t *testing.T) {
@@ -386,6 +389,7 @@ func TestWriteError(t *testing.T) {
 	}
 	time.Sleep(backoffRetryBase * time.Duration(sum))
 	assert.True(t, svc.AssertNumberOfCalls(t, "PutMetricData", 5))
+	cloudWatchOutput.Close()
 }
 
 // TestPublish verifies metric batches do not get pushed immediately when
@@ -540,6 +544,7 @@ func TestBackoffRetries(t *testing.T) {
 		start := time.Now()
 		c.backoffSleep()
 		// Expect time since start is between sleeps[i]/2 and sleeps[i].
+		// Except that github automation fails on this for MacOs, so allow leniency.
 		assert.Less(sleeps[i] / 2, time.Since(start))
 		assert.Greater(sleeps[i], time.Since(start))
 	}

--- a/plugins/outputs/cloudwatch/util.go
+++ b/plugins/outputs/cloudwatch/util.go
@@ -52,7 +52,7 @@ var doOnce sync.Once
 var gRand *rand.Rand
 
 // publisJitterInt returns a random int64 between 0 and the given maxVal.
-func publisJitterInt(maxVal int64) int64 {
+func getJitter(maxVal int64) int64 {
 	// Set seed once at startup
 	doOnce.Do(func() {
 		gRand = rand.New(rand.NewSource(time.Now().Unix()))
@@ -64,7 +64,7 @@ func publisJitterInt(maxVal int64) int64 {
 
 // publishJitter returns a random duration between 0 and the given publishInterval.
 func publishJitter(publishInterval time.Duration) time.Duration {
-	jitter := publisJitterInt(int64(publishInterval.Seconds()))
+	jitter := getJitter(int64(publishInterval.Seconds()))
 	return time.Duration(jitter) * time.Second
 }
 

--- a/plugins/outputs/cloudwatch/util.go
+++ b/plugins/outputs/cloudwatch/util.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"math/rand"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent/metric/distribution"
@@ -47,25 +46,13 @@ const (
 	unitOverheads = 42
 )
 
-// Global set once.
-var doOnce sync.Once
-var gRand *rand.Rand
-
-// publisJitterInt returns a random int64 between 0 and the given maxVal.
-func getJitter(maxVal int64) int64 {
-	// Set seed once at startup
-	doOnce.Do(func() {
-		gRand = rand.New(rand.NewSource(time.Now().Unix()))
-	})
-
-	jitter := gRand.Int63n(maxVal)
-	return jitter
-}
+// Set seed once.
+var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // publishJitter returns a random duration between 0 and the given publishInterval.
 func publishJitter(publishInterval time.Duration) time.Duration {
-	jitter := getJitter(int64(publishInterval.Seconds()))
-	return time.Duration(jitter) * time.Second
+	jitter := seededRand.Int63n(int64(publishInterval))
+	return time.Duration(jitter)
 }
 
 func setNewDistributionFunc(maxValuesPerDatumLimit int) {

--- a/plugins/outputs/cloudwatch/util_test.go
+++ b/plugins/outputs/cloudwatch/util_test.go
@@ -18,10 +18,16 @@ import (
 )
 
 func TestPublishJitter(t *testing.T) {
-	publishJitter := publishJitter(time.Minute)
-	log.Printf("Got publisherJitter %v", publishJitter)
-	assert.True(t, publishJitter >= 0)
-	assert.True(t, publishJitter < time.Minute)
+	// Loop an arbitrary number of times.
+	last := time.Duration(-1)
+	for i := 0; i < 100; i++ {
+		publishJitter := publishJitter(time.Minute)
+		log.Printf("Got publisherJitter %v", publishJitter)
+		assert.GreaterOrEqual(t, publishJitter, time.Duration(0))
+		assert.Less(t, publishJitter, time.Minute)
+		assert.NotEqual(t, publishJitter, last)
+		last = publishJitter
+	}
 }
 
 func TestSetNewDistributionFunc(t *testing.T) {

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -316,10 +316,10 @@ func (p *pusher) send() {
 
 func retryWait(n int) time.Duration {
 	const base = 200 * time.Millisecond
-	const max = 1 * time.Minute
-	d := base * time.Duration(1<<int64(n))
-	if n > 5 {
-		d = max
+	// Max wait time is 1 minute (jittered)
+	d := 1 * time.Minute
+	if n < 5 {
+		d = base * time.Duration(1<<int64(n))
 	}
 	return time.Duration(seededRand.Int63n(int64(d/2)) + int64(d/2))
 }


### PR DESCRIPTION
# Description of the issue
When the agent is configured to monitor StatsD, and there is a burst of 10,000 metrics collected and aggregated every minute (same issue if it is done every 5 minutes), the agent's internal buffer of batches will fill up and it will immediately try pushing to CloudWatch. And as soon as that is published the batch will fill up again, and the agent will push again, and again...

This becomes problematic if there are _many_ hosts, because they will all try pushing during the first second of each minute, and will repeat with little to no delay.

Inevitably this will reach the PutMetricData API throttle limit of 150 transaction per second.
 
Change CloudWatch.publish() to avoid bursting backend when datumBatchChan is full.
Change CloudWatch.backoffSleep() to use jitter.
Update tests.

# Description of changes
1. Change API retries to use randomized jitter.
2. Change what happens when the buffer of metricBatches is full. Instead of publishing immediately, gradually reduce the delay. Please note there are other buffers in the agent, so even if the buffer of metricBatches remains full for _awhile_ it doesn't mean metric will be dropped.


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. New test - `go test -v ./plugins/outputs/cloudwatch -count=1 -run TestPublish`
2. All tests - `make test`
3. Ran this python script against the current agent, and with my change. Verified the burst of uploads is reduced to a gradually more frequent set of uploads.
```
import statsd
import os
import sys
import time

"""
Each API call can include 20 metrics.
So a metricBatch hold 20 metrics.
CWA has a buffer/channel for these batches with a size of 50.
So it takes 50 batches of 20 metrics each to fill the buffer and cause CWA to 
upload  immediately. 1,000 metrics total.

When NUM_METRICS=1000, CWA hits the full condition and makes 50 API calls.
When NUM_METRICS=10,000, CWA makes 500 API calls.

Using the new publish() where the interval is cut in half, 10K metrics takes:
30 sec - first full batchBuffer, so 50*20=1,000 metrics.
15 sec - 1,000 metrics
7.5 sec - 1,000
.
.
.
30 + 15 + 7.5 + ... = 41 seconds for 10 full buffers of 50 batches = 500 API calls.
"""
NUM_METRICS = 10000
VALUES_PER_METRIC = 2
SLEEP_INTERVAL = 60 / VALUES_PER_METRIC

def send_metrics(statsd_client):
    for i in range(NUM_METRICS):
        name = "adam" + str(i)
        statsd_client.incr(name)

def main():
    statsd_client = statsd.StatsClient("localhost", 8125)
    count = 0
    while 1:
        count += 1
        print("loop", count)
        send_metrics(statsd_client)
        time.sleep(SLEEP_INTERVAL)
        
if __name__ == "__main__":
    main()
```

CWA config:
```
{
	"metrics": {
		"metrics_collected": {
			"statsd": {
				"metrics_aggregation_interval": 60,
				"metrics_collection_interval": 10,
				"service_address": ":8125"
			}
		}
	}
}
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
4. Run `make linter`

NOTE: I am skipping these requirements because it would seriously clutter this PR.
If required, I can do it in a separate PR.



