### PR TITLE
fix file glob matching

### DIFF
--- a/plugins/inputs/logfile/globpath/globpath.go
+++ b/plugins/inputs/logfile/globpath/globpath.go
@@ -33,7 +33,7 @@ func Compile(path string) (*GlobPath, error) {
 
 	// if there are no glob meta characters in the path, don't bother compiling
 	// a glob object or finding the root directory. (see short-circuit in Match)
-	if !out.hasMeta || !out.hasSuperMeta {
+	if !out.hasMeta && !out.hasSuperMeta {
 		return &out, nil
 	}
 
@@ -59,19 +59,6 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 			out[g.path] = info
 		} else {
 			log.Printf("D! Stat file %v failed due to %v", g.path, err)
-		}
-		return out
-	}
-	if !g.hasSuperMeta {
-		out := make(map[string]os.FileInfo)
-		files, _ := filepath.Glob(g.path)
-		for _, file := range files {
-			info, err := os.Stat(file)
-			if info != nil {
-				out[file] = info
-			} else {
-				log.Printf("D! Stat file %v failed due to %v", g.path, err)
-			}
 		}
 		return out
 	}

--- a/plugins/inputs/logfile/globpath/globpath.go
+++ b/plugins/inputs/logfile/globpath/globpath.go
@@ -52,7 +52,7 @@ func Compile(path string) (*GlobPath, error) {
 }
 
 func (g *GlobPath) Match() map[string]os.FileInfo {
-	if !g.hasMeta {
+	if !g.hasMeta && !g.hasSuperMeta {
 		out := make(map[string]os.FileInfo)
 		info, err := os.Stat(g.path)
 		if info != nil {
@@ -61,8 +61,7 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 			log.Printf("D! Stat file %v failed due to %v", g.path, err)
 		}
 		return out
-	}
-	if !g.hasSuperMeta {
+	} else if !g.hasSuperMeta {
 		out := make(map[string]os.FileInfo)
 		files, _ := filepath.Glob(g.path)
 		for _, file := range files {

--- a/plugins/inputs/logfile/globpath/globpath.go
+++ b/plugins/inputs/logfile/globpath/globpath.go
@@ -62,6 +62,19 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 		}
 		return out
 	}
+	if !g.hasSuperMeta {
+		out := make(map[string]os.FileInfo)
+		files, _ := filepath.Glob(g.path)
+		for _, file := range files {
+			info, err := os.Stat(file)
+			if info != nil {
+				out[file] = info
+			} else {
+				log.Printf("D! Stat file %v failed due to %v", g.path, err)
+			}
+		}
+		return out
+	}
 	return walkFilePath(g.root, g.g)
 }
 
@@ -126,7 +139,8 @@ func hasMeta(path string) bool {
 	return strings.ContainsAny(path, "*?[")
 }
 
-// hasSuperMeta reports whether path contains any super magic glob characters (**).
+// hasSuperMeta reports whether path contains any super magic glob characters (**), or glob characters
+// that are not supported by filepath.Glob (!{})
 func hasSuperMeta(path string) bool {
-	return strings.Contains(path, "**")
+	return strings.Contains(path, "**") || strings.ContainsAny(path, "!{}")
 }

--- a/plugins/inputs/logfile/globpath/globpath_test.go
+++ b/plugins/inputs/logfile/globpath/globpath_test.go
@@ -118,6 +118,13 @@ func TestCompileGlob(t *testing.T) {
 			numMatched:   1,
 		},
 		{
+			path:         "/nested1/nested2/{nested, foo}.txt",
+			hasGlob:      true,
+			hasMeta:      false,
+			hasSuperMeta: true,
+			numMatched:   1,
+		},
+		{
 			path:       "/i_dont_exist.log",
 			numMatched: 0,
 		},


### PR DESCRIPTION
# Description of the issue
The CloudWatch agent does not properly enforce glob patterns in its file configurations. In the scenario where a user supplies something like `[!abc]at`, the agent determines that this has a meta character `[`, but no super meta character `**`. Thus, when the agent tries to find matching files, it defaults to `filepath.Glob`, which does not interpret the `!` inversion operator for the glob pattern. 

# Description of changes
Updated the `Match` function so that it doesn't use `filepath.Glob` when there are nonstandard glob characters that are not operable with `filepath.Glob`, such as `!`. Updated the `Compile` function to change the short-circuit behavior, since there is technically a glob that needs to be compiled, even for the characters that can be interpreted in `filepath.Glob`. 

To illustrate this, I added a test for `/[something?`, which should be an invalid glob pattern because it does not close the `[` with a subsequent `]` character. The current behavior would treat this as a raw string to match against, when this _should_ be interpreted as a bad glob configuration. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests and ensured they failed before the change, and pass after. 

## Performance benchmarking
<img width="1879" alt="Screenshot 2023-08-15 at 5 55 00 PM" src="https://github.com/aws/amazon-cloudwatch-agent/assets/17056456/743f32c0-cb83-493f-9b20-5d8b4fab21f7">

The blue line is with my changes, and the orange line is the baseline (what is currently released to Amazon Linux). 

Ran on t3.medium Amazon Linux 2023 instances. The log file configuration is as follows:
```json
    "logs": {
        "logs_collected": {
            "files": {
                "collect_list": [
                    {
                        "file_path": "/tmp/[a-g]oo",
                        "log_group_name": "something",
                        "log_stream_name": "somethingElse"
                    }
                ]
            }
        }
    }
```
Since I'm lazy, I wrote a script in python to write to a log file that rotates
```python
import logging
from logging.handlers import TimedRotatingFileHandler
import time

handler = TimedRotatingFileHandler("/tmp/foo", when='M', interval=5, backupCount=5)
fmt = '%(asctime)s %(message)s'
handler.setFormatter(logging.Formatter(fmt))
logger = logging.getLogger('root')
logger.addHandler(handler)
logger.setLevel(logging.INFO)

while True:
    logger.info("hello there")
    time.sleep(1)
```

I also verified that the agent is publishing logs from both instances, though the glob `[a-g]oo` is valid even now. I did validate that using glob characters like `!` and `{}` work after my change, but not with the current release. 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




