### PR TITLE
Add log output when log files are deleted with auto_removal feature #636

### DIFF
--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -278,6 +278,8 @@ func (ts *tailerSrc) cleanUp() {
 	if ts.autoRemoval {
 		if err := os.Remove(ts.tailer.Filename); err != nil {
 			log.Printf("W! [logfile] Failed to auto remove file %v: %v", ts.tailer.Filename, err)
+		} else {
+			log.Printf("I! [logfile] Successfully removed file %v with auto_removal feature", ts.tailer.Filename)
 		}
 	}
 	for _, clf := range ts.cleanUpFns {


### PR DESCRIPTION
# Description of the issue
Added log output when log files are deleted with [auto_removal feature](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Logssection). This is related to #636. 

It seems that assignee (pradeepnnv) is  not working on the issue but fewer changes required. So I worked on the issue although suddenly.

# Description of changes
It will become more clear that CloudWatch Agent deleted old log files with auto_removal feature.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Run unit and build test with make command
- make test
- make release

Verify operation in my Amazon Linux 2 instance.
```
$ cat /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
...
2022-12-17T05:03:17Z I! [logfile] Successfully removed file /tmp/test/main.log.2022-12-22 with auto_removal feature
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




