### PR TITLE
Add family flag to performance test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,9 +9,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_NAME: "zhihonl/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/zhihonl/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "performance-windows"
 
 on:
   push:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,6 @@ env:
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
   CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
-
 on:
   push:
     branches:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -252,6 +252,7 @@ jobs:
   MakeMacPkg:
     name: 'MakeMacPkg'
     runs-on: macos-11
+    if: false
     permissions:
       id-token: write
       contents: read
@@ -463,6 +464,7 @@ jobs:
     needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
     name: 'EC2NVIDIAGPUIntegrationTest'
     runs-on: ubuntu-latest
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -576,6 +578,7 @@ jobs:
     needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
     name: 'Test'
     runs-on: ubuntu-latest
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -665,6 +668,7 @@ jobs:
     needs: [BuildMSI, GenerateTestMatrix]
     name: 'EC2WinIntegrationTest'
     runs-on: ubuntu-latest
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -746,6 +750,7 @@ jobs:
     needs: [MakeMacPkg, GenerateTestMatrix]
     name: 'EC2DarwinIntegrationTest'
     runs-on: ubuntu-latest
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -863,6 +868,7 @@ jobs:
     name: 'ECSEC2IntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -945,6 +951,7 @@ jobs:
     name: 'ECSFargateIntegrationTest'
     runs-on: ubuntu-latest
     needs: [MakeBinary, GenerateTestMatrix]
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1024,6 +1031,7 @@ jobs:
     name: 'EKSIntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1106,6 +1114,7 @@ jobs:
     name: 'EKSPrometheusIntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1253,6 +1262,7 @@ jobs:
     name: "StressTrackingTest"
     needs: [MakeBinary, GenerateTestMatrix]
     runs-on: ubuntu-latest
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -146,7 +146,6 @@ jobs:
       ec2_mac_matrix: ${{ steps.set-matrix.outputs.ec2_mac_matrix }}
       ec2_performance_matrix: ${{steps.set-matrix.outputs.ec2_performance_matrix}}
       ec2_windows_performance_matrix: ${{steps.set-matrix.outputs.ec2_windows_performance_matrix}}
-      ec2_windows_stress_matrix: ${{steps.set-matrix.outputs.ec2_windows_windows_matrix}}
       ec2_stress_matrix: ${{steps.set-matrix.outputs.ec2_stress_matrix}}
       ecs_ec2_launch_daemon_matrix: ${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}
       ecs_fargate_matrix: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1244,6 +1244,7 @@ jobs:
               -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
               -var="ssh_key_name=${KEY_NAME}" \
               -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
+              -var="family=${{ matrix.arrays.family}}"\
               -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
             else
               terraform destroy -auto-approve && exit 1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1218,6 +1218,7 @@ jobs:
       - name: Cache if success
         id: performance-tracking
         uses: actions/cache@v3
+        if: false
         with:
           path: go.mod
           key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,9 +9,9 @@ env:
   S3_INTEGRATION_BUCKET: ${{ secrets.S3_INTEGRATION_BUCKET }}
   KEY_NAME: ${{ secrets.KEY_NAME }}
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
-  CWA_GITHUB_TEST_REPO_NAME: "zhihonl/amazon-cloudwatch-agent-test"
-  CWA_GITHUB_TEST_REPO_URL: "https://github.com/zhihonl/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "performance-windows"
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
 on:
   push:
@@ -252,7 +252,6 @@ jobs:
   MakeMacPkg:
     name: 'MakeMacPkg'
     runs-on: macos-11
-    if: false
     permissions:
       id-token: write
       contents: read
@@ -464,7 +463,6 @@ jobs:
     needs: [ MakeBinary, BuildMSI, StartLocalStack, GenerateTestMatrix ]
     name: 'EC2NVIDIAGPUIntegrationTest'
     runs-on: ubuntu-latest
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -578,7 +576,6 @@ jobs:
     needs: [MakeBinary, StartLocalStack, GenerateTestMatrix]
     name: 'Test'
     runs-on: ubuntu-latest
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -668,7 +665,6 @@ jobs:
     needs: [BuildMSI, GenerateTestMatrix]
     name: 'EC2WinIntegrationTest'
     runs-on: ubuntu-latest
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -750,7 +746,6 @@ jobs:
     needs: [MakeMacPkg, GenerateTestMatrix]
     name: 'EC2DarwinIntegrationTest'
     runs-on: ubuntu-latest
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -868,7 +863,6 @@ jobs:
     name: 'ECSEC2IntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -951,7 +945,6 @@ jobs:
     name: 'ECSFargateIntegrationTest'
     runs-on: ubuntu-latest
     needs: [MakeBinary, GenerateTestMatrix]
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1031,7 +1024,6 @@ jobs:
     name: 'EKSIntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1114,7 +1106,6 @@ jobs:
     name: 'EKSPrometheusIntegrationTest'
     runs-on: ubuntu-latest
     needs: [ MakeBinary, GenerateTestMatrix ]
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -1218,7 +1209,6 @@ jobs:
       - name: Cache if success
         id: performance-tracking
         uses: actions/cache@v3
-        if: false
         with:
           path: go.mod
           key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
@@ -1264,7 +1254,6 @@ jobs:
     name: "StressTrackingTest"
     needs: [MakeBinary, GenerateTestMatrix]
     runs-on: ubuntu-latest
-    if: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Description of the issue
Current performance test only runs for Linux. We should add the workflow for Windows to get a better understanding on how the agent performs on Windows.

# Description of changes
Add Windows performance test workflow to integration test.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[Test run](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5614285048) showing `family` being read separately for Linux and Windows 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




