### PR TITLE
fix user-agent string when exporting using emf exporter (container in…

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent_test.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent_test.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/otelcol"
+)
+
+func Test_getCollectorParams(t *testing.T) {
+	type args struct {
+		factories otelcol.Factories
+		provider  otelcol.ConfigProvider
+	}
+	tests := []struct {
+		name string
+		args args
+		want otelcol.CollectorSettings
+	}{
+		{
+			name: "BuildInfoIsSet",
+			args: args{
+				factories: otelcol.Factories{},
+				provider:  nil,
+			},
+			want: otelcol.CollectorSettings{
+				Factories:      otelcol.Factories{},
+				ConfigProvider: nil,
+				BuildInfo: component.BuildInfo{
+					Command:     "CWAgent",
+					Description: "CloudWatch Agent",
+					Version:     "Unknown",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getCollectorParams(tt.args.factories, tt.args.provider); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getCollectorParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…sights)

# Description of the issue
The user agent is not correctly set for container insights, which exports via the emf exporter

# Description of changes
Populates BuildInfo

before:
```
2023-08-22T18:16:37.360Z	warn	cwlogs@v0.79.0/cwlog_client.go:218	CHAD - buildInfo	{"kind": "exporter", "data_type": "metrics", "name": "awsemf/containerinsights", "Command": "", "Version": ""}
2023-08-22T18:19:43.163Z	warn	cwlogs@v0.79.0/cwlog_client.go:206	CHAD - user agent string	{"kind": "exporter", "data_type": "metrics", "name": "awsemf/containerinsights", "UserAgent": "/ (EnhancedEKSContainerInsights) aws-sdk-go/1.44.309 (go1.20.3; linux; amd64)"}
```

after:
```
2023-08-22T19:08:44.126Z	warn	cwlogs@v0.79.0/cwlog_client.go:206	CHAD - user agent string	{"kind": "exporter", "data_type": "metrics", "name": "awsemf/containerinsights", "UserAgent": "CWAgent/Unknown (EnhancedEKSContainerInsights) aws-sdk-go/1.44.309 (go1.20.3; linux; amd64)"}
```

I will test again with an "official" build, I expect the version to be set and not be unknown.  I verified if I hardcoded the version number it propogated all the way through
```
2023-08-22T19:05:50.433Z	warn	cwlogs@v0.79.0/cwlog_client.go:206	CHAD - user agent string	{"kind": "exporter", "data_type": "metrics", "name": "awsemf/containerinsights", "UserAgent": "CWAgent/1.234 (EnhancedEKSContainerInsights) aws-sdk-go/1.44.309 (go1.20.3; linux; amd64)"}
```

for context, ADOT also adds BuildInfo:
https://github.com/aws-observability/aws-otel-collector/blob/7d2e6076dd53c1694987624605b595a34bd9f8fe/cmd/awscollector/main.go#L62

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




