### PR TITLE
Add iam role policy in readme for test cleanup

### DIFF
--- a/integration/terraform/ec2/README.md
+++ b/integration/terraform/ec2/README.md
@@ -230,7 +230,9 @@ Outputs:
         "iam:RemoveRoleFromInstanceProfile",
         "ec2:DeleteKeyPair",
         "iam:ListPolicyVersions",
-        "iam:DeleteInstanceProfile"
+        "iam:DeleteInstanceProfile",
+        "iam:DeletePolicy",
+        "iam:ListInstanceProfilesForRole"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
# Description of the issue
All e2e tests eventually think they failed because resource cleanup failed, with the initial readme I added. 

# Description of changes
Added a couple more policies in order to succeed cleanup after tests.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Verified that cleanups were successful for the test jobs in my personal fork.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




