### PR TITLE
Implementing apiserver flowcontrol metrics

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -169,6 +169,10 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_list_duration_seconds
+      - dimensions: [ [ClusterName, priority_level], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_flowcontrol_request_concurrency_limit
       - dimensions: [ [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -180,6 +184,7 @@ exporters:
           - rest_client_request_duration_seconds
           - rest_client_requests_total
           - etcd_request_duration_seconds
+          - apiserver_flowcontrol_rejected_requests_total
     metric_descriptors:
           - metric_name: apiserver_storage_objects
             unit: Count
@@ -204,6 +209,12 @@ exporters:
             overwrite: true
           - metric_name: etcd_request_duration_seconds
             unit: Seconds
+            overwrite: true
+          - metric_name: apiserver_flowcontrol_rejected_requests_total
+            unit: Count
+            overwrite: true
+          - metric_name: apiserver_flowcontrol_request_concurrency_limit
+            unit: Count
             overwrite: true
     namespace: ContainerInsights
     no_verify_ssl: false

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -140,6 +140,10 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_list_duration_seconds
+      - dimensions: [ [ClusterName, priority_level], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_flowcontrol_request_concurrency_limit
       - dimensions: [ [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -151,6 +155,7 @@ exporters:
           - rest_client_request_duration_seconds
           - rest_client_requests_total
           - etcd_request_duration_seconds
+          - apiserver_flowcontrol_rejected_requests_total
     metric_descriptors:
       - metric_name: apiserver_storage_objects
         unit: Count
@@ -175,6 +180,12 @@ exporters:
         overwrite: true
       - metric_name: etcd_request_duration_seconds
         unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_flowcontrol_rejected_requests_total
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_flowcontrol_request_concurrency_limit
+        unit: Count
         overwrite: true
     namespace: ContainerInsights
     no_verify_ssl: false

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -169,6 +169,10 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_list_duration_seconds
+      - dimensions: [ [ClusterName, priority_level], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_flowcontrol_request_concurrency_limit
       - dimensions: [ [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -180,6 +184,7 @@ exporters:
           - rest_client_request_duration_seconds
           - rest_client_requests_total
           - etcd_request_duration_seconds
+          - apiserver_flowcontrol_rejected_requests_total
     metric_descriptors:
       - metric_name: apiserver_storage_objects
         unit: Count
@@ -204,6 +209,12 @@ exporters:
         overwrite: true
       - metric_name: etcd_request_duration_seconds
         unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_flowcontrol_rejected_requests_total
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_flowcontrol_request_concurrency_limit
+        unit: Count
         overwrite: true
     namespace: ContainerInsights
     no_verify_ssl: false

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -276,6 +276,12 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 				},
 			},
 			{
+				Dimensions: [][]string{{"ClusterName", "priority_level"}, {"ClusterName"}},
+				MetricNameSelectors: []string{
+					"apiserver_flowcontrol_request_concurrency_limit",
+				},
+			},
+			{
 				Dimensions: [][]string{{"ClusterName"}},
 				MetricNameSelectors: []string{
 					"apiserver_storage_objects",
@@ -286,6 +292,7 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 					"rest_client_request_duration_seconds",
 					"rest_client_requests_total",
 					"etcd_request_duration_seconds",
+					"apiserver_flowcontrol_rejected_requests_total",
 				},
 			},
 		}...)
@@ -336,6 +343,16 @@ func getControlPlaneMetricDescriptors(conf *confmap.Conf) []awsemfexporter.Metri
 			{
 				MetricName: "etcd_request_duration_seconds",
 				Unit:       "Seconds",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "apiserver_flowcontrol_rejected_requests_total",
+				Unit:       "Count",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "apiserver_flowcontrol_request_concurrency_limit",
+				Unit:       "Count",
 				Overwrite:  true,
 			},
 		}

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -284,15 +284,15 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 			{
 				Dimensions: [][]string{{"ClusterName"}},
 				MetricNameSelectors: []string{
-					"apiserver_storage_objects",
+					"apiserver_admission_controller_admission_duration_seconds",
+					"apiserver_flowcontrol_rejected_requests_total",
+					"apiserver_request_duration_seconds",
 					"apiserver_request_total",
 					"apiserver_request_total_5xx",
-					"apiserver_request_duration_seconds",
-					"apiserver_admission_controller_admission_duration_seconds",
+					"apiserver_storage_objects",
+					"etcd_request_duration_seconds",
 					"rest_client_request_duration_seconds",
 					"rest_client_requests_total",
-					"etcd_request_duration_seconds",
-					"apiserver_flowcontrol_rejected_requests_total",
 				},
 			},
 		}...)
@@ -306,8 +306,23 @@ func getControlPlaneMetricDescriptors(conf *confmap.Conf) []awsemfexporter.Metri
 		// the control plane metrics do not have units so we need to add them manually
 		return []awsemfexporter.MetricDescriptor{
 			{
-				MetricName: "apiserver_storage_objects",
+				MetricName: "apiserver_admission_controller_admission_duration_seconds",
+				Unit:       "Seconds",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "apiserver_flowcontrol_rejected_requests_total",
 				Unit:       "Count",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "apiserver_flowcontrol_request_concurrency_limit",
+				Unit:       "Count",
+				Overwrite:  true,
+			},
+			{
+				MetricName: "apiserver_request_duration_seconds",
+				Unit:       "Seconds",
 				Overwrite:  true,
 			},
 			{
@@ -321,12 +336,12 @@ func getControlPlaneMetricDescriptors(conf *confmap.Conf) []awsemfexporter.Metri
 				Overwrite:  true,
 			},
 			{
-				MetricName: "apiserver_request_duration_seconds",
-				Unit:       "Seconds",
+				MetricName: "apiserver_storage_objects",
+				Unit:       "Count",
 				Overwrite:  true,
 			},
 			{
-				MetricName: "apiserver_admission_controller_admission_duration_seconds",
+				MetricName: "etcd_request_duration_seconds",
 				Unit:       "Seconds",
 				Overwrite:  true,
 			},
@@ -337,21 +352,6 @@ func getControlPlaneMetricDescriptors(conf *confmap.Conf) []awsemfexporter.Metri
 			},
 			{
 				MetricName: "rest_client_requests_total",
-				Unit:       "Count",
-				Overwrite:  true,
-			},
-			{
-				MetricName: "etcd_request_duration_seconds",
-				Unit:       "Seconds",
-				Overwrite:  true,
-			},
-			{
-				MetricName: "apiserver_flowcontrol_rejected_requests_total",
-				Unit:       "Count",
-				Overwrite:  true,
-			},
-			{
-				MetricName: "apiserver_flowcontrol_request_concurrency_limit",
 				Unit:       "Count",
 				Overwrite:  true,
 			},

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -352,21 +352,38 @@ func TestTranslator(t *testing.T) {
 					},
 					{
 						Dimensions: [][]string{{"ClusterName"}},
-						MetricNameSelectors: []string{"apiserver_storage_objects",
+						MetricNameSelectors: []string{
+							"apiserver_admission_controller_admission_duration_seconds",
+							"apiserver_flowcontrol_rejected_requests_total",
+							"apiserver_request_duration_seconds",
 							"apiserver_request_total",
 							"apiserver_request_total_5xx",
-							"apiserver_request_duration_seconds",
-							"apiserver_admission_controller_admission_duration_seconds",
+							"apiserver_storage_objects",
+							"etcd_request_duration_seconds",
 							"rest_client_request_duration_seconds",
 							"rest_client_requests_total",
-							"etcd_request_duration_seconds",
-							"apiserver_flowcontrol_rejected_requests_total"},
+						},
 					},
 				},
 				"metric_descriptors": []awsemfexporter.MetricDescriptor{
 					{
-						MetricName: "apiserver_storage_objects",
+						MetricName: "apiserver_admission_controller_admission_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_flowcontrol_request_concurrency_limit",
 						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_flowcontrol_rejected_requests_total",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_request_duration_seconds",
+						Unit:       "Seconds",
 						Overwrite:  true,
 					},
 					{
@@ -380,12 +397,12 @@ func TestTranslator(t *testing.T) {
 						Overwrite:  true,
 					},
 					{
-						MetricName: "apiserver_request_duration_seconds",
-						Unit:       "Seconds",
+						MetricName: "apiserver_storage_objects",
+						Unit:       "Count",
 						Overwrite:  true,
 					},
 					{
-						MetricName: "apiserver_admission_controller_admission_duration_seconds",
+						MetricName: "etcd_request_duration_seconds",
 						Unit:       "Seconds",
 						Overwrite:  true,
 					},
@@ -396,21 +413,6 @@ func TestTranslator(t *testing.T) {
 					},
 					{
 						MetricName: "rest_client_requests_total",
-						Unit:       "Count",
-						Overwrite:  true,
-					},
-					{
-						MetricName: "etcd_request_duration_seconds",
-						Unit:       "Seconds",
-						Overwrite:  true,
-					},
-					{
-						MetricName: "apiserver_flowcontrol_request_concurrency_limit",
-						Unit:       "Count",
-						Overwrite:  true,
-					},
-					{
-						MetricName: "apiserver_flowcontrol_rejected_requests_total",
 						Unit:       "Count",
 						Overwrite:  true,
 					},

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -347,6 +347,10 @@ func TestTranslator(t *testing.T) {
 						MetricNameSelectors: []string{"apiserver_storage_list_duration_seconds"},
 					},
 					{
+						Dimensions:          [][]string{{"ClusterName", "priority_level"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"apiserver_flowcontrol_request_concurrency_limit"},
+					},
+					{
 						Dimensions: [][]string{{"ClusterName"}},
 						MetricNameSelectors: []string{"apiserver_storage_objects",
 							"apiserver_request_total",
@@ -355,7 +359,8 @@ func TestTranslator(t *testing.T) {
 							"apiserver_admission_controller_admission_duration_seconds",
 							"rest_client_request_duration_seconds",
 							"rest_client_requests_total",
-							"etcd_request_duration_seconds"},
+							"etcd_request_duration_seconds",
+							"apiserver_flowcontrol_rejected_requests_total"},
 					},
 				},
 				"metric_descriptors": []awsemfexporter.MetricDescriptor{
@@ -397,6 +402,16 @@ func TestTranslator(t *testing.T) {
 					{
 						MetricName: "etcd_request_duration_seconds",
 						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_flowcontrol_request_concurrency_limit",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_flowcontrol_rejected_requests_total",
+						Unit:       "Count",
 						Overwrite:  true,
 					},
 				},


### PR DESCRIPTION
# Description of the issue
Implementing apiserver flowcontrol metrics

# Description of changes
Implementing apiserver_flowcontrol_request_concurrency_limit and apiserver_flowcontrol_rejected_requests_total

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
![Screen Shot 2023-08-25 at 17 19 03](https://github.com/aws/amazon-cloudwatch-agent/assets/44349099/f807829e-0124-4345-8625-b929af511e42)


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




