### PR TITLE
Add config option to disable extraction of metrics from EMF logs for …

### DIFF
--- a/plugins/processors/k8sdecorator/k8sdecorator.go
+++ b/plugins/processors/k8sdecorator/k8sdecorator.go
@@ -15,14 +15,15 @@ import (
 )
 
 type K8sDecorator struct {
-	started         bool
-	stores          []stores.K8sStore
-	shutdownC       chan bool
-	TagService      bool   `toml:"tag_service"`
-	ClusterName     string `toml:"cluster_name"`
-	HostIP          string `toml:"host_ip"`
-	NodeName        string `toml:"node_name"`
-	PrefFullPodName bool   `toml:"prefer_full_pod_name"`
+	started                 bool
+	stores                  []stores.K8sStore
+	shutdownC               chan bool
+	DisableMetricExtraction bool   `toml:"disable_metric_extraction"`
+	TagService              bool   `toml:"tag_service"`
+	ClusterName             string `toml:"cluster_name"`
+	HostIP                  string `toml:"host_ip"`
+	NodeName                string `toml:"node_name"`
+	PrefFullPodName         bool   `toml:"prefer_full_pod_name"`
 }
 
 func (k *K8sDecorator) Description() string {
@@ -53,7 +54,9 @@ OUTER:
 		}
 		structuredlogsadapter.AddKubernetesInfo(metric, kubernetesBlob)
 		structuredlogsadapter.TagMetricSource(metric)
-		structuredlogsadapter.TagMetricRule(metric)
+		if !k.DisableMetricExtraction {
+			structuredlogsadapter.TagMetricRule(metric)
+		}
 		structuredlogsadapter.TagLogGroup(metric)
 		metric.AddTag(logscommon.LogStreamNameTag, k.NodeName)
 		out = append(out, metric)

--- a/plugins/processors/k8sdecorator/k8sdecorator_test.go
+++ b/plugins/processors/k8sdecorator/k8sdecorator_test.go
@@ -37,7 +37,7 @@ func TestDisableMetricExtraction(t *testing.T) {
 				},
 			},
 			DimensionSets: [][]string{{"ClusterName"}},
-			Namespace:     "",
+			Namespace:     "ContainerInsights",
 		},
 	}, m1.Fields()["CloudWatchMetrics"])
 

--- a/plugins/processors/k8sdecorator/k8sdecorator_test.go
+++ b/plugins/processors/k8sdecorator/k8sdecorator_test.go
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package k8sdecorator
+
+import (
+	. "github.com/aws/amazon-cloudwatch-agent/internal/containerinsightscommon"
+	"github.com/aws/amazon-cloudwatch-agent/internal/structuredlogscommon"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestDisableMetricExtraction(t *testing.T) {
+	tags := map[string]string{MetricType: TypeCluster}
+	fields := map[string]interface{}{MetricName(TypeCluster, NodeCount): 10, MetricName(TypeCluster, FailedNodeCount): 1}
+
+	m1 := metric.New("testClusterMetric", tags, fields, time.Now())
+	decorator := &K8sDecorator{
+		started:                 true,
+		DisableMetricExtraction: false,
+		ClusterName:             "TestK8sCluster",
+	}
+	decorator.Apply(m1)
+	assert.Equal(t, "Sources,CloudWatchMetrics", m1.Tags()["attributesInFields"])
+	assert.Equal(t, []structuredlogscommon.MetricRule{
+		{
+			Metrics: []structuredlogscommon.MetricAttr{
+				{
+					Unit: "Count",
+					Name: "cluster_node_count",
+				},
+				{
+					Unit: "Count",
+					Name: "cluster_failed_node_count",
+				},
+			},
+			DimensionSets: [][]string{{"ClusterName"}},
+			Namespace:     "",
+		},
+	}, m1.Fields()["CloudWatchMetrics"])
+
+	m2 := metric.New("testClusterMetric", tags, fields, time.Now())
+	decorator = &K8sDecorator{
+		started:                 true,
+		DisableMetricExtraction: true,
+		ClusterName:             "TestK8sCluster",
+	}
+	decorator.Apply(m2)
+	assert.Equal(t, "Sources", m2.Tags()["attributesInFields"])
+	assert.Equal(t, nil, m2.Fields()["CloudWatchMetrics"])
+}

--- a/translator/totomlconfig/sampleConfig/log_metric_only.conf
+++ b/translator/totomlconfig/sampleConfig/log_metric_only.conf
@@ -66,6 +66,7 @@
 
   [[processors.k8sdecorator]]
     cluster_name = "TestCluster"
+    disable_metric_extraction = true
     host_ip = "127.0.0.1"
     node_name = "host_name_from_env"
     order = 1

--- a/translator/totomlconfig/sampleConfig/log_metric_only.json
+++ b/translator/totomlconfig/sampleConfig/log_metric_only.json
@@ -9,7 +9,8 @@
       "kubernetes": {
         "cluster_name": "TestCluster",
         "metrics_collection_interval": 30,
-        "prefer_full_pod_name": true
+        "prefer_full_pod_name": true,
+        "disable_metric_extraction": true
       }
     },
     "force_flush_interval": 5,

