### PR TITLE
Add fallback shared config files for credential ordering.

### DIFF
--- a/cfg/aws/credentials.go
+++ b/cfg/aws/credentials.go
@@ -6,12 +6,14 @@ package aws
 import (
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -76,11 +78,19 @@ func OverwriteCredentialsChain(providers ...RootCredentialsProvider) {
 }
 
 func getSession(config *aws.Config) *session.Session {
-	ses, err := session.NewSession(config)
+	cfgFiles := getFallbackSharedConfigFiles(backwardsCompatibleUserHomeDir)
+	log.Printf("D! Fallback shared config file(s): %v", cfgFiles)
+	ses, err := session.NewSessionWithOptions(session.Options{
+		Config:            *config,
+		SharedConfigFiles: cfgFiles,
+	})
 	if err != nil {
 		log.Printf("E! Failed to create credential sessions, retrying in 15s, error was '%s' \n", err)
 		time.Sleep(15 * time.Second)
-		ses, err = session.NewSession(config)
+		ses, err = session.NewSessionWithOptions(session.Options{
+			Config:            *config,
+			SharedConfigFiles: cfgFiles,
+		})
 		if err != nil {
 			log.Printf("E! Retry failed for creating credential sessions, error was '%s' \n", err)
 			return ses
@@ -92,6 +102,19 @@ func getSession(config *aws.Config) *session.Session {
 		log.Printf("E! Failed to get credential from session: %v", err)
 	} else {
 		log.Printf("D! Using credential %s from %s", cred.AccessKeyID, cred.ProviderName)
+	}
+	if cred.ProviderName == ec2rolecreds.ProviderName {
+		var found []string
+		cfgFiles = getFallbackSharedConfigFiles(currentUserHomeDir)
+		for _, cfgFile := range cfgFiles {
+			if _, err = os.Stat(cfgFile); err == nil {
+				found = append(found, cfgFile)
+			}
+		}
+		if len(found) > 0 {
+			log.Printf("W! Unused shared config file(s) found: %v. If you would like to use them, "+
+				"please update your common-config.toml.", found)
+		}
 	}
 	return ses
 }

--- a/cfg/aws/shared_config.go
+++ b/cfg/aws/shared_config.go
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package aws
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	envAwsSdkLoadConfig         = "AWS_SDK_LOAD_CONFIG"
+	envAwsSharedCredentialsFile = "AWS_SHARED_CREDENTIALS_FILE"
+	envAwsSharedConfigFile      = "AWS_CONFIG_FILE"
+)
+
+// getFallbackSharedConfigFiles follows the same logic as the AWS SDK but takes a getUserHomeDir
+// function.
+func getFallbackSharedConfigFiles(userHomeDirProvider func() string) []string {
+	var sharedCredentialsFile, sharedConfigFile string
+	setFromEnvVal(&sharedCredentialsFile, envAwsSharedCredentialsFile)
+	setFromEnvVal(&sharedConfigFile, envAwsSharedConfigFile)
+	if sharedCredentialsFile == "" {
+		sharedCredentialsFile = defaultSharedCredentialsFile(userHomeDirProvider())
+	}
+	if sharedConfigFile == "" {
+		sharedConfigFile = defaultSharedConfig(userHomeDirProvider())
+	}
+	var cfgFiles []string
+	enableSharedConfig, _ := strconv.ParseBool(os.Getenv(envAwsSdkLoadConfig))
+	if enableSharedConfig {
+		cfgFiles = append(cfgFiles, sharedConfigFile)
+	}
+	return append(cfgFiles, sharedCredentialsFile)
+}
+
+func setFromEnvVal(dst *string, keys ...string) {
+	for _, k := range keys {
+		if v := os.Getenv(k); len(v) != 0 {
+			*dst = v
+			break
+		}
+	}
+}
+
+func defaultSharedCredentialsFile(dir string) string {
+	return filepath.Join(dir, ".aws", "credentials")
+}
+
+func defaultSharedConfig(dir string) string {
+	return filepath.Join(dir, ".aws", "config")
+}
+
+// backwardsCompatibleUserHomeDir provides the home directory based on
+// environment variables.
+//
+// Based on v1.44.106 of the AWS SDK.
+func backwardsCompatibleUserHomeDir() string {
+	home, _ := os.UserHomeDir()
+	return home
+}
+
+// currentUserHomeDir attempts to use the environment variables before falling
+// back on the current user's home directory.
+//
+// Based on v1.44.332 of the AWS SDK.
+func currentUserHomeDir() string {
+	var home string
+
+	home = backwardsCompatibleUserHomeDir()
+	if len(home) > 0 {
+		return home
+	}
+
+	currUser, _ := user.Current()
+	if currUser != nil {
+		home = currUser.HomeDir
+	}
+
+	return home
+}

--- a/cfg/aws/shared_config_test.go
+++ b/cfg/aws/shared_config_test.go
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFallbackSharedConfigFiles(t *testing.T) {
+	noOpGetUserHomeDir := func() string { return "home" }
+	t.Setenv(envAwsSdkLoadConfig, "true")
+	t.Setenv(envAwsSharedCredentialsFile, "credentials")
+	t.Setenv(envAwsSharedConfigFile, "config")
+
+	got := getFallbackSharedConfigFiles(noOpGetUserHomeDir)
+	assert.Equal(t, []string{"config", "credentials"}, got)
+
+	t.Setenv(envAwsSdkLoadConfig, "false")
+	got = getFallbackSharedConfigFiles(noOpGetUserHomeDir)
+	assert.Equal(t, []string{"credentials"}, got)
+
+	t.Setenv(envAwsSdkLoadConfig, "true")
+	t.Setenv(envAwsSharedCredentialsFile, "")
+	t.Setenv(envAwsSharedConfigFile, "")
+
+	got = getFallbackSharedConfigFiles(noOpGetUserHomeDir)
+	assert.Equal(t, []string{defaultSharedConfig("home"), defaultSharedCredentialsFile("home")}, got)
+}


### PR DESCRIPTION
# Description of the issue
The AWS SDK implementation for getting the user home directory for the default shared config files changed from purely environment variables ([v1.44.106](https://github.com/aws/aws-sdk-go/blob/v1.44.106/internal/shareddefaults/shared_config.go#L33)) to a fallback on getting it from the OS in [more recent versions](https://github.com/aws/aws-sdk-go/blame/v1.44.332/internal/shareddefaults/shared_config.go#L32). This change breaks the credential ordering when running as root and the agent with systemd. In the previous version, the environment variables would not resolve properly and would result in the SDK trying to use `.aws/credentials` rather than `/root/.aws/credentials`, which would allow it to fallthrough to the EC2RoleProvider.

# Description of changes
Sets the fallback shared config files using the backwards compatible user home directory provider. Logs a warning if the EC2RoleProvider is used and the new user home directory provider would have found valid files.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Did manual testing by running `aws configure` for the root user and running a standard config.

Before change (v1.300026.0):
```
2023-08-28T19:57:43Z D! Successfully created credential sessions
2023-08-28T19:57:43Z D! Using credential <redacted> from SharedConfigCredentials: /root/.aws/credentials
```

After change (current branch):
```
2023-08-28T19:39:21Z D! Fallback shared config files: [.aws/credentials]
2023-08-28T19:39:21Z D! Successfully created credential sessions
2023-08-28T19:39:21Z D! Using credential <redacted> from EC2RoleProvider
2023-08-28T19:39:21Z W! Shared config/credentials file (/root/.aws/credentials) found but not used
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




