### PR TITLE
Use multiple Windows OS for testing

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Build Binaries
         if: steps.cached_binaries.outputs.cache-hit != 'true'
         working-directory: cwa
-        run: make amazon-cloudwatch-agent-mac package-darwin
+        run: make amazon-cloudwatch-agent-darwin package-darwin
 
       - name: Copy binary
         if: steps.cached_binaries.outputs.cache-hit != 'true'
@@ -673,6 +673,7 @@ jobs:
             -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
             -var="cwa_github_sha=${GITHUB_SHA}"  \
             -var="test_dir=${{ matrix.arrays.test_dir }}" \
+            -var="ami=${{ matrix.arrays.ami }}" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
               terraform destroy -auto-approve
             else


### PR DESCRIPTION
# Description of the issue
Cloudwatch Agent integration test workflow uses a single hardcoded Windows OS for integration tests which is not good test range.

# Description of changes
Make the workflow read in the AMI images that were added in the amazon-cloudwatch-agent-test repo for a wider selection of Windows OS

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested on fork action https://github.com/zhihonl/amazon-cloudwatch-agent/actions/runs/4812727528. All other integration tests have been disabled for this workflow for time efficiency purpose however they should not affect the Windows test since they are not dependencies for it.

Verified that each test instance is using unique AMI ID
```
  # aws_instance.cwagent will be created
  + resource "aws_instance" "cwagent" {
      + ami                                  = "ami-077da8562c8707e20"
```
```
  # aws_instance.cwagent will be created
  + resource "aws_instance" "cwagent" {
      + ami                                  = "ami-0e65446a007414c32"
```
```
  # aws_instance.cwagent will be created
  + resource "aws_instance" "cwagent" {
      + ami                                  = "ami-01f4b72a8fd83be9f"
```
```
  # aws_instance.cwagent will be created
  + resource "aws_instance" "cwagent" {
      + ami                                  = "ami-0e56d7da518da6f58"
```
```
  # aws_instance.cwagent will be created
  + resource "aws_instance" "cwagent" {
      + ami                                  = "ami-0f99bbd8a2162c8ec"
```
# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




