### PR TITLE
Fix DetectAgentMode so auto resolves to onPrem if not ec2

### DIFF
--- a/translator/util/sdkutil.go
+++ b/translator/util/sdkutil.go
@@ -22,8 +22,10 @@ const (
 	DEFAULT_PROFILE = "AmazonCloudWatchAgent"
 )
 
-var DetectRegion func(mode string, credsConfig map[string]string) string = detectRegion
-var DetectCredentialsPath func() string = detectCredentialsPath
+var DetectRegion = detectRegion
+var DetectCredentialsPath = detectCredentialsPath
+var DefaultEC2Region = defaultEC2Region
+var DefaultECSRegion = defaultECSRegion
 var runInAws = os.Getenv(config.RUN_IN_AWS)
 
 func DetectAgentMode(configuredMode string) string {
@@ -36,17 +38,17 @@ func DetectAgentMode(configuredMode string) string {
 		return config.ModeEC2
 	}
 
-	if defaultEC2Region() != "" {
+	if DefaultEC2Region() != "" {
 		fmt.Println("I! Detected the instance is EC2")
 		return config.ModeEC2
 	}
 
-	if defaultECSRegion() != "" {
+	if DefaultECSRegion() != "" {
 		fmt.Println("I! Detected the instance is ECS")
 		return config.ModeEC2
 	}
 	fmt.Println("I! Detected the instance is OnPremise")
-	return configuredMode
+	return config.ModeOnPrem
 }
 
 func SDKRegionWithCredsMap(mode string, credsConfig map[string]string) (region string) {
@@ -93,15 +95,15 @@ func detectRegion(mode string, credsConfig map[string]string) (region string) {
 	// For ec2, fallback to metadata when no region info found in credential profile.
 	if region == "" && mode == config.ModeEC2 {
 		fmt.Println("I! Trying to detect region from ec2")
-		region = defaultEC2Region()
+		region = DefaultEC2Region()
 	}
 
 	// try to get region from ecs metadata
 	if region == "" && mode == config.ModeEC2 {
 		fmt.Println("I! Trying to detect region from ecs")
-		region = defaultECSRegion()
+		region = DefaultECSRegion()
 	}
-	
+
 	return
 }
 

--- a/translator/util/sdkutil_test.go
+++ b/translator/util/sdkutil_test.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+)
+
+func TestDetectAgentModeAuto(t *testing.T) {
+	testCases := map[string]struct {
+		runInAws  string
+		ec2Region string
+		ecsRegion string
+		wantMode  string
+	}{
+		"WithRunInAWS":  {runInAws: config.RUN_IN_AWS_TRUE, wantMode: config.ModeEC2},
+		"WithEC2Region": {ec2Region: "us-east-1", wantMode: config.ModeEC2},
+		"WithECSRegion": {ecsRegion: "us-east-1", wantMode: config.ModeEC2},
+		"WithNone":      {wantMode: config.ModeOnPrem},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			runInAws = testCase.runInAws
+			DefaultEC2Region = func() string { return testCase.ec2Region }
+			DefaultECSRegion = func() string { return testCase.ecsRegion }
+			require.Equal(t, testCase.wantMode, DetectAgentMode("auto"))
+		})
+	}
+}


### PR DESCRIPTION
# Description of the issue
In the `DetectAgentMode` function, if `auto` is passed in as the mode and it detects it as on premise, it should return `onPrem` or `onPremise`. Currently, it will return the value passed in which is `auto`. This causes the `SetMode` function in the context to panic (https://github.com/aws/amazon-cloudwatch-agent/blob/main/translator/context/context.go#L109-L120)

# Description of changes
Changed the function to return `onPrem` and added a simple unit test.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added a unit test to cover the auto cases.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




