### PR TITLE
cleanup weird file path and doc comment

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -37,7 +37,7 @@ const (
 	maxConcurrentPublisher                = 10 // the number of CloudWatch clients send request concurrently
 	pushIntervalInSec                     = 60 // 60 sec
 	highResolutionTagKey                  = "aws:StorageResolution"
-	defaultRetryCount                     = 5 // this is the retry count, the total attempts would be retry count + 1 at most.
+	defaultRetryCount                     = 5 // the total number of attempts to submit a given metric
 	backoffRetryBase                      = 200 * time.Millisecond
 	MaxDimensions                         = 30
 )

--- a/tool/processors/migration/linux/linuxMigration_test.go
+++ b/tool/processors/migration/linux/linuxMigration_test.go
@@ -96,9 +96,9 @@ func TestProcessConfigFromPythonConfigParserFile(t *testing.T) {
 	[general]
 		state_file = /var/lib/awslogs/agent-state
 
-	[/apollo/env/BaldrBifrost/var/output/log/audit_pusher.log]
-		file = /apollo/env/BaldrBifrost/var/output/log/audit_pusher.log
-		log_group_name = Bifrost/audit_pusher
+	[/var/log/audit_pusher.log]
+		file = /var/log/audit_pusher.log
+		log_group_name = audit_pusher
 		log_stream_name = hsm-bqvuwqn72vk
 		datetime_format = %b %d %H:%M:%S,%f
 		encoding = euc_jp
@@ -119,8 +119,8 @@ func TestProcessConfigFromPythonConfigParserFile(t *testing.T) {
 			"files": map[string]interface{}{
 				"collect_list": []map[string]interface{}{
 					{
-						"file_path":         "/apollo/env/BaldrBifrost/var/output/log/audit_pusher.log",
-						"log_group_name":    "Bifrost/audit_pusher",
+						"file_path":         "/var/log/audit_pusher.log",
+						"log_group_name":    "audit_pusher",
 						"timestamp_format":  "%b %d %H:%M:%S,%f",
 						"log_stream_name":   "hsm-bqvuwqn72vk",
 						"encoding":          "euc-jp",


### PR DESCRIPTION
Pretty straightforward. The log path in the sample test was unintuitive. Separately, the comment for the cloudwatch plugin retry is misleading, because we make up to 5 call attempts, but the comment indicated that we do 6. The API call happens inside of the retry loop, so it doesn't make sense.



