### PR TITLE
Fix parsing win event log message

### DIFF
--- a/plugins/inputs/windows_event_log/wineventlog/utils.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils.go
@@ -187,26 +187,22 @@ func insertPlaceholderValues(rawMessage string, evtDataValues []Data) string {
 	searchingIndex := false
 	for i, c := range rawMessage {
 		// found `%` previously. Determine the index number from the following character(s)
-		if searchingIndex {
-			// found the 1st char other than [0-9]
-			if c > 57 || c < 48 {
-				ind, err := strconv.Atoi(rawMessage[prevIndex+1 : i])
-				// Convert the Slice since the last `%` and see if it's a valid number.
-				// If the index is in [1 - len(evtDataValues)], get it from evtDataValues.
-				if err == nil && ind <= len(evtDataValues) && ind > 0 {
-					sb.WriteString(evtDataValues[ind-1].Value)
-				} else {
-					sb.WriteString(rawMessage[prevIndex:i])
-				}
-				prevIndex = i
-				// In case of consecutive `%`, continue searching for the next index
-				if c != 37 {
-					searchingIndex = false
-				}
+		if searchingIndex && (c > '9' || c < '0') {
+			// Convert the Slice since the last `%` and see if it's a valid number.
+			ind, err := strconv.Atoi(rawMessage[prevIndex+1 : i])
+			// If the index is in [1 - len(evtDataValues)], get it from evtDataValues.
+			if err == nil && ind <= len(evtDataValues) && ind > 0 {
+				sb.WriteString(evtDataValues[ind-1].Value)
+			} else {
+				sb.WriteString(rawMessage[prevIndex:i])
+			}
+			prevIndex = i
+			// In case of consecutive `%`, continue searching for the next index
+			if c != '%' {
+				searchingIndex = false
 			}
 		} else {
-			// ascii code of `%` is 37
-			if c == 37 {
+			if c == '%' {
 				sb.WriteString(rawMessage[prevIndex:i])
 				searchingIndex = true
 				prevIndex = i

--- a/plugins/inputs/windows_event_log/wineventlog/utils.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils.go
@@ -171,15 +171,15 @@ func WindowsEventLogLevelName(levelId int32) string {
 	}
 }
 
+// insertPlaceholderValues formats the message with the correct values if we see those data
+// in evtDataValues.
+//
 // In some cases wevtapi does not insert values when formatting the message. The message
 // will contain insertion string placeholders, of the form %n, where %1 indicates the first
 // insertion string, and so on. Noted that wevtapi start the index with 1.
 // https://learn.microsoft.com/en-us/windows/win32/eventlog/event-identifiers#insertion-strings
-//
-// If we see those data in the `EventData` section, `insertPlaceholderValues` format the message
-// with the correct values
-func insertPlaceholderValues(rawMessage string, evtDataValues []Data) string {
-	if len(evtDataValues) == 0 {
+func insertPlaceholderValues(rawMessage string, evtDataValues []Datum) string {
+	if len(evtDataValues) == 0 || len(rawMessage) == 0 {
 		return rawMessage
 	}
 	var sb strings.Builder
@@ -210,7 +210,7 @@ func insertPlaceholderValues(rawMessage string, evtDataValues []Data) string {
 
 		}
 	}
-	// handle the slice sine the last `%` to the end of rawMessage
+	// handle the slice since the last `%` to the end of rawMessage
 	ind, err := strconv.Atoi(rawMessage[prevIndex+1:])
 	if searchingIndex && err == nil && ind <= len(evtDataValues) && ind > 0 {
 		sb.WriteString(evtDataValues[ind-1].Value)

--- a/plugins/inputs/windows_event_log/wineventlog/utils_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils_test.go
@@ -99,7 +99,7 @@ func TestInsertPlaceholderValues(t *testing.T) {
 		{
 			"Handle consecutive % characters",
 			"%1 %%3% %2",
-			"value_1 %value_3%value_2",
+			"value_1 %value_3% value_2",
 		},
 		{
 			"Handle % character at the end of message",

--- a/plugins/inputs/windows_event_log/wineventlog/utils_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils_test.go
@@ -77,6 +77,43 @@ func TestFullBufferUsedWithHalfUsedSizeReturned(t *testing.T) {
 	assert.Equal(t, bufferUsed, len(str))
 }
 
+func TestInsertPlaceholderValues(t *testing.T) {
+	evtDataValues := []Data{
+		{"value_1"}, {"value_2"}, {"value_3"}, {"value_4"},
+	}
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			"Placeholders %{number} should be replaced by insertion strings",
+			"Service %1 in region %3 stop at %2",
+			"Service value_1 in region value_3 stop at value_2",
+		},
+		{
+			"Index should start from 1 and less than or equal to the amount of values in event data",
+			"%0 %3 %5",
+			"%0 value_3 %5",
+		},
+		{
+			"Handle consecutive % characters",
+			"%1 %%3% %2",
+			"value_1 %value_3%value_2",
+		},
+		{
+			"Handle % character at the end of message",
+			"%3 %2%",
+			"value_3 value_2%",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, insertPlaceholderValues(tc.message, evtDataValues))
+		})
+	}
+}
+
 func resetState() {
 	NumberOfBytesPerCharacter = 0
 }

--- a/plugins/inputs/windows_event_log/wineventlog/utils_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils_test.go
@@ -78,7 +78,7 @@ func TestFullBufferUsedWithHalfUsedSizeReturned(t *testing.T) {
 }
 
 func TestInsertPlaceholderValues(t *testing.T) {
-	evtDataValues := []Data{
+	evtDataValues := []Datum{
 		{"value_1"}, {"value_2"}, {"value_3"}, {"value_4"},
 	}
 	tests := []struct {
@@ -90,6 +90,16 @@ func TestInsertPlaceholderValues(t *testing.T) {
 			"Placeholders %{number} should be replaced by insertion strings",
 			"Service %1 in region %3 stop at %2",
 			"Service value_1 in region value_3 stop at value_2",
+		},
+		{
+			"String without a placeholder should remain the same after insertion",
+			"This is a sentence without placeholders",
+			"This is a sentence without placeholders",
+		},
+		{
+			"Empty string should remain the same",
+			"",
+			"",
 		},
 		{
 			"Index should start from 1 and less than or equal to the amount of values in event data",
@@ -105,6 +115,11 @@ func TestInsertPlaceholderValues(t *testing.T) {
 			"Handle % character at the end of message",
 			"%3 %2%",
 			"value_3 value_2%",
+		},
+		{
+			"Characters after a % other than numbers should be ignored",
+			"%foo, %foo1, %#$%^&1",
+			"%foo, %foo1, %#$%^&1",
 		},
 	}
 	for _, tc := range tests {

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -331,7 +331,7 @@ func (w *windowsEventLog) getRecord(evtHandle EvtHandle) (*windowsEventLogRecord
 	switch w.renderFormat {
 	case FormatXml, FormatDefault:
 		//XML format
-		newRecord.XmlFormatContent = string(descriptionBytes)
+		newRecord.XmlFormatContent = insertPlaceholderValues(string(descriptionBytes), newRecord.EventData.Values)
 	case FormatPlainText:
 		//old SSM agent Windows format
 		var recordMessage eventMessage
@@ -339,7 +339,7 @@ func (w *windowsEventLog) getRecord(evtHandle EvtHandle) (*windowsEventLogRecord
 		if err != nil {
 			return nil, fmt.Errorf("Unmarshal() err %v", err)
 		}
-		newRecord.System.Description = recordMessage.Message
+		newRecord.System.Description = insertPlaceholderValues(recordMessage.Message, newRecord.EventData.Values)
 	default:
 		return nil, fmt.Errorf("renderFormat is not recognized, %s", w.renderFormat)
 	}

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -329,10 +329,14 @@ func (w *windowsEventLog) getRecord(evtHandle EvtHandle) (*windowsEventLogRecord
 	}
 
 	// The insertion strings could be in either EventData or UserData
-	dataValues := newRecord.EventData.Values
+	// Notes on the insertion strings:
+	// - The EvtFormatMessage has the valueCount and values parameters, yet it does not work when we tried passing
+	//   EventData/UserData into those parameters. We can later do more research on making EvtFormatMessage with
+	//   valueCount and values parameters works and compare if there is any benefit.
+	dataValues := newRecord.EventData.Data
 	// The UserData section is used if EventData is empty
 	if len(dataValues) == 0 {
-		dataValues = newRecord.UserData.Values
+		dataValues = newRecord.UserData.Data
 	}
 	switch w.renderFormat {
 	case FormatXml, FormatDefault:

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord.go
@@ -83,23 +83,26 @@ func (record *windowsEventLogRecord) Timestamp() string {
 	return fmt.Sprint(record.System.TimeCreated.SystemTime.UnixNano())
 }
 
+type Datum struct {
+	Value string `xml:",chardata"`
+}
+
 type EventData struct {
-	Values []Data `xml:",any"`
+	Data []Datum `xml:",any"`
 }
 
 type UserData struct {
-	Values []Data `xml:",any"`
+	Data []Datum `xml:",any"`
 }
 
-// UserData has slightly different schema than EventData so that we need to overrid this
-// unmarshal function to get similar structure
+// UnmarshalXML unmarshals the UserData section in the windows event xml to UserData struct
 //
+// UserData has slightly different schema than EventData so that we need to override this
+// to get similar structure
 // https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-userdatatype-complextype
 // https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-eventdatatype-complextype
 func (u *UserData) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	in := struct {
-		Values []Data `xml:",any"`
-	}{}
+	in := EventData{}
 
 	// Read tokens until we find the first StartElement then unmarshal it.
 	for {
@@ -114,15 +117,11 @@ func (u *UserData) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 				return err
 			}
 
-			u.Values = in.Values
+			u.Data = in.Data
 			d.Skip()
 			break
 		}
 	}
 
 	return nil
-}
-
-type Data struct {
-	Value string `xml:",chardata"`
 }

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord.go
@@ -45,6 +45,10 @@ type windowsEventLogRecord struct {
 			Name string `xml:"Name,attr"`
 		} `xml:"Provider"`
 	} `xml:"System"`
+
+	EventData struct {
+		Values []Data `xml:",any"`
+	} `xml:"EventData"`
 }
 
 func newEventLogRecord(l *windowsEventLog) *windowsEventLogRecord {
@@ -77,4 +81,8 @@ func (record *windowsEventLogRecord) Value() (valueString string, err error) {
 
 func (record *windowsEventLogRecord) Timestamp() string {
 	return fmt.Sprint(record.System.TimeCreated.SystemTime.UnixNano())
+}
+
+type Data struct {
+	Value string `xml:",chardata"`
 }

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord.go
@@ -7,6 +7,7 @@
 package wineventlog
 
 import (
+	"encoding/xml"
 	"fmt"
 	"strconv"
 	"time"
@@ -46,9 +47,8 @@ type windowsEventLogRecord struct {
 		} `xml:"Provider"`
 	} `xml:"System"`
 
-	EventData struct {
-		Values []Data `xml:",any"`
-	} `xml:"EventData"`
+	EventData EventData `xml:"EventData"`
+	UserData  UserData  `xml:"UserData"`
 }
 
 func newEventLogRecord(l *windowsEventLog) *windowsEventLogRecord {
@@ -81,6 +81,46 @@ func (record *windowsEventLogRecord) Value() (valueString string, err error) {
 
 func (record *windowsEventLogRecord) Timestamp() string {
 	return fmt.Sprint(record.System.TimeCreated.SystemTime.UnixNano())
+}
+
+type EventData struct {
+	Values []Data `xml:",any"`
+}
+
+type UserData struct {
+	Values []Data `xml:",any"`
+}
+
+// UserData has slightly different schema than EventData so that we need to overrid this
+// unmarshal function to get similar structure
+//
+// https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-userdatatype-complextype
+// https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-eventdatatype-complextype
+func (u *UserData) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	in := struct {
+		Values []Data `xml:",any"`
+	}{}
+
+	// Read tokens until we find the first StartElement then unmarshal it.
+	for {
+		t, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		if se, ok := t.(xml.StartElement); ok {
+			err = d.DecodeElement(&in, &se)
+			if err != nil {
+				return err
+			}
+
+			u.Values = in.Values
+			d.Skip()
+			break
+		}
+	}
+
+	return nil
 }
 
 type Data struct {

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord_test.go
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+// +build windows
+
+package wineventlog
+
+import (
+	"encoding/xml"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUnmarshalWinEvtRecord(t *testing.T) {
+	tests := []struct {
+		xml        string
+		wEvtRecord windowsEventLogRecord
+	}{
+		{
+			xml: `
+<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
+    <EventData>
+        <Data Name='param1'>2022-10-28T22:33:25Z</Data>
+        <Data Name='param2'>RulesEngine</Data>
+        <Data Name='param3'>2</Data>
+    </EventData>
+</Event>
+			`,
+			wEvtRecord: windowsEventLogRecord{
+				EventData: EventData{
+					Data: []Datum{
+						{"2022-10-28T22:33:25Z"},
+						{"RulesEngine"},
+						{"2"},
+					},
+				},
+			},
+		},
+		{
+			xml: `
+<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
+    <UserData>
+        <RmSessionEvent xmlns='http://www.microsoft.com/2005/08/Windows/Reliability/RestartManager/'>
+            <RmSessionId>0</RmSessionId>
+            <UTCStartTime>2022-10-26T20:24:13.4253261Z</UTCStartTime>
+        </RmSessionEvent>
+    </UserData>
+</Event>
+			`,
+			wEvtRecord: windowsEventLogRecord{
+				UserData: UserData{
+					Data: []Datum{
+						{"0"},
+						{"2022-10-26T20:24:13.4253261Z"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		record := new(windowsEventLogRecord)
+		xml.Unmarshal([]byte(test.xml), record)
+		assert.Equal(t, test.wEvtRecord, record)
+	}
+}

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord_test.go
@@ -61,7 +61,7 @@ func TestUnmarshalWinEvtRecord(t *testing.T) {
 
 	for _, test := range tests {
 		record := new(windowsEventLogRecord)
-		xml.Unmarshal([]byte(test.xml), &record)
-		assert.Equal(t, test.wEvtRecord, record)
+		xml.Unmarshal([]byte(test.xml), record)
+		assert.Equal(t, test.wEvtRecord, &record)
 	}
 }

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord_test.go
@@ -61,7 +61,7 @@ func TestUnmarshalWinEvtRecord(t *testing.T) {
 
 	for _, test := range tests {
 		record := new(windowsEventLogRecord)
-		xml.Unmarshal([]byte(test.xml), record)
+		xml.Unmarshal([]byte(test.xml), &record)
 		assert.Equal(t, test.wEvtRecord, record)
 	}
 }

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlogrecord_test.go
@@ -60,8 +60,8 @@ func TestUnmarshalWinEvtRecord(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		record := new(windowsEventLogRecord)
-		xml.Unmarshal([]byte(test.xml), record)
-		assert.Equal(t, test.wEvtRecord, &record)
+		var record windowsEventLogRecord
+		xml.Unmarshal([]byte(test.xml), &record)
+		assert.Equal(t, test.wEvtRecord, record)
 	}
 }


### PR DESCRIPTION
# Description of the issue
In some cases, `EvtFormatMessage` from `wevtapi.dll` does not format the message correctly and leave the message with insertion string placeholders. For example: 
```
Successfully scheduled Software Protection service for re-start at %1. Reason: %2
```
If we find the data from `EventData` attribute,
```
    <EventData>
        <Data Name='param1'>2022-10-28T22:33:25Z</Data>
        <Data Name='param2'>RulesEngine</Data>
    </EventData>
```
we should format the message again with these values and the message would become
```
Successfully scheduled Software Protection service for re-start at 2022-10-28T22:33:25Z. Reason: RulesEngine
```

# Description of changes
- Update `windowsEventLogRecord` to include `EventData` and `UserData` attribute so that it can unmarshal correctly
- Add helper function `insertPlaceholderValues` to locate placeholders in the message and find corresponding values from the EventData or UserData
  - Add tests to cover edge cases
- Use `insertPlaceholderValues` to format message again before returning each event record

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- make build && make test
- Build binaries and run on a window instances. Send win event logs to CW to compare the log messages before and after:
  - Before:   
![image](https://user-images.githubusercontent.com/10120438/199170638-fb0da6bd-457b-4671-811f-dfb0fdd3c00d.png)
  - After: 
![image](https://user-images.githubusercontent.com/10120438/199170680-b038781b-703e-4a01-a65d-c6bbf8e2289b.png)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`
