### PR TITLE
update eks integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -981,11 +981,18 @@ jobs:
           timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
           retry_wait_seconds: 5
           command: |
-            cd terraform/eks/daemon
+            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
+              cd "${{ matrix.arrays.terraform_dir }}"
+            else
+              cd terraform/eks/daemon
+            fi
+            
             terraform init
             if terraform apply --auto-approve \
+              -var="test_dir=${{ matrix.arrays.test_dir }}"\
               -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-              -var="cwagent_image_tag=${{ github.sha }}"; then
+              -var="cwagent_image_tag=${{ github.sha }}" \
+              -var="k8s_version=${{ matrix.arrays.k8s_version }}"; then
               terraform destroy -auto-approve
             else
               terraform destroy -auto-approve && exit 1


### PR DESCRIPTION
# Description of changes
- Add kubernetes version as a test param
- Add tf directory path param to execute a set of terraform files dynamically 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
```
null_resource.validator (local-exec): 2023/05/18 16:45:30 >>>>>>>>>>>>>>Successful<<<<<<<<<<<<<<
null_resource.validator (local-exec): 2023/05/18 16:45:30 ==============EKSStatsD==============
null_resource.validator (local-exec): 2023/05/18 16:45:30 ==============Successful==============
null_resource.validator (local-exec): statsd_counter_1   Successful
null_resource.validator (local-exec): statsd_gauge_2     Successful
null_resource.validator (local-exec): 2023/05/18 16:45:30 ==============================
null_resource.validator (local-exec): 2023/05/18 16:45:30 >>>>>>>>>>>>>>><<<<<<<<<<<<<<<
null_resource.validator (local-exec): >>>> Finished StatsDTestSuite
null_resource.validator (local-exec): --- PASS: TestStatsdSuite (180.29s)
null_resource.validator (local-exec):     --- PASS: TestStatsdSuite/TestAllInSuite (180.29s)
null_resource.validator (local-exec): PASS
null_resource.validator (local-exec): ok  	github.com/aws/amazon-cloudwatch-agent-test/test/statsd	180.296s
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




