### PR TITLE
Add workflow to sync latest to private staging repo

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,0 +1,22 @@
+name: Repo Sync
+// https://github.com/marketplace/actions/github-repo-sync
+
+on:
+  schedule:
+  - cron:  "0 0 * * 0" # every sunday at 12AM
+  workflow_dispatch:
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - name: repo-sync
+      uses: repo-sync/github-sync@v2
+      with:
+        source_repo: "https://github.com/aws/amazon-cloudwatch-agent.git"
+        source_branch: "master"
+        destination_branch: "repo-sync"
+        github_token: ${{ secrets.REPO_SYNC_PAT }}


### PR DESCRIPTION
# Description of the issue
Syncs the latest to the private staging repo

# Description of changes

[Please read this PR](https://github.com/aws/private-amazon-cloudwatch-agent-staging/pull/32) for details. `repo-sync.yml` only needs to exist here to avoid merge conflicts on private staging repo. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
I tried this exact setup on dummy repos before proposing these changes