### PR TITLE
Cleanup stale windows, performance & stress test instances

### DIFF
--- a/tool/clean/clean_host/clean_host.go
+++ b/tool/clean/clean_host/clean_host.go
@@ -50,6 +50,9 @@ func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
 		"CWADockerImageBuilderX86",
 		"CWADockerImageBuilderARM64",
 		"cwagent-integ-test-ec2*",
+		"cwagent-integ-test-ec2-windows-*",
+		"cwagent-performance-*",
+		"cwagent-stress-*",
 	}}
 
 	instanceInput := ec2.DescribeInstancesInput{


### PR DESCRIPTION
# Description of the issue
We currently do not cleanup windows, performance & stress test stale instances.

# Description of changes
Update the name filters to include these.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




