### PR TITLE
Add metadata flag for ECS test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -963,7 +963,7 @@ jobs:
 
   EC2WinPerformanceTest:
     name: "EC2WinPerformanceTest"
-    needs: [ BuildMSI, GenerateTestMatrix ]
+    needs: [ BuildAndUpload, GenerateTestMatrix ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1101,7 +1101,7 @@ jobs:
 
   EC2WinStressTrackingTest:
     name: "EC2WinStressTrackingTest"
-    needs: [BuildMSI, GenerateTestMatrix]
+    needs: [BuildAndUpload, GenerateTestMatrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -632,6 +632,7 @@ jobs:
               -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}"\
               -var="cwagent_image_tag=${{ github.sha }}"\
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="metadataEnabled=${{ matrix.arrays.metadataEnabled }}" \
               -var="ami=${{ matrix.arrays.ami }}" ; then
               terraform destroy -auto-approve
             else


### PR DESCRIPTION
# Description of the issue
We want to to test if EMF still works with EC2 metadata turned off. 

# Description of changes
Add `metadataEnabled` variable to have test case where EC2 metadata is turned off for ECS integration test.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test run for CCWA: https://github.com/aws/private-amazon-cloudwatch-agent-staging/actions/runs/5731828918/job/15533934402
Test run for CWA: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/5731945038/job/15534084015#step:7:721
Test failed when metadata is disabled. We need to investigate this and have a separate PR to address the issue.
