### PR TITLE
Change to env for GITHUB SHA

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -645,8 +645,8 @@ jobs:
         run: echo "::set-output name=sha_date::$(git show -s --format=%ct ${{ steps.sha.outputs.sha_short }} )"
 
       - name: Check env
-        run: echo "SHA ${{ GITHUB_SHA }} | Date ${{ steps.sha_date.outputs.sha_date }} "
-      # nick-invision/retry@v2 starts at base dir
+        run: echo "SHA ${GITHUB_SHA} | Date ${{ steps.sha_date.outputs.sha_date }}"
+
       - name: Terraform apply
         if: steps.performance-tracking.outputs.cache-hit != 'true'
         uses: nick-invision/retry@v2


### PR DESCRIPTION
# Description of the issue
Change to `${GITHUB_SHA}` since Github Action only recognizes `${GITHUB_SHA}`, `$GITHUB_SHA` or `${{env.GITHUB_SHA}}`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Before changing: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/2636869905
After changing: https://github.com/khanhntd/amazon-cloudwatch-agent/actions/runs/2638538645

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




