### PR TITLE
Fix duplicate retention case

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -52,18 +52,18 @@ type LogDest interface {
 
 // LogAgent is the agent handles pure log pipelines
 type LogAgent struct {
-	Config      *config.Config
-	backends    map[string]LogBackend
-	destNames   map[LogDest]string
-	collections []LogCollection
+	Config              *config.Config
+	backends            map[string]LogBackend
+	destNames           map[LogDest]string
+	collections         []LogCollection
 	retentionAlreadySet map[string]bool
 }
 
 func NewLogAgent(c *config.Config) *LogAgent {
 	return &LogAgent{
-		Config:    c,
-		backends:  make(map[string]LogBackend),
-		destNames: make(map[LogDest]string),
+		Config:              c,
+		backends:            make(map[string]LogBackend),
+		destNames:           make(map[LogDest]string),
 		retentionAlreadySet: make(map[string]bool),
 	}
 }
@@ -109,7 +109,7 @@ func (l *LogAgent) Run(ctx context.Context) {
 						continue
 					}
 					retention := src.Retention()
-					if retention > 0 && l.retentionAlreadySet[src.Group()] == true {
+					if retention > 0 && l.retentionAlreadySet[src.Group()] {
 						log.Printf("D! [logagent] Retention already set for log group %v/%v retention:%v) ", src.Group(), src.Stream(), src.Retention())
 						retention = -1
 					} else if retention > 0 {

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -1,0 +1,18 @@
+package logs
+
+import (
+	"github.com/influxdata/telegraf/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRetentionAlreadySet(t *testing.T) {
+	c := config.NewConfig()
+	l := NewLogAgent(c)
+	assert.False(t, l.retentionAlreadyAttempted["logGroup1"])
+	firstAttempt := l.checkRetentionAlreadyAttempted(3, "logGroup1")
+	assert.Equal(t, 3, firstAttempt)
+	secondAttempt := l.checkRetentionAlreadyAttempted(3, "logGroup1")
+	assert.Equal(t, -1, secondAttempt)
+	assert.True(t, l.retentionAlreadyAttempted["logGroup1"])
+}

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -383,7 +383,7 @@ func (p *pusher) putRetentionPolicy() {
 				p.Log.Errorf("Unable to put retention policy for log group %v: %v ", p.Group, err)
 			}
 		} else {
-			p.Log.Debugf("successfully updated log retention policy for log group %v", p.Group)
+			p.Log.Debugf("successfully updated log retention policy for log group %v with log stream %v", p.Group, p.Stream)
 		}
 	}
 }

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -383,7 +383,7 @@ func (p *pusher) putRetentionPolicy() {
 				p.Log.Errorf("Unable to put retention policy for log group %v: %v ", p.Group, err)
 			}
 		} else {
-			p.Log.Debugf("successfully updated log retention policy for log group %v with log stream %v", p.Group, p.Stream)
+			p.Log.Debugf("successfully updated log retention policy for log group %v", p.Group)
 		}
 	}
 }

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
@@ -735,7 +735,7 @@ func TestConflictingRetention(t *testing.T) {
 		"file_path":         "path1",
 		"log_group_name":    "test1",
 		"pipe":              false,
-		"retention_in_days": -1,
+		"retention_in_days": 5,
 		"from_beginning":    true,
 	}}
 	assert.Equal(t, "Under path : /logs/logs_collected/files/collect_list/ | Error : Different retention_in_days values can't be set for the same log group: test1", translator.ErrorMessages[len(translator.ErrorMessages)-1])

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
@@ -697,7 +697,7 @@ func TestDuplicateRetention(t *testing.T) {
 		"file_path":         "path1",
 		"log_group_name":    "test1",
 		"pipe":              false,
-		"retention_in_days": -1,
+		"retention_in_days": 3,
 		"from_beginning":    true,
 	}}
 	assert.Equal(t, expectVal, val)

--- a/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
+++ b/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
@@ -125,7 +125,7 @@ func TestDuplicateRetention(t *testing.T) {
 			"event_format":      "xml",
 			"log_group_name":    "System",
 			"batch_read_size":   BatchReadSizeValue,
-			"retention_in_days": -1,
+			"retention_in_days": 3,
 		},
 		map[string]interface{}{
 			"event_name":        "Application",
@@ -133,7 +133,7 @@ func TestDuplicateRetention(t *testing.T) {
 			"event_format":      "xml",
 			"log_group_name":    "System",
 			"batch_read_size":   BatchReadSizeValue,
-			"retention_in_days": -1,
+			"retention_in_days": 3,
 		},
 	}
 

--- a/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
+++ b/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
@@ -193,7 +193,7 @@ func TestConflictingRetention(t *testing.T) {
 			"event_format":      "xml",
 			"log_group_name":    "System",
 			"batch_read_size":   BatchReadSizeValue,
-			"retention_in_days": -1,
+			"retention_in_days": 1,
 		},
 	}
 

--- a/translator/translate/logs/util/validate_retention.go
+++ b/translator/translate/logs/util/validate_retention.go
@@ -32,8 +32,6 @@ func ValidateLogRetentionSettings(logConfigs []interface{}, currPath string) []i
 								currPath,
 								fmt.Sprintf("Different retention_in_days values can't be set for the same log group: %v", logGroup))
 						}
-						// Retention for a log group has been configured in multiple places. Unset it so that the retention api is only called once
-						logConfigMap[logRetentionKey] = -1
 					} else {
 						configMap[logGroup] = retention
 					}


### PR DESCRIPTION
# Description of the issue
[todo] https://github.com/aws/amazon-cloudwatch-agent/issues/554

# Description of changes
When the same retention is set multiple times for a log group, retention will be set as long as any file_path is created for that log group.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests + manual tests linked below

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`
3. 

<img width="864" alt="image" src="https://user-images.githubusercontent.com/22218928/184660569-9b1f9e12-4599-4f90-afcc-38547beca361.png">


<img width="1385" alt="Screen Shot 2022-08-15 at 10 22 41 AM" src="https://user-images.githubusercontent.com/22218928/184660338-d5d6c9e5-efdb-46a0-aa54-65e204bab90f.png">




