### PR TITLE
Clean Old File System

### DIFF
--- a/.github/workflows/clean-aws-resources.yml
+++ b/.github/workflows/clean-aws-resources.yml
@@ -26,6 +26,24 @@ jobs:
 
       - name: Clean old ami
         run: go run ./tool/clean/clean_ami/clean_ami.go --tags=clean
+
+  clean-old-file-systems:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Clean old file system
+        run: go run ./tool/clean/clean_file_system/clean_file_system.go --tags=clean
   
   clean-opensource-dedicated-hosts:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -55,10 +55,11 @@ require (
 	github.com/Jeffail/gabs v1.4.0
 	github.com/Rican7/retry v0.1.1-0.20160712041035-272ad122d6e5
 	github.com/aws/aws-sdk-go v1.44.106
-	github.com/aws/aws-sdk-go-v2 v1.16.13
+	github.com/aws/aws-sdk-go-v2 v1.17.5
 	github.com/aws/aws-sdk-go-v2/config v1.15.3
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.1.0
-	github.com/aws/smithy-go v1.13.1
+	github.com/aws/aws-sdk-go-v2/service/efs v1.19.7
+	github.com/aws/smithy-go v1.13.5
 	github.com/bigkevmcd/go-configparser v0.0.0-20200217161103-d137835d2579
 	github.com/go-kit/kit v0.11.0
 	github.com/gobwas/glob v0.2.3
@@ -120,8 +121,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.3 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.9 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/aws/aws-sdk-go-v2 v1.1.0/go.mod h1:smfAbmpW+tcRVuNUjo3MOArSZmW72t62rk
 github.com/aws/aws-sdk-go-v2 v1.9.1/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.16.2/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
-github.com/aws/aws-sdk-go-v2 v1.16.13 h1:HgF7OX2q0gSZtcXoo9DMEA8A2Qk/GCxmWyM0RI7Yz2Y=
-github.com/aws/aws-sdk-go-v2 v1.16.13/go.mod h1:xSyvSnzh0KLs5H4HJGeIEsNYemUWdNIl0b/rP6SIsLU=
+github.com/aws/aws-sdk-go-v2 v1.17.5 h1:TzCUW1Nq4H8Xscph5M/skINUitxM5UBAyvm2s7XBzL4=
+github.com/aws/aws-sdk-go-v2 v1.17.5/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1 h1:SdK4Ppk5IzLs64ZMvr6MrSficMtjY2oS0WOORXTlxwU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1/go.mod h1:n8Bs1ElDD2wJ9kCRTczA83gYbBmjSwZp3umc6zF4EeM=
 github.com/aws/aws-sdk-go-v2/config v1.8.3/go.mod h1:4AEiLtAb8kLs7vgw2ZV3p2VZ1+hBavOc84hqxVNpCyw=
@@ -244,10 +244,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.6.0/go.mod h1:gqlclDEZp4aqJOanc
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.3 h1:LWPg5zjHV9oz/myQr4wMs0gi4CjnDN/ILmyZUFYXZsU=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.3/go.mod h1:uk1vhHHERfSVCUnqSqz8O48LBYDSC+k6brng09jcMOk=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.5.3 h1:0O72494cCsazjpsGfo+LXezru6PMSp0HUB1m5UfpaRU=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.9 h1:onz/VaaxZ7Z4V+WIN9Txly9XLTmoOh1oJ8XcAC3pako=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.9/go.mod h1:AnVH5pvai0pAF4lXRq0bmhbes1u9R8wTE+g+183bZNM=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.3 h1:9stUQR/u2KXU6HkFJYlqnZEjBnbgrVbG6I5HN09xZh0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 h1:9/aKwwus0TQxppPXFmf010DFrE+ssSbzroLVYINA+xE=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29/go.mod h1:Dip3sIGv485+xerzVv24emnjX5Sg88utCL8fwGmCeWg=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.3/go.mod h1:ssOhaLpRlh88H3UmEcsBoVKq309quMvm3Ds8e9d4eJM=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 h1:b/Vn141DBuLVgXbhRWIrl9g+ww7G+ScV5SzniWR13jQ=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23/go.mod h1:mr6c4cHC+S/MMkrjtSlG4QA36kOznDep+0fga5L/fGQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.2.4/go.mod h1:ZcBrrI3zBKlhGFNYWvju0I3TR93I7YIgAfy82Fh4lcQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.10 h1:by9P+oy3P/CwggN4ClnW2D4oL91QV7pBzBICi1chZvQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.10/go.mod h1:8DcYQcz0+ZJaSxANlHIsbbi6S+zMwjwdDqwW3r9AzaE=
@@ -260,6 +262,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.13.0 h1:NfqONXoDwWtBCnkPV
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.14.0 h1:P+eF8PKkeaiTfN/VBe5GI3uNdhwCPVYCQxchRewJcWk=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.1.0 h1:+VnEgB1yp+7KlOsk6FXX/v/fU9uL5oSujIMkKQBBmp8=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.1.0/go.mod h1:/6514fU/SRcY3+ousB1zjUqiXjruSuti2qcfE70osOc=
+github.com/aws/aws-sdk-go-v2/service/efs v1.19.7 h1:BmyhflgczNmmuAPFhAhMQuLc9zSHiqIY5ouS+oSwxPQ=
+github.com/aws/aws-sdk-go-v2/service/efs v1.19.7/go.mod h1:ENSgtHyPiYyBcTAi26Hpr8Xp636IB18qr0D5Ho8EQWA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.1 h1:T4pFel53bkHjL2mMo+4DKE6r6AuoZnM0fg7k1/ratr4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.1/go.mod h1:GeUru+8VzrTXV/83XyMJ80KpH8xO89VPoUileyNQ+tc=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.3 h1:I0dcwWitE752hVSMrsLCxqNQ+UdEp3nACx2bYNMQq+k=
@@ -284,8 +288,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.3.2 h1:1s/RRA5Owuz4/G/eW
 github.com/aws/smithy-go v1.0.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
-github.com/aws/smithy-go v1.13.1 h1:q09BdpUiaqpothcv393ACfWJJHzlzjB5HaNL1XHKmoQ=
-github.com/aws/smithy-go v1.13.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
+github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/telegraf v0.10.2-0.20220502160831-c20ebe67c5ef h1:O53nKbZm2XpdudUywNdqbohwUxje9k4vE0xRXWeIVbE=
 github.com/aws/telegraf v0.10.2-0.20220502160831-c20ebe67c5ef/go.mod h1:6maU8S0L0iMSa0ZvH5b2W7dBX1xjK0D5ONAqe7WTqXc=
 github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20220502160831-c20ebe67c5ef h1:iiO0qNErnQgaU6mJY+PRlwnoHp+s9VTk2Ax1A8KRoG4=

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
 	"log"
 	"time"
 
@@ -18,9 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	smithyTime "github.com/aws/smithy-go/time"
 )
