### PR TITLE
Log the open file count once a minute to aid debugging.

### DIFF
--- a/internal/atomiccounter/atomiccounter.go
+++ b/internal/atomiccounter/atomiccounter.go
@@ -17,7 +17,7 @@ func (ac *AtomicCounter) Increment() {
 	atomic.AddInt64(&ac.val, 1)
 }
 
-func (ac *AtomicCounter) Decremenet() {
+func (ac *AtomicCounter) Decrement() {
 	atomic.AddInt64(&ac.val, -1)
 }
 

--- a/internal/atomiccounter/atomiccounter.go
+++ b/internal/atomiccounter/atomiccounter.go
@@ -1,0 +1,28 @@
+package atomiccounter
+
+import (
+	"sync/atomic"
+)
+
+type AtomicCounter struct {
+	val int64
+}
+
+// NewAtomicCounter returns a new counter with the default value of 0.
+func NewAtomicCounter() AtomicCounter {
+	return AtomicCounter{}
+}
+
+func (ac *AtomicCounter) Increment() {
+	atomic.AddInt64(&ac.val, 1)
+}
+
+func (ac *AtomicCounter) Decremenet() {
+	atomic.AddInt64(&ac.val, -1)
+}
+
+// Get is not safe to use for synchronizing work between goroutines.
+// It is just for logging the current value.
+func (ac *AtomicCounter) Get() int64 {
+	return ac.val
+}

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -93,11 +93,10 @@ func (l *LogAgent) Run(ctx context.Context) {
 
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
-	minuteTicker := time.NewTicker(time.Minute)
-	defer minuteTicker.Stop()
 	for {
 		select {
 		case <-t.C:
+			log.Printf("D! [logagent] open file count, %v", tail.OpenFileCount.Get())
 			for _, c := range l.collections {
 				srcs := c.FindLogSrc()
 				for _, src := range srcs {
@@ -113,8 +112,6 @@ func (l *LogAgent) Run(ctx context.Context) {
 					go l.runSrcToDest(src, dest)
 				}
 			}
-		case <-minuteTicker.C:
-			log.Printf("I! [logagent] open file count, %v", tail.OpenFileCount.Get())
 		case <-ctx.Done():
 			return
 		}

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -93,12 +93,9 @@ func (l *LogAgent) Run(ctx context.Context) {
 
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
-	last := time.Now()
+	minuteTicker := time.NewTicker(time.Minute)
+	defer minuteTicker.Stop()
 	for {
-		if time.Since(last) >= 1 * time.Minute {
-			last = time.Now()
-			log.Printf("I! [logagent] open file count, %v", tail.OpenFileCount())
-		}
 		select {
 		case <-t.C:
 			for _, c := range l.collections {
@@ -116,6 +113,8 @@ func (l *LogAgent) Run(ctx context.Context) {
 					go l.runSrcToDest(src, dest)
 				}
 			}
+		case <-minuteTicker.C:
+			log.Printf("I! [logagent] open file count, %v", tail.OpenFileCount.Get())
 		case <-ctx.Done():
 			return
 		}

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail"
 	"github.com/influxdata/telegraf/config"
 )
 
@@ -92,7 +93,12 @@ func (l *LogAgent) Run(ctx context.Context) {
 
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
+	last := time.Now()
 	for {
+		if time.Since(last) >= 1 * time.Minute {
+			last = time.Now()
+			log.Printf("I! [logagent] open file count, %v", tail.OpenFileCount())
+		}
 		select {
 		case <-t.C:
 			for _, c := range l.collections {

--- a/plugins/inputs/logfile/tail/tail.go
+++ b/plugins/inputs/logfile/tail/tail.go
@@ -209,6 +209,7 @@ func (tail *Tail) reopen() error {
 		}
 		break
 	}
+	OpenFileCount.Increment()
 	return nil
 }
 

--- a/plugins/inputs/logfile/tail/tail.go
+++ b/plugins/inputs/logfile/tail/tail.go
@@ -184,7 +184,7 @@ func (tail *Tail) closeFile() {
 	if tail.file != nil {
 		tail.file.Close()
 		tail.file = nil
-		OpenFileCount.Decremenet()
+		OpenFileCount.Decrement()
 	}
 }
 

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -27,10 +27,6 @@ func (p *profiler) AddStats(key []string, value float64) {
 	p.Lock()
 	defer p.Unlock()
 	k := strings.Join(key, "_")
-
-	if _, ok := p.stats[k]; !ok {
-		p.stats[k] = 0
-	}
 	p.stats[k] += value
 }
 


### PR DESCRIPTION
# Description of the issue
Close #432 

# Description of changes
Add atomic counter which is modified when files are opened and closed.
Counter is logged once a minute at info level.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manual test on a Windows 2016 EC2 instance.
Sample log:
```
2022-07-08T20:48:08Z I! [logagent] open file count, 2
2022-07-08T20:49:08Z I! [logagent] open file count, 2
2022-07-08T20:50:08Z I! [logagent] open file count, 2
2022-07-08T20:51:09Z I! [logagent] open file count, 2
2022-07-08T20:51:20Z I! [logagent] piping log from banana.log/i-086864b800a839c94(C:\adam\banana.log.2) to cloudwatchlogs with retention 30
2022-07-08T20:52:10Z I! [logagent] open file count, 3
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




