### PR TITLE
Increase agentRuntime in TestBundle

### DIFF
--- a/integration/test/ca_bundle/ca_bundle_test.go
+++ b/integration/test/ca_bundle/ca_bundle_test.go
@@ -22,8 +22,8 @@ const configJSON = "/config.json"
 const commonConfigTOML = "/common-config.toml"
 const targetString = "x509: certificate signed by unknown authority"
 
-//Let the agent run for 1 minutes. This will give agent enough time to call server
-const agentRuntime = 1 * time.Minute
+//Let the agent run for 2 minutes. This will give agent enough time to call server
+const agentRuntime = 2 * time.Minute
 
 type input struct {
 	findTarget bool


### PR DESCRIPTION
# Description of the issue
`TestBundle` failing after removal of ADOT
![Screen Shot 2022-10-04 at 7 32 04 AM](https://user-images.githubusercontent.com/45324375/193813657-88e5c84a-74fd-4e83-9d5d-08ca26debd3e.png)

# Description of changes
Increase `agentRuntime` in TestBundle from 1 minute to 2.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[Run GitHub Actions on personal fork
](https://github.com/ymtaye/amazon-cloudwatch-agent/actions/runs/3181891326)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




