### PR TITLE
Performance Tracker Statistics Calculation

### DIFF
--- a/integration/test/performancetest/performance_query_utils.go
+++ b/integration/test/performancetest/performance_query_utils.go
@@ -18,7 +18,8 @@ const (
 	Namespace = "CWAgent"
 	DimensionName = "InstanceId"
 	Stat = "Average"
-	Period = 30
+	Period = 10
+	configPath = "./resources/config.json"
 )
 
 /*

--- a/integration/test/performancetest/transmitter.go
+++ b/integration/test/performancetest/transmitter.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
-	"os"
-	"time"
-	"strconv"
 	"log"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -197,6 +198,7 @@ func (transmitter *TransmitterAPI) SendItem(data []byte) (string, error) {
 	sentItem, err := transmitter.AddItem(packet)
 	return sentItem, err
 }
+
 func (transmitter *TransmitterAPI) Parser(data []byte) (map[string]interface{}, error) {
 	dataHolder := collectorData{}
 	err := json.Unmarshal(data, &dataHolder)
@@ -205,44 +207,62 @@ func (transmitter *TransmitterAPI) Parser(data []byte) (map[string]interface{}, 
 	}
 	packet := make(map[string]interface{})
 	packet[PARTITION_KEY] = time.Now().Year()
-	packet[HASH] =  os.Getenv(SHA_ENV) //fmt.Sprintf("%d", time.Now().UnixNano())
+	packet[HASH] = os.Getenv(SHA_ENV) //fmt.Sprintf("%d", time.Now().UnixNano())
 	packet[COMMIT_DATE],_ = strconv.Atoi(os.Getenv(SHA_DATE_ENV))
-	
+
 	for _, rawMetricData := range dataHolder {
-		numDataPoints := float64(len(rawMetricData.Timestamps))
-		var avg float64
-		max := 0.0
-		min := 10000.0
-		if numDataPoints <= 0{
-			avg = 0.0
-			max = 0.0
-			min = 0.0
-			log.Fatalf("Error there is no data points")
-		}else{
-			// @TODO:ADD GetMetricStatistics after merging with data collection code
-			sum :=0.0
-			for _,val := range rawMetricData.Values {
-				sum += val
-				if max < val{
-					max = val
-				}
-				if min > val {
-					min = val
-				}
-			}
-			
-			avg =  sum /numDataPoints
-		}
-		//----------------
-		metric := Metric{
-			Average: avg,
-			Max:     max,
-			Min:     min,
-			P99:     0.0,
-			Std: 	rand.Float64(),
-			Period:  int(METRIC_PERIOD / (numDataPoints)),
-			Data:    rawMetricData.Values}
+
+		metric := CalcStats(rawMetricData.Values)
+
 		packet[rawMetricData.Label] = metric
 	}
 	return packet, nil
+}
+
+//CalcStats takes in an array of data and returns the average, min, max, p99, and stdev of the data in a Metric struct
+func CalcStats(data []float64) Metric {
+	length := len(data)
+	if length == 0 {
+		return Metric{}
+	}
+
+	//make a copy so we aren't modifying original
+	dataCopy := make([]float64, length)
+	copy(dataCopy, data)
+	sort.Float64s(dataCopy)
+
+	min := dataCopy[0]
+	max := dataCopy[length - 1]
+
+	sum := 0.0
+	for _, value := range dataCopy {
+		sum += value
+	}
+
+	avg := sum / float64(length)
+
+	if length < 99 {
+		log.Println("Note: less than 99 values given, p99 value will be equal the max value")
+	}
+	p99Index := int(float64(length) * .99) - 1
+	p99Val := dataCopy[p99Index]
+
+	stdDevSum := 0.0
+	for _, value := range dataCopy {
+		stdDevSum += math.Pow(avg - value, 2)
+	}
+
+	stdDev := math.Sqrt(stdDevSum / float64(length))
+
+	metrics := Metric{
+		Average: avg,
+		Max:     max,
+		Min:     min,
+		P99:     p99Val,
+		Std:     stdDev,
+		Period:  int(METRIC_PERIOD / float64(length)),
+		Data:    data,
+	}
+
+	return metrics
 }


### PR DESCRIPTION
# Description of the issue
The performance benchmarking of CloudWatch Agent does not currently calculate statistics on the data it receives.

# Description of changes
Adds statistics calculations on GetMetricData data before it pushes the data into the database.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit testing to verify statistics are calculated correctly.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




