### PR TITLE
Use Systemctl Command To Restart Agent

### DIFF
--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -96,7 +96,7 @@ agent_start() {
      if [ "${SYSTEMD}" = 'true' ]; then
           systemctl daemon-reload || return
           systemctl enable "${agent_name}.service" || return
-          service "${agent_name}" restart || return
+          systemctl restart "${agent_name}.service" || return
      else
           start "${agent_name}" || return
           sleep 1


### PR DESCRIPTION
# Description of the issue
On ol9 service alias not starting agent. 

# Description of changes
Use systemctl command directly instead to start agent

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[_Describe what tests you have done._](https://github.com/sethAmazon/amazon-cloudwatch-agent/actions/runs/3570899143/jobs/6002383229)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




