### PR TITLE
Add support for running EKS integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -983,23 +983,27 @@ jobs:
           command: |
             cd terraform/eks/daemon
             terraform init
-            if terraform apply --auto-approve \
+            terraform apply --auto-approve \
               -var="test_dir=${{ matrix.arrays.test_dir }}" \
               -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-              -var="cwagent_image_tag=${{ github.sha }}"; then
-              terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
+              -var="cwagent_image_tag=${{ github.sha }}"
+#            if terraform apply --auto-approve \
+#              -var="test_dir=${{ matrix.arrays.test_dir }}" \
+#              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
+#              -var="cwagent_image_tag=${{ github.sha }}"; then
+#              terraform destroy -auto-approve
+#            else
+#              terraform destroy -auto-approve && exit 1
+#            fi
 
-      - name: Terraform destroy
-        if: ${{ cancelled() && steps.eks-ec2-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 5
-          command: cd terraform/eks/daemon && terraform destroy --auto-approve
+#      - name: Terraform destroy
+#        if: ${{ cancelled() && steps.eks-ec2-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 8
+#          retry_wait_seconds: 5
+#          command: cd terraform/eks/daemon && terraform destroy --auto-approve
 
 #  StressTrackingTest:
 #    name: "StressTrackingTest"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -977,8 +977,8 @@ jobs:
         if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 3
-          timeout_minutes: 15
+          max_attempts: 1
+          timeout_minutes: 60
           retry_wait_seconds: 5
           command: |
             cd terraform/eks/daemon

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -145,6 +145,7 @@ jobs:
       ec2_stress_matrix: ${{steps.set-matrix.outputs.ec2_stress_matrix}}
       ecs_ec2_launch_daemon_matrix: ${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}
       ecs_fargate_matrix: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}
+      eks_daemon_matrix: ${{ steps.set-matrix.outputs.eks_daemon_matrix }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -168,6 +169,7 @@ jobs:
           echo "::set-output name=ec2_stress_matrix::$(echo $(cat generator/resources/ec2_stress_complete_test_matrix.json))"
           echo "::set-output name=ecs_ec2_launch_daemon_matrix::$(echo $(cat generator/resources/ecs_ec2_daemon_complete_test_matrix.json))"
           echo "::set-output name=ecs_fargate_matrix::$(echo $(cat generator/resources/ecs_fargate_complete_test_matrix.json))"
+          echo "::set-output name=eks_daemon_matrix::$(echo $(cat generator/resources/eks_daemon_test_matrix.json))"
 
       - name: Echo test plan matrix
         run: |
@@ -177,8 +179,9 @@ jobs:
           echo "ec2_mac_matrix: ${{ steps.set-matrix.outputs.ec2_mac_matrix }}"
           echo "ec2_performance_matrix: ${{ steps.set-matrix.outputs.ec2_performance_matrix}}"
           echo "ec2_stress_matrix: ${{ steps.set-matrix.outputs.ec2_stress_matrix}}"
-          echo "ecs_ec2_launch_daemon_matrix${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}"
-          echo "ecs_fargate_matrix${{ steps.set-matrix.outputs.ecs_fargate_matrix }}"
+          echo "ecs_ec2_launch_daemon_matrix: ${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}"
+          echo "ecs_fargate_matrix: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}"
+          echo "eks_daemon_matrix: ${{ steps.set-matrix.outputs.eks_daemon_matrix }}"
 
   MakeMSIZip:
     name: 'MakeMSIZip'
@@ -929,6 +932,74 @@ jobs:
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: cd terraform/ecs_fargate/linux && terraform destroy --auto-approve
+
+
+  EKSIntegrationTest:
+    name: 'EKSIntegrationTest'
+    runs-on: ubuntu-latest
+    needs: [ MakeBinary, GenerateTestMatrix ]
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.eks_daemon_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Cache if success
+        id: eks-ec2-integration-test
+        uses: actions/cache@v2
+        with:
+          path: go.mod
+          key: eks-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+
+      - name: Login ECR
+        id: login-ecr
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Verify Terraform version
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
+        run: terraform --version
+
+      - name: Terraform apply
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 15
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/eks/daemon
+            terraform init
+            if terraform apply --auto-approve\
+              -var="test_dir=${{ matrix.arrays.test_dir }}"\
+              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
+              -var="cwagent_image_tag=${{ github.sha }}"\
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.eks-ec2-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/eks/daemon && terraform destroy --auto-approve
 
   StressTrackingTest:
     name: "StressTrackingTest"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -984,7 +984,6 @@ jobs:
             cd terraform/eks/daemon
             terraform init
             if terraform apply --auto-approve \
-              -var="test_dir=${{ matrix.arrays.test_dir }}" \
               -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
               -var="cwagent_image_tag=${{ github.sha }}"; then
               terraform destroy -auto-approve

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -984,7 +984,6 @@ jobs:
             cd terraform/eks/daemon
             terraform init
             terraform apply --auto-approve \
-              -var="test_dir=${{ matrix.arrays.test_dir }}" \
               -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
               -var="cwagent_image_tag=${{ github.sha }}"
 #            if terraform apply --auto-approve \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -405,49 +405,49 @@ jobs:
           aws s3 cp packages/amd64/amazon-cloudwatch-agent.pkg.sig s3://${S3_INTEGRATION_BUCKET}/integration-test/packaging/${{ github.sha }}/amd64/amazon-cloudwatch-agent.pkg.sig
           aws s3 cp packages/arm64/amazon-cloudwatch-agent.pkg.sig s3://${S3_INTEGRATION_BUCKET}/integration-test/packaging/${{ github.sha }}/arm64/amazon-cloudwatch-agent.pkg.sig
   
-  StartLocalStack:
-    name: 'StartLocalStack'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: terraform/ec2/localstack
-    outputs:
-      local_stack_host_name: ${{ steps.localstack.outputs.local_stack_host_name }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Verify Terraform version
-        run: terraform --version
-
-      - name: Terraform init
-        run: terraform init
-
-      - name: Terraform apply
-        id: localstack
-        run: >
-          echo run terraform and execute test code &&
-          terraform apply --auto-approve
-          -var="ssh_key_value=${PRIVATE_KEY}"
-          -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}"
-          -var="cwa_github_sha=${GITHUB_SHA}"
-          -var="s3_bucket=${S3_INTEGRATION_BUCKET}"
-          -var="ssh_key_name=${KEY_NAME}" &&
-          LOCAL_STACK_HOST_NAME=$(terraform output -raw public_dns) &&
-          echo $LOCAL_STACK_HOST_NAME &&
-          echo "::set-output name=local_stack_host_name::$LOCAL_STACK_HOST_NAME" &&
-          aws s3 cp terraform.tfstate s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate
+#  StartLocalStack:
+#    name: 'StartLocalStack'
+#    runs-on: ubuntu-latest
+#    defaults:
+#      run:
+#        working-directory: terraform/ec2/localstack
+#    outputs:
+#      local_stack_host_name: ${{ steps.localstack.outputs.local_stack_host_name }}
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: us-west-2
+#
+#      - name: Verify Terraform version
+#        run: terraform --version
+#
+#      - name: Terraform init
+#        run: terraform init
+#
+#      - name: Terraform apply
+#        id: localstack
+#        run: >
+#          echo run terraform and execute test code &&
+#          terraform apply --auto-approve
+#          -var="ssh_key_value=${PRIVATE_KEY}"
+#          -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}"
+#          -var="cwa_github_sha=${GITHUB_SHA}"
+#          -var="s3_bucket=${S3_INTEGRATION_BUCKET}"
+#          -var="ssh_key_name=${KEY_NAME}" &&
+#          LOCAL_STACK_HOST_NAME=$(terraform output -raw public_dns) &&
+#          echo $LOCAL_STACK_HOST_NAME &&
+#          echo "::set-output name=local_stack_host_name::$LOCAL_STACK_HOST_NAME" &&
+#          aws s3 cp terraform.tfstate s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate
   
 #  EC2NvidiaGPUIntegrationTest:
 #    needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
@@ -762,40 +762,40 @@ jobs:
 #          retry_wait_seconds: 5
 #          command: cd terraform/ec2/mac && terraform destroy --auto-approve
 
-  StopLocalStack:
-    name: 'StopLocalStack'
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [ StartLocalStack, EC2LinuxIntegrationTest ]
-    defaults:
-      run:
-        working-directory: terraform/ec2/localstack
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Copy state
-        run: aws s3 cp s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate .
-
-      - name: Verify Terraform version
-        run: terraform --version
-
-      - name: Terraform init
-        run: terraform init
-
-      - name: Terraform destroy
-        run: terraform destroy --auto-approve
+#  StopLocalStack:
+#    name: 'StopLocalStack'
+#    runs-on: ubuntu-latest
+#    if: ${{ always() }}
+#    needs: [ StartLocalStack, EC2LinuxIntegrationTest ]
+#    defaults:
+#      run:
+#        working-directory: terraform/ec2/localstack
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: us-west-2
+#
+#      - name: Copy state
+#        run: aws s3 cp s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate .
+#
+#      - name: Verify Terraform version
+#        run: terraform --version
+#
+#      - name: Terraform init
+#        run: terraform init
+#
+#      - name: Terraform destroy
+#        run: terraform destroy --auto-approve
 
 #  ECSEC2IntegrationTest:
 #    name: 'ECSEC2IntegrationTest'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "SaxyPandaBear/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/SaxyPandaBear/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "eks"
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
 on:
   push:
@@ -405,533 +405,533 @@ jobs:
           aws s3 cp packages/amd64/amazon-cloudwatch-agent.pkg.sig s3://${S3_INTEGRATION_BUCKET}/integration-test/packaging/${{ github.sha }}/amd64/amazon-cloudwatch-agent.pkg.sig
           aws s3 cp packages/arm64/amazon-cloudwatch-agent.pkg.sig s3://${S3_INTEGRATION_BUCKET}/integration-test/packaging/${{ github.sha }}/arm64/amazon-cloudwatch-agent.pkg.sig
   
-#  StartLocalStack:
-#    name: 'StartLocalStack'
-#    runs-on: ubuntu-latest
-#    defaults:
-#      run:
-#        working-directory: terraform/ec2/localstack
-#    outputs:
-#      local_stack_host_name: ${{ steps.localstack.outputs.local_stack_host_name }}
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Verify Terraform version
-#        run: terraform --version
-#
-#      - name: Terraform init
-#        run: terraform init
-#
-#      - name: Terraform apply
-#        id: localstack
-#        run: >
-#          echo run terraform and execute test code &&
-#          terraform apply --auto-approve
-#          -var="ssh_key_value=${PRIVATE_KEY}"
-#          -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}"
-#          -var="cwa_github_sha=${GITHUB_SHA}"
-#          -var="s3_bucket=${S3_INTEGRATION_BUCKET}"
-#          -var="ssh_key_name=${KEY_NAME}" &&
-#          LOCAL_STACK_HOST_NAME=$(terraform output -raw public_dns) &&
-#          echo $LOCAL_STACK_HOST_NAME &&
-#          echo "::set-output name=local_stack_host_name::$LOCAL_STACK_HOST_NAME" &&
-#          aws s3 cp terraform.tfstate s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate
+  StartLocalStack:
+    name: 'StartLocalStack'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform/ec2/localstack
+    outputs:
+      local_stack_host_name: ${{ steps.localstack.outputs.local_stack_host_name }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+      - name: Terraform init
+        run: terraform init
+
+      - name: Terraform apply
+        id: localstack
+        run: >
+          echo run terraform and execute test code &&
+          terraform apply --auto-approve
+          -var="ssh_key_value=${PRIVATE_KEY}"
+          -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}"
+          -var="cwa_github_sha=${GITHUB_SHA}"
+          -var="s3_bucket=${S3_INTEGRATION_BUCKET}"
+          -var="ssh_key_name=${KEY_NAME}" &&
+          LOCAL_STACK_HOST_NAME=$(terraform output -raw public_dns) &&
+          echo $LOCAL_STACK_HOST_NAME &&
+          echo "::set-output name=local_stack_host_name::$LOCAL_STACK_HOST_NAME" &&
+          aws s3 cp terraform.tfstate s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate
   
-#  EC2NvidiaGPUIntegrationTest:
-#    needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
-#    name: 'EC2NVIDIAGPUIntegrationTest'
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_gpu_matrix) }}
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Cache if success
-#        id: ec2-linux-integration-test
-#        uses: actions/cache@v3
-#        with:
-#          path: go.mod
-#          key: ec2-nvidia-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-#
-#      - name: Echo Test Info
-#        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
-#
-#      - name: Verify Terraform version
-#        run: terraform --version
-#
-#      # nick-fields/retry@v2 starts at base dir
-#      - name: Terraform apply
-#        if: ${{ matrix.arrays.family == 'linux' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 30
-#          retry_wait_seconds: 5
-#          command: |
-#            cd terraform/ec2/linux
-#            terraform init
-#            if terraform apply --auto-approve \
-#              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-#              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
-#              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
-#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-#              -var="user=${{ matrix.arrays.username }}" \
-#              -var="ami=${{ matrix.arrays.ami }}" \
-#              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
-#              -var="arc=${{ matrix.arrays.arc }}" \
-#              -var="binary_name=${{ matrix.arrays.binaryName }}" \
-#              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
-#              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
-#              -var="ssh_key_name=${KEY_NAME}" \
-#              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
-#      - name: Terraform apply
-#        if: ${{ matrix.arrays.family == 'window' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 30
-#          retry_wait_seconds: 5
-#          command: |
-#            cd terraform/ec2/win
-#            terraform init
-#            if terraform apply --auto-approve \
-#              -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}" \
-#              -var="github_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-#              -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
-#              -var="test_dir=${{ matrix.arrays.test_dir }}" \
-#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-#              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
-#      #This is here just in case workflow cancel
-#      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 8
-#          retry_wait_seconds: 5
-#          command: |
-#            if "${{ matrix.arrays.os }}" == window
-#              cd terraform/ec2/win
-#            else
-#              cd terraform/ec2/linux
-#            fi
-#            terraform destroy --auto-approve
-#
-#  EC2LinuxIntegrationTest:
-#    needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
-#    name: 'Test'
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_linux_matrix) }}
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Cache if success
-#        id: ec2-linux-integration-test
-#        uses: actions/cache@v3
-#        with:
-#          path: go.mod
-#          key: ec2-linux-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-#
-#      - name: Echo Test Info
-#        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
-#
-#      - name: Verify Terraform version
-#        run: terraform --version
-#
-#      # nick-fields/retry@v2 starts at base dir
-#      - name: Terraform apply
-#        if: steps.ec2-linux-integration-test.outputs.cache-hit != 'true'
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 60
-#          retry_wait_seconds: 5
-#          command: |
-#            cd terraform/ec2/linux
-#            terraform init
-#            if terraform apply --auto-approve \
-#              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-#              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
-#              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
-#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-#              -var="user=${{ matrix.arrays.username }}" \
-#              -var="ami=${{ matrix.arrays.ami }}" \
-#              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
-#              -var="arc=${{ matrix.arrays.arc }}" \
-#              -var="binary_name=${{ matrix.arrays.binaryName }}" \
-#              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
-#              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
-#              -var="plugin_tests='${{ github.event.inputs.plugins }}'" \
-#              -var="ssh_key_name=${KEY_NAME}" \
-#              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
-#      #This is here just in case workflow cancel
-#      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.ec2-linux-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 8
-#          retry_wait_seconds: 5
-#          command: cd terraform/ec2/linux && terraform destroy --auto-approve
-#
-#  EC2WinIntegrationTest:
-#    needs: [BuildMSI, GenerateTestMatrix]
-#    name: 'EC2WinIntegrationTest'
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_windows_matrix) }}
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Cache if success
-#        id: ec2-win-integration-test
-#        uses: actions/cache@v2
-#        with:
-#          path: go.mod
-#          key: ec2-win-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-#
-#      - name: Echo OS
-#        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
-#
-#      - name: Verify Terraform version
-#        run: terraform --version
-#
-#        # nick-fields/retry@v2 starts at base dir
-#      - name: Terraform apply
-#        if: steps.ec2-win-integration-test.outputs.cache-hit != 'true'
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 30
-#          retry_wait_seconds: 5
-#          command: |
-#            cd terraform/ec2/win
-#            terraform init
-#            if terraform apply --auto-approve \
-#            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-#            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
-#            -var="cwa_github_sha=${GITHUB_SHA}"  \
-#            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-#            -var="ami=${{ matrix.arrays.ami }}" \
-#            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
-#              terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
-#
-#      #This is here just in case workflow cancel
-#      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.ec2-win-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 8
-#          retry_wait_seconds: 5
-#          command: cd terraform/ec2/win && terraform destroy --auto-approve
-#
-#  EC2DarwinIntegrationTest:
-#    needs: [MakeMacPkg, EC2LinuxIntegrationTest, GenerateTestMatrix]
-#    name: 'EC2DarwinIntegrationTest'
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_mac_matrix) }}
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Cache if success
-#        id: ec2-mac-integration-test
-#        uses: actions/cache@v2
-#        with:
-#          path: go.mod
-#          key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-#
-#      - name: Echo OS
-#        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
-#
-#      - name: Verify Terraform version
-#        run: terraform --version
-#
-#        # nick-fields/retry@v2 starts at base dir
-#      - name: Terraform apply
-#        if: steps.ec2-mac-integration-test.outputs.cache-hit != 'true'
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 30
-#          retry_wait_seconds: 5
-#          command: |
-#            cd terraform/ec2/mac
-#            terraform init
-#            if terraform apply --auto-approve \
-#            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
-#            -var="arc=${{ matrix.arrays.arc }}" \
-#            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-#            -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
-#            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-#            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
-#              terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
-#
-#      #This is here just in case workflow cancel
-#      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.ec2-mac-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 8
-#          retry_wait_seconds: 5
-#          command: cd terraform/ec2/mac && terraform destroy --auto-approve
+  EC2NvidiaGPUIntegrationTest:
+    needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
+    name: 'EC2NVIDIAGPUIntegrationTest'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_gpu_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
 
