### PR TITLE
Support both for onPremise and onPrem within interal binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,7 @@ amazon-cloudwatch-agent-config-wizard: copy-version-file
 	$(LINUX_AMD64_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
 	$(LINUX_ARM64_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
 	$(WIN_BUILD)/amazon-cloudwatch-agent-config-wizard.exe github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
-	$(DARW
-_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
+	$(DARWIN_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
 
 config-downloader: copy-version-file
 	@echo Building config-downloader

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,8 @@ amazon-cloudwatch-agent-config-wizard: copy-version-file
 	$(LINUX_AMD64_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
 	$(LINUX_ARM64_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
 	$(WIN_BUILD)/amazon-cloudwatch-agent-config-wizard.exe github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
-	$(DARWIN_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
+	$(DARW
+_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard
 
 config-downloader: copy-version-file
 	@echo Building config-downloader

--- a/cmd/config-translator/translator.go
+++ b/cmd/config-translator/translator.go
@@ -28,7 +28,7 @@ func initFlags() {
 	var inputJsonFile = flag.String("input", "", "Please provide the path of input agent json config file")
 	var inputJsonDir = flag.String("input-dir", "", "Please provide the path of input agent json config directory.")
 	var inputTomlFile = flag.String("output", "", "Please provide the path of the output CWAgent config file")
-	var inputMode = flag.String("mode", "ec2", "Please provide the mode, i.e. ec2, onPremise, auto")
+	var inputMode = flag.String("mode", "ec2", "Please provide the mode, i.e. ec2, onPremise, onPrem, auto")
 	var inputConfig = flag.String("config", "", "Please provide the common-config file")
 	var multiConfig = flag.String("multi-config", "remove", "valid values: default, append, remove")
 	flag.Parse()

--- a/translator/config/mode.go
+++ b/translator/config/mode.go
@@ -4,6 +4,7 @@
 package config
 
 const (
-	ModeEC2    = "ec2"
-	ModeOnPrem = "onPremise"
+	ModeEC2       = "ec2"
+	ModeOnPrem    = "onPrem"
+	ModeOnPremise = "onPremise"
 )

--- a/translator/context/context.go
+++ b/translator/context/context.go
@@ -113,7 +113,7 @@ func (ctx *Context) SetMode(mode string) {
 	case config.ModeOnPrem,config.ModeOnPremise:
 		ctx.mode = config.ModeOnPrem
 	default:
-		log.Panicf("Invalid mode %s. Valid mode values are %s and %s.", mode, config.ModeEC2, config.ModeOnPrem)
+		log.Panicf("Invalid mode %s. Valid mode values are %s, %s and %s.", mode, config.ModeEC2, config.ModeOnPrem, config.ModeOnPremise)
 	}
 }
 

--- a/translator/context/context.go
+++ b/translator/context/context.go
@@ -110,10 +110,10 @@ func (ctx *Context) SetMode(mode string) {
 	switch mode {
 	case config.ModeEC2:
 		ctx.mode = config.ModeEC2
-	case config.ModeOnPrem:
+	case config.ModeOnPrem,config.ModeOnPremise:
 		ctx.mode = config.ModeOnPrem
 	default:
-		log.Panicf("Invalid mode %s. Valid mode values are %s and %s.", mode, config.ModeEC2, config.ModeOnPrem)
+		log.Panicf("Invalid mode %s. Valid mode values are %s, %s and %s.", mode, config.ModeEC2, config.ModeOnPrem, config.ModeOnPremise)
 	}
 }
 

--- a/translator/context/context.go
+++ b/translator/context/context.go
@@ -113,7 +113,7 @@ func (ctx *Context) SetMode(mode string) {
 	case config.ModeOnPrem,config.ModeOnPremise:
 		ctx.mode = config.ModeOnPrem
 	default:
-		log.Panicf("Invalid mode %s. Valid mode values are %s, %s and %s.", mode, config.ModeEC2, config.ModeOnPrem, config.ModeOnPremise)
+		log.Panicf("Invalid mode %s. Valid mode values are %s and %s.", mode, config.ModeEC2, config.ModeOnPrem)
 	}
 }
 


### PR DESCRIPTION
Close #474

# Description of the issue
Support both onPrem and onPremise for config translator due to breaking changes


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
For testing, building binaries from external repo and implement the changes:
* On Mac (with CTL) - CTL only supports on Premise

```
sudo ./amazon-cloudwatch-agent-ctl -a fetch-config -m onPremise -s -c file:./config.json

Got Home directory: /var/root
I! Set home dir Linux: /var/root
I! SDKRegionWithCredsMap region:  us-west-2
Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp
2022/08/02 14:15:18 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp ...
2022/08/02 14:15:18 I! Valid Json input schema.
```
* On Mac (with Translator) - OnPrem
```
khanhntd@88665a0eaf54 amazon-cloudwatch-agent-pre-pkg % ./config-translator --input ./config.json --mode onPrem   
2022/08/02 14:05:54 Reading json config file path: ./config.json ...
Cannot access : lstat : no such file or directory 
2022/08/02 14:05:54 unable to scan config dir  with error: lstat : no such file or directory
2022/08/02 14:05:54 I! Valid Json input schema.
```

* On Mac (with Translator) - OnPremise
```
khanhntd@88665a0eaf54 amazon-cloudwatch-agent-pre-pkg % ./config-translator --input ./config.json --mode onPremise
2022/08/02 14:06:03 Reading json config file path: ./config.json ...
Cannot access : lstat : no such file or directory 
2022/08/02 14:06:03 unable to scan config dir  with error: lstat : no such file or directory
2022/08/02 14:06:03 I! Valid Json input schema.
```

* On Mac (with Translator) - Unexpected mode

```
khanhntd@88665a0eaf54 amazon-cloudwatch-agent-pre-pkg % ./config-translator --input ./config.json --mode onPremi
2022/08/02 14:05:58 Invalid mode onPremi. Valid mode values are ec2, onPrem and onPremise.
panic: Invalid mode onPremi. Valid mode values are ec2, onPrem and onPremise.

goroutine 1 [running]:
log.Panicf({0x162887b?, 0x7?}, {0xc00019fd50?, 0xc0003443c0?, 0x0?})

```

* On Linux (similar test case to Mac)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




