### PR TITLE
Fix github actions to use go 1.19.

### DIFF
--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -22,12 +22,12 @@ concurrency:
 jobs:
   linux-unittest:
     runs-on: ubuntu-latest
-    steps:  
+    steps:
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ~1.18.3
+        go-version: ~1.19.2
 
     - name: Check out code
       uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
 
     - uses: zencargo/github-action-go-mod-tidy@v1
       with:
-        go-version: 1.18.3
+        go-version: 1.19.2
 
     - name: Cache build output
       uses: actions/cache@v2

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -9,7 +9,7 @@ on:
       - '**/*.md'
       - '.github/**'
       - '!.github/workflows/build-*'
-      
+
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -22,12 +22,12 @@ concurrency:
 jobs:
   macos-unittest:
     runs-on: macos-latest
-    steps:  
+    steps:
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ~1.18.3
+        go-version: ~1.19.2
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.18.3
+          go-version: ~1.19.2
 
       - name: Cache Go
         uses: actions/cache@v2

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.18.3
+          go-version: ~1.19.2
 
       - name: Install rpm
         run: sudo apt install rpm
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.18.3
+          go-version: ~1.19.2
 
       - name: Generate matrix
         id: set-matrix
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.18.3
+          go-version: ~1.19.2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -192,7 +192,7 @@ jobs:
         if: steps.cached_win_zip.outputs.cache-hit != 'true'
         run: |
           sudo apt install unzip
-          unzip windows/amd64/amazon-cloudwatch-agent.zip -d windows-agent  
+          unzip windows/amd64/amazon-cloudwatch-agent.zip -d windows-agent
 
       - name: Create msi dep folder and copy deps
         if: steps.cached_win_zip.outputs.cache-hit != 'true'
@@ -230,7 +230,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.18.3
+          go-version: ~1.19.2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -483,7 +483,7 @@ jobs:
             else
               terraform destroy -auto-approve && exit 1
             fi
-            
+
       #This is here just in case workflow cancel
       - name: Terraform destroy
         if: ${{ cancelled() && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
@@ -493,13 +493,13 @@ jobs:
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if "${{ matrix.arrays.os }}" == window 
+            if "${{ matrix.arrays.os }}" == window
               cd terraform/ec2/win
             else
               cd terraform/ec2/linux
             fi
             terraform destroy --auto-approve
-          
+
   EC2LinuxIntegrationTest:
     needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
     name: 'EC2LinuxIntegrationTest'
@@ -723,7 +723,7 @@ jobs:
           command: |
             cd terraform/ecs/linux
             terraform init
-            if terraform apply --auto-approve -var="test_dir=${{ matrix.arrays.test_dir }}" -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" -var="cwagent_image_tag=${{ github.sha }}" ; then 
+            if terraform apply --auto-approve -var="test_dir=${{ matrix.arrays.test_dir }}" -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" -var="cwagent_image_tag=${{ github.sha }}" ; then
               terraform destroy -auto-approve
             else
               terraform destroy -auto-approve && exit 1

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.18.3
+          go-version: ~1.19.2
         id: go
 
       - name: Configure AWS Credentials

--- a/.github/workflows/releaseTest.yml
+++ b/.github/workflows/releaseTest.yml
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT
 
-name: Release Update 
+name: Release Update
 env:
   PRIVATE_KEY: ${{ secrets.AWS_PRIVATE_KEY  }}
   TERRAFORM_AWS_ASSUME_ROLE: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
@@ -17,7 +17,7 @@ env:
 on:
   release:
       types: [created]
-    
+
   workflow_dispatch:
 
 concurrency:
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ~1.18.3
+          go-version: ~1.19.2
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -52,4 +52,3 @@ jobs:
             export SHA=$GITHUB_SHA
             export RELEASE_NAME=${{ github.event.release.tag_name }}
             go test -run TestUpdateCommit -p 1 -v --tags=integration
-            

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-cloudwatch-agent
 
-go 1.18
+go 1.19
 
 replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20220502160831-c20ebe67c5ef
 


### PR DESCRIPTION
# Description of the issue
My last PR uses a feature introduced in go 1.19 (sync/atomic).
The GitHub Actions that run unit tests are now failing:
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/3396628110/jobs/5647902403
```
# github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail
Error: plugins\inputs\logfile\tail\tail.go:27:37: undefined: atomic.Int64
```

CloudWatch Agent is already being built and released using Golang 1.19.2.

# Description of changes
Use go 1.19 in GitHub Actions.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
```
make release
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




