### PR TITLE
Increase timeouts for stress and performance tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1147,7 +1147,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           max_attempts: 1
-          timeout_minutes: 30
+          timeout_minutes: 60
           retry_wait_seconds: 5
           command: |
             cd terraform/performance
@@ -1213,7 +1213,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           max_attempts: 1
-          timeout_minutes: 30
+          timeout_minutes: 60
           retry_wait_seconds: 5
           command: |
             cd terraform/stress


### PR DESCRIPTION
# Description of the issue
Some stress tests timing out at 30 mins. And since we will add more workloads to these soon, increasing the timeouts to an hour.

# Description of changes
Increase timeouts

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




