### PR TITLE
Fix flaky aggregator shutdown test.

### DIFF
--- a/plugins/outputs/cloudwatch/aggregator_test.go
+++ b/plugins/outputs/cloudwatch/aggregator_test.go
@@ -147,8 +147,7 @@ func TestAggregator_ShutdownBehavior(t *testing.T) {
 	// The Aggregator creates a new durationAggregator for each metric.
 	// And there is a delay when each new durationAggregator begins.
 	// So submit a metric and wait for the first aggregation to occur.
-	time.Sleep(aggregationInterval + time.Second)
-	assertMetricContent(t, metricChan, 1*time.Second, m, expectedFieldContent{
+	assertMetricContent(t, metricChan, 3*aggregationInterval, m, expectedFieldContent{
 		"value", 1, 1, 1, 1, "", []float64{1.0488088481701516}, []float64{1}})
 	assertNoMetricsInChan(t, metricChan)
 	// Now submit the same metric and it should be routed to the existing
@@ -156,8 +155,7 @@ func TestAggregator_ShutdownBehavior(t *testing.T) {
 	timestamp = time.Now()
 	m = metric.New(metricName, tags, fields, timestamp)
 	aggregator.AddMetric(m)
-	// Shutdown before the aggregationInterval
-	time.Sleep(aggregationInterval / 2)
+	// Shutdown before the 2nd aggregationInterval completes.
 	close(shutdownChan)
 	wg.Wait()
 	assertMetricContent(t, metricChan, 1*time.Second, m, expectedFieldContent{


### PR DESCRIPTION
# Description of the issue
This test is flaky.
It passes quite often on my dev machine, but fails frequently when github actions runs the unit tests.
The point of this test case is to shutdown before aggregation has "naturally" occurred.
The problem is mainly because the `aggregating()` method has this line:
```
time.Sleep(now.Truncate(durationAgg.aggregationDuration).Add(durationAgg.aggregationDuration).Sub(now))
```
Whch means when a new metric name is first seen and a `durationAggregator` is started, it could take between `aggregationInterval` and `2*aggregationInterval` for the first Aggregation.

You would think the test shouldn't care, it can just shutdown right after `AddMetric` is called and expect the shutdown/flush to happen ASAP.

You'd be wrong because of the randomness of selecting when 2 cases are "ready":
- `case m := <-durationAgg.aggregationChan:`
- `case <-durationAgg.shutdownChan:`

# Description of changes
The test case submits 1 metric and waits _sufficiently long_ for that metric to be "naturally" aggregated.
Then it submits the same metric-name again and immediately shuts down.
We could delay between `AddMetric()` and shutdown, but it is not necessary.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
```
go test -count=100 -v --failfast ./plugins/outputs/cloudwatch -run ShutdownBehavior
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




