### PR TITLE
Fix backoffSleep() so it jitters the sleep time.

### DIFF
--- a/plugins/outputs/cloudwatch/aggregator_test.go
+++ b/plugins/outputs/cloudwatch/aggregator_test.go
@@ -39,6 +39,7 @@ func TestAggregator_NoAggregationKeyFound(t *testing.T) {
 
 	assertNoMetricsInChan(t, metricChan)
 	close(shutdownChan)
+	wg.Wait()
 }
 
 func TestAggregator_NotDurationType(t *testing.T) {
@@ -60,6 +61,7 @@ func TestAggregator_NotDurationType(t *testing.T) {
 
 	assertNoMetricsInChan(t, metricChan)
 	close(shutdownChan)
+	wg.Wait()
 }
 
 func TestAggregator_ProperAggregationKey(t *testing.T) {
@@ -78,6 +80,7 @@ func TestAggregator_ProperAggregationKey(t *testing.T) {
 
 	assertNoMetricsInChan(t, metricChan)
 	close(shutdownChan)
+	wg.Wait()
 }
 
 func TestAggregator_MultipleAggregationPeriods(t *testing.T) {
@@ -121,6 +124,7 @@ func TestAggregator_MultipleAggregationPeriods(t *testing.T) {
 
 	assertNoMetricsInChan(t, metricChan)
 	close(shutdownChan)
+	wg.Wait()
 }
 
 func TestAggregator_ShutdownBehavior(t *testing.T) {

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -525,25 +525,32 @@ func buildCloudWatchFromToml(contents string) (*CloudWatch, error) {
 
 func TestBackoffRetries(t *testing.T) {
 	c := &CloudWatch{}
-	sleeps := []time.Duration{time.Millisecond * 200, time.Millisecond * 400, time.Millisecond * 800,
-		time.Millisecond * 1600, time.Millisecond * 3200, time.Millisecond * 6400}
+	sleeps := []time.Duration{
+		time.Millisecond * 200,
+		time.Millisecond * 400,
+		time.Millisecond * 800,
+		time.Millisecond * 1600,
+		time.Millisecond * 3200,
+		time.Millisecond * 6400}
 	a := assert.New(t)
+	// tolerance is necessary because GitHub/MacOs does not have an accurate sleep().
+	tolerance := 200 * time.Millisecond
 	for i := 0; i <= defaultRetryCount; i++ {
 		start := time.Now()
 		c.backoffSleep()
 		a.LessOrEqual(sleeps[i] / 2, time.Since(start))
-		a.GreaterOrEqual(sleeps[i], time.Since(start))
+		a.GreaterOrEqual(sleeps[i] + tolerance, time.Since(start))
 	}
 	start := time.Now()
 	c.backoffSleep()
 	a.LessOrEqual(time.Minute / 2, time.Since(start))
-	a.GreaterOrEqual(time.Minute, time.Since(start))
+	a.GreaterOrEqual(time.Minute + tolerance, time.Since(start))
 
 	c.retries = 0
 	start = time.Now()
 	c.backoffSleep()
 	a.LessOrEqual(sleeps[0] / 2, time.Since(start))
-	a.GreaterOrEqual(sleeps[0], time.Since(start))
+	a.GreaterOrEqual(sleeps[0] + tolerance, time.Since(start))
 }
 
 func TestCloudWatch_metricDatumBatchFull(t *testing.T) {

--- a/plugins/outputs/cloudwatch/util.go
+++ b/plugins/outputs/cloudwatch/util.go
@@ -46,11 +46,13 @@ const (
 	unitOverheads = 42
 )
 
-func publishJitter(publishInterval time.Duration) (publishJitter time.Duration) {
-	r := rand.New(rand.NewSource(time.Now().Unix()))
-	jitter := r.Int63n(int64(publishInterval.Seconds()))
-	publishJitter = time.Duration(jitter) * time.Second
-	return
+// Set seed once.
+var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// publishJitter returns a random duration between 0 and the given publishInterval.
+func publishJitter(publishInterval time.Duration) time.Duration {
+	jitter := seededRand.Int63n(int64(publishInterval))
+	return time.Duration(jitter)
 }
 
 func setNewDistributionFunc(maxValuesPerDatumLimit int) {

--- a/plugins/outputs/cloudwatch/util_test.go
+++ b/plugins/outputs/cloudwatch/util_test.go
@@ -18,10 +18,16 @@ import (
 )
 
 func TestPublishJitter(t *testing.T) {
-	publishJitter := publishJitter(time.Minute)
-	log.Printf("Got publisherJitter %v", publishJitter)
-	assert.True(t, publishJitter >= 0)
-	assert.True(t, publishJitter < time.Minute)
+	// Loop an arbitrary number of times.
+	last := time.Duration(-1)
+	for i := 0; i < 100; i++ {
+		publishJitter := publishJitter(time.Minute)
+		log.Printf("Got publisherJitter %v", publishJitter)
+		assert.GreaterOrEqual(t, publishJitter, time.Duration(0))
+		assert.Less(t, publishJitter, time.Minute)
+		assert.NotEqual(t, publishJitter, last)
+		last = publishJitter
+	}
 }
 
 func TestSetNewDistributionFunc(t *testing.T) {

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -316,10 +316,10 @@ func (p *pusher) send() {
 
 func retryWait(n int) time.Duration {
 	const base = 200 * time.Millisecond
-	const max = 1 * time.Minute
-	d := base * time.Duration(1<<int64(n))
-	if n > 5 {
-		d = max
+	// Max wait time is 1 minute (jittered)
+	d := 1 * time.Minute
+	if n < 5 {
+		d = base * time.Duration(1<<int64(n))
 	}
 	return time.Duration(seededRand.Int63n(int64(d/2)) + int64(d/2))
 }


### PR DESCRIPTION
# Description of the issue
When a burst of metrics is forwards to the output plugin and the number of metrics exceeds the internal buffer size, CWA will push the metrics immediately. If there are many hosts running CWA and they all get a burst of metrics at the beginning of each minute, then they will all try uploading at the beginning of the minute. The burst of uploads is likely to surpass API rate limits, and will need to be retried.

Currently when PutMetricData API calls fail, they are retried after deterministic delays instead of jittered.

# Description of changes
Fix backoffSleep() so it jitters the sleep time.
Fix publish() so it does not use a negative sleep time.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Updated unit tests.
- Manually tested a burst of 10K, 20K, 30K statsd metrics.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`

(skipped formatting to keep PR small)




