### PR TITLE
add units for control plane metrics

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -177,7 +177,28 @@ exporters:
           - rest_client_request_duration_seconds
           - rest_client_requests_total
           - etcd_request_duration_seconds
-    metric_descriptors: []
+    metric_descriptors:
+          - metric_name: apiserver_storage_objects
+            unit: Count
+            overwrite: true
+          - metric_name: apiserver_request_total
+            unit: Count
+            overwrite: true
+          - metric_name: apiserver_request_duration_seconds
+            unit: Seconds
+            overwrite: true
+          - metric_name: apiserver_admission_controller_admission_duration_seconds
+            unit: Seconds
+            overwrite: true
+          - metric_name: rest_client_request_duration_seconds
+            unit: Seconds
+            overwrite: true
+          - metric_name: rest_client_requests_total
+            unit: Count
+            overwrite: true
+          - metric_name: etcd_request_duration_seconds
+            unit: Seconds
+            overwrite: true
     namespace: ContainerInsights
     no_verify_ssl: false
     num_workers: 8

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -149,7 +149,28 @@ exporters:
           - rest_client_request_duration_seconds
           - rest_client_requests_total
           - etcd_request_duration_seconds
-    metric_descriptors: []
+    metric_descriptors:
+      - metric_name: apiserver_storage_objects
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_request_total
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_request_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_admission_controller_admission_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: rest_client_request_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: rest_client_requests_total
+        unit: Count
+        overwrite: true
+      - metric_name: etcd_request_duration_seconds
+        unit: Seconds
+        overwrite: true
     namespace: ContainerInsights
     no_verify_ssl: false
     num_workers: 8

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -177,7 +177,28 @@ exporters:
           - rest_client_request_duration_seconds
           - rest_client_requests_total
           - etcd_request_duration_seconds
-    metric_descriptors: [ ]
+    metric_descriptors:
+      - metric_name: apiserver_storage_objects
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_request_total
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_request_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_admission_controller_admission_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: rest_client_request_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: rest_client_requests_total
+        unit: Count
+        overwrite: true
+      - metric_name: etcd_request_duration_seconds
+        unit: Seconds
+        overwrite: true
     namespace: ContainerInsights
     no_verify_ssl: false
     num_workers: 8

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -47,6 +47,7 @@ func setKubernetesMetricDeclaration(conf *confmap.Conf, cfg *awsemfexporter.Conf
 	kubernetesMetricDeclarations = append(kubernetesMetricDeclarations, getControlPlaneMetricDeclarations(conf)...)
 
 	cfg.MetricDeclarations = kubernetesMetricDeclarations
+	cfg.MetricDescriptors = getControlPlaneMetricDescriptors(conf)
 
 	return nil
 }
@@ -296,4 +297,50 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 		}...)
 	}
 	return metricDeclarations
+}
+
+func getControlPlaneMetricDescriptors(conf *confmap.Conf) []awsemfexporter.MetricDescriptor {
+	containerInsightsGranularityLevel := awscontainerinsight.GetGranularityLevel(conf)
+	if containerInsightsGranularityLevel >= awscontainerinsight.EnhancedClusterMetrics {
+		// the control plane metrics do not have units so we need to add them manually
+		return []awsemfexporter.MetricDescriptor{
+			{
+				MetricName: "apiserver_storage_objects",
+				Unit:       "Count",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "apiserver_request_total",
+				Unit:       "Count",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "apiserver_request_duration_seconds",
+				Unit:       "Seconds",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "apiserver_admission_controller_admission_duration_seconds",
+				Unit:       "Seconds",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "rest_client_request_duration_seconds",
+				Unit:       "Seconds",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "rest_client_requests_total",
+				Unit:       "Count",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "etcd_request_duration_seconds",
+				Unit:       "Seconds",
+				Overwrite:  true,
+			},
+		}
+	}
+	return []awsemfexporter.MetricDescriptor{}
+
 }

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -358,8 +358,43 @@ func TestTranslator(t *testing.T) {
 							"etcd_request_duration_seconds"},
 					},
 				},
-				"metric_descriptors": nilMetricDescriptorsSlice,
-			},
+				"metric_descriptors": []awsemfexporter.MetricDescriptor{
+					{
+						MetricName: "apiserver_storage_objects",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_request_total",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_request_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_admission_controller_admission_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "rest_client_request_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "rest_client_requests_total",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "etcd_request_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+				}},
 		},
 		"GenerateAwsEmfExporterConfigKubernetesWithEnableFullPodAndContainerMetrics": {
 			input: map[string]interface{}{
@@ -478,7 +513,43 @@ func TestTranslator(t *testing.T) {
 							"etcd_request_duration_seconds"},
 					},
 				},
-				"metric_descriptors": nilMetricDescriptorsSlice,
+				"metric_descriptors": []awsemfexporter.MetricDescriptor{
+					{
+						MetricName: "apiserver_storage_objects",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_request_total",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_request_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_admission_controller_admission_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "rest_client_request_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "rest_client_requests_total",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "etcd_request_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+				},
 			},
 		},
 		"GenerateAwsEmfExporterConfigPrometheus": {


### PR DESCRIPTION
# Description of the issue
Enhanced container insights control plane metrics do not have units.  

# Description of changes
The prometheus receiver that ingests these metrics does not assign them units.  We can add units by correctly configuring the EMF exporter

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
![Screen Shot 2023-08-24 at 12 25 12 PM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/d3cb3386-11d6-4c8a-8bb1-5194c21f72f5)
![Screen Shot 2023-08-24 at 12 26 23 PM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/e80698d3-32ad-4755-b7e6-da7f3f0bad63)
![Screen Shot 2023-08-24 at 12 26 38 PM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/2166b7a1-e276-4441-9b3c-508ca080bd7c)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




