### PR TITLE
disable ec2tagger for kubernetes when onprem

### DIFF
--- a/translator/totomlconfig/sampleConfig/log_metric_and_log_on_prem.conf
+++ b/translator/totomlconfig/sampleConfig/log_metric_and_log_on_prem.conf
@@ -1,0 +1,94 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = "host_name_from_env"
+  interval = "60s"
+  logfile = ""
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.cadvisor]]
+    container_orchestrator = "eks"
+    interval = "30s"
+    mode = "detail"
+    [inputs.cadvisor.tags]
+      metricPath = "logs"
+
+  [[inputs.k8sapiserver]]
+    interval = "30s"
+    node_name = "host_name_from_env"
+    [inputs.k8sapiserver.tags]
+      metricPath = "logs_k8sapiserver"
+
+  [[inputs.logfile]]
+    destination = "cloudwatchlogs"
+    file_state_folder = "/opt/aws/amazon-cloudwatch-agent/logs/state"
+
+    [[inputs.logfile.file_config]]
+      file_path = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+      from_beginning = true
+      log_group_name = "amazon-cloudwatch-agent.log"
+      log_stream_name = "amazon-cloudwatch-agent.log"
+      multi_line_start_pattern = "{timestamp_regex}"
+      pipe = false
+      retention_in_days = -1
+      timestamp_layout = "02 Jan 2006 15:04:05"
+      timestamp_regex = "(\\d{2} \\w{3} \\d{4} \\d{2}:\\d{2}:\\d{2})"
+      timezone = "UTC"
+
+    [[inputs.logfile.file_config]]
+      file_path = "/opt/aws/amazon-cloudwatch-agent/logs/test.log"
+      from_beginning = true
+      log_group_name = "test.log"
+      log_stream_name = "test.log"
+      pipe = false
+      retention_in_days = -1
+      timezone = "UTC"
+    [inputs.logfile.tags]
+      metricPath = "logs"
+
+  [[inputs.socket_listener]]
+    data_format = "emf"
+    name_override = "emf"
+    service_address = "udp://:25888"
+    [inputs.socket_listener.tags]
+      metricPath = "logs_socket_listener"
+
+  [[inputs.socket_listener]]
+    data_format = "emf"
+    name_override = "emf"
+    service_address = "tcp://:25888"
+    [inputs.socket_listener.tags]
+      metricPath = "logs_socket_listener"
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    endpoint_override = "https://fake_endpoint"
+    force_flush_interval = "5s"
+    log_stream_name = "host_name_from_env"
+    region = "us-east-1"
+    tagexclude = ["metricPath"]
+    [outputs.cloudwatchlogs.tagpass]
+      metricPath = ["logs", "logs_k8sapiserver", "logs_socket_listener"]
+
+[processors]
+
+  [[processors.k8sdecorator]]
+    cluster_name = "TestCluster"
+    host_ip = "127.0.0.1"
+    node_name = "host_name_from_env"
+    order = 1
+    prefer_full_pod_name = true
+    tag_service = true
+    [processors.k8sdecorator.tagpass]
+      metricPath = ["logs", "logs_k8sapiserver"]

--- a/translator/totomlconfig/sampleConfig/log_metric_only_on_prem.conf
+++ b/translator/totomlconfig/sampleConfig/log_metric_only_on_prem.conf
@@ -1,0 +1,67 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = "host_name_from_env"
+  interval = "60s"
+  logfile = ""
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.cadvisor]]
+    container_orchestrator = "eks"
+    interval = "30s"
+    mode = "detail"
+    [inputs.cadvisor.tags]
+      metricPath = "logs"
+
+  [[inputs.k8sapiserver]]
+    interval = "30s"
+    node_name = "host_name_from_env"
+    [inputs.k8sapiserver.tags]
+      metricPath = "logs_k8sapiserver"
+
+  [[inputs.socket_listener]]
+    data_format = "emf"
+    name_override = "emf"
+    service_address = "udp://:25888"
+    [inputs.socket_listener.tags]
+      metricPath = "logs_socket_listener"
+
+  [[inputs.socket_listener]]
+    data_format = "emf"
+    name_override = "emf"
+    service_address = "tcp://:25888"
+    [inputs.socket_listener.tags]
+      metricPath = "logs_socket_listener"
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    endpoint_override = "https://fake_endpoint"
+    force_flush_interval = "5s"
+    log_stream_name = "host_name_from_env"
+    region = "us-east-1"
+    tagexclude = ["metricPath"]
+    [outputs.cloudwatchlogs.tagpass]
+      metricPath = ["logs", "logs_k8sapiserver", "logs_socket_listener"]
+
+[processors]
+
+  [[processors.k8sdecorator]]
+    cluster_name = "TestCluster"
+    host_ip = "127.0.0.1"
+    node_name = "host_name_from_env"
+    order = 1
+    prefer_full_pod_name = true
+    tag_service = true
+    [processors.k8sdecorator.tagpass]
+      metricPath = ["logs", "logs_k8sapiserver"]

