### PR TITLE
Reduce Name Of EC2LinuxIntegrationTest To Show More Test Info In GHA

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -501,7 +501,7 @@ jobs:
 
   EC2LinuxIntegrationTest:
     needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
-    name: 'EC2LinuxIntegrationTest'
+    name: 'Test'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Description of the issue
Test info is being cut off. 

# Description of changes
Reduce test name size to increase test info shown. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
None

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