-#  StopLocalStack:
-#    name: 'StopLocalStack'
-#    runs-on: ubuntu-latest
-#    if: ${{ always() }}
-#    needs: [ StartLocalStack, EC2LinuxIntegrationTest ]
-#    defaults:
-#      run:
-#        working-directory: terraform/ec2/localstack
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Copy state
-#        run: aws s3 cp s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate .
-#
-#      - name: Verify Terraform version
-#        run: terraform --version
-#
-#      - name: Terraform init
-#        run: terraform init
-#
-#      - name: Terraform destroy
-#        run: terraform destroy --auto-approve
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
 
-#  ECSEC2IntegrationTest:
-#    name: 'ECSEC2IntegrationTest'
-#    runs-on: ubuntu-latest
-#    needs: [ MakeBinary, GenerateTestMatrix ]
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ecs_ec2_launch_daemon_matrix) }}
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Cache if success
-#        id: ecs-ec2-integration-test
-#        uses: actions/cache@v2
-#        with:
-#          path: go.mod
-#          key: ecs-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
-#
-#      - name: Login ECR
-#        id: login-ecr
-#        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
-#        uses: aws-actions/amazon-ecr-login@v1
-#
-#      - name: Verify Terraform version
-#        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
-#        run: terraform --version
-#
-#      - name: Terraform apply
-#        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 15
-#          retry_wait_seconds: 5
-#          command: |
-#            cd terraform/ecs_ec2/daemon
-#            terraform init
-#            if terraform apply --auto-approve\
-#              -var="test_dir=${{ matrix.arrays.test_dir }}"\
-#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-#              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
-#              -var="cwagent_image_tag=${{ github.sha }}"\
-#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-#              -var="ami=${{ matrix.arrays.ami }}" ; then
-#              terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
-#
-#      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.ecs-ec2-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 8
-#          retry_wait_seconds: 5
-#          command: cd terraform/ecs_ec2/daemon && terraform destroy --auto-approve
-#
-#  ECSFargateIntegrationTest:
-#    name: 'ECSFargateIntegrationTest'
-#    runs-on: ubuntu-latest
-#    needs: [MakeBinary, GenerateTestMatrix]
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ecs_fargate_matrix) }}
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Cache if success
-#        id: ecs-fargate-integration-test
-#        uses: actions/cache@v3
-#        with:
-#          path: go.mod
-#          key: ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
-#
-#      - name: Login ECR
-#        id: login-ecr
-#        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
-#        uses: aws-actions/amazon-ecr-login@v1
-#
-#      - name: Verify Terraform version
-#        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
-#        run: terraform --version
-#
-#      - name: Terraform apply
-#        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 15
-#          retry_wait_seconds: 5
-#          command: |
-#            cd terraform/ecs_fargate/linux
-#            terraform init
-#            if terraform apply --auto-approve\
-#              -var="test_dir=${{ matrix.arrays.test_dir }}"\
-#              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
-#              -var="cwagent_image_tag=${{ github.sha }}"; then
-#              terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
-#      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.ecs-fargate-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 8
-#          retry_wait_seconds: 5
-#          command: cd terraform/ecs_fargate/linux && terraform destroy --auto-approve
+      - name: Cache if success
+        id: ec2-linux-integration-test
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ec2-nvidia-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
+      - name: Echo Test Info
+        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+      # nick-fields/retry@v2 starts at base dir
+      - name: Terraform apply
+        if: ${{ matrix.arrays.family == 'linux' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 30
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/ec2/linux
+            terraform init
+            if terraform apply --auto-approve \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
+              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="user=${{ matrix.arrays.username }}" \
+              -var="ami=${{ matrix.arrays.ami }}" \
+              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
+              -var="arc=${{ matrix.arrays.arc }}" \
+              -var="binary_name=${{ matrix.arrays.binaryName }}" \
+              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
+              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
+              -var="ssh_key_name=${KEY_NAME}" \
+              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+      - name: Terraform apply
+        if: ${{ matrix.arrays.family == 'window' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 30
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/ec2/win
+            terraform init
+            if terraform apply --auto-approve \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}" \
+              -var="github_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+              -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
+              -var="test_dir=${{ matrix.arrays.test_dir }}" \
+              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+      #This is here just in case workflow cancel
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: |
+            if "${{ matrix.arrays.os }}" == window
+              cd terraform/ec2/win
+            else
+              cd terraform/ec2/linux
+            fi
+            terraform destroy --auto-approve
+
+  EC2LinuxIntegrationTest:
+    needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
+    name: 'Test'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_linux_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Cache if success
+        id: ec2-linux-integration-test
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ec2-linux-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
+      - name: Echo Test Info
+        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+      # nick-fields/retry@v2 starts at base dir
+      - name: Terraform apply
+        if: steps.ec2-linux-integration-test.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 60
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/ec2/linux
+            terraform init
+            if terraform apply --auto-approve \
+              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
+              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="user=${{ matrix.arrays.username }}" \
+              -var="ami=${{ matrix.arrays.ami }}" \
+              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
+              -var="arc=${{ matrix.arrays.arc }}" \
+              -var="binary_name=${{ matrix.arrays.binaryName }}" \
+              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
+              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
+              -var="plugin_tests='${{ github.event.inputs.plugins }}'" \
+              -var="ssh_key_name=${KEY_NAME}" \
+              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+      #This is here just in case workflow cancel
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.ec2-linux-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/ec2/linux && terraform destroy --auto-approve
+
+  EC2WinIntegrationTest:
+    needs: [BuildMSI, GenerateTestMatrix]
+    name: 'EC2WinIntegrationTest'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_windows_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Cache if success
+        id: ec2-win-integration-test
+        uses: actions/cache@v2
+        with:
+          path: go.mod
+          key: ec2-win-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
+      - name: Echo OS
+        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+        # nick-fields/retry@v2 starts at base dir
+      - name: Terraform apply
+        if: steps.ec2-win-integration-test.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 30
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/ec2/win
+            terraform init
+            if terraform apply --auto-approve \
+            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
+            -var="cwa_github_sha=${GITHUB_SHA}"  \
+            -var="test_dir=${{ matrix.arrays.test_dir }}" \
+            -var="ami=${{ matrix.arrays.ami }}" \
+            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.ec2-win-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/ec2/win && terraform destroy --auto-approve
+
+  EC2DarwinIntegrationTest:
+    needs: [MakeMacPkg, EC2LinuxIntegrationTest, GenerateTestMatrix]
+    name: 'EC2DarwinIntegrationTest'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_mac_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Cache if success
+        id: ec2-mac-integration-test
+        uses: actions/cache@v2
+        with:
+          path: go.mod
+          key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
+      - name: Echo OS
+        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+        # nick-fields/retry@v2 starts at base dir
+      - name: Terraform apply
+        if: steps.ec2-mac-integration-test.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 30
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/ec2/mac
+            terraform init
+            if terraform apply --auto-approve \
+            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
+            -var="arc=${{ matrix.arrays.arc }}" \
+            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+            -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
+            -var="test_dir=${{ matrix.arrays.test_dir }}" \
+            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.ec2-mac-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/ec2/mac && terraform destroy --auto-approve
+
+  StopLocalStack:
+    name: 'StopLocalStack'
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [ StartLocalStack, EC2LinuxIntegrationTest ]
+    defaults:
+      run:
+        working-directory: terraform/ec2/localstack
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Copy state
+        run: aws s3 cp s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate .
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+      - name: Terraform init
+        run: terraform init
+
+      - name: Terraform destroy
+        run: terraform destroy --auto-approve
+
+  ECSEC2IntegrationTest:
+    name: 'ECSEC2IntegrationTest'
+    runs-on: ubuntu-latest
+    needs: [ MakeBinary, GenerateTestMatrix ]
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ecs_ec2_launch_daemon_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Cache if success
+        id: ecs-ec2-integration-test
+        uses: actions/cache@v2
+        with:
+          path: go.mod
+          key: ecs-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+
+      - name: Login ECR
+        id: login-ecr
+        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Verify Terraform version
+        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
+        run: terraform --version
+
+      - name: Terraform apply
+        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 15
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/ecs_ec2/daemon
+            terraform init
+            if terraform apply --auto-approve\
+              -var="test_dir=${{ matrix.arrays.test_dir }}"\
+              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
+              -var="cwagent_image_tag=${{ github.sha }}"\
+              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="ami=${{ matrix.arrays.ami }}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.ecs-ec2-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/ecs_ec2/daemon && terraform destroy --auto-approve
+
+  ECSFargateIntegrationTest:
+    name: 'ECSFargateIntegrationTest'
+    runs-on: ubuntu-latest
+    needs: [MakeBinary, GenerateTestMatrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ecs_fargate_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Cache if success
+        id: ecs-fargate-integration-test
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+
+      - name: Login ECR
+        id: login-ecr
+        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Verify Terraform version
+        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
+        run: terraform --version
+
+      - name: Terraform apply
+        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 15
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/ecs_fargate/linux
+            terraform init
+            if terraform apply --auto-approve\
+              -var="test_dir=${{ matrix.arrays.test_dir }}"\
+              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
+              -var="cwagent_image_tag=${{ github.sha }}"; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.ecs-fargate-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/ecs_fargate/linux && terraform destroy --auto-approve
 
 
   EKSIntegrationTest:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -983,10 +983,10 @@ jobs:
           command: |
             cd terraform/eks/daemon
             terraform init
-            if terraform apply --auto-approve\
-              -var="test_dir=${{ matrix.arrays.test_dir }}"\
-              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
-              -var="cwagent_image_tag=${{ github.sha }}"\
+            if terraform apply --auto-approve \
+              -var="test_dir=${{ matrix.arrays.test_dir }}" \
+              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
+              -var="cwagent_image_tag=${{ github.sha }}"; then
               terraform destroy -auto-approve
             else
               terraform destroy -auto-approve && exit 1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -977,8 +977,8 @@ jobs:
         if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 1
-          timeout_minutes: 60
+          max_attempts: 3
+          timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
           retry_wait_seconds: 5
           command: |
             cd terraform/eks/daemon

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Cache go
         if: steps.cached_binaries.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod
@@ -280,7 +280,7 @@ jobs:
 
       - name: Cache pkg
         if: steps.cached_binaries.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/Library/Caches/go-build
@@ -649,7 +649,7 @@ jobs:
 
       - name: Cache if success
         id: ec2-win-integration-test
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: go.mod
           key: ec2-win-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
@@ -718,7 +718,7 @@ jobs:
 
       - name: Cache if success
         id: ec2-mac-integration-test
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: go.mod
           key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
@@ -822,7 +822,7 @@ jobs:
 
       - name: Cache if success
         id: ecs-ec2-integration-test
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: go.mod
           key: ecs-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
@@ -959,7 +959,7 @@ jobs:
 
       - name: Cache if success
         id: eks-ec2-integration-test
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: go.mod
           key: eks-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
@@ -1000,69 +1000,69 @@ jobs:
           retry_wait_seconds: 5
           command: cd terraform/eks/daemon && terraform destroy --auto-approve
 
-#  StressTrackingTest:
-#    name: "StressTrackingTest"
-#    needs: [MakeBinary, EC2LinuxIntegrationTest, ECSEC2IntegrationTest, ECSFargateIntegrationTest, GenerateTestMatrix]
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_stress_matrix) }}
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: us-west-2
-#
-#      - name: Cache if success
-#        id: stress-tracking
-#        uses: actions/cache@v3
-#        with:
-#          path: go.mod
-#          key: stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-#
-#      - name: Verify Terraform version
-#        if: steps.stress-tracking.outputs.cache-hit != 'true'
-#        run: terraform --version
-#
-#      - name: Terraform apply
-#        if: steps.stress-tracking.outputs.cache-hit != 'true'
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 1
-#          timeout_minutes: 30
-#          retry_wait_seconds: 5
-#          command: |
-#            cd terraform/performance
-#            terraform init
-#            if terraform apply --auto-approve \
-#              -var="ssh_key_value=${PRIVATE_KEY}"  \
-#              -var="cwa_github_sha=${GITHUB_SHA}" \
-#              -var="user=${{ matrix.arrays.username }}" \
-#              -var="ami=${{ matrix.arrays.ami }}" \
-#              -var="arc=${{ matrix.arrays.arc }}" \
-#              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
-#              -var="ssh_key_name=${KEY_NAME}" \
-#              -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
-#              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
-#
-#      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.stress-tracking.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 8
-#          retry_wait_seconds: 5
-#          command: cd terraform/performance && terraform destroy --auto-approve
+  StressTrackingTest:
+    name: "StressTrackingTest"
+    needs: [MakeBinary, EC2LinuxIntegrationTest, ECSEC2IntegrationTest, ECSFargateIntegrationTest, GenerateTestMatrix]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_stress_matrix) }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Cache if success
+        id: stress-tracking
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
+      - name: Verify Terraform version
+        if: steps.stress-tracking.outputs.cache-hit != 'true'
+        run: terraform --version
+
+      - name: Terraform apply
+        if: steps.stress-tracking.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 1
+          timeout_minutes: 30
+          retry_wait_seconds: 5
+          command: |
+            cd terraform/performance
+            terraform init
+            if terraform apply --auto-approve \
+              -var="ssh_key_value=${PRIVATE_KEY}"  \
+              -var="cwa_github_sha=${GITHUB_SHA}" \
+              -var="user=${{ matrix.arrays.username }}" \
+              -var="ami=${{ matrix.arrays.ami }}" \
+              -var="arc=${{ matrix.arrays.arc }}" \
+              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
+              -var="ssh_key_name=${KEY_NAME}" \
+              -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
+              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.stress-tracking.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/performance && terraform destroy --auto-approve

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_NAME: "SaxyPandaBear/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/SaxyPandaBear/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "eks"
 
 on:
   push:
