### PR TITLE
Create security test job in integration test workflow

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_NAME: "ChenaLee/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/ChenaLee/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "securityRevision"
 
 on:
   push:

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -894,7 +894,7 @@ jobs:
 #          command: cd terraform/ec2/linux && terraform destroy --auto-approve
 
   EC2AcceptanceIntegrationTest:
-    needs: [ECSFargateIntegrationTest, ECSEC2LaunchDaemonIntegrationTest, EC2LinuxIntegrationTest] #For now to make testing easier. Later this will be moved to post feature tests
+    needs: [ECSFargateIntegrationTest, ECSEC2LaunchDaemonIntegrationTest, EC2LinuxIntegrationTest]
     name: 'Acceptance'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -132,6 +132,7 @@ jobs:
       ec2_performance_matrix: ${{steps.set-matrix.outputs.ec2_performance_matrix}}
       ecs_ec2_launch_daemon_matrix: ${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}
       ecs_fargate_matrix: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}
+      ec2_security_matrix: ${{ steps.set-matrix.outputs.ec2_security_matrix }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -152,6 +153,8 @@ jobs:
           echo "::set-output name=ec2_performance_matrix::$(echo $(cat generator/resources/ec2_performance_complete_test_matrix.json))"
           echo "::set-output name=ecs_ec2_launch_daemon_matrix::$(echo $(cat generator/resources/ecs_ec2_daemon_complete_test_matrix.json))"
           echo "::set-output name=ecs_fargate_matrix::$(echo $(cat generator/resources/ecs_fargate_complete_test_matrix.json))"
+          echo "::set-output name=ec2_security_matrix::$(echo $(cat generator/resources/ec2_security_complete_test_matrix.json))"
+
       - name: Echo test plan matrix
         run: |
           echo "ec2_gpu_matrix: ${{ steps.set-matrix.outputs.ec2_gpu_matrix }}"
@@ -159,6 +162,8 @@ jobs:
           echo "ec2_performance_matrix: ${{ steps.set-matrix.outputs.ec2_performance_matrix}}"
           echo "ecs_ec2_launch_daemon_matrix${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}"
           echo "ecs_fargate_matrix${{ steps.set-matrix.outputs.ecs_fargate_matrix }}"
+          echo "ec2_security_matrix${{ steps.set-matrix.outputs.ec2_security_matrix }}"
+
   MakeMSIZip:
     name: 'MakeMSIZip'
     runs-on: ubuntu-latest
@@ -888,7 +893,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_linux_matrix) }}
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_security_matrix) }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "ChenaLee/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/ChenaLee/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "securityWorkflow"
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
 on:
   push:
@@ -648,7 +648,7 @@ jobs:
     name: 'StopLocalStack'
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [ StartLocalStack, EC2LinuxIntegrationTest ]
+    needs: [ StartLocalStack, EC2LinuxIntegrationTest, EC2SecurityIntegrationTest ]
     defaults:
       run:
         working-directory: terraform/ec2/localstack
@@ -701,6 +701,13 @@ jobs:
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+
+      - name: Cache if success
+          id: ecs-ec2-launch-daemon-integration-test
+          uses: actions/cache@v2
+          with:
+            path: go.mod
+            key: ecs-ec2-launch-daemon-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
       - name: Login ECR
         id: login-ecr
@@ -887,7 +894,7 @@ jobs:
 #          command: cd terraform/ec2/linux && terraform destroy --auto-approve
 
   EC2SecurityIntegrationTest:
-    needs: [MakeBinary, StartLocalStack, GenerateTestMatrix] #For now to make testing easier. Later this will be moved to post feature tests
+    needs: [ECSFargateIntegrationTest, ECSEC2LaunchDaemonIntegrationTest, EC2LinuxIntegrationTest] #For now to make testing easier. Later this will be moved to post feature tests
     name: 'Security'
     runs-on: ubuntu-latest
     strategy:
@@ -909,13 +916,12 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
 
- # For now, to rerun tests during development
- #     - name: Cache if success
- #       id: ec2-linux-integration-test
- #       uses: actions/cache@v2
- #       with:
- #         path: go.mod
- #         key: ec2-security-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+      - name: Cache if success
+        id: ec2-linux-integration-test
+        uses: actions/cache@v2
+        with:
+          path: go.mod
+          key: ec2-security-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
       - name: Echo Test Info
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -916,12 +916,12 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
 
-      - name: Cache if success
-        id: ec2-linux-integration-test
-        uses: actions/cache@v2
-        with:
-          path: go.mod
-          key: ec2-security-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+#      - name: Cache if success
+#        id: ec2-linux-integration-test
+#        uses: actions/cache@v2
+#        with:
+#          path: go.mod
+#          key: ec2-security-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
       - name: Echo Test Info
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -894,7 +894,7 @@ jobs:
 #          command: cd terraform/ec2/linux && terraform destroy --auto-approve
 
   EC2AcceptanceIntegrationTest:
-    needs: [ECSFargateIntegrationTest, ECSEC2LaunchDaemonIntegrationTest, EC2LinuxIntegrationTest]
+    needs: [ECSFargateIntegrationTest, ECSEC2LaunchDaemonIntegrationTest, EC2LinuxIntegrationTest, GenerateTestMatrix]
     name: 'Acceptance'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_NAME: "ChenaLee/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/ChenaLee/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "securityWorkflow"
 
 on:
   push:

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -132,7 +132,7 @@ jobs:
       ec2_performance_matrix: ${{steps.set-matrix.outputs.ec2_performance_matrix}}
       ecs_ec2_launch_daemon_matrix: ${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}
       ecs_fargate_matrix: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}
