### PR TITLE
Fix Source Label Proxy For haproxy_backend_http_responses_total

### DIFF
--- a/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/amazon-cloudwatch-container-insights/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -47,7 +47,7 @@ data:
                   ]
                 },
                 {
-                  "source_labels": ["Service"],
+                  "source_labels": ["Service", "backend"],
                   "label_matcher": ".*haproxy-ingress-.*metrics",
                   "dimensions": [["Service","Namespace","ClusterName","backend","code"]],
                   "metric_selectors": [


### PR DESCRIPTION
# Description of the issue
Can't get metric haproxy_backend_http_responses_total

# Description of changes
Missing proxy information. Added proxy. 

# Tests
Created eks cluster in my personal aws account. Use the latest haproxy helm chart. Prometheus scrape worked. 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