--- a/translator/totomlconfig/toTomlConfig_test.go
+++ b/translator/totomlconfig/toTomlConfig_test.go
@@ -50,6 +50,18 @@ func TestLogMetricOnly(t *testing.T) {
 	os.Unsetenv(config.HOST_IP)
 }
 
+func TestLogMetricOnPrem(t *testing.T) {
+	resetContext()
+	context.CurrentContext().SetRunInContainer(true)
+	os.Setenv(config.HOST_NAME, "host_name_from_env")
+	os.Setenv(config.HOST_IP, "127.0.0.1")
+	context.CurrentContext().SetMode(config.ModeOnPrem)
+	checkTomlTranslation(t, "./sampleConfig/log_metric_only.json", "./sampleConfig/log_metric_only_on_prem.conf", "linux")
+	checkTomlTranslation(t, "./sampleConfig/log_metric_only.json", "./sampleConfig/log_metric_only_on_prem.conf", "darwin")
+	os.Unsetenv(config.HOST_NAME)
+	os.Unsetenv(config.HOST_IP)
+}
+
 func TestLogMetricAndLog(t *testing.T) {
 	resetContext()
 	context.CurrentContext().SetRunInContainer(true)
@@ -57,6 +69,18 @@ func TestLogMetricAndLog(t *testing.T) {
 	os.Setenv(config.HOST_IP, "127.0.0.1")
 	checkTomlTranslation(t, "./sampleConfig/log_metric_and_log.json", "./sampleConfig/log_metric_and_log.conf", "linux")
 	checkTomlTranslation(t, "./sampleConfig/log_metric_and_log.json", "./sampleConfig/log_metric_and_log.conf", "darwin")
+	os.Unsetenv(config.HOST_NAME)
+	os.Unsetenv(config.HOST_IP)
+}
+
+func TestLogMetricAndLogOnPrem(t *testing.T) {
+	resetContext()
+	context.CurrentContext().SetRunInContainer(true)
+	os.Setenv(config.HOST_NAME, "host_name_from_env")
+	os.Setenv(config.HOST_IP, "127.0.0.1")
+	context.CurrentContext().SetMode(config.ModeOnPrem)
+	checkTomlTranslation(t, "./sampleConfig/log_metric_and_log.json", "./sampleConfig/log_metric_and_log_on_prem.conf", "linux")
+	checkTomlTranslation(t, "./sampleConfig/log_metric_and_log.json", "./sampleConfig/log_metric_and_log_on_prem.conf", "darwin")
 	os.Unsetenv(config.HOST_NAME)
 	os.Unsetenv(config.HOST_IP)
 }
@@ -195,6 +219,7 @@ func checkTomlTranslation(t *testing.T, jsonPath string, desiredTomlPath string,
 	err := json.Unmarshal([]byte(ReadFromFile(jsonPath)), &input)
 	assert.NoError(t, err)
 	actualOutput := ToTomlConfig(input)
+	log.Printf("output is %v", actualOutput)
 	checkIfIdenticalToml(t, desiredTomlPath, actualOutput)
 }
 

--- a/translator/translate/logs/metrics_collected/kubernetes/kubernetes.go
+++ b/translator/translate/logs/metrics_collected/kubernetes/kubernetes.go
@@ -5,6 +5,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
@@ -52,8 +53,13 @@ func (k *Kubernetes) ApplyRule(input interface{}) (returnKey string, returnVal i
 			key, val := rule.ApplyRule(im[SectionKey])
 			if key == "cadvisor" || key == "k8sapiserver" {
 				inputs[key] = []interface{}{val}
-			} else if key == "ec2tagger" || key == "k8sdecorator" {
+			} else if key == "k8sdecorator" {
 				processors[key] = []interface{}{val}
+			} else if key == "ec2tagger" {
+				// Only enable ec2tagger if in ec2 mode
+				if context.CurrentContext().Mode() == config.ModeEC2 {
+					processors[key] = []interface{}{val}
+				}
 			} else if key != "" {
 				translator.AddErrorMessages(GetCurPath(), fmt.Sprintf("Find unexpected key %s", key))
 				return


### PR DESCRIPTION
# Description of the issue
EC2Tagger is enabled for kubernetes while onPrem which causes agent to fail translation and not start up

# Description of changes
Disable ec2tagger for kubernetes while onPremise flag is present

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests confirming ec2tagger is disabled when onprem is enabled

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




