### PR TITLE
Remove usage of deprecated ioutil package

### DIFF
--- a/cfg/agentinfo/info_test.go
+++ b/cfg/agentinfo/info_test.go
@@ -44,7 +44,7 @@ func TestReadVersionFile(t *testing.T) {
 	vfp := filepath.Join(filepath.Dir(ex), versionFilename)
 	expectedVersion := "TEST_VERSION"
 
-	if err = ioutil.WriteFile(vfp, []byte(expectedVersion), 0644); err != nil {
+	if err = os.WriteFile(vfp, []byte(expectedVersion), 0644); err != nil {
 		t.Fatalf("failed to write version file at %v: %v", vfp, err)
 	}
 	defer os.Remove(vfp)


### PR DESCRIPTION
# Description of the issue
_This change resolves #648 by removing the ioutil usage and corresponding os and io equivalents._

# Description of changes
_removing the ioutil usage and corresponding os and io equivalents, according to the information seen in #648._

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. - Agreed.

# Tests
_None because, I received this message: go: cannot run *test.go files. If needed, please let me know how to run tests. As this is my second commit ever and I used pipelines to conduct builds and testing in the past._

Running ... /home/ec2-user/environment/workspace/amazon-cloudwatch-agent/cfg/agentinfo/info.go
package command-line-arguments is not a main package

Running ... /home/ec2-user/environment/workspace/amazon-cloudwatch-agent/cfg/agentinfo/info.go
package command-line-arguments is not a main package

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter` - had trouble with this step explained below:

Sorry in advance if I am missing a basic concept here but, I tried running "make linter" and I got the following error:

fatal: No names found, cannot describe anything.
make: *** No rule to make target `linter'.  Stop.

Then, I tried "make lint" and here is a following output:

"WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive." 

followed by multiple errors afterwards. 