-      ec2_security_matrix: ${{ steps.set-matrix.outputs.ec2_security_matrix }}
+      ec2_acceptance_matrix: ${{ steps.set-matrix.outputs.ec2_acceptance_matrix }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -153,7 +153,7 @@ jobs:
           echo "::set-output name=ec2_performance_matrix::$(echo $(cat generator/resources/ec2_performance_complete_test_matrix.json))"
           echo "::set-output name=ecs_ec2_launch_daemon_matrix::$(echo $(cat generator/resources/ecs_ec2_daemon_complete_test_matrix.json))"
           echo "::set-output name=ecs_fargate_matrix::$(echo $(cat generator/resources/ecs_fargate_complete_test_matrix.json))"
-          echo "::set-output name=ec2_security_matrix::$(echo $(cat generator/resources/ec2_security_complete_test_matrix.json))"
+          echo "::set-output name=ec2_acceptance_matrix::$(echo $(cat generator/resources/ec2_acceptance_complete_test_matrix.json))"
 
       - name: Echo test plan matrix
         run: |
@@ -162,7 +162,7 @@ jobs:
           echo "ec2_performance_matrix: ${{ steps.set-matrix.outputs.ec2_performance_matrix}}"
           echo "ecs_ec2_launch_daemon_matrix${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}"
           echo "ecs_fargate_matrix${{ steps.set-matrix.outputs.ecs_fargate_matrix }}"
-          echo "ec2_security_matrix${{ steps.set-matrix.outputs.ec2_security_matrix }}"
+          echo "ec2_acceptance_matrix${{ steps.set-matrix.outputs.ec2_acceptance_matrix }}"
 
   MakeMSIZip:
     name: 'MakeMSIZip'
@@ -648,7 +648,7 @@ jobs:
     name: 'StopLocalStack'
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [ StartLocalStack, EC2LinuxIntegrationTest, EC2SecurityIntegrationTest ]
+    needs: [ StartLocalStack, EC2LinuxIntegrationTest, EC2AcceptanceIntegrationTest ]
     defaults:
       run:
         working-directory: terraform/ec2/localstack
@@ -893,14 +893,14 @@ jobs:
 #          retry_wait_seconds: 5
 #          command: cd terraform/ec2/linux && terraform destroy --auto-approve
 
-  EC2SecurityIntegrationTest:
+  EC2AcceptanceIntegrationTest:
     needs: [ECSFargateIntegrationTest, ECSEC2LaunchDaemonIntegrationTest, EC2LinuxIntegrationTest] #For now to make testing easier. Later this will be moved to post feature tests
-    name: 'Security'
+    name: 'Acceptance'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_security_matrix) }}
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_acceptance_matrix) }}
     permissions:
       id-token: write
       contents: read
@@ -921,7 +921,7 @@ jobs:
 #        uses: actions/cache@v2
 #        with:
 #          path: go.mod
-#          key: ec2-security-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+#          key: ec2-acceptance-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
       - name: Echo Test Info
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
@@ -931,7 +931,7 @@ jobs:
 
       # nick-fields/retry@v2 starts at base dir
       - name: Terraform apply
-        if: steps.ec2-security-test.outputs.cache-hit != 'true'
+        if: steps.ec2-acceptance-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -961,7 +961,7 @@ jobs:
 
       #This is here just in case workflow cancel
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-security-test.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() && steps.ec2-acceptance-test.outputs.cache-hit != 'true' }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -703,11 +703,11 @@ jobs:
           aws-region: us-west-2
 
       - name: Cache if success
-          id: ecs-ec2-launch-daemon-integration-test
-          uses: actions/cache@v2
-          with:
-            path: go.mod
-            key: ecs-ec2-launch-daemon-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+        id: ecs-ec2-launch-daemon-integration-test
+        uses: actions/cache@v2
+        with:
+          path: go.mod
+          key: ecs-ec2-launch-daemon-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
       - name: Login ECR
         id: login-ecr

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -880,3 +880,80 @@ jobs:
 #          timeout_minutes: 8
 #          retry_wait_seconds: 5
 #          command: cd terraform/ec2/linux && terraform destroy --auto-approve
+
+  EC2SecurityIntegrationTest:
+    needs: [MakeBinary, StartLocalStack, GenerateTestMatrix] #For now to make testing easier. Later this will be moved to post feature tests
+    name: 'Security'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_linux_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+ # For now, to rerun tests during development
+ #     - name: Cache if success
+ #       id: ec2-linux-integration-test
+ #       uses: actions/cache@v2
+ #       with:
+ #         path: go.mod
+ #         key: ec2-security-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
+      - name: Echo Test Info
+        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+      # nick-fields/retry@v2 starts at base dir
+      - name: Terraform apply
+        if: steps.ec2-security-test.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 60
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/ec2/linux
+            terraform init
+            if terraform apply --auto-approve \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
+              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="user=${{ matrix.arrays.username }}" \
+              -var="ami=${{ matrix.arrays.ami }}" \
+              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
+              -var="arc=${{ matrix.arrays.arc }}" \
+              -var="binary_name=${{ matrix.arrays.binaryName }}" \
+              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
+              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
+              -var="ssh_key_name=${KEY_NAME}" \
+              -var="test_name=${{ matrix.arrays.os }}" \
+              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.ec2-security-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/ec2/linux && terraform destroy --auto-approve


### PR DESCRIPTION
# Description of the issue
Need to test that agent config file can only be modified by root.

# Description of changes
Added a new job to do security tests, post all the feature tests. 
Run tests added in here: https://github.com/aws/amazon-cloudwatch-agent-test/pull/104

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/ChenaLee/amazon-cloudwatch-agent/actions/runs/4027559302
Workflow orders as desired.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




