### PR TITLE
Release's Name Update

### DIFF
--- a/.github/workflows/releaseTest.yml
+++ b/.github/workflows/releaseTest.yml
@@ -42,7 +42,8 @@ jobs:
           aws-access-key-id: ${{ secrets.TERRAFORM_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TERRAFORM_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-
+      - name: Get Release Tag
+        run: echo ${{ github.event.release.tag_name }}
       - name: Update isRelease for this release
         run: |
             cd integration/test/performancetest

--- a/.github/workflows/releaseTest.yml
+++ b/.github/workflows/releaseTest.yml
@@ -49,5 +49,6 @@ jobs:
             cd integration/test/performancetest
             export IS_RELEASE=true
             export SHA=$GITHUB_SHA
+            export RELEASE_NAME=${{ github.event.release.tag_name }}
             go test -run TestUpdateCommit -p 1 -v --tags=integration
             

--- a/integration/test/performancetest/performance_query_utils.go
+++ b/integration/test/performancetest/performance_query_utils.go
@@ -30,6 +30,7 @@ const (
 	HASH = "Hash"
 	COMMIT_DATE= "CommitDate"
 	SHA_ENV  = "SHA"
+	RELEASE_NAME_ENV = "RELEASE_NAME"
 	SHA_DATE_ENV = "SHA_DATE"
 	IS_RELEASE = "isRelease"
 	TEST_ID ="TestID"

--- a/integration/test/performancetest/performance_test.go
+++ b/integration/test/performancetest/performance_test.go
@@ -259,11 +259,12 @@ func TestUpdateCommit(t*testing.T){
 	}
 	t.Log("Updating Release Commit",os.Getenv(SHA_ENV))
 	dynamoDB := InitializeTransmitterAPI("CWAPerformanceMetrics") //add cwa version here
-	testHash := os.Getenv(SHA_ENV)
+	releaseHash := os.Getenv(SHA_ENV)
+	releaseName := os.Getenv(RELEASE_NAME_ENV)
 	if dynamoDB == nil{
 		t.Fatalf("Error: generating dynamo table")
 	return
 	}
 
-	dynamoDB.UpdateReleaseTag(testHash)
+	dynamoDB.UpdateReleaseTag(releaseHash,releaseName)
 }

--- a/integration/test/performancetest/performance_test.go
+++ b/integration/test/performancetest/performance_test.go
@@ -266,5 +266,8 @@ func TestUpdateCommit(t*testing.T){
 	return
 	}
 
-	dynamoDB.UpdateReleaseTag(releaseHash,releaseName)
+	err := dynamoDB.UpdateReleaseTag(releaseHash,releaseName)
+	if err!=nil{
+		t.Fatalf("Error: %s",err)
+	}
 }

--- a/integration/test/performancetest/transmitter.go
+++ b/integration/test/performancetest/transmitter.go
@@ -291,7 +291,6 @@ func (transmitter *TransmitterAPI) UpdateItem(hash string, packet map[string]int
 	var ae *types.ConditionalCheckFailedException // this exception represent the atomic check has failed
 	rand.Seed(time.Now().UnixNano())
 	randomSleepDuration := time.Duration(rand.Intn(UPDATE_DELAY_THRESHOLD)) * time.Second
-	// hash := packet[HASH].(string)
 	for attemptCount := 0; attemptCount < MAX_ATTEMPTS; attemptCount++ {
 		fmt.Println("Updating:", hash)
 		item, err := transmitter.Query(hash) // get most Up to date item from dynamo | O(1) bcs of global sec. idx.

--- a/integration/test/performancetest/transmitter.go
+++ b/integration/test/performancetest/transmitter.go
@@ -266,7 +266,7 @@ func (transmitter *TransmitterAPI) PacketMerger(newPacket map[string]interface{}
 		newAttributes[RESULTS] = mergedResults
 	}
 	if newPacket[IS_RELEASE] != nil {
-		newAttributes[IS_RELEASE] = true
+		newAttributes[IS_RELEASE] = newPacket[IS_RELEASE]
 	}
 	if newPacket[HASH] !=currentPacket[HASH]{
 		newAttributes[HASH] = newPacket[HASH]

--- a/integration/test/performancetest/transmitter.go
+++ b/integration/test/performancetest/transmitter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/uuid"
 )
 
 const (
@@ -223,7 +224,7 @@ func (transmitter *TransmitterAPI) SendItem(packet map[string]interface{}, tps i
 		fmt.Println("Item already exist going to update", len(currentItem))
 	}
 	// item already exist so update the item instead
-	err = transmitter.UpdateItem(packet[HASH].(string),packet, tps) //try to update the item
+	err = transmitter.UpdateItem(packet[HASH].(string), packet, tps) //try to update the item
 	//this may be overwritten by other test threads, in that case it will return a specific error
 	if err != nil {
 		return "", err
@@ -268,7 +269,7 @@ func (transmitter *TransmitterAPI) PacketMerger(newPacket map[string]interface{}
 	if newPacket[IS_RELEASE] != nil {
 		newAttributes[IS_RELEASE] = newPacket[IS_RELEASE]
 	}
-	if newPacket[HASH] !=currentPacket[HASH]{
+	if newPacket[HASH] != currentPacket[HASH] {
 		newAttributes[HASH] = newPacket[HASH]
 	}
 	// newAttributes, _ := attributevalue.MarshalMap(mergedResults)
@@ -286,7 +287,7 @@ Params:
 	targetAttributes: this is the targetAttribute to be added to the dynamo item
 	testHash: this is the hash of the last item, used like a version check
 */
-func (transmitter *TransmitterAPI) UpdateItem(hash string,packet map[string]interface{}, tps int) error {
+func (transmitter *TransmitterAPI) UpdateItem(hash string, packet map[string]interface{}, tps int) error {
 	var ae *types.ConditionalCheckFailedException // this exception represent the atomic check has failed
 	rand.Seed(time.Now().UnixNano())
 	randomSleepDuration := time.Duration(rand.Intn(UPDATE_DELAY_THRESHOLD)) * time.Second
@@ -310,19 +311,23 @@ func (transmitter *TransmitterAPI) UpdateItem(hash string,packet map[string]inte
 		}
 		//setup the update expression
 		expressionAttributeValues := make(map[string]types.AttributeValue)
+		expressionAttributeNames := make(map[string]string)
 		expression := "set "
 		n_expression := len(targetAttributes)
 		i := 0
 		for attribute, value := range targetAttributes {
-			expressionName := ":" + strings.ToLower(attribute)
-			expression += fmt.Sprintf("%s = %s", attribute, expressionName)
-			expressionAttributeValues[expressionName] = value
+			expressionKey := ":" + strings.ToLower(attribute)
+			expressionName := "#" + strings.ToLower(attribute)
+			expression += fmt.Sprintf("%s = %s", expressionName, expressionKey)
+			expressionAttributeValues[expressionKey] = value
+			expressionAttributeNames[expressionName] = attribute
 			if n_expression-1 > i {
 				expression += ", "
 			}
 			i++
 		}
 		expressionAttributeValues[":testID"] = &types.AttributeValueMemberS{Value: testHash}
+		expressionAttributeNames["#testID"] = TEST_ID
 		//call update
 		_, err = transmitter.dynamoDbClient.UpdateItem(context.TODO(), &dynamodb.UpdateItemInput{
 			TableName: aws.String(transmitter.DataBaseName),
@@ -333,9 +338,7 @@ func (transmitter *TransmitterAPI) UpdateItem(hash string,packet map[string]inte
 			UpdateExpression:          aws.String(expression),
 			ExpressionAttributeValues: expressionAttributeValues,
 			ConditionExpression:       aws.String("#testID = :testID"),
-			ExpressionAttributeNames: map[string]string{
-				"#testID": TEST_ID,
-			},
+			ExpressionAttributeNames:  expressionAttributeNames,
 		})
 		if errors.As(err, &ae) { //check if our call got overwritten
 			// item has changed
@@ -358,12 +361,13 @@ UpdateReleaseTag()
 Desc: This function takes in a commit hash and updates the release value to true
 Param: commit hash in terms of string
 */
-func (transmitter *TransmitterAPI) UpdateReleaseTag(hash string,tagName string) error {
+func (transmitter *TransmitterAPI) UpdateReleaseTag(hash string, tagName string) error {
 	var err error
 	packet := make(map[string]interface{})
 	packet[HASH] = tagName
 	packet[IS_RELEASE] = true
-	err = transmitter.UpdateItem(hash,packet, 0) //try to update the item
+	packet[TEST_ID] = uuid.New().String()
+	err = transmitter.UpdateItem(hash, packet, 0) //try to update the item
 	//this may be overwritten by other test threads, in that case it will return a specific error
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description of the issue
The release test updates the isRelease attribute but not the hash. We cant to make it so that it also updates the Hash attribute to release's tag's name. This makes it easier to distinguish in frontend and backend.

# Description of changes
* releaseTest.yml now feeds in the release tag's name as a env. variable
* UpdateReleaseTag now takes in a release name as a parameter and sets it as Hash in a packet.
* UpdateItem now requires a hash as a separate parameter
* UpdateItem now generates expressionAttributeNames similar to expressionAttributeValues
* PacketMerger now also merges hashes with the updated version similar to isRelease
* Bug Fix: all commits were saved like releases due to a bug in if condition inside PacketMerger, now fixed.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* I ran integration test, then created a release which caused releaseTest.yml to run.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