@@ -449,318 +449,318 @@ jobs:
           echo "::set-output name=local_stack_host_name::$LOCAL_STACK_HOST_NAME" &&
           aws s3 cp terraform.tfstate s3://${S3_INTEGRATION_BUCKET}/integration-test/local-stack-terraform-state/${GITHUB_SHA}/terraform.tfstate
   
-  EC2NvidiaGPUIntegrationTest:
-    needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
-    name: 'EC2NVIDIAGPUIntegrationTest'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_gpu_matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Cache if success
-        id: ec2-linux-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ec2-nvidia-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
-      - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
-
-      - name: Verify Terraform version
-        run: terraform --version
-
-      # nick-fields/retry@v2 starts at base dir
-      - name: Terraform apply
-        if: ${{ matrix.arrays.family == 'linux' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 30
-          retry_wait_seconds: 5
-          command: |
-            cd terraform/ec2/linux
-            terraform init
-            if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
-              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-              -var="user=${{ matrix.arrays.username }}" \
-              -var="ami=${{ matrix.arrays.ami }}" \
-              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
-              -var="arc=${{ matrix.arrays.arc }}" \
-              -var="binary_name=${{ matrix.arrays.binaryName }}" \
-              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
-              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
-              -var="ssh_key_name=${KEY_NAME}" \
-              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
-      - name: Terraform apply
-        if: ${{ matrix.arrays.family == 'window' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 30
-          retry_wait_seconds: 5
-          command: |
-            cd terraform/ec2/win
-            terraform init
-            if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}" \
-              -var="github_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-              -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
-              -var="test_dir=${{ matrix.arrays.test_dir }}" \
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
-      #This is here just in case workflow cancel
-      - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 5
-          command: |
-            if "${{ matrix.arrays.os }}" == window
-              cd terraform/ec2/win
-            else
-              cd terraform/ec2/linux
-            fi
-            terraform destroy --auto-approve
-
-  EC2LinuxIntegrationTest:
-    needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
-    name: 'Test'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_linux_matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Cache if success
-        id: ec2-linux-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ec2-linux-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
-      - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
-
-      - name: Verify Terraform version
-        run: terraform --version
-
-      # nick-fields/retry@v2 starts at base dir
-      - name: Terraform apply
-        if: steps.ec2-linux-integration-test.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 60
-          retry_wait_seconds: 5
-          command: |
-            cd terraform/ec2/linux
-            terraform init
-            if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
-              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-              -var="user=${{ matrix.arrays.username }}" \
-              -var="ami=${{ matrix.arrays.ami }}" \
-              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
-              -var="arc=${{ matrix.arrays.arc }}" \
-              -var="binary_name=${{ matrix.arrays.binaryName }}" \
-              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
-              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
-              -var="plugin_tests='${{ github.event.inputs.plugins }}'" \
-              -var="ssh_key_name=${KEY_NAME}" \
-              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
-      #This is here just in case workflow cancel
-      - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-linux-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 5
-          command: cd terraform/ec2/linux && terraform destroy --auto-approve
-
-  EC2WinIntegrationTest:
-    needs: [BuildMSI, GenerateTestMatrix]
-    name: 'EC2WinIntegrationTest'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_windows_matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Cache if success
-        id: ec2-win-integration-test
-        uses: actions/cache@v2
-        with:
-          path: go.mod
-          key: ec2-win-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
-      - name: Echo OS
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
-
-      - name: Verify Terraform version
-        run: terraform --version
-
-        # nick-fields/retry@v2 starts at base dir
-      - name: Terraform apply
-        if: steps.ec2-win-integration-test.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 30
-          retry_wait_seconds: 5
-          command: |
-            cd terraform/ec2/win
-            terraform init
-            if terraform apply --auto-approve \
-            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
-            -var="cwa_github_sha=${GITHUB_SHA}"  \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
-              terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
-
-      #This is here just in case workflow cancel
-      - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-win-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 5
-          command: cd terraform/ec2/win && terraform destroy --auto-approve 
-    
-  EC2DarwinIntegrationTest:
-    needs: [MakeMacPkg, EC2LinuxIntegrationTest, GenerateTestMatrix]
-    name: 'EC2DarwinIntegrationTest'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_mac_matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Cache if success
-        id: ec2-mac-integration-test
-        uses: actions/cache@v2
-        with:
-          path: go.mod
-          key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
-      - name: Echo OS
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
-
-      - name: Verify Terraform version
-        run: terraform --version
-
-        # nick-fields/retry@v2 starts at base dir
-      - name: Terraform apply
-        if: steps.ec2-mac-integration-test.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 30
-          retry_wait_seconds: 5
-          command: |
-            cd terraform/ec2/mac
-            terraform init
-            if terraform apply --auto-approve \
-            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
-            -var="arc=${{ matrix.arrays.arc }}" \
-            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-            -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
-              terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
-
-      #This is here just in case workflow cancel
-      - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-mac-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 5
-          command: cd terraform/ec2/mac && terraform destroy --auto-approve 
+#  EC2NvidiaGPUIntegrationTest:
+#    needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
+#    name: 'EC2NVIDIAGPUIntegrationTest'
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_gpu_matrix) }}
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: us-west-2
+#
+#      - name: Cache if success
+#        id: ec2-linux-integration-test
+#        uses: actions/cache@v3
+#        with:
+#          path: go.mod
+#          key: ec2-nvidia-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+#
+#      - name: Echo Test Info
+#        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+#
+#      - name: Verify Terraform version
+#        run: terraform --version
+#
+#      # nick-fields/retry@v2 starts at base dir
+#      - name: Terraform apply
+#        if: ${{ matrix.arrays.family == 'linux' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 30
+#          retry_wait_seconds: 5
+#          command: |
+#            cd terraform/ec2/linux
+#            terraform init
+#            if terraform apply --auto-approve \
+#              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+#              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+#              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
+#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+#              -var="user=${{ matrix.arrays.username }}" \
+#              -var="ami=${{ matrix.arrays.ami }}" \
+#              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
+#              -var="arc=${{ matrix.arrays.arc }}" \
+#              -var="binary_name=${{ matrix.arrays.binaryName }}" \
+#              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
+#              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
+#              -var="ssh_key_name=${KEY_NAME}" \
+#              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
+#            else
+#              terraform destroy -auto-approve && exit 1
+#            fi
+#      - name: Terraform apply
+#        if: ${{ matrix.arrays.family == 'window' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 30
+#          retry_wait_seconds: 5
+#          command: |
+#            cd terraform/ec2/win
+#            terraform init
+#            if terraform apply --auto-approve \
+#              -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}" \
+#              -var="github_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+#              -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
+#              -var="test_dir=${{ matrix.arrays.test_dir }}" \
+#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+#              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then terraform destroy -auto-approve
+#            else
+#              terraform destroy -auto-approve && exit 1
+#            fi
+#      #This is here just in case workflow cancel
+#      - name: Terraform destroy
+#        if: ${{ cancelled() && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 8
+#          retry_wait_seconds: 5
+#          command: |
+#            if "${{ matrix.arrays.os }}" == window
+#              cd terraform/ec2/win
+#            else
+#              cd terraform/ec2/linux
+#            fi
+#            terraform destroy --auto-approve
+#
+#  EC2LinuxIntegrationTest:
+#    needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
+#    name: 'Test'
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_linux_matrix) }}
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: us-west-2
+#
+#      - name: Cache if success
+#        id: ec2-linux-integration-test
+#        uses: actions/cache@v3
+#        with:
+#          path: go.mod
+#          key: ec2-linux-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+#
+#      - name: Echo Test Info
+#        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+#
+#      - name: Verify Terraform version
+#        run: terraform --version
+#
+#      # nick-fields/retry@v2 starts at base dir
+#      - name: Terraform apply
+#        if: steps.ec2-linux-integration-test.outputs.cache-hit != 'true'
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 60
+#          retry_wait_seconds: 5
+#          command: |
+#            cd terraform/ec2/linux
+#            terraform init
+#            if terraform apply --auto-approve \
+#              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+#              -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+#              -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
+#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+#              -var="user=${{ matrix.arrays.username }}" \
+#              -var="ami=${{ matrix.arrays.ami }}" \
+#              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
+#              -var="arc=${{ matrix.arrays.arc }}" \
+#              -var="binary_name=${{ matrix.arrays.binaryName }}" \
+#              -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
+#              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
+#              -var="plugin_tests='${{ github.event.inputs.plugins }}'" \
+#              -var="ssh_key_name=${KEY_NAME}" \
+#              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
+#            else
+#              terraform destroy -auto-approve && exit 1
+#            fi
+#      #This is here just in case workflow cancel
+#      - name: Terraform destroy
+#        if: ${{ cancelled() && steps.ec2-linux-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 8
+#          retry_wait_seconds: 5
+#          command: cd terraform/ec2/linux && terraform destroy --auto-approve
+#
+#  EC2WinIntegrationTest:
+#    needs: [BuildMSI, GenerateTestMatrix]
+#    name: 'EC2WinIntegrationTest'
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_windows_matrix) }}
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - uses: actions/checkout@v2
+#        with:
+#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: us-west-2
+#
+#      - name: Cache if success
+#        id: ec2-win-integration-test
+#        uses: actions/cache@v2
+#        with:
+#          path: go.mod
+#          key: ec2-win-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+#
+#      - name: Echo OS
+#        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
+#
+#      - name: Verify Terraform version
+#        run: terraform --version
+#
+#        # nick-fields/retry@v2 starts at base dir
+#      - name: Terraform apply
+#        if: steps.ec2-win-integration-test.outputs.cache-hit != 'true'
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 30
+#          retry_wait_seconds: 5
+#          command: |
+#            cd terraform/ec2/win
+#            terraform init
+#            if terraform apply --auto-approve \
+#            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+#            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
+#            -var="cwa_github_sha=${GITHUB_SHA}"  \
+#            -var="test_dir=${{ matrix.arrays.test_dir }}" \
+#            -var="ami=${{ matrix.arrays.ami }}" \
+#            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
+#              terraform destroy -auto-approve
+#            else
+#              terraform destroy -auto-approve && exit 1
+#            fi
+#
+#      #This is here just in case workflow cancel
+#      - name: Terraform destroy
+#        if: ${{ cancelled() && steps.ec2-win-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 8
+#          retry_wait_seconds: 5
+#          command: cd terraform/ec2/win && terraform destroy --auto-approve
+#
+#  EC2DarwinIntegrationTest:
+#    needs: [MakeMacPkg, EC2LinuxIntegrationTest, GenerateTestMatrix]
+#    name: 'EC2DarwinIntegrationTest'
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_mac_matrix) }}
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - uses: actions/checkout@v2
+#        with:
+#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: us-west-2
+#
+#      - name: Cache if success
+#        id: ec2-mac-integration-test
+#        uses: actions/cache@v2
+#        with:
+#          path: go.mod
+#          key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+#
+#      - name: Echo OS
+#        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
+#
+#      - name: Verify Terraform version
+#        run: terraform --version
+#
+#        # nick-fields/retry@v2 starts at base dir
+#      - name: Terraform apply
+#        if: steps.ec2-mac-integration-test.outputs.cache-hit != 'true'
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 30
+#          retry_wait_seconds: 5
+#          command: |
+#            cd terraform/ec2/mac
+#            terraform init
+#            if terraform apply --auto-approve \
+#            -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
+#            -var="arc=${{ matrix.arrays.arc }}" \
+#            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+#            -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
+#            -var="test_dir=${{ matrix.arrays.test_dir }}" \
+#            -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
+#              terraform destroy -auto-approve
+#            else
+#              terraform destroy -auto-approve && exit 1
+#            fi
+#
+#      #This is here just in case workflow cancel
+#      - name: Terraform destroy
+#        if: ${{ cancelled() && steps.ec2-mac-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 8
+#          retry_wait_seconds: 5
+#          command: cd terraform/ec2/mac && terraform destroy --auto-approve
 
   StopLocalStack:
     name: 'StopLocalStack'