--- a/translator/totomlconfig/sampleConfig/log_metric_only_on_prem.conf
+++ b/translator/totomlconfig/sampleConfig/log_metric_only_on_prem.conf
@@ -58,6 +58,7 @@
 
   [[processors.k8sdecorator]]
     cluster_name = "TestCluster"
+    disable_metric_extraction = true
     host_ip = "127.0.0.1"
     node_name = "host_name_from_env"
     order = 1

--- a/translator/totomlconfig/tomlConfigTemplate/tomlConfig.go
+++ b/translator/totomlconfig/tomlConfigTemplate/tomlConfig.go
@@ -323,12 +323,13 @@ type (
 	}
 
 	k8sDecoratorConfig struct {
-		ClusterName       string `toml:"cluster_name"`
-		HostIp            string `toml:"host_ip"`
-		NodeName          string `toml:"host_name_from_env"`
-		Order             int
-		PreferFullPodName bool `toml:"prefer_full_pod_name"`
-		TagService        bool `toml:"tag_service"`
-		TagPass           map[string][]string
+		ClusterName             string `toml:"cluster_name"`
+		DisableMetricExtraction bool   `toml:"disable_metric_extraction"`
+		HostIp                  string `toml:"host_ip"`
+		NodeName                string `toml:"host_name_from_env"`
+		Order                   int
+		PreferFullPodName       bool `toml:"prefer_full_pod_name"`
+		TagService              bool `toml:"tag_service"`
+		TagPass                 map[string][]string
 	}
 )

--- a/translator/translate/logs/metrics_collected/kubernetes/k8sdecorator/ruleDisableMetricExtraction.go
+++ b/translator/translate/logs/metrics_collected/kubernetes/k8sdecorator/ruleDisableMetricExtraction.go
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package k8sdecorator
+
+import (
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+)
+
+const (
+	SectionKeyDisableMetricExtraction = "disable_metric_extraction"
+)
+
+type DisableMetricExtraction struct {
+}
+
+func (t *DisableMetricExtraction) ApplyRule(input interface{}) (string, interface{}) {
+	return translator.DefaultCase(SectionKeyDisableMetricExtraction, false, input)
+}
+
+func init() {
+	RegisterRule(SectionKeyDisableMetricExtraction, new(DisableMetricExtraction))
+}


### PR DESCRIPTION
…kubernetes

# Description of the issue
Currently, by default, all metrics for Kubernetes Container Insights are published as EMF logs and are extracted into metrics behind the scenes. What distinguishes a EMF log from a regular json log is the presence of `CloudWatchMetrics` field in the json (since the header to indicate is now optional).
A subset of customers in very specific scenarios need the ability to disable the default extraction of these metrics from EMF logs.

Ideally we want this option for ECS & Prometheus as well. But these will be made available in a future commit when we contribute a similar change to `awsemfexporter` in a central place that can be leveraged for all plugins using EMF logs to push metrics (which include ECS & Prometheus).

# Description of changes
Adds a config option that allows a customer to disable the default extraction of metrics from EMF logs.
When this option is set, we skip adding the `CloudWatchMetrics` blob to the json and hence there is nothing to extract. This will leave the datapoints in the logs as-is and just not create any metrics.

Sample log event when option is not set (default):
```
{
  "CloudWatchMetrics": [
    {
      "Metrics": [
        {
          "Unit": "Count",
          "Name": "service_number_of_running_pods"
        }
      ],
      "Dimensions": [
        [
          "Service",
          "Namespace",
          "ClusterName"
        ],
        [
          "ClusterName"
        ]
      ],
      "Namespace": "ContainerInsights/Disable-1.0"
    }
  ],
  "ClusterName": "cw1",
  "Namespace": "kube-system",
  "Service": "kube-dns",
  "Sources": [
    "apiserver"
  ],
  "Timestamp": "1679370382569",
  "Type": "ClusterService",
  "Version": "0",
  "kubernetes": {
    "namespace_name": "kube-system",
    "service_name": "kube-dns"
  },
  "service_number_of_running_pods": 2
}
```

Sample log event when option is set:
```
{
  "ClusterName": "cw1",
  "Namespace": "kube-system",
  "Service": "kube-dns",
  "Sources": [
    "apiserver"
  ],
  "Timestamp": "1679371926278",
  "Type": "ClusterService",
  "Version": "0",
  "kubernetes": {
    "namespace_name": "kube-system",
    "service_name": "kube-dns"
  },
  "service_number_of_running_pods": 2
}
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Unit tests
* Tested changes manually in an EKS cluster

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




