### PR TITLE
E2e test package separation

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -637,12 +637,13 @@ jobs:
     needs: [ StartLocalStack, EC2LinuxIntegrationTest ]
     defaults:
       run:
-        working-directory: integration/terraform/ec2/localstack
+        working-directory: terraform/ec2/localstack
     permissions:
       id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v2
+        with: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -12,6 +12,8 @@ env:
   GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
   GPG_TTY: $(tty)
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
 
 on:
   push:
@@ -128,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -161,7 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -223,7 +225,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -368,7 +370,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -388,7 +390,7 @@ jobs:
           echo run terraform and execute test code &&
           terraform apply --auto-approve
           -var="ssh_key_value=${PRIVATE_KEY}"
-          -var="github_test_repo=https://github.com/aws/amazon-cloudwatch-agent-test.git"
+          -var="github_test_repo=${CWA_GITHUB_TEST_REPO_URL}"
           -var="cwa_github_sha=${GITHUB_SHA}"
           -var="s3_bucket=${S3_INTEGRATION_BUCKET}"
           -var="ssh_key_name=${KEY_NAME}" &&
@@ -411,7 +413,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -444,7 +446,7 @@ jobs:
             cd terraform/ec2/linux
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=https://github.com/aws/amazon-cloudwatch-agent-test.git" \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${CWA_GITHUB_TEST_REPO_URL}" \
               -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
               -var="user=${{ matrix.arrays.username }}" \
@@ -473,7 +475,7 @@ jobs:
             terraform init
             if terraform apply --auto-approve \
               -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}" \
-              -var="github_repo=aws/amazon-cloudwatch-agent-test.git" \
+              -var="github_repo=${CWA_GITHUB_TEST_REPO_URL}" \
               -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
               -var="test_dir=${{ matrix.arrays.test_dir }}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
@@ -512,7 +514,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -545,7 +547,7 @@ jobs:
             cd terraform/ec2/linux
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=https://github.com/aws/amazon-cloudwatch-agent-test.git" \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${CWA_GITHUB_TEST_REPO_URL}" \
               -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
               -var="user=${{ matrix.arrays.username }}" \
@@ -653,7 +655,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -687,7 +689,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -750,7 +752,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: aws/amazon-cloudwatch-agent-test
+          repository: ${CWA_GITHUB_TEST_REPO_NAME}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -788,7 +790,7 @@ jobs:
             cd terraform/ec2/linux
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=https://github.com/aws/amazon-cloudwatch-agent-test.git" \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${CWA_GITHUB_TEST_REPO_URL}" \
               -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="user=${{ matrix.arrays.username }}" \
               -var="ami=${{ matrix.arrays.ami }}" \

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -159,6 +159,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+        with: aws/amazon-cloudwatch-agent-test
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -195,10 +196,10 @@ jobs:
           export version=$(cat CWAGENT_VERSION)
           echo cw agent version $version
           mkdir msi_dep
-          cp -r integration/msi/tools/. msi_dep/
+          cp -r msi/tools/. msi_dep/
           cp -r windows-agent/amazon-cloudwatch-agent/. msi_dep/
-          go run integration/msi/tools/msiversion/msiversionconverter.go $version msi_dep/amazon-cloudwatch-agent.wxs '<version>' --tags=integration
-          go run integration/msi/tools/msiversion/msiversionconverter.go $version msi_dep/manifest.json __VERSION__ --tags=integration
+          go run msi/tools/msiversion/msiversionconverter.go $version msi_dep/amazon-cloudwatch-agent.wxs '<version>' --tags=integration
+          go run msi/tools/msiversion/msiversionconverter.go $version msi_dep/manifest.json __VERSION__ --tags=integration
 
       - name: Zip
         if: steps.cached_win_zip.outputs.cache-hit != 'true'

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -684,6 +684,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -715,7 +717,7 @@ jobs:
           timeout_minutes: 15
           retry_wait_seconds: 5
           command: |
-            cd integration/terraform/ecs/linux
+            cd terraform/ecs/linux
             terraform init
             if terraform apply --auto-approve -var="test_dir=${{ matrix.arrays.test_dir }}" -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" -var="cwagent_image_tag=${{ github.sha }}" ; then 
               terraform destroy -auto-approve