@@ -797,141 +797,141 @@ jobs:
       - name: Terraform destroy
         run: terraform destroy --auto-approve
 
-  ECSEC2IntegrationTest:
-    name: 'ECSEC2IntegrationTest'
-    runs-on: ubuntu-latest
-    needs: [ MakeBinary, GenerateTestMatrix ]
-    strategy:
-      fail-fast: false
-      matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ecs_ec2_launch_daemon_matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Cache if success
-        id: ecs-ec2-integration-test
-        uses: actions/cache@v2
-        with:
-          path: go.mod
-          key: ecs-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
-
-      - name: Login ECR
-        id: login-ecr
-        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Verify Terraform version
-        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
-        run: terraform --version
-
-      - name: Terraform apply
-        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 15
-          retry_wait_seconds: 5
-          command: |
-            cd terraform/ecs_ec2/daemon
-            terraform init
-            if terraform apply --auto-approve\
-              -var="test_dir=${{ matrix.arrays.test_dir }}"\
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
-              -var="cwagent_image_tag=${{ github.sha }}"\
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-              -var="ami=${{ matrix.arrays.ami }}" ; then 
-              terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
-
-      - name: Terraform destroy
-        if: ${{ cancelled() && steps.ecs-ec2-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 5
-          command: cd terraform/ecs_ec2/daemon && terraform destroy --auto-approve
-
-  ECSFargateIntegrationTest:
-    name: 'ECSFargateIntegrationTest'
-    runs-on: ubuntu-latest
-    needs: [MakeBinary, GenerateTestMatrix]
-    strategy:
-      fail-fast: false
-      matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ecs_fargate_matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Cache if success
-        id: ecs-fargate-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
-
-      - name: Login ECR
-        id: login-ecr
-        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Verify Terraform version
-        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
-        run: terraform --version
-
-      - name: Terraform apply
-        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 15
-          retry_wait_seconds: 5
-          command: |
-            cd terraform/ecs_fargate/linux
-            terraform init
-            if terraform apply --auto-approve\
-              -var="test_dir=${{ matrix.arrays.test_dir }}"\
-              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
-              -var="cwagent_image_tag=${{ github.sha }}"; then 
-              terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
-      - name: Terraform destroy
-        if: ${{ cancelled() && steps.ecs-fargate-integration-test.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 5
-          command: cd terraform/ecs_fargate/linux && terraform destroy --auto-approve
+#  ECSEC2IntegrationTest:
+#    name: 'ECSEC2IntegrationTest'
+#    runs-on: ubuntu-latest
+#    needs: [ MakeBinary, GenerateTestMatrix ]
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ecs_ec2_launch_daemon_matrix) }}
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: us-west-2
+#
+#      - name: Cache if success
+#        id: ecs-ec2-integration-test
+#        uses: actions/cache@v2
+#        with:
+#          path: go.mod
+#          key: ecs-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+#
+#      - name: Login ECR
+#        id: login-ecr
+#        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
+#        uses: aws-actions/amazon-ecr-login@v1
+#
+#      - name: Verify Terraform version
+#        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
+#        run: terraform --version
+#
+#      - name: Terraform apply
+#        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 15
+#          retry_wait_seconds: 5
+#          command: |
+#            cd terraform/ecs_ec2/daemon
+#            terraform init
+#            if terraform apply --auto-approve\
+#              -var="test_dir=${{ matrix.arrays.test_dir }}"\
+#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+#              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
+#              -var="cwagent_image_tag=${{ github.sha }}"\
+#              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+#              -var="ami=${{ matrix.arrays.ami }}" ; then
+#              terraform destroy -auto-approve
+#            else
+#              terraform destroy -auto-approve && exit 1
+#            fi
+#
+#      - name: Terraform destroy
+#        if: ${{ cancelled() && steps.ecs-ec2-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 8
+#          retry_wait_seconds: 5
+#          command: cd terraform/ecs_ec2/daemon && terraform destroy --auto-approve
+#
+#  ECSFargateIntegrationTest:
+#    name: 'ECSFargateIntegrationTest'
+#    runs-on: ubuntu-latest
+#    needs: [MakeBinary, GenerateTestMatrix]
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ecs_fargate_matrix) }}
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: us-west-2
+#
+#      - name: Cache if success
+#        id: ecs-fargate-integration-test
+#        uses: actions/cache@v3
+#        with:
+#          path: go.mod
+#          key: ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+#
+#      - name: Login ECR
+#        id: login-ecr
+#        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
+#        uses: aws-actions/amazon-ecr-login@v1
+#
+#      - name: Verify Terraform version
+#        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
+#        run: terraform --version
+#
+#      - name: Terraform apply
+#        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 15
+#          retry_wait_seconds: 5
+#          command: |
+#            cd terraform/ecs_fargate/linux
+#            terraform init
+#            if terraform apply --auto-approve\
+#              -var="test_dir=${{ matrix.arrays.test_dir }}"\
+#              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
+#              -var="cwagent_image_tag=${{ github.sha }}"; then
+#              terraform destroy -auto-approve
+#            else
+#              terraform destroy -auto-approve && exit 1
+#            fi
+#      - name: Terraform destroy
+#        if: ${{ cancelled() && steps.ecs-fargate-integration-test.outputs.cache-hit != 'true' }}
+#        uses: nick-fields/retry@v2
+#        with:
+#          max_attempts: 3
+#          timeout_minutes: 8
+#          retry_wait_seconds: 5
+#          command: cd terraform/ecs_fargate/linux && terraform destroy --auto-approve
 
 
   EKSIntegrationTest:
