### PR TITLE
update statefile cleanup error log

### DIFF
--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -76,6 +76,7 @@ type tailerSrc struct {
 	startTailerOnce sync.Once
 	cleanUpFns      []func()
 }
+
 // Verify tailerSrc implements LogSrc
 var _ logs.LogSrc = (*tailerSrc)(nil)
 
@@ -313,7 +314,7 @@ func (ts *tailerSrc) runSaveState() {
 			log.Printf("W! [logfile] deleting state file %s", ts.stateFilePath)
 			err := os.Remove(ts.stateFilePath)
 			if err != nil {
-				log.Printf("E! [logfile] Error happened while deleting state file %s on cleanup", ts.stateFilePath)
+				log.Printf("W! [logfile] Error happened while deleting state file %s on cleanup: %v", ts.stateFilePath, err)
 			}
 			return
 		case <-ts.done:


### PR DESCRIPTION
# Description of changes
An error from removing this file is benign, so it doesn't make sense to make it at error level, but should still distinguish it from regular logs since it is not expected to have a failure. Forgot to add the error in the log that gets emitted, so added that too.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.





