### PR TITLE
Replace stress tests with performance tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1108,14 +1108,14 @@ jobs:
           retry_wait_seconds: 5
           command: cd terraform/eks/deployment && terraform destroy --auto-approve
 
-  StressTrackingTest:
-    name: "StressTrackingTest"
-    needs: [MakeBinary, EC2LinuxIntegrationTest, ECSEC2IntegrationTest, ECSFargateIntegrationTest, GenerateTestMatrix]
+  PerformanceTrackingTest:
+    name: "PerformanceTrackingTest"
+    needs: [MakeBinary, GenerateTestMatrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_stress_matrix) }}
+        arrays: ${{ fromJson(needs.GenerateTestMatrix.outputs.ec2_performance_matrix) }}
     permissions:
       id-token: write
       contents: read
@@ -1132,18 +1132,18 @@ jobs:
           aws-region: us-west-2
 
       - name: Cache if success
-        id: stress-tracking
+        id: performance-tracking
         uses: actions/cache@v3
         with:
           path: go.mod
-          key: stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+          key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
       - name: Verify Terraform version
-        if: steps.stress-tracking.outputs.cache-hit != 'true'
+        if: steps.performance-tracking.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
-        if: steps.stress-tracking.outputs.cache-hit != 'true'
+        if: steps.performance-tracking.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 1
@@ -1155,7 +1155,6 @@ jobs:
             if terraform apply --auto-approve \
               -var="ssh_key_value=${PRIVATE_KEY}"  \
               -var="cwa_github_sha=${GITHUB_SHA}" \
-              -var="user=${{ matrix.arrays.username }}" \
               -var="ami=${{ matrix.arrays.ami }}" \
               -var="arc=${{ matrix.arrays.arc }}" \
               -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \


### PR DESCRIPTION
# Description of the issue
The current setup does not work as a result of a bad merge in the past that mixes up both stress & performance tests.

# Description of changes
Cleanup the GHA to only run performance tests for now and the stress tests need some additional work on the test repo itself.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
GHA run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5293201956 shows passing performance tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




