### PR TITLE
Add excluded_tests flag to Linux test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -602,7 +602,7 @@ jobs:
         if: steps.ec2-linux-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 3
+          max_attempts: 1
           timeout_minutes: 60
           retry_wait_seconds: 5
           command: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -458,6 +458,7 @@ jobs:
     needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
     name: 'EC2NVIDIAGPUIntegrationTest'
     runs-on: ubuntu-latest
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -820,6 +821,7 @@ jobs:
     name: 'ECSEC2IntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -895,6 +897,7 @@ jobs:
     name: 'ECSFargateIntegrationTest'
     runs-on: ubuntu-latest
     needs: [MakeBinary, GenerateTestMatrix]
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -967,6 +970,7 @@ jobs:
     name: 'EKSIntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1042,6 +1046,7 @@ jobs:
     name: 'EKSPrometheusIntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1114,6 +1119,7 @@ jobs:
   PerformanceTrackingTest:
     name: "PerformanceTrackingTest"
     needs: [MakeBinary, GenerateTestMatrix]
+    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1180,6 +1186,7 @@ jobs:
   StressTrackingTest:
     name: "StressTrackingTest"
     needs: [MakeBinary, GenerateTestMatrix]
+    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "zhihonl/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/zhihonl/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "exclude-test"
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
 on:
   push:
@@ -1213,7 +1213,7 @@ jobs:
         if: steps.stress-tracking.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 1
+          max_attempts: 3
           timeout_minutes: 60
           retry_wait_seconds: 5
           command: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,9 +8,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_NAME: "zhihonl/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/zhihonl/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "exclude-test"
 
 on:
   push:
@@ -190,6 +190,7 @@ jobs:
     name: 'MakeMSIZip'
     runs-on: ubuntu-latest
     needs: [MakeBinary]
+    if: false
     permissions:
       id-token: write
       contents: read
@@ -249,6 +250,7 @@ jobs:
   MakeMacPkg:
     name: 'MakeMacPkg'
     runs-on: macos-11
+    if: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -599,7 +599,7 @@ jobs:
         if: steps.ec2-linux-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 1
+          max_attempts: 3
           timeout_minutes: 60
           retry_wait_seconds: 5
           command: |
@@ -1213,7 +1213,7 @@ jobs:
         if: steps.stress-tracking.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 3
+          max_attempts: 1
           timeout_minutes: 60
           retry_wait_seconds: 5
           command: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -626,6 +626,7 @@ jobs:
               -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
               -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
               -var="plugin_tests='${{ github.event.inputs.plugins }}'" \
+              -var="excluded_tests='${{ matrix.arrays.excludedTests }}'" \
               -var="ssh_key_name=${KEY_NAME}" \
               -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
             else

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -190,7 +190,6 @@ jobs:
     name: 'MakeMSIZip'
     runs-on: ubuntu-latest
     needs: [MakeBinary]
-    if: false
     permissions:
       id-token: write
       contents: read
@@ -250,7 +249,6 @@ jobs:
   MakeMacPkg:
     name: 'MakeMacPkg'
     runs-on: macos-11
-    if: false
     permissions:
       id-token: write
       contents: read
@@ -458,7 +456,6 @@ jobs:
     needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
     name: 'EC2NVIDIAGPUIntegrationTest'
     runs-on: ubuntu-latest
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -587,7 +584,6 @@ jobs:
       - name: Cache if success
         id: ec2-linux-integration-test
         uses: actions/cache@v3
-        if: false
         with:
           path: go.mod
           key: ec2-linux-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
@@ -822,7 +818,6 @@ jobs:
     name: 'ECSEC2IntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -898,7 +893,6 @@ jobs:
     name: 'ECSFargateIntegrationTest'
     runs-on: ubuntu-latest
     needs: [MakeBinary, GenerateTestMatrix]
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -971,7 +965,6 @@ jobs:
     name: 'EKSIntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1047,7 +1040,6 @@ jobs:
     name: 'EKSPrometheusIntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1120,7 +1112,6 @@ jobs:
   PerformanceTrackingTest:
     name: "PerformanceTrackingTest"
     needs: [MakeBinary, GenerateTestMatrix]
-    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1187,7 +1178,6 @@ jobs:
   StressTrackingTest:
     name: "StressTrackingTest"
     needs: [MakeBinary, GenerateTestMatrix]
-    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -587,6 +587,7 @@ jobs:
       - name: Cache if success
         id: ec2-linux-integration-test
         uses: actions/cache@v3
+        if: false
         with:
           path: go.mod
           key: ec2-linux-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}


### PR DESCRIPTION
# Description of the issue
In order to exclude test for specific OS, using variables from the test matrix is necessary. We have to modify the flag for `terraform apply` so it can exclude the correct subset of tests 

# Description of changes
Add `excludedTests` flag to Linux integration test's `terraform apply`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[Test run](https://github.com/zhihonl/amazon-cloudwatch-agent/actions/runs/5360603893/jobs/9725712414) that removes collectd and mem tests from SLES12. All others OS have complete tests except RenameSSM test because the document is only present on CWAgent test account.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




