### PR TITLE
Log AWS provider name

### DIFF
--- a/cfg/aws/credentials.go
+++ b/cfg/aws/credentials.go
@@ -62,12 +62,6 @@ func getRootCredentialsFromChain(c *CredentialConfig) *credentials.Credentials {
 	for _, provider := range credentialsChain {
 		creds := provider.Credentials(c)
 		if creds != nil {
-			v, e := creds.Get()
-			if e != nil {
-				log.Printf("E! Failed to retrieve credentials from provider %s: %v", provider.Name(), e)
-			} else {
-				log.Printf("I! Using credential %s from %s", v.AccessKeyID, v.ProviderName)
-			}
 			return creds
 		}
 	}
@@ -94,6 +88,12 @@ func getSession(config *aws.Config) *session.Session {
 		}
 	}
 	log.Printf("D! Successfully created credential sessions\n")
+	cred, err := ses.Config.Credentials.Get()
+	if err != nil {
+		log.Printf("E! Failed to get credential from session: %v", err)
+	} else {
+		log.Printf("D! Using credential %s from %s", cred.AccessKeyID, cred.ProviderName)
+	}
 	return ses
 }
 

--- a/cfg/aws/credentials.go
+++ b/cfg/aws/credentials.go
@@ -60,9 +60,15 @@ var credentialsChain = make([]RootCredentialsProvider, 0)
 
 func getRootCredentialsFromChain(c *CredentialConfig) *credentials.Credentials {
 	for _, provider := range credentialsChain {
-		credentials := provider.Credentials(c)
-		if credentials != nil {
-			return credentials
+		creds := provider.Credentials(c)
+		if creds != nil {
+			v, e := creds.Get()
+			if e != nil {
+				log.Printf("E! Failed to retrieve credentials from provider %s: %v", provider.Name(), e)
+			} else {
+				log.Printf("I! Using credential %s from %s", v.AccessKeyID, v.ProviderName)
+			}
+			return creds
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description of changes
Adds a debug log to help identify the source that the agent is inheriting creds from.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested using the regular EC2 instance profile credential path, and saw that it logged a specific provider name:
```
2022-07-12T21:26:34Z D! Using credential ASIAT6CRPX66DBNTTAWB from EC2RoleProvider
```

Configured my host to use a static credential file, and checked the logs after restarting the agent:
```
2022-07-12T21:37:05Z I! will use file based credentials provider 
2022-07-12T21:37:05Z D! Successfully created credential sessions
2022-07-12T21:37:05Z D! Using credential AKIAT6CRPX66KKUO6BTU from SharedCredentialsProvider
```





