### PR TITLE
Add daily cleanup for integration test resource

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -498,6 +498,7 @@ jobs:
             terraform init
             if terraform apply --auto-approve \
               -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+              -var="test_name=${{ matrix.arrays.os }}" \
               -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
@@ -598,6 +599,7 @@ jobs:
             terraform init
             if terraform apply --auto-approve \
               -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
+              -var="test_name=${{ matrix.arrays.os }}" \
               -var="cwa_github_sha=${GITHUB_SHA}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
@@ -674,6 +676,7 @@ jobs:
             if terraform apply --auto-approve \
             -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
             -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
+            -var="test_name=${{ matrix.arrays.os }}" \
             -var="cwa_github_sha=${GITHUB_SHA}"  \
             -var="test_dir=${{ matrix.arrays.test_dir }}" \
             -var="ami=${{ matrix.arrays.ami }}" \
@@ -742,6 +745,7 @@ jobs:
             terraform init
             if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
+            -var="test_name=${{ matrix.arrays.os }}" \
             -var="arc=${{ matrix.arrays.arc }}" \
             -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
             -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -536,7 +536,7 @@ jobs:
             fi
       #This is here just in case workflow cancel
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -618,7 +618,7 @@ jobs:
             fi
       #This is here just in case workflow cancel
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-linux-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -688,7 +688,7 @@ jobs:
 
       #This is here just in case workflow cancel
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-win-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -745,7 +745,6 @@ jobs:
             terraform init
             if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}" -var="ssh_key_name=${KEY_NAME}"  \
-            -var="test_name=${{ matrix.arrays.os }}" \
             -var="arc=${{ matrix.arrays.arc }}" \
             -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
             -var="cwa_github_sha=${GITHUB_SHA}" -var="ami=${{ matrix.arrays.ami }}" \
@@ -758,7 +757,7 @@ jobs:
 
       #This is here just in case workflow cancel
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.ec2-mac-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -863,7 +862,7 @@ jobs:
             fi
 
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.ecs-ec2-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -929,7 +928,7 @@ jobs:
               terraform destroy -auto-approve && exit 1
             fi
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.ecs-fargate-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -1003,7 +1002,7 @@ jobs:
             fi
 
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.eks-ec2-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -1070,7 +1069,7 @@ jobs:
             fi
 
       - name: Terraform destroy
-        if: ${{ cancelled() && steps.stress-tracking.outputs.cache-hit != 'true' }}
+        if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3

--- a/tool/clean/clean_host/clean_host.go
+++ b/tool/clean/clean_host/clean_host.go
@@ -49,6 +49,7 @@ func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
 		"IntegrationTestBase",
 		"CWADockerImageBuilderX86",
 		"CWADockerImageBuilderARM64",
+		"cwagent-integ-test-ec2*",
 	}}
 
 	instanceInput := ec2.DescribeInstancesInput{


### PR DESCRIPTION
# Description of the issue
Currently when terraform fails during integration test, some resources will not get destroyed. Sometimes when the test fails the terraform data on instance launch is lost therefore making it difficult to enforce cleanup after test failure.

# Description of changes
Add a name regex to daily resource cleanup code that terminates instances with tag name value of `cwagent-integ-test-ec2` when the instance existed for longer than a day which is sufficient time to run the current tests. Also adds OS names to the instance names for better readabiilty.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
In this [test run](https://github.com/zhihonl/amazon-cloudwatch-agent/actions/runs/5017645071/jobs/8996025587), the name regex is used to terminate all instances with name starting with cwagent-integ-test-ec2. It has been verified that instances that were created with same naming scheme but not one day old remained running.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