-
-const daysToKeep = 60
-const keepDuration = -1 * time.Hour * 24 * time.Duration(daysToKeep)
 
 func main() {
 	err := cleanAMI()
@@ -32,7 +30,7 @@ func main() {
 func cleanAMI() error {
 	log.Print("Begin to clean EC2 AMI")
 
-	expirationDate := time.Now().UTC().Add(keepDuration)
+	expirationDate := time.Now().UTC().Add(clean.KeepDurationSixtyDay)
 	cxt := context.Background()
 	defaultConfig, err := config.LoadDefaultConfig(cxt)
 	if err != nil {

--- a/tool/clean/clean_dedicated_host/clean_dedicated_host.go
+++ b/tool/clean/clean_dedicated_host/clean_dedicated_host.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
 	"log"
 	"time"
 
@@ -18,7 +19,6 @@ import (
 )
 
 // Can't release a host if it was being used within the last 24 hr add 2 hr as a buffer
-const keepDurationDedicatedHost = -1 * time.Hour * 26
 const tagName = "tag:Name"
 const tagValue = "IntegrationTestMacDedicatedHost"
 
@@ -32,7 +32,7 @@ func main() {
 func cleanDedicatedHost() error {
 	log.Print("Begin to clean EC2 Dedicated Host")
 
-	expirationDateDedicatedHost := time.Now().UTC().Add(keepDurationDedicatedHost)
+	expirationDateDedicatedHost := time.Now().UTC().Add(clean.KeepDurationTwentySixHours)
 	cxt := context.Background()
 	defaultConfig, err := config.LoadDefaultConfig(cxt)
 	if err != nil {

--- a/tool/clean/clean_file_system/clean_file_system.go
+++ b/tool/clean/clean_file_system/clean_file_system.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build clean
+// +build clean
+
+package main
+
+import (
+	"context"
+	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/efs"
+	"log"
+	"time"
+)
+
+func main()  {
+	log.Printf("Begin to clean EFS resources")
+	expirationDate := time.Now().UTC().Add(clean.KeepDurationOneDay)
+	cxt := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(cxt)
+	if err != nil {
+		log.Fatalf("Error getting default config %v", err)
+	}
+	efsclient := efs.NewFromConfig(defaultConfig)
+
+	//get efs to delete
+	var nextToken *string
+	fileSystemIdSlice := make([]*string, 0)
+	for {
+		describeFileSystemsInput := efs.DescribeFileSystemsInput{Marker: nextToken}
+		describeFileSystemsOutput, err := efsclient.DescribeFileSystems(cxt, &describeFileSystemsInput)
+		if err != nil {
+			log.Fatalf("Err %v", err)
+		}
+		for _, fileSystem := range describeFileSystemsOutput.FileSystems {
+			if expirationDate.After(*fileSystem.CreationTime) {
+				log.Printf("Trying to delete file system %s launch-date %v", *fileSystem.FileSystemId, fileSystem.CreationTime)
+				if fileSystem.NumberOfMountTargets > 0 {
+					err = deleteMountTargets(cxt, efsclient, fileSystem.FileSystemId)
+				}
+
+				if err == nil {
+					fileSystemIdSlice = append(fileSystemIdSlice, fileSystem.FileSystemId)
+				} else {
+					log.Printf("Unable to delete all the mount targets for %s due to %v", *fileSystem.FileSystemId, err)
+				}
+			}
+		}
+		if describeFileSystemsOutput.NextMarker == nil {
+			break
+		}
+		nextToken = describeFileSystemsOutput.NextMarker
+	}
+	for _, fileSystemId := range fileSystemIdSlice {
+		terminateFileSystemsInput := efs.DeleteFileSystemInput{FileSystemId: fileSystemId}
+		if _, err = efsclient.DeleteFileSystem(cxt, &terminateFileSystemsInput); err != nil {
+			log.Printf("Unable to delete file system %s due to %v", *fileSystemId, err)
+		} else {
+			log.Printf("Deleted file system %s successfully", *fileSystemId)
+		}
+	}
+}
+
+func deleteMountTargets(cxt context.Context, client *efs.Client, fileSystemId *string) error {
+	var marker *string
+	for {
+		dmti := &efs.DescribeMountTargetsInput{Marker: marker, FileSystemId: fileSystemId}
+		dmto, err := client.DescribeMountTargets(cxt, dmti)
+		if err != nil {
+			return err
+		}
+		for _, mountTarget := range dmto.MountTargets {
+			dlmti := &efs.DeleteMountTargetInput{MountTargetId: mountTarget.MountTargetId}
+			if _, err = client.DeleteMountTarget(cxt, dlmti); err != nil {
+				return err
+			}
+			log.Printf("Deleted mount target %s for %s successfully", *mountTarget.MountTargetId, *fileSystemId)
+		}
+		if dmto.Marker == nil {
+			break
+		}
+		marker = dmto.Marker
+	}
+	return nil
+}

--- a/tool/clean/clean_util.go
+++ b/tool/clean/clean_util.go
@@ -1,0 +1,9 @@
+package clean
+
+import "time"
+
+const (
+	KeepDurationOneDay = -1 * time.Hour * 24
+	KeepDurationSixtyDay = KeepDurationOneDay * time.Duration(60)
+	KeepDurationTwentySixHours = KeepDurationOneDay +  time.Hour * 2
+)


### PR DESCRIPTION
# Description of the issue
You have reached the maximum number of mount targets (400) in your VPC vpc-72252d0a. Delete a mount target and add a new one, use an existing mount target, or work in another VPC.

# Description of changes
Remove 30 day old efs

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/4246475983/jobs/7383434533

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




