### PR TITLE
fix typo

### DIFF
--- a/internal/k8sCommon/kubeletutil/kubeletclient.go
+++ b/internal/k8sCommon/kubeletutil/kubeletclient.go
@@ -28,7 +28,7 @@ type KubeClient struct {
 	tls.ClientConfig
 }
 
-var ErrKubeClientAccessFailure = errors.New("KubeClinet Access Failure")
+var ErrKubeClientAccessFailure = errors.New("KubeClient Access Failure")
 
 func (k *KubeClient) ListPods() ([]corev1.Pod, error) {
 	var result []corev1.Pod


### PR DESCRIPTION
# Description of the issue
There is a typo in the Kubeclient error message

# Description of changes
Fixes the error message string

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




