### PR TITLE
[GH-606][FEATURE] Add config mode for ModeWithIRSA to support using d…

### DIFF
--- a/translator/config/defaultConfig.go
+++ b/translator/config/defaultConfig.go
@@ -195,8 +195,6 @@ func DefaultJsonConfig(os string, mode string) string {
 	default:
 		if mode == ModeEC2 {
 			return defaultLinuxEC2Config
-		} else if mode == ModeWithIRSA {
-			return defaultLinuxOnPremConfig
 		} else {
 			return defaultLinuxOnPremConfig
 		}

--- a/translator/config/defaultConfig.go
+++ b/translator/config/defaultConfig.go
@@ -195,6 +195,8 @@ func DefaultJsonConfig(os string, mode string) string {
 	default:
 		if mode == ModeEC2 {
 			return defaultLinuxEC2Config
+		} else if mode == ModeWithIRSA {
+			return defaultLinuxOnPremConfig
 		} else {
 			return defaultLinuxOnPremConfig
 		}

--- a/translator/config/envconst.go
+++ b/translator/config/envconst.go
@@ -8,6 +8,8 @@ const (
 	RUN_IN_CONTAINER_TRUE   = "True"
 	RUN_IN_AWS              = "RUN_IN_AWS"
 	RUN_IN_AWS_TRUE         = "True"
+	RUN_WITH_IRSA           = "RUN_WITH_IRSA"
+	RUN_WITH_IRSA_TRUE      = "True"
 	USE_DEFAULT_CONFIG      = "USE_DEFAULT_CONFIG"
 	USE_DEFAULT_CONFIG_TRUE = "True"
 	HOST_NAME               = "HOST_NAME"

--- a/translator/config/mode.go
+++ b/translator/config/mode.go
@@ -6,5 +6,6 @@ package config
 const (
 	ModeEC2       = "ec2"
 	ModeOnPrem    = "onPrem"
-        ModeOnPremise = "onPremise"
+	ModeOnPremise = "onPremise"
+	ModeWithIRSA  = "withIRSA"
 )

--- a/translator/context/context.go
+++ b/translator/context/context.go
@@ -114,7 +114,6 @@ func (ctx *Context) SetMode(mode string) {
 		ctx.mode = config.ModeOnPrem
 	case config.ModeOnPremise:
 		ctx.mode = config.ModeOnPremise
-		ctx.mode = config.ModeOnPrem
 	case config.ModeWithIRSA:
 		ctx.mode = config.ModeWithIRSA
 	default:

--- a/translator/context/context.go
+++ b/translator/context/context.go
@@ -28,7 +28,7 @@ func CurrentContext() *Context {
 	return ctx
 }
 
-//Testing only
+// Testing only
 func ResetContext() {
 	ctx = nil
 }
@@ -114,8 +114,11 @@ func (ctx *Context) SetMode(mode string) {
 		ctx.mode = config.ModeOnPrem
 	case config.ModeOnPremise:
 		ctx.mode = config.ModeOnPremise
+		ctx.mode = config.ModeOnPrem
+	case config.ModeWithIRSA:
+		ctx.mode = config.ModeWithIRSA
 	default:
-		log.Panicf("Invalid mode %s. Valid mode values are %s, %s and %s.", mode, config.ModeEC2, config.ModeOnPrem, config.ModeOnPremise)
+		log.Panicf("Invalid mode %s. Valid mode values are %s, %s, %s and %s.", mode, config.ModeEC2, config.ModeOnPrem, config.ModeOnPremise, config.ModeWithIRSA)
 	}
 }
 

--- a/translator/util/sdkutil.go
+++ b/translator/util/sdkutil.go
@@ -27,6 +27,7 @@ var DetectCredentialsPath = detectCredentialsPath
 var DefaultEC2Region = defaultEC2Region
 var DefaultECSRegion = defaultECSRegion
 var runInAws = os.Getenv(config.RUN_IN_AWS)
+var runWithIrsa = os.Getenv(config.RUN_WITH_IRSA)
 
 func DetectAgentMode(configuredMode string) string {
 	if configuredMode != "auto" {
@@ -38,6 +39,11 @@ func DetectAgentMode(configuredMode string) string {
 		return config.ModeEC2
 	}
 
+	if runWithIrsa == config.RUN_WITH_IRSA_TRUE {
+		fmt.Println("I! Detected from ENV RUN_WITH_IRSA is True")
+		return config.ModeWithIRSA
+	}
+
 	if DefaultEC2Region() != "" {
 		fmt.Println("I! Detected the instance is EC2")
 		return config.ModeEC2
@@ -47,6 +53,7 @@ func DetectAgentMode(configuredMode string) string {
 		fmt.Println("I! Detected the instance is ECS")
 		return config.ModeEC2
 	}
+
 	fmt.Println("I! Detected the instance is OnPremise")
 	return config.ModeOnPrem
 }


### PR DESCRIPTION
[GH-606][FEATURE] Add config mode for ModeWithIRSA to support using default credential provider with RUN_WITH_IRSA environment variable as True

# Description of the issue
Config mode OnPrem injects profile & file based credential configs to `amazon-cloudwatch-agent.toml`, thereby breaking support for using the default credential provider chain when running in EKS Anywhere or other k8s on-premises environments with IRSA.

Linked Issue: [GH-606](https://github.com/aws/amazon-cloudwatch-agent/issues/606)

# Description of changes
Change adds a new config mode (`ModeWithIRSA`) to prevent from adding profile & file based credentials and allowing the SDK to assume the default credential provider chain.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests have been executed and passed.

Agent has been deployed as DaemonSet to EKS Anywhere and validated functionality with `AssumeRoleWithWebIdentity` / IRSA.



