### PR TITLE
ignore unrelated files for CI

### DIFF
--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -8,6 +8,10 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      - 'NOTICE'
+      - 'RELEASE_NOTES'
+      - 'THIRD-PARTY'
+      - 'LICENSE'
       - '.github/**'
       - '!.github/workflows/build-*'
 

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -8,6 +8,10 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      - 'NOTICE'
+      - 'RELEASE_NOTES'
+      - 'THIRD-PARTY'
+      - 'LICENSE'
       - '.github/**'
       - '!.github/workflows/build-*'
 

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -8,6 +8,10 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      - 'NOTICE'
+      - 'RELEASE_NOTES'
+      - 'THIRD-PARTY'
+      - 'LICENSE'
       - '.github/**'
       - '!.github/workflows/build-*'
 

--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -16,6 +16,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'NOTICE'
+      - 'RELEASE_NOTES'
+      - 'THIRD-PARTY'
+      - 'LICENSE'
   workflow_dispatch:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ CWAGENT_VERSION
 terraform.*
 **/.terraform/*
 coverage.txt
-integration/generator/resources/*complete*.json


### PR DESCRIPTION
# Description of changes
1. Listed more files that don't need to trigger CI checks (namely RELEASE_NOTES)
2. Cleaned up gitignore


