### PR TITLE
Test CPU metric values greater than zero

### DIFF
--- a/integration/generator/test_case_generator.go
+++ b/integration/generator/test_case_generator.go
@@ -27,8 +27,9 @@ var osToTestDirMap = map[string][]string{
 		"./integration/test/ca_bundle",
 		"./integration/test/cloudwatchlogs",
 		"./integration/test/metrics_number_dimension",
+		"./integration/test/metric_value_benchmark",
 	},
-	"ec2_performance":{
+	"ec2_performance": {
 		"./integration/test/performancetest",
 	},
 	// @TODO add real tests
@@ -48,14 +49,14 @@ func main() {
 
 func genMatrix(targetOS string, testDirList []string) []map[string]string {
 	openTestMatrix, err := os.Open(fmt.Sprintf("integration/generator/resources/%v_test_matrix.json", targetOS))
-	
+
 	if err != nil {
 		log.Panicf("can't read file %v_test_matrix.json err %v", targetOS, err)
 	}
-	
+
 	byteValueTestMatrix, _ := ioutil.ReadAll(openTestMatrix)
 	_ = openTestMatrix.Close()
-	
+
 	var testMatrix []map[string]string
 	err = json.Unmarshal(byteValueTestMatrix, &testMatrix)
 	if err != nil {

--- a/integration/test/metric/cpu.go
+++ b/integration/test/metric/cpu.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build linux && integration
+// +build linux,integration
+
+package metric
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"log"
+)
+
+type CPUMetricValueFetcher struct {
+	base *baseMetricValueFetcher
+}
+
+func (f *CPUMetricValueFetcher) Fetch(namespace string, metricName string, stat Statistics) ([]float64, error) {
+	dimensions := f.getMetricSpecificDimensions()
+	values, err := f.fetch(namespace, dimensions, metricName, stat)
+	if err != nil {
+		log.Printf("Error while fetching metric value for %v: %v", metricName, err.Error())
+	}
+	return values, err
+}
+
+func (f *CPUMetricValueFetcher) fetch(namespace string, metricSpecificDimensions []types.Dimension, metricName string, stat Statistics) ([]float64, error) {
+	return f.base.fetch(namespace, metricSpecificDimensions, metricName, stat)
+}
+
+var cpuSupportedMetricValues = map[string]struct{}{
+	"cpu_time_active":      {},
+	"cpu_time_guest":       {},
+	"cpu_time_guest_nice":  {},
+	"cpu_time_idle":        {},
+	"cpu_time_iowait":      {},
+	"cpu_time_irq":         {},
+	"cpu_time_nice":        {},
+	"cpu_time_softirq":     {},
+	"cpu_time_steal":       {},
+	"cpu_time_system":      {},
+	"cpu_time_user":        {},
+	"cpu_usage_active":     {},
+	"cpu_usage_quest":      {},
+	"cpu_usage_quest_nice": {},
+	"cpu_usage_idle":       {},
+	"cpu_usage_iowait":     {},
+	"cpu_usage_irq":        {},
+	"cpu_usage_nice":       {},
+	"cpu_usage_softirq":    {},
+	"cpu_usage_steal":      {},
+	"cpu_usage_system":     {},
+	"cpu_usage_user":       {},
+}
+
+func (f *CPUMetricValueFetcher) isApplicable(metricName string) bool {
+	_, exists := cpuSupportedMetricValues[metricName]
+	return exists
+}
+
+func (f *CPUMetricValueFetcher) getMetricSpecificDimensions() []types.Dimension {
+	cpuDimension := types.Dimension{
+		Name:  aws.String("cpu"),
+		Value: aws.String("cpu-total"),
+	}
+	dimensions := make([]types.Dimension, 1)
+	dimensions[0] = cpuDimension
+
+	return dimensions
+}

--- a/integration/test/metric/cpu.go
+++ b/integration/test/metric/cpu.go
@@ -56,13 +56,13 @@ func (f *CPUMetricValueFetcher) isApplicable(metricName string) bool {
 	return exists
 }
 
-func (f *CPUMetricValueFetcher) getMetricSpecificDimensions() []types.Dimension {
-	cpuDimension := types.Dimension{
+var cpuMetricsSpecificDimension = []types.Dimension{
+	{
 		Name:  aws.String("cpu"),
 		Value: aws.String("cpu-total"),
-	}
-	dimensions := make([]types.Dimension, 1)
-	dimensions[0] = cpuDimension
+	},
+}
 
-	return dimensions
+func (f *CPUMetricValueFetcher) getMetricSpecificDimensions() []types.Dimension {
+	return cpuMetricsSpecificDimension
 }

--- a/integration/test/metric/cpu.go
+++ b/integration/test/metric/cpu.go
@@ -14,7 +14,7 @@ import (
 )
 
 type CPUMetricValueFetcher struct {
-	base *baseMetricValueFetcher
+	baseMetricValueFetcher
 }
 
 func (f *CPUMetricValueFetcher) Fetch(namespace string, metricName string, stat Statistics) ([]float64, error) {
@@ -24,10 +24,6 @@ func (f *CPUMetricValueFetcher) Fetch(namespace string, metricName string, stat 
 		log.Printf("Error while fetching metric value for %v: %v", metricName, err.Error())
 	}
 	return values, err
-}
-
-func (f *CPUMetricValueFetcher) fetch(namespace string, metricSpecificDimensions []types.Dimension, metricName string, stat Statistics) ([]float64, error) {
-	return f.base.fetch(namespace, metricSpecificDimensions, metricName, stat)
 }
 
 var cpuSupportedMetricValues = map[string]struct{}{

--- a/integration/test/metric/cpu.go
+++ b/integration/test/metric/cpu.go
@@ -7,9 +7,10 @@
 package metric
 
 import (
+	"log"
+
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"log"
 )
 
 type CPUMetricValueFetcher struct {

--- a/integration/test/metric/metric_value_query.go
+++ b/integration/test/metric/metric_value_query.go
@@ -17,7 +17,7 @@ import (
 )
 
 var metricValueFetchers = []MetricValueFetcher{
-	&CPUMetricValueFetcher{base: &baseMetricValueFetcher{}},
+	&CPUMetricValueFetcher{},
 }
 
 func GetMetricFetcher(metricName string) (MetricValueFetcher, error) {

--- a/integration/test/metric/metric_value_query.go
+++ b/integration/test/metric/metric_value_query.go
@@ -8,13 +8,12 @@ package metric
 
 import (
 	"fmt"
-	"log"
-	"time"
-
 	"github.com/aws/amazon-cloudwatch-agent/integration/test"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go/aws"
+	"log"
+	"time"
 )
 
 var metricValueFetchers = []MetricValueFetcher{
@@ -59,7 +58,7 @@ func (f *baseMetricValueFetcher) fetch(namespace string, metricSpecificDimension
 		MetricStat: &types.MetricStat{
 			Metric: &metricToFetch,
 			Period: &metricQueryPeriod,
-			Stat:   aws.String(stat.String()),
+			Stat:   aws.String(string(stat)),
 		},
 		Id: aws.String(metricName),
 	}

--- a/integration/test/metric/metric_value_query.go
+++ b/integration/test/metric/metric_value_query.go
@@ -54,16 +54,16 @@ func (f *baseMetricValueFetcher) fetch(namespace string, metricSpecificDimension
 	}
 
 	metricQueryPeriod := int32(60)
-	metricQuery := types.MetricDataQuery{
-		MetricStat: &types.MetricStat{
-			Metric: &metricToFetch,
-			Period: &metricQueryPeriod,
-			Stat:   aws.String(string(stat)),
+	metricDataQueries := []types.MetricDataQuery{
+		{
+			MetricStat: &types.MetricStat{
+				Metric: &metricToFetch,
+				Period: &metricQueryPeriod,
+				Stat:   aws.String(string(stat)),
+			},
+			Id: aws.String(metricName),
 		},
-		Id: aws.String(metricName),
 	}
-	metricDataQueries := make([]types.MetricDataQuery, 1)
-	metricDataQueries[0] = metricQuery
 
 	endTime := time.Now()
 	startTime := subtractMinutes(endTime, 10)

--- a/integration/test/metric/metric_value_query.go
+++ b/integration/test/metric/metric_value_query.go
@@ -16,42 +16,52 @@ import (
 	"time"
 )
 
-func subtractMinutes(fromTime time.Time, minutes int) time.Time {
-	tenMinutes := time.Duration(-1*minutes) * time.Minute
-	return fromTime.Add(tenMinutes)
+var metricValueFetchers = []MetricValueFetcher{
+	&CPUMetricValueFetcher{base: &baseMetricValueFetcher{}},
 }
 
-func FetchMetricValues() error {
+func GetMetricFetcher(metricName string) (MetricValueFetcher, error) {
+	for _, fetcher := range metricValueFetchers {
+		if fetcher.isApplicable(metricName) {
+			return fetcher, nil
+		}
+	}
+	err := fmt.Errorf("No metric fetcher for metricName %v", metricName)
+	log.Printf("%s", err)
+	return nil, err
+}
+
+type MetricValueFetcher interface {
+	Fetch(namespace string, metricName string, stat Statistics) ([]float64, error)
+	fetch(namespace string, metricSpecificDimensions []types.Dimension, metricName string, stat Statistics) ([]float64, error)
+	isApplicable(metricName string) bool
+	getMetricSpecificDimensions() []types.Dimension
+}
+
+type baseMetricValueFetcher struct{}
+
+func (f *baseMetricValueFetcher) fetch(namespace string, metricSpecificDimensions []types.Dimension, metricName string, stat Statistics) ([]float64, error) {
 	ec2InstanceId := test.GetInstanceId()
 	instanceIdDimension := types.Dimension{
 		Name:  aws.String("InstanceId"),
 		Value: aws.String(ec2InstanceId),
 	}
-	cpuDimension := types.Dimension{
-		Name:  aws.String("cpu"),
-		Value: aws.String("cpu-total"),
-	}
-	dimensions := make([]types.Dimension, 2)
-	dimensions[0] = instanceIdDimension
-	dimensions[1] = cpuDimension
-
+	dimensions := append(metricSpecificDimensions, instanceIdDimension)
 	metricToFetch := types.Metric{
-		Namespace:  aws.String("MetricValueBenchmarkTest"),
-		MetricName: aws.String("cpu_usage_active"),
+		Namespace:  aws.String(namespace),
+		MetricName: aws.String(metricName),
 		Dimensions: dimensions,
 	}
 
 	metricQueryPeriod := int32(60)
-
 	metricQuery := types.MetricDataQuery{
 		MetricStat: &types.MetricStat{
 			Metric: &metricToFetch,
 			Period: &metricQueryPeriod,
-			Stat:   aws.String("Average"),
+			Stat:   aws.String(stat.String()),
 		},
-		Id: aws.String("cpuUsageActive"),
+		Id: aws.String(metricName),
 	}
-
 	metricDataQueries := make([]types.MetricDataQuery, 1)
 	metricDataQueries[0] = metricQuery
 
@@ -67,74 +77,21 @@ func FetchMetricValues() error {
 
 	cwmClient, clientContext, err := test.GetCloudWatchMetricsClient()
 	if err != nil {
-		return fmt.Errorf("Error occurred while creating CloudWatch client: %v", err.Error())
+		return nil, fmt.Errorf("Error occurred while creating CloudWatch client: %v", err.Error())
 	}
 
 	output, err := cwmClient.GetMetricData(*clientContext, &getMetricDataInput)
 	if err != nil {
-		return fmt.Errorf("Error getting metric data %v", err)
+		return nil, fmt.Errorf("Error getting metric data %v", err)
 	}
 
-	log.Printf("Metric Value is : %s", fmt.Sprint(output.MetricDataResults[0].Values))
-	return nil
+	result := output.MetricDataResults[0].Values
+	log.Printf("Metric Value is : %s", fmt.Sprint(result))
+
+	return result, nil
 }
 
-// GetMetricDataInput = start time, end time,MetricDataQuery
-
-// https://github.com/aws/aws-sdk-go-v2/blob/main/service/cloudwatch/api_op_GetMetricData.go
-
-/*
-
-func BuildDimensionFilterList(appendDimension int) []types.DimensionFilter {
-	// we append dimension from 0 to max number - 2
-	// then we add dimension instance id
-	// thus for max dimension 10, 0 to 8 + instance id = 10 dimension
-	ec2InstanceId := GetInstanceId()
-	dimensionFilter := make([]types.DimensionFilter, appendDimension)
-	for i := 0; i < appendDimension-1; i++ {
-		dimensionFilter[i] = types.DimensionFilter{
-			Name:  aws.String(fmt.Sprintf("%s%d", appendMetric, i)),
-			Value: aws.String(fmt.Sprintf("%s%d", loremIpsum+appendMetric, i)),
-		}
-	}
-	dimensionFilter[appendDimension-1] = types.DimensionFilter{
-		Name:  aws.String(instanceId),
-		Value: aws.String(ec2InstanceId),
-	}
-	return dimensionFilter
+func subtractMinutes(fromTime time.Time, minutes int) time.Time {
+	tenMinutes := time.Duration(-1*minutes) * time.Minute
+	return fromTime.Add(tenMinutes)
 }
-
-// ValidateMetrics takes the metric name, metric dimension and corresponding namespace that contains the metric
-func ValidateMetrics(t *testing.T, metricName, namespace string, dimensionsFilter []types.DimensionFilter) {
-	cwmClient, clientContext, err := GetCloudWatchMetricsClient()
-	if err != nil {
-		t.Fatalf("Error occurred while creating CloudWatch Logs SDK client: %v", err.Error())
-	}
-
-	listMetricsInput := cloudwatch.ListMetricsInput{
-		MetricName:     aws.String(metricName),
-		Namespace:      aws.String(namespace),
-		RecentlyActive: "PT3H",
-		Dimensions:     dimensionsFilter,
-	}
-	data, err := cwmClient.ListMetrics(*clientContext, &listMetricsInput)
-	if err != nil {
-		t.Errorf("Error getting metric data %v", err)
-	}
-
-	// Only validate if certain metrics are published by CloudWatchAgent in corresponding namespace
-	// Since the metric value can be unpredictive.
-	if len(data.Metrics) == 0 {
-		metrics := make([]metric, len(dimensionsFilter))
-		for i, filter := range dimensionsFilter {
-			metrics[i] = metric{
-				name:  *filter.Name,
-				value: *filter.Value,
-			}
-		}
-		t.Errorf("No metrics found for dimension %v metric name %v namespace %v",
-			metrics, metricName, namespace)
-	}
-
-}
-*/

--- a/integration/test/metric/metric_value_query.go
+++ b/integration/test/metric/metric_value_query.go
@@ -8,12 +8,13 @@ package metric
 
 import (
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/aws/amazon-cloudwatch-agent/integration/test"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"log"
-	"time"
 )
 
 var metricValueFetchers = []MetricValueFetcher{

--- a/integration/test/metric/metric_value_query.go
+++ b/integration/test/metric/metric_value_query.go
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build linux && integration
+// +build linux,integration
+
+package metric
+
+import (
+	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent/integration/test"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"log"
+	"time"
+)
+
+func subtractMinutes(fromTime time.Time, minutes int) time.Time {
+	tenMinutes := time.Duration(-1*minutes) * time.Minute
+	return fromTime.Add(tenMinutes)
+}
+
+func FetchMetricValues() error {
+	ec2InstanceId := test.GetInstanceId()
+	instanceIdDimension := types.Dimension{
+		Name:  aws.String("InstanceId"),
+		Value: aws.String(ec2InstanceId),
+	}
+	cpuDimension := types.Dimension{
+		Name:  aws.String("cpu"),
+		Value: aws.String("cpu-total"),
+	}
+	dimensions := make([]types.Dimension, 2)
+	dimensions[0] = instanceIdDimension
+	dimensions[1] = cpuDimension
+
+	metricToFetch := types.Metric{
+		Namespace:  aws.String("MetricValueBenchmarkTest"),
+		MetricName: aws.String("cpu_usage_active"),
+		Dimensions: dimensions,
+	}
+
+	metricQueryPeriod := int32(60)
+
+	metricQuery := types.MetricDataQuery{
+		MetricStat: &types.MetricStat{
+			Metric: &metricToFetch,
+			Period: &metricQueryPeriod,
+			Stat:   aws.String("Average"),
+		},
+		Id: aws.String("cpuUsageActive"),
+	}
+
+	metricDataQueries := make([]types.MetricDataQuery, 1)
+	metricDataQueries[0] = metricQuery
+
+	endTime := time.Now()
+	startTime := subtractMinutes(endTime, 10)
+	getMetricDataInput := cloudwatch.GetMetricDataInput{
+		StartTime:         &startTime,
+		EndTime:           &endTime,
+		MetricDataQueries: metricDataQueries,
+	}
+
+	log.Printf("Metric data input is : %s", fmt.Sprint(getMetricDataInput))
+
+	cwmClient, clientContext, err := test.GetCloudWatchMetricsClient()
+	if err != nil {
+		return fmt.Errorf("Error occurred while creating CloudWatch client: %v", err.Error())
+	}
+
+	output, err := cwmClient.GetMetricData(*clientContext, &getMetricDataInput)
+	if err != nil {
+		return fmt.Errorf("Error getting metric data %v", err)
+	}
+
+	log.Printf("Metric Value is : %s", fmt.Sprint(output.MetricDataResults[0].Values))
+	return nil
+}
+
+// GetMetricDataInput = start time, end time,MetricDataQuery
+
+// https://github.com/aws/aws-sdk-go-v2/blob/main/service/cloudwatch/api_op_GetMetricData.go
+
+/*
+
+func BuildDimensionFilterList(appendDimension int) []types.DimensionFilter {
+	// we append dimension from 0 to max number - 2
+	// then we add dimension instance id
+	// thus for max dimension 10, 0 to 8 + instance id = 10 dimension
+	ec2InstanceId := GetInstanceId()
+	dimensionFilter := make([]types.DimensionFilter, appendDimension)
+	for i := 0; i < appendDimension-1; i++ {
+		dimensionFilter[i] = types.DimensionFilter{
+			Name:  aws.String(fmt.Sprintf("%s%d", appendMetric, i)),
+			Value: aws.String(fmt.Sprintf("%s%d", loremIpsum+appendMetric, i)),
+		}
+	}
+	dimensionFilter[appendDimension-1] = types.DimensionFilter{
+		Name:  aws.String(instanceId),
+		Value: aws.String(ec2InstanceId),
+	}
+	return dimensionFilter
+}
+
+// ValidateMetrics takes the metric name, metric dimension and corresponding namespace that contains the metric
+func ValidateMetrics(t *testing.T, metricName, namespace string, dimensionsFilter []types.DimensionFilter) {
+	cwmClient, clientContext, err := GetCloudWatchMetricsClient()
+	if err != nil {
+		t.Fatalf("Error occurred while creating CloudWatch Logs SDK client: %v", err.Error())
+	}
+
+	listMetricsInput := cloudwatch.ListMetricsInput{
+		MetricName:     aws.String(metricName),
+		Namespace:      aws.String(namespace),
+		RecentlyActive: "PT3H",
+		Dimensions:     dimensionsFilter,
+	}
+	data, err := cwmClient.ListMetrics(*clientContext, &listMetricsInput)
+	if err != nil {
+		t.Errorf("Error getting metric data %v", err)
+	}
+
+	// Only validate if certain metrics are published by CloudWatchAgent in corresponding namespace
+	// Since the metric value can be unpredictive.
+	if len(data.Metrics) == 0 {
+		metrics := make([]metric, len(dimensionsFilter))
+		for i, filter := range dimensionsFilter {
+			metrics[i] = metric{
+				name:  *filter.Name,
+				value: *filter.Value,
+			}
+		}
+		t.Errorf("No metrics found for dimension %v metric name %v namespace %v",
+			metrics, metricName, namespace)
+	}
+
+}
+*/

--- a/integration/test/metric/query-json.json
+++ b/integration/test/metric/query-json.json
@@ -1,0 +1,23 @@
+[
+  {
+    "Id": "m1",
+    "MetricStat": {
+      "Metric": {
+        "Namespace": "MetricValueBenchmarkTest",
+        "MetricName": "cpu_usage_active",
+        "Dimensions": [
+          {
+            "Name": "InstanceId",
+            "Value": "i-095d623fa10a192e3"
+          },
+          {
+            "Name": "cpu",
+            "Value": "cpu-total"
+          }
+        ]
+      },
+      "Period": 60,
+      "Stat": "Average"
+    }
+  }
+]

--- a/integration/test/metric/stat.go
+++ b/integration/test/metric/stat.go
@@ -1,0 +1,11 @@
+package metric
+
+type Statistics int
+
+const (
+	AVERAGE Statistics = iota
+)
+
+func (s Statistics) String() string {
+	return [...]string{"Average"}[s]
+}

--- a/integration/test/metric/stat.go
+++ b/integration/test/metric/stat.go
@@ -1,11 +1,7 @@
 package metric
 
-type Statistics int
+type Statistics string
 
 const (
-	AVERAGE Statistics = iota
+	AVERAGE Statistics = "Average"
 )
-
-func (s Statistics) String() string {
-	return [...]string{"Average"}[s]
-}

--- a/integration/test/metric_value_benchmark/agent_configs/base_config.json
+++ b/integration/test/metric_value_benchmark/agent_configs/base_config.json
@@ -1,0 +1,24 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root",
+    "debug": true,
+    "logfile": ""
+  },
+  "metrics": {
+    "namespace": "MetricValueBenchmarkTest",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "cpu": {
+        "measurement": [
+          "time_active", "time_guest", "time_guest_nice", "time_idle", "time_iowait", "time_irq",
+          "time_nice", "time_softirq", "time_steal", "time_system", "time_user",
+          "usage_active", "usage_guest", "usage_guest_nice", "usage_idle", "usage_iowait", "usage_irq",
+          "usage_nice", "usage_softirq", "usage_steal", "usage_system", "usage_user"
+        ]
+      }
+    }
+  }
+}

--- a/integration/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/integration/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -119,12 +119,10 @@ func printTestResult(testSuiteStatus status.TestStatus, testSummary map[string]s
 }
 
 func getTestSuiteStatus(testSummary map[string]status.TestStatus) status.TestStatus {
-	isAllSuccessful := status.SUCCESSFUL
 	for _, value := range testSummary {
 		if value == status.FAILED {
-			isAllSuccessful = status.FAILED
-			break
+			return status.FAILED
 		}
 	}
-	return isAllSuccessful
+	return status.SUCCESSFUL
 }

--- a/integration/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/integration/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build linux && integration
+// +build linux,integration
+
+package metric_value_benchmark
+
+import (
+	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent/integration/test"
+	"github.com/aws/amazon-cloudwatch-agent/integration/test/metric"
+	"log"
+	"testing"
+	"time"
+)
+
+const configOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+const configJSON = "/base_config.json"
+
+//const namespace = "MetricValueBenchmarkTest"
+const instanceId = "InstanceId"
+
+//Let the agent run for 2 minutes. This will give agent enough time to call server
+const agentRuntime = 3 * time.Minute
+
+func TestCPUValue(t *testing.T) {
+	log.Printf("testing cpu value...")
+
+	resourcePath := "agent_configs"
+
+	log.Printf("resource file location %s", resourcePath)
+
+	t.Run(fmt.Sprintf("resource file location %s ", resourcePath), func(t *testing.T) {
+		test.CopyFile(resourcePath+configJSON, configOutputPath)
+		err := test.StartAgent(configOutputPath, false)
+
+		if err != nil {
+			t.Fatalf("Agent could not start")
+		}
+
+		time.Sleep(agentRuntime)
+		log.Printf("Agent has been running for : %s", agentRuntime.String())
+		test.StopAgent()
+
+		err = metric.FetchMetricValues()
+		if err != nil {
+			t.Fatalf("Error while fetching metric value: %v", err.Error())
+		}
+
+		log.Printf("Finished Testing CPU Value")
+		/*
+			// test for cloud watch metrics
+			dimensionFilter := buildDimensionFilterList(parameter.numberDimensionsInCW)
+			test.ValidateMetrics(t, parameter.metricName, namespace, dimensionFilter) */
+	})
+
+	// TODO: Get CPU value > 0
+	// TODO: Range test with >0 and <100
+	// TODO: Range test: which metric to get? api reference check. should I get average or test every single datapoint for 10 minutes? (and if 90%> of them are in range, we are good)
+}

--- a/integration/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/integration/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -12,17 +12,17 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/integration/test/metric"
 	"log"
 	"testing"
+	"text/tabwriter"
 	"time"
 )
 
 const configOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
 const configJSON = "/base_config.json"
 
-//const namespace = "MetricValueBenchmarkTest"
+const namespace = "MetricValueBenchmarkTest"
 const instanceId = "InstanceId"
 
-//Let the agent run for 2 minutes. This will give agent enough time to call server
-const agentRuntime = 3 * time.Minute
+const minimumAgentRuntime = 3 * time.Minute
 
 func TestCPUValue(t *testing.T) {
 	log.Printf("testing cpu value...")
@@ -39,23 +39,90 @@ func TestCPUValue(t *testing.T) {
 			t.Fatalf("Agent could not start")
 		}
 
-		time.Sleep(agentRuntime)
-		log.Printf("Agent has been running for : %s", agentRuntime.String())
+		time.Sleep(minimumAgentRuntime)
+		log.Printf("Agent has been running for : %s", minimumAgentRuntime.String())
 		test.StopAgent()
 
-		err = metric.FetchMetricValues()
-		if err != nil {
-			t.Fatalf("Error while fetching metric value: %v", err.Error())
-		}
+		isAllTestPassed, testResult := validateCpuMetrics()
+		printTestResult(isAllTestPassed, testResult)
 
-		log.Printf("Finished Testing CPU Value")
-		/*
-			// test for cloud watch metrics
-			dimensionFilter := buildDimensionFilterList(parameter.numberDimensionsInCW)
-			test.ValidateMetrics(t, parameter.metricName, namespace, dimensionFilter) */
+		if !isAllTestPassed {
+			t.Fatalf("Cpu test failed to validate that every metric value is greater than zero")
+		}
 	})
 
 	// TODO: Get CPU value > 0
 	// TODO: Range test with >0 and <100
 	// TODO: Range test: which metric to get? api reference check. should I get average or test every single datapoint for 10 minutes? (and if 90%> of them are in range, we are good)
+}
+
+func validateCpuMetrics() (bool, map[string]bool) {
+	metricsToFetch := []string{
+		"cpu_time_active", "cpu_time_guest", "cpu_time_guest_nice", "cpu_time_idle", "cpu_time_iowait", "cpu_time_irq",
+		"cpu_time_nice", "cpu_time_softirq", "cpu_time_steal", "cpu_time_system", "cpu_time_user",
+		"cpu_usage_active", "cpu_usage_quest", "cpu_usage_quest_nice", "cpu_usage_idle", "cpu_usage_iowait",
+		"cpu_usage_irq", "cpu_usage_nice", "cpu_usage_softirq", "cpu_usage_steal", "cpu_usage_system", "cpu_usage_user"}
+	isAllValid := true
+	validationResult := map[string]bool{}
+	for _, metricName := range metricsToFetch {
+		validationResult[metricName] = true
+		fetcher, err := metric.GetMetricFetcher(metricName)
+		if err != nil {
+			isAllValid = false
+			validationResult[metricName] = false
+		}
+		values, err := fetcher.Fetch(namespace, metricName, metric.AVERAGE)
+		if err != nil {
+			isAllValid = false
+			validationResult[metricName] = false
+			continue
+		}
+		if !isAllValuesGreaterThanZero(metricName, values) {
+			isAllValid = false
+			validationResult[metricName] = false
+			continue
+		}
+	}
+	return isAllValid, validationResult
+}
+
+func isAllValuesGreaterThanZero(metricName string, values []float64) bool {
+	if len(values) == 0 {
+		log.Printf("No values found %v", metricName)
+		return false
+	}
+	for _, value := range values {
+		if value <= 0 {
+			log.Printf("Values are not all greater than zero for %v", metricName)
+			return false
+		}
+	}
+	log.Printf("Values are all greater than zero for %v", metricName)
+	return true
+}
+
+func printTestResult(isAllTestPassed bool, testSummary map[string]bool) {
+	testSuite := "CPU Test"
+	var status string
+	if isAllTestPassed {
+		status = "Succeeded"
+	} else {
+		status = "Failed"
+	}
+
+	log.Printf("Finished %v", testSuite)
+	log.Printf("==============%v==============", testSuite)
+	log.Printf("==============%v==============", status)
+	w := tabwriter.NewWriter(log.Writer(), 1, 1, 1, ' ', 0)
+	for metricName, isSucessful := range testSummary {
+		var status string
+		if isSucessful {
+			status = "Success"
+		} else {
+			status = "Failed"
+		}
+		fmt.Fprintln(w, metricName, "\t", status, "\t")
+	}
+	w.Flush()
+	log.Printf("==============================")
 }

--- a/integration/test/metric_value_benchmark/metrics_value_benchmark_test.go
+++ b/integration/test/metric_value_benchmark/metrics_value_benchmark_test.go
@@ -8,12 +8,13 @@ package metric_value_benchmark
 
 import (
 	"fmt"
-	"github.com/aws/amazon-cloudwatch-agent/integration/test"
-	"github.com/aws/amazon-cloudwatch-agent/integration/test/metric"
 	"log"
 	"testing"
 	"text/tabwriter"
 	"time"
+
+	"github.com/aws/amazon-cloudwatch-agent/integration/test"
+	"github.com/aws/amazon-cloudwatch-agent/integration/test/metric"
 )
 
 const configOutputPath = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"

--- a/integration/test/status/test_status.go
+++ b/integration/test/status/test_status.go
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build linux && integration
+// +build linux,integration
+
+package status
+
+type TestStatus string
+
+const (
+	SUCCESSFUL TestStatus = "Successful"
+	FAILED     TestStatus = "Failed"
+)


### PR DESCRIPTION
# Description of the issue
Based on our testing decisions, we need to add benchmark testing for metric values. To create a foundation for that, we are starting with adding sanity tests to verify we get values and they are greater than zero for all metrics.

# Description of changes
- Added CPU metric value sanity test and query logic, with extensibility for future tests in mind.

## Out of scope / next steps
- Note that some metrics weren't reporting with this set up, so this test currently fails (see test result below). Need to verify with subject matter experts in the team whether who need. Might need to change validation logic or figure out what to change in the testing environment in order to have those metrics get reported for testing purposes.
- Will refactor the main test function and structure in a way that improves readability and even easier to add new sanity and benchmark tests.
- Will add some readme or resources that helps people learn how to add tests

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
<img width="1272" alt="Screen Shot 2022-10-11 at 14 10 56" src="https://user-images.githubusercontent.com/24197975/195178484-bb7c0663-5286-45f4-b460-697eb5f9fda6.png">

# Requirements
I did run and committed linter changers just for the files I added or modified.
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`