@@ -1001,145 +1001,69 @@ jobs:
           retry_wait_seconds: 5
           command: cd terraform/eks/daemon && terraform destroy --auto-approve
 
-  StressTrackingTest:
-    name: "StressTrackingTest"
-    needs: [MakeBinary, EC2LinuxIntegrationTest, ECSEC2IntegrationTest, ECSFargateIntegrationTest, GenerateTestMatrix]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_stress_matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
-          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: us-west-2
-
-      - name: Cache if success
-        id: stress-tracking
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-      
-      - name: Verify Terraform version
-        if: steps.stress-tracking.outputs.cache-hit != 'true'
-        run: terraform --version
-
-      - name: Terraform apply
-        if: steps.stress-tracking.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 1
-          timeout_minutes: 30
-          retry_wait_seconds: 5
-          command: |
-            cd terraform/performance
-            terraform init
-            if terraform apply --auto-approve \
-              -var="ssh_key_value=${PRIVATE_KEY}"  \
-              -var="cwa_github_sha=${GITHUB_SHA}" \
-              -var="user=${{ matrix.arrays.username }}" \
-              -var="ami=${{ matrix.arrays.ami }}" \
-              -var="arc=${{ matrix.arrays.arc }}" \
-              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
-              -var="ssh_key_name=${KEY_NAME}" \
-              -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
-              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
-            else
-              terraform destroy -auto-approve && exit 1
-            fi
-
-      - name: Terraform destroy
-        if: ${{ cancelled() && steps.stress-tracking.outputs.cache-hit != 'true' }}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 5
-          command: cd terraform/performance && terraform destroy --auto-approve
-  
-  #  PerformanceTrackingTest:
-#    name: "PerformanceTrackingTest"
-#    needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
+#  StressTrackingTest:
+#    name: "StressTrackingTest"
+#    needs: [MakeBinary, EC2LinuxIntegrationTest, ECSEC2IntegrationTest, ECSFargateIntegrationTest, GenerateTestMatrix]
 #    runs-on: ubuntu-latest
 #    strategy:
 #      fail-fast: false
 #      matrix:
