### PR TITLE
Performance Tracking convert memory byte to megabyte

### DIFF
--- a/integration/test/performancetest/performance_query_utils.go
+++ b/integration/test/performancetest/performance_query_utils.go
@@ -198,6 +198,12 @@ func GetPerformanceMetrics(instanceId string, agentRuntime, logNum, tps int, age
 
 	//add actual test data with statistics
 	for _, result := range metrics.MetricDataResults {
+		//convert memory bytes to MB
+		if (*result.Label == "procstat_memory_rss") {
+			for i, val := range(result.Values) {
+				result.Values[i] = val / (1000000)
+			}
+		}
 		stats:= CalcStats(result.Values)
 		testMetricResults[*result.Label] = stats
 	}


### PR DESCRIPTION
# Description of the issue
The data returned for memory used is returned in bytes, which can be difficult to interpret easily.

# Description of changes
Converts the memory values returned from GetMetricData from bytes to megabytes.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran as integration test.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




