### PR TITLE
Correcting latency health metric units to be milliseconds

### DIFF
--- a/cfg/agentinfo/info.go
+++ b/cfg/agentinfo/info.go
@@ -61,13 +61,13 @@ type agentInfo struct {
 }
 
 type agentStats struct {
-	CpuPercent          *float64       `json:"cpu,omitempty"`
-	MemoryBytes         *uint64        `json:"mem,omitempty"`
-	FileDescriptorCount *int32         `json:"fd,omitempty"`
-	ThreadCount         *int32         `json:"th,omitempty"`
-	LatencyMillis       *time.Duration `json:"lat,omitempty"`
-	PayloadBytes        *int           `json:"load,omitempty"`
-	StatusCode          *int           `json:"code,omitempty"`
+	CpuPercent          *float64 `json:"cpu,omitempty"`
+	MemoryBytes         *uint64  `json:"mem,omitempty"`
+	FileDescriptorCount *int32   `json:"fd,omitempty"`
+	ThreadCount         *int32   `json:"th,omitempty"`
+	LatencyMillis       *int64   `json:"lat,omitempty"`
+	PayloadBytes        *int     `json:"load,omitempty"`
+	StatusCode          *int     `json:"code,omitempty"`
 }
 
 func New(groupName string) AgentInfo {
@@ -99,12 +99,12 @@ func (ai *agentInfo) UserAgent() string {
 	return ai.userAgent
 }
 
-func (ai *agentInfo) RecordOpData(latencyMillis time.Duration, payloadBytes int, err error) {
+func (ai *agentInfo) RecordOpData(latency time.Duration, payloadBytes int, err error) {
 	if ai.proc == nil {
 		return
 	}
 
-	ai.stats.LatencyMillis = &latencyMillis
+	ai.stats.LatencyMillis = aws.Int64(latency.Milliseconds())
 	ai.stats.PayloadBytes = aws.Int(payloadBytes)
 	ai.stats.StatusCode = getStatusCode(err)
 

--- a/cfg/agentinfo/info_test.go
+++ b/cfg/agentinfo/info_test.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -41,7 +40,7 @@ func TestRecordOpData(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte("{"+stats+"}"), &expectedStats))
 	assert.Equal(t, expectedStats, ai.stats)
 
-	ai.RecordOpData(100, 10, nil)
+	ai.RecordOpData(100000000, 10, nil)
 	stats = ai.StatsHeader()
 	require.NoError(t, json.Unmarshal([]byte("{"+stats+"}"), &expectedStats))
 	assert.Equal(t, expectedStats, ai.stats)
@@ -49,14 +48,14 @@ func TestRecordOpData(t *testing.T) {
 	assert.EqualValues(t, 10, *ai.stats.PayloadBytes)
 	assert.EqualValues(t, http.StatusOK, *ai.stats.StatusCode)
 
-	ai.RecordOpData(200, 20, errors.New(""))
+	ai.RecordOpData(200000000, 20, errors.New(""))
 	stats = ai.StatsHeader()
 	require.NoError(t, json.Unmarshal([]byte("{"+stats+"}"), &expectedStats))
 	assert.EqualValues(t, 200, *ai.stats.LatencyMillis)
 	assert.EqualValues(t, 20, *ai.stats.PayloadBytes)
 	assert.Nil(t, ai.stats.StatusCode)
 
-	ai.RecordOpData(300, 30, awserr.NewRequestFailure(awserr.New("", "", errors.New("")), 500, ""))
+	ai.RecordOpData(300000000, 30, awserr.NewRequestFailure(awserr.New("", "", errors.New("")), 500, ""))
 	stats = ai.StatsHeader()
 	require.NoError(t, json.Unmarshal([]byte("{"+stats+"}"), &expectedStats))
 	assert.EqualValues(t, 300, *ai.stats.LatencyMillis)
@@ -88,13 +87,12 @@ func TestSetComponents(t *testing.T) {
 }
 
 func TestGetAgentStats(t *testing.T) {
-	latencyMillis := time.Duration(1234)
 	stats := agentStats{
 		CpuPercent:          aws.Float64(1.2),
 		MemoryBytes:         aws.Uint64(123),
 		FileDescriptorCount: aws.Int32(456),
 		ThreadCount:         aws.Int32(789),
-		LatencyMillis:       &latencyMillis,
+		LatencyMillis:       aws.Int64(1234),
 		PayloadBytes:        aws.Int(5678),
 		StatusCode:          aws.Int(200),
 	}

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -348,7 +348,7 @@ func (p *pusher) createLogGroupAndStream() error {
 		_, err = p.Service.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
 			LogGroupName: &p.Group,
 		})
-		p.agentInfo.RecordOpData(time.Since(opStartTime), p.bufferredSize, err)
+		p.agentInfo.RecordOpData(time.Since(opStartTime), 1, err)
 
 		// attempt to create stream again if group created successfully.
 		if err == nil {


### PR DESCRIPTION
# Description of the issue
The agent stat for latency is being published in nanoseconds and it should be in milliseconds.

# Description of changes
* Changing the value of the latency to milliseconds
* Minor change to logs pusher `RecordOpData` call for `CreateLogGroup`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
make

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