-#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_performance_matrix) }}
+#        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_stress_matrix) }}
 #    permissions:
 #      id-token: write
 #      contents: read
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #        with:
 #          repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+#          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
 #
 #      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v1
+#        uses: aws-actions/configure-aws-credentials@v2
 #        with:
 #          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
 #          aws-region: us-west-2
 #
 #      - name: Cache if success
-#        id: performance-tracking
+#        id: stress-tracking
 #        uses: actions/cache@v3
 #        with:
 #          path: go.mod
-#          key: performance-tracking-test-${{ github.sha }}
+#          key: stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 #
-#      - name: Echo Test Info
-#        run: echo run performance-tracking
-#      - name: Get SHA
-#        id: sha
-#        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-#      - name: Get git date
-#        id: sha_date
-#        run: echo "::set-output name=sha_date::$(git show -s --format=%ct ${{ steps.sha.outputs.sha_short }} )"
-#      - name: Check env
-#        run: echo "SHA ${{ steps.sha.outputs.sha_short }} | Date ${{ steps.sha_date.outputs.sha_date }} "
 #      - name: Verify Terraform version
+#        if: steps.stress-tracking.outputs.cache-hit != 'true'
 #        run: terraform --version
+#
 #      - name: Terraform apply
-#        if: steps.performance-tracking.outputs.cache-hit != 'true'
+#        if: steps.stress-tracking.outputs.cache-hit != 'true'
 #        uses: nick-fields/retry@v2
 #        with:
 #          max_attempts: 1
 #          timeout_minutes: 30
 #          retry_wait_seconds: 5
 #          command: |
