### PR TITLE
Tags

### DIFF
--- a/translator/translate/util/placeholderUtil.go
+++ b/translator/translate/util/placeholderUtil.go
@@ -4,6 +4,7 @@
 package util
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -19,6 +20,7 @@ type Metadata struct {
 	Hostname   string
 	PrivateIP  string
 	AccountID  string
+	Tags       map[string]string
 }
 
 type MetadataInfoProvider func() *Metadata
@@ -30,6 +32,7 @@ var Ec2MetadataInfoProvider = func() *Metadata {
 		Hostname:   ec2.Hostname,
 		PrivateIP:  ec2.PrivateIP,
 		AccountID:  ec2.AccountID,
+		Tags:       ec2.Tags,
 	}
 }
 
@@ -90,10 +93,22 @@ func GetMetadataInfo(provider MetadataInfoProvider) map[string]string {
 		accountID = unknownAccountId
 	}
 
-	return map[string]string{instanceIdPlaceholder: instanceID, hostnamePlaceholder: hostname,
-		localHostnamePlaceholder: localHostname, ipAddressPlaceholder: ipAddress, awsRegionPlaceholder: awsRegion,
-		accountIdPlaceholder: accountID,
+	metadata := map[string]string{
+		instanceIdPlaceholder:    instanceID,
+		hostnamePlaceholder:      hostname,
+		localHostnamePlaceholder: localHostname,
+		ipAddressPlaceholder:     ipAddress,
+		awsRegionPlaceholder:     awsRegion,
+		accountIdPlaceholder:     accountID,
 	}
+
+	tags := provider().Tags
+	for tagKey, tagValue := range tags {
+		tagPlaceholder := fmt.Sprintf("{tag:%s}", tagKey)
+		metadata[tagPlaceholder] = tagValue
+	}
+
+	return metadata
 }
 
 func getHostName() string {

--- a/translator/util/ec2util/ec2util.go
+++ b/translator/util/ec2util/ec2util.go
@@ -48,7 +48,7 @@ func initEC2UtilSingleton() (newInstance *ec2Util) {
 		Tags:      make(map[string]string),
 	}
 
-	if (context.CurrentContext().Mode() == config.ModeOnPrem) || (context.CurrentContext().Mode() == config.ModeOnPremise) {
+	if (context.CurrentContext().Mode() == config.ModeOnPrem) || (context.CurrentContext().Mode() == config.ModeOnPremise){
 		return
 	}
 


### PR DESCRIPTION
# Description of the issue
Hello, I've had the same problem like the author of [this issue](https://github.com/aws/amazon-cloudwatch-agent/issues/300). I'd like to use an instance tag to create a log group in the agent configuration to construct and display environment name based on a tag value.

Thank you for considering this change. If there are changes needed, please provide any suggestions to improve the solution.

# Description of changes
The change fetches a list of instance tags from EC2 instance metadata, stores it locally and uses the list to translate the tag placeholders in the configuration file.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
I've tested the solution on EC2 instance with Enabled instance tags and a custom tag.
Steps:
1) Add tags of your choice, for example use `TestTag` and assign `TestValue`
2) Use tags in the cloudwatch-agent `config.json`, for example use `"log_stream_name": "{instance_id}_{tag:TestTag}"`
3) Enable instance metadata tags
4) Observe the translation of `{tag:TestTag}` to `TestValue` in `amazon-cloudwatch-agent.log`