@@ -730,7 +732,7 @@ jobs:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
-          command: cd integration/terraform/ecs/linux && terraform destroy --auto-approve
+          command: cd terraform/ecs/linux && terraform destroy --auto-approve
 
   PerformanceTrackingTest:
     name: "PerformanceTrackingTest"

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -354,7 +354,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: integration/terraform/ec2/localstack
+        working-directory: terraform/ec2/localstack
     outputs:
       local_stack_host_name: ${{ steps.localstack.outputs.local_stack_host_name }}
     permissions:
@@ -362,6 +362,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+        with: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -381,8 +382,8 @@ jobs:
           echo run terraform and execute test code &&
           terraform apply --auto-approve
           -var="ssh_key_value=${PRIVATE_KEY}"
-          -var="github_repo=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
-          -var="github_sha=${GITHUB_SHA}" 
+          -var="github_test_repo=https://github.com/aws/amazon-cloudwatch-agent-test.git"
+          -var="cwa_github_sha=${GITHUB_SHA}"
           -var="s3_bucket=${S3_INTEGRATION_BUCKET}"
           -var="ssh_key_name=${KEY_NAME}" &&
           LOCAL_STACK_HOST_NAME=$(terraform output -raw public_dns) &&

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -127,6 +127,7 @@ jobs:
       ecs_fargate_matrix: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}
     steps:
       - uses: actions/checkout@v2
+        with: aws/amazon-cloudwatch-agent-test
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -136,9 +137,9 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          go run --tags=generator integration/generator/test_case_generator.go
-          echo "::set-output name=ec2_gpu_matrix::$(echo $(cat integration/generator/resources/ec2_gpu_complete_test_matrix.json))"
-          echo "::set-output name=ec2_linux_matrix::$(echo $(cat integration/generator/resources/ec2_linux_complete_test_matrix.json))"
+          go run --tags=generator generator/test_case_generator.go
+          echo "::set-output name=ec2_gpu_matrix::$(echo $(cat generator/resources/ec2_gpu_complete_test_matrix.json))"
+          echo "::set-output name=ec2_linux_matrix::$(echo $(cat generator/resources/ec2_linux_complete_test_matrix.json))"
           echo "::set-output name=ec2_performance_matrix::$(echo $(cat integration/generator/resources/ec2_performance_complete_test_matrix.json))"
           echo "::set-output name=ecs_fargate_matrix::$(echo $(cat integration/generator/resources/ecs_fargate_complete_test_matrix.json))"
 

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -222,6 +222,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -251,8 +253,8 @@ jobs:
         run: |
           echo cw agent version $(cat CWAGENT_VERSION)
           cp CWAGENT_VERSION /tmp/CWAGENT_VERSION
-          cp -r integration/pkg/tools/. /tmp/
-          cp -r integration/pkg/tools/. /tmp/arm64/
+          cp -r pkg/tools/. /tmp/
+          cp -r pkg/tools/. /tmp/arm64/
           cp -r darwin/amd64/. /tmp/
           cp -r darwin/arm64/. /tmp/arm64/
 

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -503,6 +503,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+        with: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -532,11 +533,11 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |
-            cd integration/terraform/ec2/linux
+            cd terraform/ec2/linux
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_repo=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" \
-              -var="github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=https://github.com/aws/amazon-cloudwatch-agent-test.git" \
+              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
               -var="user=${{ matrix.arrays.username }}" \
               -var="ami=${{ matrix.arrays.ami }}" \
@@ -560,7 +561,7 @@ jobs:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
-          command: cd integration/terraform/ec2/linux && terraform destroy --auto-approve
+          command: cd terraform/ec2/linux && terraform destroy --auto-approve
 
 #  @TODO add back when we add back windows tests
 #  EC2WinIntegrationTest:

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -141,8 +141,8 @@ jobs:
           go run --tags=generator generator/test_case_generator.go
           echo "::set-output name=ec2_gpu_matrix::$(echo $(cat generator/resources/ec2_gpu_complete_test_matrix.json))"
           echo "::set-output name=ec2_linux_matrix::$(echo $(cat generator/resources/ec2_linux_complete_test_matrix.json))"