-#            cd terraform/ec2/linux
+#            cd terraform/performance
 #            terraform init
 #            if terraform apply --auto-approve \
-#              -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+#              -var="ssh_key_value=${PRIVATE_KEY}"  \
 #              -var="cwa_github_sha=${GITHUB_SHA}" \
 #              -var="user=${{ matrix.arrays.username }}" \
 #              -var="ami=${{ matrix.arrays.ami }}" \
 #              -var="arc=${{ matrix.arrays.arc }}" \
 #              -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
 #              -var="ssh_key_name=${KEY_NAME}" \
-#              -var="cwa_github_sha_date=${{ steps.sha_date.outputs.sha_date }}" \
-#              -var="performance_number_of_logs=${{ matrix.arrays.performance_number_of_logs}}"\
+#              -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
 #              -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
 #            else
 #              terraform destroy -auto-approve && exit 1
 #            fi
 #
-      #This is here just in case workflow cancel
 #      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.ec2-linux-integration-test.outputs.cache-hit != 'true' }}
+#        if: ${{ cancelled() && steps.stress-tracking.outputs.cache-hit != 'true' }}
 #        uses: nick-fields/retry@v2
 #        with:
 #          max_attempts: 3
 #          timeout_minutes: 8
 #          retry_wait_seconds: 5
