### PR TITLE
Remove Linux test as dependency of macOS test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -818,7 +818,7 @@ jobs:
           path: go.mod
           key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
-      - name: Echo Test Info
+      - name: Echo OS
         run: echo run on ec2 instance os ${{ matrix.arrays.os }}
 
       - name: Verify Terraform version

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,6 +40,7 @@ jobs:
   MakeBinary:
     name: 'MakeBinary'
     runs-on: ubuntu-latest
+    if: false
     permissions:
       id-token: write
       contents: read
@@ -193,6 +194,7 @@ jobs:
     name: 'MakeMSIZip'
     runs-on: ubuntu-latest
     needs: [MakeBinary]
+    if: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,7 +40,6 @@ jobs:
   MakeBinary:
     name: 'MakeBinary'
     runs-on: ubuntu-latest
-    if: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "zhihonl/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/zhihonl/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "macos-test"
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
 on:
   push:
@@ -40,7 +40,6 @@ jobs:
   MakeBinary:
     name: 'MakeBinary'
     runs-on: ubuntu-latest
-    if: false
     permissions:
       id-token: write
       contents: read
@@ -194,7 +193,6 @@ jobs:
     name: 'MakeMSIZip'
     runs-on: ubuntu-latest
     needs: [MakeBinary]
-    if: false
     permissions:
       id-token: write
       contents: read
@@ -820,8 +818,8 @@ jobs:
           path: go.mod
           key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
-      - name: Echo OS
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
+      - name: Echo Test Info
+        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
 
       - name: Verify Terraform version
         run: terraform --version

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -500,7 +500,12 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |
-            cd terraform/ec2/linux
+            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
+              cd "${{ matrix.arrays.terraform_dir }}"
+            else
+              cd terraform/ec2/linux
+            fi
+
             terraform init
             if terraform apply --auto-approve \
               -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
@@ -601,7 +606,12 @@ jobs:
           timeout_minutes: 60
           retry_wait_seconds: 5
           command: |
-            cd terraform/ec2/linux
+            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
+              cd "${{ matrix.arrays.terraform_dir }}"
+            else
+              cd terraform/ec2/linux
+            fi
+
             terraform init
             if terraform apply --auto-approve \
               -var="ssh_key_value=${PRIVATE_KEY}" -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
@@ -929,7 +939,12 @@ jobs:
           timeout_minutes: 15
           retry_wait_seconds: 5
           command: |
-            cd terraform/ecs_ec2/daemon
+            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
+              cd "${{ matrix.arrays.terraform_dir }}"
+            else
+              cd terraform/ecs_ec2/daemon
+            fi
+            
             terraform init
             if terraform apply --auto-approve\
               -var="test_dir=${{ matrix.arrays.test_dir }}"\
@@ -999,7 +1014,12 @@ jobs:
           timeout_minutes: 15
           retry_wait_seconds: 5
           command: |
-            cd terraform/ecs_fargate/linux
+            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
+              cd "${{ matrix.arrays.terraform_dir }}"
+            else
+              cd terraform/ecs_fargate/linux
+            fi
+            
             terraform init
             if terraform apply --auto-approve\
               -var="test_dir=${{ matrix.arrays.test_dir }}"\

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_NAME: "zhihonl/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/zhihonl/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "macos-test"
 
 on:
   push:
@@ -40,6 +40,7 @@ jobs:
   MakeBinary:
     name: 'MakeBinary'
     runs-on: ubuntu-latest
+    if: false
     permissions:
       id-token: write
       contents: read
@@ -193,6 +194,7 @@ jobs:
     name: 'MakeMSIZip'
     runs-on: ubuntu-latest
     needs: [MakeBinary]
+    if: false
     permissions:
       id-token: write
       contents: read
@@ -789,7 +791,7 @@ jobs:
           command: cd terraform/ec2/win && terraform destroy --auto-approve
 
   EC2DarwinIntegrationTest:
-    needs: [MakeMacPkg, EC2LinuxIntegrationTest, GenerateTestMatrix]
+    needs: [MakeMacPkg, GenerateTestMatrix]
     name: 'EC2DarwinIntegrationTest'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_NAME: "zhihonl/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/zhihonl/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "macos-test"
 
 on:
   push:
@@ -40,6 +40,7 @@ jobs:
   MakeBinary:
     name: 'MakeBinary'
     runs-on: ubuntu-latest
+    if: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -831,7 +831,7 @@ jobs:
         if: steps.ec2-mac-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 1
+          max_attempts: 3
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -831,7 +831,7 @@ jobs:
         if: steps.ec2-mac-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 3
+          max_attempts: 1
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "zhihonl/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/zhihonl/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "macos-test"
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
 on:
   push:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -819,7 +819,7 @@ jobs:
           key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
 
       - name: Verify Terraform version
         run: terraform --version

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -816,6 +816,7 @@ jobs:
       - name: Cache if success
         id: ec2-mac-integration-test
         uses: actions/cache@v3
+        if: false
         with:
           path: go.mod
           key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,7 +40,6 @@ jobs:
   MakeBinary:
     name: 'MakeBinary'
     runs-on: ubuntu-latest
-    if: false
     permissions:
       id-token: write
       contents: read
@@ -194,7 +193,6 @@ jobs:
     name: 'MakeMSIZip'
     runs-on: ubuntu-latest
     needs: [MakeBinary]
-    if: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -816,7 +816,6 @@ jobs:
       - name: Cache if success
         id: ec2-mac-integration-test
         uses: actions/cache@v3
-        if: false
         with:
           path: go.mod
           key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}


### PR DESCRIPTION
# Description of the issue
macOS tests depend on all Linux tests to pass in order to run. This often prevents macOS test from running at all even though the results of Linux tests should not be relevant for macOS tests.

# Description of changes
Remove Linux test as dependency for macOS test

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[Test run ](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5286575006)that shows macOS tests running after Linux test failure

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




