### PR TITLE
Change LogFile.restoreState() so it does not return negative offset.

### DIFF
--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -139,7 +139,7 @@ func (t *LogFile) Stop() {
 	close(t.done)
 }
 
-//Try to find if there is any new file needs to be added for monitoring.
+// Try to find if there is any new file needs to be added for monitoring.
 func (t *LogFile) FindLogSrc() []logs.LogSrc {
 	if !t.started {
 		return nil
@@ -313,7 +313,7 @@ func (t *LogFile) getTargetFiles(fileconfig *FileConfig) ([]string, error) {
 	return targetFileList, nil
 }
 
-//The plugin will look at the state folder, and restore the offset of the file seeked if such state exists.
+// The plugin will look at the state folder, and restore the offset of the file seeked if such state exists.
 func (t *LogFile) restoreState(filename string) (int64, error) {
 	filePath := t.getStateFilePath(filename)
 
@@ -334,8 +334,10 @@ func (t *LogFile) restoreState(filename string) (int64, error) {
 		return 0, err
 	}
 
+	if offset < 0 {
+		return 0, fmt.Errorf("negative state file offset, %v, %v", filePath, offset)
+	}
 	t.Log.Infof("Reading from offset %v in %s", offset, filename)
-
 	return offset, nil
 }
 


### PR DESCRIPTION
# Description of the issue
Avoid returning a negative offset so that CWA never tries seeking to a negative offset.

# Description of changes
add a conditional block.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. Added to the existing test case
```
go test -count=1 -v ./plugins/inputs/logfile -run TestRestoreState

=== RUN   TestRestoreState
2022/11/30 15:53:50 Reading from offset 9323 in /tmp/logfile.log
--- PASS: TestRestoreState (0.00s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile	0.739s
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
3. Run `make linter`

I just ran `go fmt` on the 2 modified files.



