### PR TITLE
update SEH test to round

### DIFF
--- a/metric/distribution/seh1/seh1_distribution_test.go
+++ b/metric/distribution/seh1/seh1_distribution_test.go
@@ -4,6 +4,7 @@
 package seh1
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,11 +25,12 @@ func TestSEH1Distribution(t *testing.T) {
 	assert.Equal(t, "Count", dist.Unit())
 	values, counts := dist.ValuesAndCounts()
 	assert.Equal(t, len(values), len(counts))
-	valuesCountsMap := map[float64]float64{}
+	valuesCountsMap := map[string]float64{}
 	for i := 0; i < len(values); i++ {
-		valuesCountsMap[values[i]] = counts[i]
+		valuesCountsMap[truncate(values[i])] = counts[i]
 	}
-	expectedValuesCountsMap := map[float64]float64{20.13119624437727: 1, 29.474084421392764: 1, 52.21513847164702: 1}
+	expectedValuesCountsMap := map[string]float64{"20.13119624": 1, "29.47408442": 1, "52.21513847": 1}
+
 	assert.Equal(t, expectedValuesCountsMap, valuesCountsMap)
 
 	//another dist new and add entry
@@ -45,11 +47,11 @@ func TestSEH1Distribution(t *testing.T) {
 	assert.Equal(t, "", anotherDist.Unit())
 	values, counts = anotherDist.ValuesAndCounts()
 	assert.Equal(t, len(values), len(counts))
-	valuesCountsMap = map[float64]float64{}
+	valuesCountsMap = map[string]float64{}
 	for i := 0; i < len(values); i++ {
-		valuesCountsMap[values[i]] = counts[i]
+		valuesCountsMap[truncate(values[i])] = counts[i]
 	}
-	expectedValuesCountsMap = map[float64]float64{20.13119624437727: 1, 22.144315868814992: 3}
+	expectedValuesCountsMap = map[string]float64{"20.13119624": 1, "22.14431587": 3}
 	assert.Equal(t, expectedValuesCountsMap, valuesCountsMap)
 
 	//clone dist and anotherDist
@@ -65,11 +67,11 @@ func TestSEH1Distribution(t *testing.T) {
 	assert.Equal(t, "Count", dist.Unit())
 	values, counts = dist.ValuesAndCounts()
 	assert.Equal(t, len(values), len(counts))
-	valuesCountsMap = map[float64]float64{}
+	valuesCountsMap = map[string]float64{}
 	for i := 0; i < len(values); i++ {
-		valuesCountsMap[values[i]] = counts[i]
+		valuesCountsMap[truncate(values[i])] = counts[i]
 	}
-	expectedValuesCountsMap = map[float64]float64{20.13119624437727: 2, 22.144315868814992: 3, 29.474084421392764: 1, 52.21513847164702: 1}
+	expectedValuesCountsMap = map[string]float64{"20.13119624": 2, "22.14431587": 3, "29.47408442": 1, "52.21513847": 1}
 	assert.Equal(t, expectedValuesCountsMap, valuesCountsMap)
 
 	//add distClone into another dist
@@ -90,4 +92,8 @@ func cloneSEH1Distribution(dist *SEH1Distribution) *SEH1Distribution {
 		clonedDist.buckets[k] = v
 	}
 	return clonedDist
+}
+
+func truncate(f float64) string {
+	return big.NewFloat(f).SetPrec(100).String()
 }


### PR DESCRIPTION
# Description of the issue
Closes #729 

# Description of changes
On ARM, the SEH1 unit test fails because one of the expected keys in the map is truncated by one digit of precision, so it can't do an exact match or lookup.

Changed the test to round precision up. There's still 8 digits of precision, which frankly is more than enough. I could have kept it as `map[float64]float64{}`, but this keeps the truncation logic simple. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
After fixing the test:
```
[ec2-user@ip-172-31-57-99 amazon-cloudwatch-agent]$ uname -m
aarch64
[ec2-user@ip-172-31-57-99 amazon-cloudwatch-agent]$ go test -v -run TestSEH1Distribution ./metric/distribution/seh1/
=== RUN   TestSEH1Distribution
--- PASS: TestSEH1Distribution (0.00s)
PASS
ok      github.com/aws/amazon-cloudwatch-agent/metric/distribution/seh1
```
See the linked issue for when I ran the test prior to this fix

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




