### PR TITLE
Update cwa ctl agent stop to use systemctl instead of service cmd

### DIFF
--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -158,7 +158,7 @@ agent_stop() {
      fi
 
      if [ "${SYSTEMD}" = 'true' ]; then
-          service "${agent_name}" stop || return
+          systemctl stop "${agent_name}.service" || return
      else
           stop "${agent_name}" || return
      fi


### PR DESCRIPTION
# Description of the issue
Currently, CWA ctl stop cmd uses `service` cmd instead of `systemctl`. For older linux kernels that come bundled with an older version of `service` cmd, it looks for the `.service` file in a diff location and is unable to properly redirect to `systemctl`.

# Description of changes
To avoid relying on `service` cmd properly redirecting to `systemctl`, this change updates to directly use `systemctl`. This brings the stop action in sync with other actions such as disable and runStatus.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested `install CWA -> start CWA -> uninstall CWA` on the following EC2s with and without change:
* Amazon Linux 2 Kernel 5.10 AMI 2.0.20220719.0 x86_64 HVM gp2
* Amazon Linux 2 Kernel 4.14 AMI 2.0.20220719.0 x86_64 HVM gp2
* Red Hat Enterprise Linux 8

Output of uninstall before change:
```
$ sudo rpm -e --nodeps amazon-cloudwatch-agent
cwagent-otel-collector has already been stopped
Redirecting to /bin/systemctl stop amazon-cloudwatch-agent.service
Removed symlink /etc/systemd/system/multi-user.target.wants/amazon-cloudwatch-agent.service.
```
Output of uninstall after change:
```
$ sudo rpm -e --nodeps amazon-cloudwatch-agent
cwagent-otel-collector has already been stopped
Removed symlink /etc/systemd/system/multi-user.target.wants/amazon-cloudwatch-agent.service.
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




