### PR TITLE
fix: no dot when converting %f to timestamp layout

### DIFF
--- a/translator/translate/logs/logs_collected/files/collect_list/ruleTimestampFormat.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleTimestampFormat.go
@@ -76,7 +76,7 @@ var TimeFormatMap = map[string]string{
 	"%p":  "PM",
 	"%Z":  "MST",
 	"%z":  "-0700",
-	"%f":  ".000",
+	"%f":  "000",
 }
 
 var TimeFormatRexMap = map[string]string{
@@ -100,7 +100,7 @@ var TimeFormatRexMap = map[string]string{
 	"%p":  "\\w{2}",
 	"%Z":  "\\w{3}",
 	"%z":  "[\\+-]\\d{4}",
-	"%f":  "(\\d{1,9})",
+	"%f":  "\\d{1,9}",
 }
 
 // The characters required to be escaped are these characters special in regex, but normal in json.


### PR DESCRIPTION
# Description of the issue
In a timestamp format, %f (fraction of seconds) represents the digits, not including the decimal mark (point or comma). So when converting a format to a layout, %f should be replaced with 000.

For example, the format "%H:%M:%S.%f" should be converted to the layout "15:04:05.000". Currently, the code incorrectly converts that format to "15:04:05..000" (note the two dots).

The capturing group for %f in TimeFormatRexMap looks wrong as no other mapping uses a capturing group.

# Description of changes
%f in a format is mapped to "000", instead of ".000", in a layout.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
None.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`
