### PR TITLE
Replace deprecated ioutil calls with os equivalent

### DIFF
--- a/cfg/agentinfo/info.go
+++ b/cfg/agentinfo/info.go
@@ -5,7 +5,6 @@ package agentinfo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -95,7 +94,7 @@ func readVersionFile() (string, error) {
 		return "", fmt.Errorf("the agent version file %s does not exist: %v", versionFilePath, err)
 	}
 
-	byteArray, err := ioutil.ReadFile(versionFilePath)
+	byteArray, err := os.ReadFile(versionFilePath)
 	if err != nil {
 		return "", fmt.Errorf("issue encountered when reading content from file %s: %v", versionFilePath, err)
 	}

--- a/cfg/agentinfo/info_test.go
+++ b/cfg/agentinfo/info_test.go
@@ -5,7 +5,6 @@ package agentinfo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -44,7 +43,7 @@ func TestReadVersionFile(t *testing.T) {
 	vfp := filepath.Join(filepath.Dir(ex), versionFilename)
 	expectedVersion := "TEST_VERSION"
 
-	if err = ioutil.WriteFile(vfp, []byte(expectedVersion), 0644); err != nil {
+	if err = os.WriteFile(vfp, []byte(expectedVersion), 0644); err != nil {
 		t.Fatalf("failed to write version file at %v: %v", vfp, err)
 	}
 	defer os.Remove(vfp)

--- a/cfg/aws/refreshable_shared_credentials_provider_test.go
+++ b/cfg/aws/refreshable_shared_credentials_provider_test.go
@@ -4,7 +4,6 @@
 package aws
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -14,10 +13,10 @@ import (
 )
 
 func TestSharedCrednetialsProviderExpiryWindowIsExpired(t *testing.T) {
-	tmpFile, _ := ioutil.TempFile(os.TempDir(), "credential")
+	tmpFile, _ := os.CreateTemp(os.TempDir(), "credential")
 	defer os.Remove(tmpFile.Name())
-	bytes, _ := ioutil.ReadFile("./testdata/credential_original")
-	ioutil.WriteFile(tmpFile.Name(), bytes, 0644)
+	bytes, _ := os.ReadFile("./testdata/credential_original")
+	os.WriteFile(tmpFile.Name(), bytes, 0644)
 	p := credentials.NewCredentials(&Refreshable_shared_credentials_provider{
 		sharedCredentialsProvider: &credentials.SharedCredentialsProvider{
 			Filename: tmpFile.Name(),
@@ -31,8 +30,8 @@ func TestSharedCrednetialsProviderExpiryWindowIsExpired(t *testing.T) {
 
 	assert.False(t, p.IsExpired(), "Expect creds not to be expired.")
 
-	bytes_rotate, _ := ioutil.ReadFile("./testdata/credential_rotate")
-	ioutil.WriteFile(tmpFile.Name(), bytes_rotate, 0644)
+	bytes_rotate, _ := os.ReadFile("./testdata/credential_rotate")
+	os.WriteFile(tmpFile.Name(), bytes_rotate, 0644)
 
 	time.Sleep(2 * time.Second)
 

--- a/cfg/migrate/confmigrate.go
+++ b/cfg/migrate/confmigrate.go
@@ -2,7 +2,7 @@ package migrate
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
@@ -17,7 +17,7 @@ func AddRule(rule Rule) {
 }
 
 func IsOldConfig(path string) (bool, error) {
-	cf, err := ioutil.ReadFile(path)
+	cf, err := os.ReadFile(path)
 	if err != nil {
 		return false, err
 	}
@@ -40,7 +40,7 @@ func IsOldConfig(path string) (bool, error) {
 }
 
 func MigrateFile(path string) (string, error) {
-	cf, err := ioutil.ReadFile(path)
+	cf, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -51,7 +51,7 @@ func MigrateFile(path string) (string, error) {
 	}
 
 	dir, _ := filepath.Split(path)
-	of, err := ioutil.TempFile(dir, "migrated-*.conf")
+	of, err := os.CreateTemp(dir, "migrated-*.conf")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary migrated config file: %v", err)
 	}

--- a/cfg/migrate/confmigrate_test.go
+++ b/cfg/migrate/confmigrate_test.go
@@ -3,7 +3,6 @@ package migrate
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,7 +12,7 @@ import (
 )
 
 func getTests() ([]string, error) {
-	files, err := ioutil.ReadDir("new/")
+	files, err := os.ReadDir("new/")
 	if err != nil {
 		return nil, fmt.Errorf("unable to list test case dir: %v", err)
 	}
@@ -72,7 +71,7 @@ func TestMigrateFile(t *testing.T) {
 			continue
 		}
 
-		mcb, err := ioutil.ReadFile(mf)
+		mcb, err := os.ReadFile(mf)
 		if err != nil {
 			t.Errorf("Failed to read test file '%v' from old folder: %v", test, err)
 			continue
@@ -84,7 +83,7 @@ func TestMigrateFile(t *testing.T) {
 			continue
 		}
 
-		ncb, err := ioutil.ReadFile(fmt.Sprintf("new/%v", test))
+		ncb, err := os.ReadFile(fmt.Sprintf("new/%v", test))
 		if err != nil {
 			t.Errorf("Failed to read test file '%v' from new folder: %v", test, err)
 			continue
@@ -115,7 +114,7 @@ func TestMigrateConfigs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ocb, err := ioutil.ReadFile(fmt.Sprintf("old/%v", test))
+		ocb, err := os.ReadFile(fmt.Sprintf("old/%v", test))
 		if err != nil {
 			t.Fatalf("Failed to read test file '%v' from old folder: %v", test, err)
 		}
@@ -125,7 +124,7 @@ func TestMigrateConfigs(t *testing.T) {
 			t.Fatalf("Failed to unmarshal old test file '%v': %v", test, err)
 		}
 
-		ncb, err := ioutil.ReadFile(fmt.Sprintf("new/%v", test))
+		ncb, err := os.ReadFile(fmt.Sprintf("new/%v", test))
 		if err != nil {
 			t.Fatalf("Failed to read test file '%v' from new folder: %v", test, err)
 		}

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
@@ -28,14 +27,15 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/agentinfo"
 	"github.com/aws/amazon-cloudwatch-agent/cfg/migrate"
-	"github.com/aws/amazon-cloudwatch-agent/logs"
-	"github.com/aws/amazon-cloudwatch-agent/profiler"
 	"github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent/internal"
+	"github.com/aws/amazon-cloudwatch-agent/logs"
 	_ "github.com/aws/amazon-cloudwatch-agent/plugins"
-	
+	"github.com/aws/amazon-cloudwatch-agent/profiler"
+
 	"github.com/influxdata/telegraf/agent"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/logger"
+
 	//_ "github.com/influxdata/telegraf/plugins/aggregators/all"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	//_ "github.com/influxdata/telegraf/plugins/inputs/all"
@@ -46,7 +46,7 @@ import (
 
 const (
 	defaultEnvCfgFileName = "env-config.json"
-	LogTargetEventLog = "eventlog"
+	LogTargetEventLog     = "eventlog"
 )
 
 var fDebug = flag.Bool("debug", false,
@@ -190,7 +190,7 @@ func loadEnvironmentVariables(path string) error {
 		return fmt.Errorf("No env config file specified")
 	}
 
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("Can't read env config file %s due to: %s", path, err.Error())
 	}
@@ -447,7 +447,7 @@ func main() {
 		if *fEnvConfig != "" {
 			parts := strings.SplitN(*fSetEnv, "=", 2)
 			if len(parts) == 2 {
-				bytes, err := ioutil.ReadFile(*fEnvConfig)
+				bytes, err := os.ReadFile(*fEnvConfig)
 				if err != nil {
 					log.Fatalf("E! Failed to read env config: %v", err)
 				}
@@ -458,14 +458,14 @@ func main() {
 				}
 				envVars[parts[0]] = parts[1]
 				bytes, err = json.MarshalIndent(envVars, "", "\t")
-				if err = ioutil.WriteFile(*fEnvConfig, bytes, 0644); err != nil {
+				if err = os.WriteFile(*fEnvConfig, bytes, 0644); err != nil {
 					log.Fatalf("E! Failed to update env config: %v", err)
 				}
 			}
 		}
 		return
 	}
-		
+
 	if runtime.GOOS == "windows" && windowsRunAsService() {
 		programFiles := os.Getenv("ProgramFiles")
 		if programFiles == "" { // Should never happen
@@ -543,7 +543,7 @@ func windowsRunAsService() bool {
 	return !service.Interactive()
 }
 
-func loadTomlConfigIntoAgent(c *config.Config) error{
+func loadTomlConfigIntoAgent(c *config.Config) error {
 	isOld, err := migrate.IsOldConfig(*fConfig)
 	if err != nil {
 		log.Printf("W! Failed to detect if config file is old format: %v", err)
@@ -578,7 +578,7 @@ func loadTomlConfigIntoAgent(c *config.Config) error{
 	return nil
 }
 
-func validateAgentFinalConfigAndPlugins(c *config.Config) error{
+func validateAgentFinalConfigAndPlugins(c *config.Config) error {
 	if !*fTest && len(c.Outputs) == 0 {
 		return errors.New("Error: no outputs found, did you provide a valid config file?")
 	}
@@ -616,6 +616,6 @@ func checkRightForBinariesFileWithInputPlugins(inputPlugins []string) (string, e
 			}
 		}
 	}
-	
+
 	return "", nil
 }

--- a/cmd/config-downloader/downloader.go
+++ b/cmd/config-downloader/downloader.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -82,7 +81,7 @@ func downloadFromSSM(region, parameterStoreName, mode string, credsConfig map[st
 }
 
 func readFromFile(filePath string) (string, error) {
-	bytes, err := ioutil.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	return string(bytes), err
 }
 
@@ -216,7 +215,7 @@ func main() {
 
 	if multiConfig != "remove" {
 		outputFilePath = filepath.Join(outputDir, outputFilePath+context.TmpFileSuffix)
-		err = ioutil.WriteFile(outputFilePath, []byte(config), 0644)
+		err = os.WriteFile(outputFilePath, []byte(config), 0644)
 		if err != nil {
 			log.Panicf("E! Failed to write the json file %v: %v", outputFilePath, err)
 		} else {

--- a/cmd/config-translator/translator_test.go
+++ b/cmd/config-translator/translator_test.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"regexp"
 	"testing"
 
@@ -180,7 +180,7 @@ func TestInvalidLogFilterConfig(t *testing.T) {
 
 // Validate all sampleConfig files schema
 func TestSampleConfigSchema(t *testing.T) {
-	if files, err := ioutil.ReadDir("../../translator/totomlconfig/sampleConfig/"); err == nil {
+	if files, err := os.ReadDir("../../translator/totomlconfig/sampleConfig/"); err == nil {
 		re := regexp.MustCompile(".json")
 		for _, file := range files {
 			if re.MatchString(file.Name()) {

--- a/cmd/start-amazon-cloudwatch-agent/start-amazon-cloudwatch-agent.go
+++ b/cmd/start-amazon-cloudwatch-agent/start-amazon-cloudwatch-agent.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -113,7 +112,7 @@ func printFileContents(path string) {
 		}
 	}()
 
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	if err != nil {
 		log.Printf("E! Error when reading file(%s), Error is %v \n", path, err)
 	}

--- a/handlers/compress.go
+++ b/handlers/compress.go
@@ -8,7 +8,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"sync"
 
@@ -17,7 +16,7 @@ import (
 
 var gzipPool = sync.Pool{
 	New: func() interface{} {
-		return gzip.NewWriter(ioutil.Discard)
+		return gzip.NewWriter(io.Discard)
 	},
 }
 

--- a/internal/ecsservicediscovery/targetsexportprocessor.go
+++ b/internal/ecsservicediscovery/targetsexportprocessor.go
@@ -5,7 +5,6 @@ package ecsservicediscovery
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -60,7 +59,7 @@ func (p *TargetsExportProcessor) Process(cluster string, taskList []*DecoratedTa
 	}
 	p.stats.AddStatsCount(ExporterDiscoveredTargetCount, len(targetsArr))
 
-	err = ioutil.WriteFile(p.tmpResultFilePath, m, 0644)
+	err = os.WriteFile(p.tmpResultFilePath, m, 0644)
 	if err != nil {
 		return nil, newServiceDiscoveryError(fmt.Sprintf("Fail to write Prometheus targets into file: %v", p.tmpResultFilePath), &err)
 	}

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -6,7 +6,6 @@ package httpclient
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
@@ -79,7 +78,7 @@ func (h *HttpClient) request(endpoint string) ([]byte, error) {
 		reader = resp.Body
 	}
 
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read response body from %s, error: %v", endpoint, err)
 	}

--- a/internal/k8sCommon/kubeletutil/kubeletclient.go
+++ b/internal/k8sCommon/kubeletutil/kubeletclient.go
@@ -6,9 +6,10 @@ package kubeletutil
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -55,7 +56,7 @@ func (k *KubeClient) ListPods() ([]corev1.Pod, error) {
 	}
 
 	if k.BearerToken != "" {
-		token, err := ioutil.ReadFile(k.BearerToken)
+		token, err := os.ReadFile(k.BearerToken)
 		if err != nil {
 			return result, err
 		}
@@ -75,7 +76,7 @@ func (k *KubeClient) ListPods() ([]corev1.Pod, error) {
 		return result, ErrKubeClientAccessFailure
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("E! Fail to read request %s body: %s", url, err)
 		return result, err

--- a/internal/k8sCommon/kubeletutil/kubeletclient_test.go
+++ b/internal/k8sCommon/kubeletutil/kubeletclient_test.go
@@ -4,11 +4,12 @@
 package kubeletutil
 
 import (
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -187,7 +188,7 @@ func (m *MockHttpRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 // Test
 func TestKubeClient_ListPods(t *testing.T) {
 	mockRoundTripper := new(MockHttpRoundTripper)
-	mockRoundTripper.On("RoundTrip", mock.Anything).Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader(podJson))})
+	mockRoundTripper.On("RoundTrip", mock.Anything).Return(&http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(podJson))})
 	client := KubeClient{roundTripper: mockRoundTripper}
 	pods, err := client.ListPods()
 	assert.Equal(t, nil, err)

--- a/internal/tls/config.go
+++ b/internal/tls/config.go
@@ -7,7 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // ClientConfig represents the standard client TLS config.
@@ -106,7 +106,7 @@ func (c *ServerConfig) TLSConfig() (*tls.Config, error) {
 func makeCertPool(certFiles []string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
 	for _, certFile := range certFiles {
-		pem, err := ioutil.ReadFile(certFile)
+		pem, err := os.ReadFile(certFile)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"could not read certificate %q: %v", certFile, err)

--- a/logger/lumberjack_const_test.go
+++ b/logger/lumberjack_const_test.go
@@ -4,7 +4,6 @@
 package logger
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestWriteLogToFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 
@@ -23,14 +22,14 @@ func TestWriteLogToFile(t *testing.T) {
 	log.Printf("I! TEST")
 	log.Printf("D! TEST") // <- should be ignored
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	log.Printf("log: %v\n", string(f))
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z I! TEST\n"))
 }
 
 func TestDebugWriteLogToFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 	config := createBasicLogConfig(tmpfile.Name())
@@ -38,13 +37,13 @@ func TestDebugWriteLogToFile(t *testing.T) {
 	logger.SetupLogging(config)
 	log.Printf("D! TEST")
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z D! TEST\n"))
 }
 
 func TestErrorWriteLogToFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 	config := createBasicLogConfig(tmpfile.Name())
@@ -53,13 +52,13 @@ func TestErrorWriteLogToFile(t *testing.T) {
 	log.Printf("E! TEST")
 	log.Printf("I! TEST") // <- should be ignored
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z E! TEST\n"))
 }
 
 func TestAddDefaultLogLevel(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 	config := createBasicLogConfig(tmpfile.Name())
@@ -67,13 +66,13 @@ func TestAddDefaultLogLevel(t *testing.T) {
 	logger.SetupLogging(config)
 	log.Printf("TEST")
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z I! TEST\n"))
 }
 
 func TestWriteToTruncatedFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 	config := createBasicLogConfig(tmpfile.Name())
@@ -81,7 +80,7 @@ func TestWriteToTruncatedFile(t *testing.T) {
 	logger.SetupLogging(config)
 	log.Printf("TEST")
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z I! TEST\n"))
 
@@ -91,7 +90,7 @@ func TestWriteToTruncatedFile(t *testing.T) {
 
 	log.Printf("SHOULD BE FIRST")
 
-	f, err = ioutil.ReadFile(tmpfile.Name())
+	f, err = os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z I! SHOULD BE FIRST\n"))
 }
@@ -101,6 +100,6 @@ func createBasicLogConfig(filename string) logger.LogConfig {
 		Logfile:             filename,
 		LogTarget:           LogTargetLumberjack,
 		RotationMaxArchives: -1,
-		LogWithTimezone: 	 "UTC",
+		LogWithTimezone:     "UTC",
 	}
 }

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -6,7 +6,6 @@ package logfile
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -322,7 +321,7 @@ func (t *LogFile) restoreState(filename string) (int64, error) {
 		return 0, err
 	}
 
-	byteArray, err := ioutil.ReadFile(filePath)
+	byteArray, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Log.Warnf("Issue encountered when reading offset from file %s: %v", filename, err)
 		return 0, err
@@ -364,7 +363,7 @@ func (t *LogFile) cleanupStateFolder() {
 			continue
 		}
 
-		byteArray, err := ioutil.ReadFile(file)
+		byteArray, err := os.ReadFile(file)
 		if err != nil {
 			t.Log.Errorf("Error happens when reading the content from file %s in clean up state fodler step: %v", file, err)
 			continue

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -5,7 +5,6 @@ package logfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -191,7 +190,7 @@ func TestCompressedFile(t *testing.T) {
 
 func TestRestoreState(t *testing.T) {
 	multilineWaitPeriod = 10 * time.Millisecond
-	tmpfolder, err := ioutil.TempDir("", "")
+	tmpfolder, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpfolder)
 
@@ -199,7 +198,7 @@ func TestRestoreState(t *testing.T) {
 	logFileStateFileName := "_tmp_logfile.log"
 
 	offset := int64(9323)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		tmpfolder+string(filepath.Separator)+logFileStateFileName,
 		[]byte(strconv.FormatInt(offset, 10)+"\n"+logFilePath),
 		os.ModePerm)
@@ -214,7 +213,7 @@ func TestRestoreState(t *testing.T) {
 
 	// Test negative offset.
 	offset = int64(-8675)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		tmpfolder+string(filepath.Separator)+logFileStateFileName,
 		[]byte(strconv.FormatInt(offset, 10)+"\n"+logFilePath),
 		os.ModePerm)
@@ -655,7 +654,7 @@ func TestLogsFileWithOffset(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 	require.NoError(t, err)
 
-	stateDir, err := ioutil.TempDir("", "state")
+	stateDir, err := os.MkdirTemp("", "state")
 	require.NoError(t, err)
 	defer os.Remove(stateDir)
 
@@ -705,7 +704,7 @@ func TestLogsFileWithInvalidOffset(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 	require.NoError(t, err)
 
-	stateDir, err := ioutil.TempDir("", "state")
+	stateDir, err := os.MkdirTemp("", "state")
 	require.NoError(t, err)
 	defer os.Remove(stateDir)
 
@@ -761,7 +760,7 @@ func TestLogsFileRecreate(t *testing.T) {
 	_, err = tmpfile.WriteString(logEntryString + "\n")
 	require.NoError(t, err)
 
-	stateDir, err := ioutil.TempDir("", "state")
+	stateDir, err := os.MkdirTemp("", "state")
 	require.NoError(t, err)
 	defer os.Remove(stateDir)
 
@@ -896,7 +895,7 @@ func TestLogsPartialLineReading(t *testing.T) {
 func TestLogFileMultiLogsReading(t *testing.T) {
 	multilineWaitPeriod = 10 * time.Millisecond
 	logEntryString := "This is from Agent log"
-	dir, e := ioutil.TempDir("", "test")
+	dir, e := os.MkdirTemp("", "test")
 	require.NoError(t, e)
 	defer os.Remove(dir)
 	agentLog, err := createTempFile(dir, "test_agent.log")
@@ -959,7 +958,7 @@ func TestLogFileMultiLogsReading(t *testing.T) {
 func TestLogFileMultiLogsReadingAddingFile(t *testing.T) {
 	multilineWaitPeriod = 10 * time.Millisecond
 	logEntryString := "This is from Agent log"
-	dir, e := ioutil.TempDir("", "test")
+	dir, e := os.MkdirTemp("", "test")
 	require.NoError(t, e)
 	defer os.Remove(dir)
 

--- a/plugins/inputs/logfile/tail/tail_test.go
+++ b/plugins/inputs/logfile/tail/tail_test.go
@@ -2,7 +2,6 @@ package tail
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -119,7 +118,7 @@ func TestStopAtEOF(t *testing.T) {
 }
 
 func setup(t *testing.T) (*os.File, *Tail, *testLogger) {
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -5,7 +5,6 @@ package logfile
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -335,5 +334,5 @@ func (ts *tailerSrc) saveState(offset int64) error {
 	}
 
 	content := []byte(strconv.FormatInt(offset, 10) + "\n" + ts.tailer.Filename)
-	return ioutil.WriteFile(ts.stateFilePath, content, stateFileMode)
+	return os.WriteFile(ts.stateFilePath, content, stateFileMode)
 }

--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -41,7 +40,7 @@ func TestTailerSrc(t *testing.T) {
 		t.Errorf("Failed to create temp file: %v", err)
 	}
 
-	statefile, err := ioutil.TempFile("", "tailsrctest-state-*.log")
+	statefile, err := os.CreateTemp("", "tailsrctest-state-*.log")
 	defer os.Remove(statefile.Name())
 	if err != nil {
 		t.Errorf("Failed to create temp file: %v", err)
@@ -165,7 +164,7 @@ func TestOffsetDoneCallBack(t *testing.T) {
 		t.Errorf("Failed to create temp file: %v", err)
 	}
 
-	statefile, err := ioutil.TempFile("", "tailsrctest-state-*.log")
+	statefile, err := os.CreateTemp("", "tailsrctest-state-*.log")
 	defer os.Remove(statefile.Name())
 	if err != nil {
 		t.Errorf("Failed to create temp file: %v", err)
@@ -216,7 +215,7 @@ func TestOffsetDoneCallBack(t *testing.T) {
 		log.Println(i)
 		if i == 10 { // Test before first truncate
 			time.Sleep(1 * time.Second)
-			b, err := ioutil.ReadFile(statefile.Name())
+			b, err := os.ReadFile(statefile.Name())
 			if err != nil {
 				t.Errorf("Failed to read state file: %v", err)
 			}
@@ -233,7 +232,7 @@ func TestOffsetDoneCallBack(t *testing.T) {
 		if i == 15 { // Test after first truncate, saved offset should decrease
 			time.Sleep(1 * time.Second)
 			log.Println(statefile.Name())
-			b, err := ioutil.ReadFile(statefile.Name())
+			b, err := os.ReadFile(statefile.Name())
 			log.Println(b)
 			if err != nil {
 				t.Errorf("Failed to read state file: %v", err)
@@ -256,7 +255,7 @@ func TestOffsetDoneCallBack(t *testing.T) {
 
 		if i == 35 { // Test after 2nd truncate, the offset should be larger
 			time.Sleep(1 * time.Second)
-			b, err := ioutil.ReadFile(statefile.Name())
+			b, err := os.ReadFile(statefile.Name())
 			if err != nil {
 				t.Errorf("Failed to read state file: %v", err)
 			}

--- a/plugins/inputs/logfile/tmpfile.go
+++ b/plugins/inputs/logfile/tmpfile.go
@@ -4,10 +4,9 @@
 package logfile
 
 import (
-	"io/ioutil"
 	"os"
 )
 
 func createTempFile(dir, prefix string) (*os.File, error) {
-	return ioutil.TempFile(dir, prefix)
+	return os.CreateTemp(dir, prefix)
 }

--- a/plugins/inputs/logfile/tmpfile_windows.go
+++ b/plugins/inputs/logfile/tmpfile_windows.go
@@ -2,14 +2,13 @@ package logfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail/winfile"
 )
 
 func createTempFile(dir, prefix string) (*os.File, error) {
-	file, err := ioutil.TempFile(dir, prefix)
+	file, err := os.CreateTemp(dir, prefix)
 	if err := file.Close(); err != nil {
 		return nil, fmt.Errorf("Failed to close created temp file %v: %w", file.Name(), err)
 	}

--- a/plugins/inputs/prometheus_scraper/start.go
+++ b/plugins/inputs/prometheus_scraper/start.go
@@ -21,6 +21,12 @@ package prometheus_scraper
 
 import (
 	"context"
+	"os"
+	"os/signal"
+	"runtime"
+	"sync"
+	"syscall"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/run"
@@ -36,14 +42,8 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	promRuntime "github.com/prometheus/prometheus/util/runtime"
-	"io/ioutil"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
-	"os"
-	"os/signal"
-	"runtime"
-	"sync"
-	"syscall"
 )
 
 var (
@@ -270,7 +270,7 @@ const (
 
 func reloadConfig(filename string, logger log.Logger, rls ...func(*config.Config) error) (err error) {
 	level.Info(logger).Log("msg", "Loading configuration file", "filename", filename)
-	content, _ := ioutil.ReadFile(filename)
+	content, _ := os.ReadFile(filename)
 	text := string(content)
 	level.Debug(logger).Log("msg", "Prometheus configuration file", "value", text)
 

--- a/plugins/inputs/windows_event_log/wineventlog/utils.go
+++ b/plugins/inputs/windows_event_log/wineventlog/utils.go
@@ -9,7 +9,7 @@ package wineventlog
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"strconv"
 	"strings"
@@ -105,7 +105,7 @@ func utf16ToUTF8Bytes(in []byte, length uint32) ([]byte, error) {
 	win16be := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
 	utf16bom := unicode.BOMOverride(win16be.NewDecoder())
 	unicodeReader := transform.NewReader(bytes.NewReader(in[:i]), utf16bom)
-	decoded, err := ioutil.ReadAll(unicodeReader)
+	decoded, err := io.ReadAll(unicodeReader)
 	return decoded, err
 }
 

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -8,7 +8,6 @@ package wineventlog
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -226,7 +225,7 @@ func (w *windowsEventLog) saveState(offset uint64) error {
 	}
 
 	content := []byte(strconv.FormatUint(offset, 10) + "\n" + w.logGroupName)
-	return ioutil.WriteFile(w.stateFilePath, content, 0644)
+	return os.WriteFile(w.stateFilePath, content, 0644)
 }
 
 func (w *windowsEventLog) read() []*windowsEventLogRecord {
@@ -361,7 +360,7 @@ func (w *windowsEventLog) loadState() {
 		log.Printf("I! [wineventlog] The state file for %s does not exist: %v", w.stateFilePath, err)
 		return
 	}
-	byteArray, err := ioutil.ReadFile(w.stateFilePath)
+	byteArray, err := os.ReadFile(w.stateFilePath)
 	if err != nil {
 		log.Printf("W! [wineventlog] Issue encountered when reading offset from file %s: %v", w.stateFilePath, err)
 		return

--- a/plugins/processors/ecsdecorator/cgroup.go
+++ b/plugins/processors/ecsdecorator/cgroup.go
@@ -6,7 +6,6 @@ package ecsdecorator
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -97,7 +96,7 @@ func readString(dirpath string, file string) (string, error) {
 	cgroupFile := path.Join(dirpath, file)
 
 	// Read
-	out, err := ioutil.ReadFile(cgroupFile)
+	out, err := os.ReadFile(cgroupFile)
 	if err != nil {
 		// Ignore non-existent files
 		log.Printf("W! readString: Failed to read %q: %s", cgroupFile, err)

--- a/tool/processors/migration/linux/linuxMigration_test.go
+++ b/tool/processors/migration/linux/linuxMigration_test.go
@@ -4,7 +4,6 @@
 package linux
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -39,10 +38,10 @@ func TestProcessor_Process(t *testing.T) {
 		initial_position = start_of_file
 		log_group_name = /var/log/messages
 	`
-	tmpFile, _ := ioutil.TempFile("", "")
+	tmpFile, _ := os.CreateTemp("", "")
 	defer os.Remove(tmpFile.Name())
 
-	err := ioutil.WriteFile(tmpFile.Name(), []byte(tomlString), os.ModePerm)
+	err := os.WriteFile(tmpFile.Name(), []byte(tomlString), os.ModePerm)
 	assert.NoError(t, err)
 
 	expectedMap := map[string]interface{}{
@@ -139,10 +138,10 @@ func TestProcessConfigFromPythonConfigParserFile(t *testing.T) {
 		},
 	}
 
-	tmpFile, _ := ioutil.TempFile("", "")
+	tmpFile, _ := os.CreateTemp("", "")
 	defer os.Remove(tmpFile.Name())
 
-	err := ioutil.WriteFile(tmpFile.Name(), []byte(tomlString), os.ModePerm)
+	err := os.WriteFile(tmpFile.Name(), []byte(tomlString), os.ModePerm)
 	assert.NoError(t, err)
 
 	ctx := new(runtime.Context)

--- a/tool/processors/migration/windows/windows_migration.go
+++ b/tool/processors/migration/windows/windows_migration.go
@@ -5,7 +5,6 @@ package windows
 
 import (
 	"encoding/json"
-	"io/ioutil"
 
 	"fmt"
 	"os"
@@ -43,7 +42,7 @@ func migrateOldAgentConfig() {
 	// 1 - parse the old config
 	var oldConfig OldSsmCwConfig
 	absPath := util.AskWithDefault(filePathWindowsConfigQuestion, DefaultFilePathWindowsConfiguration)
-	if file, err := ioutil.ReadFile(absPath); err == nil {
+	if file, err := os.ReadFile(absPath); err == nil {
 		if err := json.Unmarshal(file, &oldConfig); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to parse the provided configuration file. Error details: %v", err)
 			os.Exit(1)

--- a/tool/processors/migration/windows/windows_util.go
+++ b/tool/processors/migration/windows/windows_util.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 )
 
@@ -23,7 +23,7 @@ func AreTwoConfigurationsEqual(config1 NewCwConfig, config2 NewCwConfig) bool {
 
 func ReadNewConfigFromPath(path string) (config NewCwConfig, err error) {
 	var file []byte
-	if file, err = ioutil.ReadFile(path); err == nil {
+	if file, err = os.ReadFile(path); err == nil {
 		if err = json.Unmarshal(file, &config); err == nil {
 			return config, nil
 		}
@@ -34,7 +34,7 @@ func ReadNewConfigFromPath(path string) (config NewCwConfig, err error) {
 
 func ReadOldConfigFromPath(path string) (config OldSsmCwConfig, err error) {
 	var file []byte
-	if file, err = ioutil.ReadFile(path); err == nil {
+	if file, err = os.ReadFile(path); err == nil {
 		if err = json.Unmarshal(file, &config); err == nil {
 			return config, nil
 		}
@@ -45,7 +45,7 @@ func ReadOldConfigFromPath(path string) (config OldSsmCwConfig, err error) {
 
 func ReadConfigFromPathAsString(path string) (str string, err error) {
 	var file []byte
-	if file, err = ioutil.ReadFile(path); err == nil {
+	if file, err = os.ReadFile(path); err == nil {
 		return string(file), nil
 	}
 	fmt.Println(err)

--- a/tool/util/util.go
+++ b/tool/util/util.go
@@ -6,7 +6,6 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -57,7 +56,7 @@ func ConfigFilePath() string {
 
 func PermissionCheck() {
 	filePath := ConfigFilePath()
-	err := ioutil.WriteFile(filePath, []byte(""), 0755)
+	err := os.WriteFile(filePath, []byte(""), 0755)
 	if err != nil {
 		fmt.Printf("Make sure that you have write permission to %s\n", filePath)
 		os.Exit(1)
@@ -66,7 +65,7 @@ func PermissionCheck() {
 
 func ReadConfigFromJsonFile() string {
 	filePath := ConfigFilePath()
-	byteArray, err := ioutil.ReadFile(filePath)
+	byteArray, err := os.ReadFile(filePath)
 	if err != nil {
 		fmt.Printf("Error in reading config from file %s: %v\n", filePath, err)
 		os.Exit(1)
@@ -85,7 +84,7 @@ func SerializeResultMapToJsonByteArray(resultMap map[string]interface{}) []byte 
 
 func SaveResultByteArrayToJsonFile(resultByteArray []byte) string {
 	filePath := ConfigFilePath()
-	err := ioutil.WriteFile(filePath, resultByteArray, 0755)
+	err := os.WriteFile(filePath, resultByteArray, 0755)
 	if err != nil {
 		fmt.Printf("Error in writing file to %s: %v\nMake sure that you have write permission to %s.", filePath, err, filePath)
 		os.Exit(1)

--- a/tool/util/util_test.go
+++ b/tool/util/util_test.go
@@ -4,7 +4,6 @@
 package util
 
 import (
-	"io/ioutil"
 	"runtime"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestCurOS(t *testing.T) {
 }
 
 func TestReadConfigFromJsonFile(t *testing.T) {
-	err := ioutil.WriteFile(ConfigFilePath(), []byte(expectResult), os.ModePerm)
+	err := os.WriteFile(ConfigFilePath(), []byte(expectResult), os.ModePerm)
 	assert.NoError(t, err)
 
 	actualResult := ReadConfigFromJsonFile()
@@ -58,7 +57,7 @@ func TestSerializeResultMapToJsonByteArray(t *testing.T) {
 
 func TestSaveResultByteArrayToJsonFile(t *testing.T) {
 	filePath := SaveResultByteArrayToJsonFile([]byte(expectResult))
-	bytes, err := ioutil.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	assert.NoError(t, err)
 	actualResult := string(bytes)
 	assert.Equal(t, expectResult, actualResult)

--- a/translator/cmdutil/translatorutil.go
+++ b/translator/cmdutil/translatorutil.go
@@ -5,7 +5,6 @@ package cmdutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -35,7 +34,7 @@ const (
 func TranslateJsonMapToTomlFile(jsonConfigValue map[string]interface{}, tomlConfigFilePath string) {
 	res := totomlconfig.ToTomlConfig(jsonConfigValue)
 	if translator.IsTranslateSuccess() {
-		if err := ioutil.WriteFile(tomlConfigFilePath, []byte(res), tomlFileMode); err != nil {
+		if err := os.WriteFile(tomlConfigFilePath, []byte(res), tomlFileMode); err != nil {
 			log.Panicf("E! Failed to create the configuration validation file. Reason: %s", err.Error())
 		} else {
 			for _, infoMessage := range translator.InfoMessages {
@@ -54,7 +53,7 @@ func TranslateJsonMapToEnvConfigFile(jsonConfigValue map[string]interface{}, env
 		return
 	}
 	bytes := toenvconfig.ToEnvConfig(jsonConfigValue)
-	if err := ioutil.WriteFile(envConfigPath, bytes, 0644); err != nil {
+	if err := os.WriteFile(envConfigPath, bytes, 0644); err != nil {
 		log.Panicf("E! Failed to create env config. Reason: %s", err.Error())
 	}
 }

--- a/translator/cmdutil/userutil_linux_test.go
+++ b/translator/cmdutil/userutil_linux_test.go
@@ -8,7 +8,6 @@ package cmdutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ import (
 )
 
 func TestGetGroupIds(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "group-file-test")
+	tmpfile, err := os.CreateTemp("", "group-file-test")
 	require.Nil(t, err, "Failed to create temp file")
 
 	defer os.Remove(tmpfile.Name())

--- a/translator/cmdutil/userutil_test.go
+++ b/translator/cmdutil/userutil_test.go
@@ -4,7 +4,6 @@
 package cmdutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -26,7 +25,7 @@ func (c *MockChowner) Chown(path string, uid, gid int) error {
 }
 
 func TestChangeFileOwner(t *testing.T) {
-	base, err := ioutil.TempDir("", "testChown")
+	base, err := os.MkdirTemp("", "testChown")
 	if err != nil {
 		t.Fatalf("failed to crate temp test folder: %v", err)
 	}

--- a/translator/config/schema_test.go
+++ b/translator/config/schema_test.go
@@ -4,7 +4,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGetJsonSchema(t *testing.T) {
-	jsonFile, err := ioutil.ReadFile("./schema.json")
+	jsonFile, err := os.ReadFile("./schema.json")
 	if err != nil {
 		panic(err)
 	}

--- a/translator/jsonconfig/mergeJsonConfig_test.go
+++ b/translator/jsonconfig/mergeJsonConfig_test.go
@@ -6,8 +6,8 @@ package jsonconfig
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"reflect"
 	"testing"
 
@@ -70,7 +70,7 @@ func executeTest(t *testing.T, testData TestData) {
 		t.Fatalf("Failed to merge json maps with error: %v", err)
 	}
 	expectedFileName := fmt.Sprintf("./sampleJsonConfig/test_%v/expected_output.json", testData.testId)
-	expectedOutputBytes, err := ioutil.ReadFile(expectedFileName)
+	expectedOutputBytes, err := os.ReadFile(expectedFileName)
 	if err != nil {
 		t.Fatalf("Failed to read expected output file %v with error: %v", expectedFileName, err)
 	}

--- a/translator/toenvconfig/toEnvConfig_test.go
+++ b/translator/toenvconfig/toEnvConfig_test.go
@@ -6,7 +6,6 @@ package toenvconfig
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"testing"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator"
@@ -22,7 +21,7 @@ import (
 )
 
 func ReadFromFile(filename string) string {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}
@@ -93,7 +92,7 @@ func TestStatsDConfig(t *testing.T) {
 	checkIfTranslateSucceed(t, ReadFromFile("../totomlconfig/sampleConfig/statsd_config.json"), "windows", expectedEnvVars)
 }
 
-//Linux only for CollectD
+// Linux only for CollectD
 func TestCollectDConfig(t *testing.T) {
 	resetContext()
 	expectedEnvVars := map[string]string{}
@@ -127,7 +126,7 @@ func TestLogOnlyConfig(t *testing.T) {
 	checkIfTranslateSucceed(t, ReadFromFile("../totomlconfig/sampleConfig/log_only_config_windows.json"), "windows", expectedEnvVars)
 }
 
-//test settings in commonconfig will override the ones in json config
+// test settings in commonconfig will override the ones in json config
 func TestStandardConfigWithCommonConfig(t *testing.T) {
 	resetContext()
 	readCommonConifg()
@@ -171,7 +170,7 @@ func TestECSNodeMetricConfig(t *testing.T) {
 func readCommonConifg() {
 	ctx := context.CurrentContext()
 	conf := commonconfig.New()
-	data, _ := ioutil.ReadFile("../totomlconfig/sampleConfig/commonConfigTest.toml")
+	data, _ := os.ReadFile("../totomlconfig/sampleConfig/commonConfigTest.toml")
 	conf.Parse(bytes.NewReader(data))
 	ctx.SetCredentials(conf.CredentialsMap())
 	ctx.SetProxy(conf.ProxyMap())

--- a/translator/totomlconfig/toTomlConfig_test.go
+++ b/translator/totomlconfig/toTomlConfig_test.go
@@ -6,7 +6,6 @@ package totomlconfig
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ import (
 )
 
 func ReadFromFile(filename string) string {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +60,6 @@ func TestLogMetricOnPrem(t *testing.T) {
 	os.Unsetenv(config.HOST_NAME)
 	os.Unsetenv(config.HOST_IP)
 }
-
 
 func TestLogMetricOnPremise(t *testing.T) {
 	resetContext()
@@ -129,14 +127,14 @@ func TestStatsDConfig(t *testing.T) {
 	checkTomlTranslation(t, "./sampleConfig/statsd_config.json", "./sampleConfig/statsd_config_windows.conf", "windows")
 }
 
-//Linux only for CollectD
+// Linux only for CollectD
 func TestCollectDConfig(t *testing.T) {
 	resetContext()
 	checkTomlTranslation(t, "./sampleConfig/collectd_config_linux.json", "./sampleConfig/collectd_config_linux.conf", "linux")
 	checkTomlTranslation(t, "./sampleConfig/collectd_config_linux.json", "./sampleConfig/collectd_config_linux.conf", "darwin")
 }
 
-//prometheus
+// prometheus
 func TestPrometheusConfig(t *testing.T) {
 	resetContext()
 	context.CurrentContext().SetRunInContainer(true)
@@ -251,7 +249,7 @@ func checkTomlTranslation(t *testing.T, jsonPath string, desiredTomlPath string,
 func readCommonConfig() {
 	ctx := context.CurrentContext()
 	config := commonconfig.New()
-	data, _ := ioutil.ReadFile("./sampleConfig/commonConfigTest.toml")
+	data, _ := os.ReadFile("./sampleConfig/commonConfigTest.toml")
 	config.Parse(bytes.NewReader(data))
 	ctx.SetCredentials(config.CredentialsMap())
 	ctx.SetProxy(config.ProxyMap())

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list.go
@@ -5,7 +5,7 @@ package collect_list
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 
@@ -37,7 +37,7 @@ func RegisterRule(fieldname string, r []Rule) {
 	ChildRule[fieldname] = r
 }
 
-//resetIndex resets the state of the Index.
+// resetIndex resets the state of the Index.
 func resetIndex() {
 	Index = 0
 }
@@ -119,7 +119,7 @@ func outputLogConfig(logConfigs []interface{}) {
 		Region:     agent.Global_Config.Region,
 	}
 	if bytes, err := json.Marshal(outputFile); err == nil {
-		ioutil.WriteFile(outputLogConfigFilePath, bytes, 0644)
+		os.WriteFile(outputLogConfigFilePath, bytes, 0644)
 	}
 }
 

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
@@ -5,7 +5,6 @@ package collect_list
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -183,9 +182,9 @@ func applyRule1(t *testing.T, buf string) interface{} {
 	return val
 }
 
-//stdNumMonth     // "1"         //%-m
-//stdDay          // "2"         //%-d
-//-hour:-minute:-seconds does not work for golang parser.
+// stdNumMonth     // "1"         //%-m
+// stdDay          // "2"         //%-d
+// -hour:-minute:-seconds does not work for golang parser.
 func TestTimestampFormat_NonZeroPadding(t *testing.T) {
 	f := new(FileConfig)
 	var input interface{}
@@ -231,7 +230,7 @@ func TestTimestampFormat_NonZeroPadding(t *testing.T) {
 	}
 }
 
-//^ . * ? | [ ] ( ) { } $
+// ^ . * ? | [ ] ( ) { } $
 func TestTimestampFormat_SpecialCharacters(t *testing.T) {
 	f := new(FileConfig)
 	var input interface{}
@@ -480,7 +479,7 @@ func TestAutoRemoval(t *testing.T) {
 }
 
 func TestFileConfigOutputFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -515,7 +514,7 @@ func TestFileConfigOutputFile(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	assert.NoError(t, err)
 
 	expectVal := "{\"version\":\"1\",\"log_configs\":[{\"log_group_name\":\"group1\"},{\"log_group_name\":\"group2\"},{\"log_group_name\":\"group3\"}],\"region\":\"us-east-1\"}"

--- a/translator/translate/logs/metrics_collected/prometheus/ruleConfigPath.go
+++ b/translator/translate/logs/metrics_collected/prometheus/ruleConfigPath.go
@@ -4,7 +4,6 @@
 package emfprocessor
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -65,7 +64,7 @@ func (obj *ConfigPath) ApplyRule(input interface{}) (string, interface{}) {
 		downloadingPath := getDownloadPath()
 		configEnv := splitConfigPath(configPath)
 		if cc, ok := os.LookupEnv(configEnv); ok {
-			if error := ioutil.WriteFile(downloadingPath, []byte(cc), yamlFileMode); error != nil {
+			if error := os.WriteFile(downloadingPath, []byte(cc), yamlFileMode); error != nil {
 				log.Panicf("Failed to download the Prometheus config yaml file. Reason: %s", error.Error())
 			} else {
 				log.Printf("Downloaded the prometheus config from ENV: %v.", configEnv)

--- a/translator/util/httpclient/httpclient.go
+++ b/translator/util/httpclient/httpclient.go
@@ -5,7 +5,7 @@ package httpclient
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"net/http"
@@ -63,7 +63,7 @@ func (h *HttpClient) request(endpoint string) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read response body from %s, error: %v", endpoint, err)
 	}

--- a/translator/util/ioutil.go
+++ b/translator/util/ioutil.go
@@ -6,7 +6,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 )
@@ -28,7 +28,7 @@ func GetDefaultJsonConfigMap(osType, mode string) (map[string]interface{}, error
 
 // get the json map from a file
 func GetJsonMapFromFile(filename string) (map[string]interface{}, error) {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description of the issue
This PR replaces calls to ioutil module which is deprecated with os module equivalent, it fixes this issue [648](https://github.com/aws/amazon-cloudwatch-agent/issues/648)

# Description of changes
_How does this change address the problem?_

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