-          echo "::set-output name=ec2_performance_matrix::$(echo $(cat integration/generator/resources/ec2_performance_complete_test_matrix.json))"
-          echo "::set-output name=ecs_fargate_matrix::$(echo $(cat integration/generator/resources/ecs_fargate_complete_test_matrix.json))"
+          echo "::set-output name=ec2_performance_matrix::$(echo $(cat generator/resources/ec2_performance_complete_test_matrix.json))"
+          echo "::set-output name=ecs_fargate_matrix::$(echo $(cat generator/resources/ecs_fargate_complete_test_matrix.json))"
 
       - name: Echo test plan matrix
         run: |

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -410,6 +410,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -439,11 +441,11 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |
-            cd integration/terraform/ec2/linux
+            cd terraform/ec2/linux
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_repo=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" \
-              -var="github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=aws/amazon-cloudwatch-agent-test.git" \
+              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
               -var="user=${{ matrix.arrays.username }}" \
               -var="ami=${{ matrix.arrays.ami }}" \
@@ -467,12 +469,12 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |
-            cd integration/terraform/ec2/win
+            cd terraform/ec2/win
             terraform init
             if terraform apply --auto-approve \
               -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}" \
-              -var="github_repo=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" \
-              -var="github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
+              -var="github_repo=aws/amazon-cloudwatch-agent-test.git" \
+              -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
               -var="test_dir=${{ matrix.arrays.test_dir }}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
               -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then terraform destroy -auto-approve
@@ -490,9 +492,9 @@ jobs:
           retry_wait_seconds: 5
           command: |
             if "${{ matrix.arrays.os }}" == window 
-              cd integration/terraform/ec2/win
+              cd terraform/ec2/win
             else
-              cd integration/terraform/ec2/linux
+              cd terraform/ec2/linux
             fi
             terraform destroy --auto-approve
           

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -444,7 +444,7 @@ jobs:
             cd terraform/ec2/linux
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=aws/amazon-cloudwatch-agent-test.git" \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=https://github.com/aws/amazon-cloudwatch-agent-test.git" \
               -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
               -var="user=${{ matrix.arrays.username }}" \
@@ -620,7 +620,7 @@ jobs:
 #            if terraform apply --auto-approve \
 #            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}" \
 #            -var="github_repo=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" \
-#            -var="github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
+#            -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
 #            -var="test_dir=${{ matrix.arrays.test_dir }}" \
 #            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
 #              terraform destroy -auto-approve
@@ -749,6 +749,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -783,11 +785,11 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |
-            cd integration/terraform/ec2/linux
+            cd terraform/ec2/linux
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_repo=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" \
-              -var="github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=https://github.com/aws/amazon-cloudwatch-agent-test.git" \
+              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="user=${{ matrix.arrays.username }}" \
               -var="ami=${{ matrix.arrays.ami }}" \
               -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
@@ -796,7 +798,7 @@ jobs:
               -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
               -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
               -var="ssh_key_name=${KEY_NAME}" \
-              -var="github_sha_date=${{ steps.sha_date.outputs.sha_date }}" \
+              -var="cwa_github_sha_date=${{ steps.sha_date.outputs.sha_date }}" \
               -var="test_name=${{ matrix.arrays.os }}" \
               -var="performance_number_of_logs=${{ matrix.arrays.performance_number_of_logs}}"\
               -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
@@ -812,4 +814,4 @@ jobs:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
-          command: cd integration/terraform/ec2/linux && terraform destroy --auto-approve
+          command: cd terraform/ec2/linux && terraform destroy --auto-approve

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -127,7 +127,8 @@ jobs:
       ecs_fargate_matrix: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}
     steps:
       - uses: actions/checkout@v2
-        with: aws/amazon-cloudwatch-agent-test
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -159,7 +160,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
-        with: aws/amazon-cloudwatch-agent-test
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -363,7 +365,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
-        with: aws/amazon-cloudwatch-agent-test
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -504,7 +507,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
-        with: aws/amazon-cloudwatch-agent-test
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -644,7 +648,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
-        with: aws/amazon-cloudwatch-agent-test
+        with:
+          repository: aws/amazon-cloudwatch-agent-test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
# Description of the issue
Test package is being separated, which meant that changes were needed in our workflow definition files

# Description of changes
Make changes to all github workflow steps to make tests run with the new test package

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran integration test workflow in my fork using the new test package https://github.com/aws/amazon-cloudwatch-agent-test


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




