### PR TITLE
Fix create_rpm.sh from reading a file that does not exist.

### DIFF
--- a/Tools/src/create_rpm.sh
+++ b/Tools/src/create_rpm.sh
@@ -6,10 +6,9 @@ set -e
 
 SPEC_FILE="${PREPKGPATH}/amazon-cloudwatch-agent.spec"
 BUILD_ROOT="${BUILD_SPACE}/private/linux_${ARCH}/rpm-build"
-AGENT_VERSION_WITHOUT_SED=$(cat ${BUILD_SPACE}/bin/CWAGENT_VERSION)
 AGENT_VERSION=$(cat ${PREPKGPATH}/CWAGENT_VERSION | sed -e "s/-/+/g")
 
-echo "BUILD_SPACE: ${BUILD_SPACE}  agent: ${AGENT_VERSION_WITHOUT_SED}  agent_version: ${AGENT_VERSION}  pre-package location:${PREPKGPATH}"
+echo "BUILD_SPACE: ${BUILD_SPACE}  agent_version: ${AGENT_VERSION}  pre-package location:${PREPKGPATH}"
 
 
 echo "Creating rpm-build workspace"


### PR DESCRIPTION
# Description of the issue
When trying to build and release CloudWatch Agent I encountered this issue:
```
cp  /tmp/1.247356.0b252215/amd64/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent.conf.rpm /tmp/1.247356.0b252215/amd64/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent.conf && ARCH=amd64 TARGET_SUPPORTED_ARCH=x86_64 BUILD_SPACE="/tmp/1.247356.0b252215" PREPKGPATH="/tmp/1.247356.0b252215/amd64/amazon-cloudwatch-agent-pre-pkg" ./create_rpm.sh


*************************************************
Creating rpm file for Amazon Linux and RHEL amd64
*************************************************
cat: /tmp/1.247356.0b252215/bin/CWAGENT_VERSION: No such file or directory
```

# Description of changes
I verified the above commands work if I modified create_rpm.sh` like so.
This is not an issue for `create_deb.sh` because it does not have the the same lines.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- manually running the above command

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




