### PR TITLE
removing the --sample-config flag

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -63,8 +63,7 @@ var fEnvConfig = flag.String("envconfig", "", "env configuration file to load")
 var fConfigDirectory = flag.String("config-directory", "",
 	"directory containing additional *.conf files")
 var fVersion = flag.Bool("version", false, "display the version and exit")
-var fSampleConfig = flag.Bool("sample-config", false,
-	"print out full sample configuration")
+
 var fPidfile = flag.String("pidfile", "", "file to write our pid to")
 var fSectionFilters = flag.String("section-filter", "",
 	"filter the sections to print, separator is ':'. Valid values are 'agent', 'global_tags', 'outputs', 'processors', 'aggregators' and 'inputs'")
@@ -426,15 +425,6 @@ func main() {
 		return
 	case *fVersion:
 		fmt.Println(agentinfo.FullVersion())
-		return
-	case *fSampleConfig:
-		config.PrintSampleConfig(
-			sectionFilters,
-			inputFilters,
-			outputFilters,
-			aggregatorFilters,
-			processorFilters,
-		)
 		return
 	case *fUsage != "":
 		err := config.PrintInputConfig(*fUsage)


### PR DESCRIPTION
# Description of the issue
The PR is going to cater issue 615.

# Description of changes
Removing the sample-config call to influxdata dependancy


# Requirements

- [ ] 1. Run `make fmt` and `make fmt-sh`

- [ ] 2. Run `make linter`