-#          command: cd terraform/ec2/linux && terraform destroy --auto-approve
+#          command: cd terraform/performance && terraform destroy --auto-approve

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_NAME: "SaxyPandaBear/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/SaxyPandaBear/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "eks"
 
 on:
   push:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -983,26 +983,23 @@ jobs:
           command: |
             cd terraform/eks/daemon
             terraform init
-            terraform apply --auto-approve \
+            if terraform apply --auto-approve \
+              -var="test_dir=${{ matrix.arrays.test_dir }}" \
               -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-              -var="cwagent_image_tag=${{ github.sha }}"
-#            if terraform apply --auto-approve \
-#              -var="test_dir=${{ matrix.arrays.test_dir }}" \
-#              -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-#              -var="cwagent_image_tag=${{ github.sha }}"; then
-#              terraform destroy -auto-approve
-#            else
-#              terraform destroy -auto-approve && exit 1
-#            fi
+              -var="cwagent_image_tag=${{ github.sha }}"; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
 
-#      - name: Terraform destroy
-#        if: ${{ cancelled() && steps.eks-ec2-integration-test.outputs.cache-hit != 'true' }}
-#        uses: nick-fields/retry@v2
-#        with:
-#          max_attempts: 3
-#          timeout_minutes: 8
-#          retry_wait_seconds: 5
-#          command: cd terraform/eks/daemon && terraform destroy --auto-approve
+      - name: Terraform destroy
+        if: ${{ cancelled() && steps.eks-ec2-integration-test.outputs.cache-hit != 'true' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: cd terraform/eks/daemon && terraform destroy --auto-approve
 
 #  StressTrackingTest:
 #    name: "StressTrackingTest"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "SaxyPandaBear/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/SaxyPandaBear/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "eks"
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
 on:
   push:


### PR DESCRIPTION
# Description of changes
Support running EKS integration tests. Dependent on https://github.com/aws/amazon-cloudwatch-agent-test/pull/209

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested on my fork: https://github.com/SaxyPandaBear/amazon-cloudwatch-agent/actions/runs/4897367790/jobs/8745372731

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




