### PR TITLE
Check for github action updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._

Best practice is to keep dependencies up-to-date as much as possible. I notice that some of the github actions which this project is using are a couple of major releases behind. For example, this project is using v2 of the cache action, but the latest version of this action is currently v3.

# Description of changes
_How does this change address the problem?_

Rather than manually check for dependency updates, an automated way to check them would be much better. This will use dependabot as that automated way of checking for dependency updates on a monthly basis.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




