### PR TITLE
Fix Ethtool Name In Input Config

### DIFF
--- a/translator/totomlconfig/tomlConfigTemplate/tomlConfig.go
+++ b/translator/totomlconfig/tomlConfigTemplate/tomlConfig.go
@@ -33,7 +33,7 @@ type (
 		Cpu               []cpuConfig
 		Disk              []diskConfig
 		DiskIo            []diskioConfig
-		Eththool          []ethtoolConfig
+		Ethtool           []ethtoolConfig
 		K8sapiserver      []k8sApiServerConfig
 		Logfile           []logFileConfig
 		Mem               []memConfig


### PR DESCRIPTION
# Description of the issue
Test translator/totomlconfig/toTomlConfig_test.go not translating input config Ethtool struct name correctly

# Description of changes
Change struct input Config Ethtool to proper name

# Tests
Ran test in intelij 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




