### PR TITLE
Fix dependency action for Windows performance and stress test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -963,7 +963,7 @@ jobs:
 
   EC2WinPerformanceTest:
     name: "EC2WinPerformanceTest"
-    needs: [ BuildMSI, GenerateTestMatrix ]
+    needs: [ BuildAndUpload, GenerateTestMatrix ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1101,7 +1101,7 @@ jobs:
 
   EC2WinStressTrackingTest:
     name: "EC2WinStressTrackingTest"
-    needs: [BuildMSI, GenerateTestMatrix]
+    needs: [BuildAndUpload, GenerateTestMatrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Description of the issue
Windows performance and stress tests are depending on old names for the build action and causing tests to not run at all. Example: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5658955241 

# Description of changes
Change to newest build action name

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5731945038 Made change on a branch and the test started running

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




