### PR TITLE
Create Docker Container With Local Deb To Reduce Docker Container Bui…

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -27,58 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  MakeDockerImage:
-    name: 'MakeDockerImage'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Cache if success
-        id: build-docker-image
-        uses: actions/cache@v2
-        with:
-          path: |
-            RELEASE_NOTES
-          key: build-docker-image-${{ github.run_id }}
-
-      - name: Configure AWS Credentials
-        if: steps.build-docker-image.outputs.cache-hit != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Login ECR
-        if: steps.build-docker-image.outputs.cache-hit != 'true'
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Set up Docker Buildx
-        if: steps.build-docker-image.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v1
-
-      - name: Set up QEMU
-        if: steps.build-docker-image.outputs.cache-hit != 'true'
-        uses: docker/setup-qemu-action@v1
-
-        #Build the cloudwatch agent image for two primary reasons:
-        #-Using the cloudwatch agent image to do the integration test (can be used for internal)
-        #-Export it for the future use in CD release pipeline
-        #Documentation: https://github.com/docker/build-push-action
-      - name: Build Cloudwatch Agent Image
-        uses: docker/build-push-action@v2
-        if: steps.build-docker-image.outputs.cache-hit != 'true'
-        with:
-          file: amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
-          context: .
-          push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}:${{ github.sha }}
-          platforms: linux/amd64, linux/arm64
-
   MakeBinary:
     name: 'MakeBinary'
     runs-on: ubuntu-latest
@@ -138,6 +86,40 @@ jobs:
       - name: Upload to s3
         if: steps.cached_binaries.outputs.cache-hit != 'true'
         run: aws s3 cp build/bin s3://${S3_INTEGRATION_BUCKET}/integration-test/binary/${{ github.sha }} --recursive
+
+      - name: Login ECR
+        if: steps.cached_binaries.outputs.cache-hit != 'true'
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set up Docker Buildx
+        if: steps.cached_binaries.outputs.cache-hit != 'true'
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set up QEMU
+        if: steps.cached_binaries.outputs.cache-hit != 'true'
+        uses: docker/setup-qemu-action@v1
+
+      # build dir is ignored in our .dockerignore thus need to copy to another dir
+      - name: Copy Binary For Agent Image Build
+        if: steps.cached_binaries.outputs.cache-hit != 'true'
+        run: cp -r build/bin/linux/* .
+
+        #Build the cloudwatch agent image for two primary reasons:
+        #-Using the cloudwatch agent image to do the integration test (can be used for internal)
+        #-Export it for the future use in CD release pipeline
+        #Documentation: https://github.com/docker/build-push-action
+      - name: Build Cloudwatch Agent Image
+        uses: docker/build-push-action@v2
+        if: steps.cached_binaries.outputs.cache-hit != 'true'
+        with:
+          file: amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localdeb/Dockerfile
+          context: .
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}:${{ github.sha }}
+          platforms: linux/amd64, linux/arm64
+
   GenerateTestMatrix:
     name: 'GenerateTestMatrix'
     runs-on: ubuntu-latest
@@ -576,7 +558,7 @@ jobs:
   ECSFargateIntegrationTest:
     name: 'ECSFargateIntegrationTest'
     runs-on: ubuntu-latest
-    needs: [MakeDockerImage, GenerateTestMatrix]
+    needs: [MakeBinary, GenerateTestMatrix]
     strategy:
       fail-fast: false
       matrix:

--- a/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localdeb/Dockerfile
+++ b/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localdeb/Dockerfile
@@ -1,11 +1,13 @@
 ARG BUILD_IMAGE=ubuntu:latest
 FROM $BUILD_IMAGE as build
 
+ARG TARGETARCH
+
 RUN apt-get update &&  \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-COPY amazon-cloudwatch-agent.deb /tmp/amazon-cloudwatch-agent.deb
+COPY ${TARGETARCH}/amazon-cloudwatch-agent.deb /tmp/amazon-cloudwatch-agent.deb
 
 RUN dpkg -i -E /tmp/amazon-cloudwatch-agent.deb && \
     rm -rf /tmp/* && \


### PR DESCRIPTION
…ld Time In Integration Tests

# Description of the issue
Takes over 1 hr to build docker images. 

# Description of changes
Copy deb instead instead of building image. 

# Tests
My fork
https://github.com/sethAmazon/amazon-cloudwatch-agent/actions/runs/2951993112 build failed due to me not having this repo in my account. So only the upload failed. 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




