### PR TITLE
Fix debug logging and revert Windows ctl script PS1 changes

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,6 +4,7 @@ Amazon CloudWatch Agent 1.247354.0 (2022-07-14)
 
 Enhancements:
 * Increase PutMetricData request size allowed in agent
+* Fix Windows ctl issues on Windows 2012R2
 
 ========================================================================
 Amazon CloudWatch Agent 1.247353.0 (2022-06-13)

--- a/cmd/config-downloader/downloader.go
+++ b/cmd/config-downloader/downloader.go
@@ -150,7 +150,7 @@ func main() {
 	region = util.DetectRegion(mode, cc.CredentialsMap())
 
 	if region == "" && downloadLocation != locationDefault {
-		log.Println("E! Unable to determine aws-region.")
+		fmt.Println("Unable to determine aws-region.")
 		if mode == config.ModeEC2 {
 			errorMessage = fmt.Sprintf("E! Please check if you can access the metadata service. For example, on linux, run 'wget -q -O - http://169.254.169.254/latest/meta-data/instance-id && echo' ")
 		} else {

--- a/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
+++ b/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
@@ -148,7 +148,7 @@ Function AgentStart() {
     if (!$svc) {
         $startCommand = "`"${CWAProgramFiles}\start-amazon-cloudwatch-agent.exe`""
         if (${service_name} -eq $CWOCServiceName) {
-            $startCommand = "`"${CWAProgramFiles}\cwagent-otel-collector.exe`" --config=`"${YAML}`""
+            $startCommand = "`"${CWAProgramFiles}\cwagent-otel-collector.exe`" --config=${YAML}"
         }
         New-Service -Name "${service_name}" -DisplayName "${service_display_name}" -Description "${service_display_name}" -DependsOn LanmanServer -BinaryPathName "${startCommand}" | Out-Null
         # object returned by New-Service gives errors so retrieve it again
@@ -363,8 +363,8 @@ Function CWAConfig() {
     if ($ConfigLocation -eq $AllConfig) {
         Remove-Item -Path "${JSON_DIR}\*" -Force -ErrorAction SilentlyContinue
     } else {
-        & cmd /c "`"$CWAProgramFiles\config-downloader.exe`" --output-dir `"${JSON_DIR}`" --download-source `"${ConfigLocation}`" --mode ${param_mode} --config `"${COMMON_CONIG}`" --multi-config ${multi_config} 2>&1"
-        CheckCMDResult # Exit immediately if config-downloader outputs any error
+        & $CWAProgramFiles\config-downloader.exe --output-dir "${JSON_DIR}" --download-source "${ConfigLocation}" --mode "${param_mode}" --config "${COMMON_CONIG}" --multi-config "${multi_config}"
+        CheckCMDResult
     }
 
     $jsonDirContent = Get-ChildItem "${JSON_DIR}" | Measure-Object
@@ -374,13 +374,11 @@ Function CWAConfig() {
         Remove-Item "${TOML}" -Force -ErrorAction SilentlyContinue
     } else {
         Write-Output "Start configuration validation..."
-        & cmd /c "`"$CWAProgramFiles\config-translator.exe`" --input `"${JSON}`" --input-dir `"${JSON_DIR}`" --output `"${TOML}`" --mode ${param_mode} --config `"${COMMON_CONIG}`" --multi-config ${multi_config} 2>&1"
-        CheckCMDResult  # Exit immediately if config-translator outputs any error
-
-        # Set ErrorActionPreference as Continue to continue on error when schema-test on toml file fails and
-        # return a UX-friendly message
+        & cmd /c "`"$CWAProgramFiles\config-translator.exe`" --input ${JSON} --input-dir ${JSON_DIR} --output ${TOML} --mode ${param_mode} --config ${COMMON_CONIG} --multi-config ${multi_config} 2>&1"
+        CheckCMDResult
+        # Let command pass so we can check return code and give user-friendly error-message
         $ErrorActionPreference = "Continue"
-        & cmd /c "`"${CWAProgramFiles}\amazon-cloudwatch-agent.exe`" --schematest --config `"${TOML}`" 2>&1" | Out-File $CVLogFile
+        & cmd /c "`"${CWAProgramFiles}\amazon-cloudwatch-agent.exe`" --schematest --config ${TOML} 2>&1" | Out-File $CVLogFile
         if ($LASTEXITCODE -ne 0) {
             Write-Output "Configuration validation second phase failed"
             Write-Output "======== Error Log ========"
@@ -451,10 +449,9 @@ Function CWOCConfig() {
         Copy-Item "${PREDEFINED_CONFIG_DATA}" -Destination "${YAML_DIR}/default.tmp"
         Write-Output "Successfully fetched the config and saved in ${YAML_DIR}\default.tmp"
     } else {
-        & cmd /c "`"$CWAProgramFiles\config-downloader.exe`" --output-dir `"${YAML_DIR}`" --download-source `"${OtelConfigLocation}`" --mode ${param_mode} --config `"${COMMON_CONIG}`" --multi-config ${multi_config} 2>&1"
-        # Use return instead of exit since CWAgent and ADOT Collector should be two independent agents as much as possible
+        & $CWAProgramFiles\config-downloader.exe --output-dir "${YAML_DIR}" --download-source "${OtelConfigLocation}" --mode "${param_mode}" --config "${COMMON_CONIG}" --multi-config "${multi_config}"
         if ($LASTEXITCODE -ne 0) {
-           return
+            return
         }
     }
 

--- a/translator/util/ec2util/ec2util.go
+++ b/translator/util/ec2util/ec2util.go
@@ -6,7 +6,6 @@ package ec2util
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -103,7 +102,7 @@ func (e *ec2Util) deriveEC2MetadataFromIMDS() error {
 	if hostname, err := md.GetMetadata("hostname"); err == nil {
 		e.Hostname = hostname
 	} else {
-		log.Println("E! [EC2] Fetch hostname from EC2 metadata fail:", err)
+		fmt.Println("E! [EC2] Fetch hostname from EC2 metadata fail:", err)
 	}
 
 	// More information on API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
@@ -113,7 +112,7 @@ func (e *ec2Util) deriveEC2MetadataFromIMDS() error {
 		e.PrivateIP = instanceIdentityDocument.PrivateIP
 		e.InstanceID = instanceIdentityDocument.InstanceID
 	} else {
-		log.Println("E! [EC2] Fetch identity document from EC2 metadata fail:", err)
+		fmt.Println("E! [EC2] Fetch identity document from EC2 metadata fail:", err)
 	}
 
 	return nil

--- a/translator/util/ec2util/ec2util.go
+++ b/translator/util/ec2util/ec2util.go
@@ -5,11 +5,12 @@ package ec2util
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"sync"
 	"time"
-	
+
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -54,7 +55,7 @@ func initEC2UtilSingleton() (newInstance *ec2Util) {
 		ifs, err := net.Interfaces()
 
 		if err != nil {
-			log.Println("E! [EC2] An error occurred while fetching network interfaces: ", err)
+			fmt.Println("E! [EC2] An error occurred while fetching network interfaces: ", err)
 		}
 
 		for _, in := range ifs {
@@ -64,22 +65,22 @@ func initEC2UtilSingleton() (newInstance *ec2Util) {
 			}
 		}
 		if networkUp {
-			log.Println("D! [EC2] Found active network interface")
+			fmt.Println("D! [EC2] Found active network interface")
 			break
 		}
 
-		log.Println("W! [EC2] Sleep until network is up")
+		fmt.Println("W! [EC2] Sleep until network is up")
 		time.Sleep(1 * time.Second)
 	}
 
 	if !networkUp {
-		log.Println("E! [EC2] No available network interface")
+		fmt.Println("E! [EC2] No available network interface")
 	}
 
 	err := newInstance.deriveEC2MetadataFromIMDS()
 
 	if err != nil {
-		log.Println("E! [EC2] Cannot get EC2 Metadata from IMDS:", err)
+		fmt.Println("E! [EC2] Cannot get EC2 Metadata from IMDS:", err)
 	}
 
 	return


### PR DESCRIPTION
# Description of the issue
#471 originally identified an issue related to some debug logging that was added. We tried getting around this with changes to the PS1 script in #473 but this just caused more problems, primarily in that the current state works for Windows OS except for Win2012R2. 

# Description of changes
Moved to using the `fmt` package instead of `log`, which pipes the output to stdout instead of stderr, alleviating the original problem, such that we can revert the bandaid fixes that were put on top of it. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested manually the same way I did in #471 to verify no regression in Win2022, and then did a similar manual test on Win2012R2 to confirm that it doesn't break there anymore

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




