### PR TITLE
Fix failing host cleaner action due to type mismatch

### DIFF
--- a/tool/clean/clean_host/clean_host.go
+++ b/tool/clean/clean_host/clean_host.go
@@ -48,7 +48,7 @@ func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
 		"buildPKG",
 		"buildMSI",
 		"MSIUpgrade_*",
-		"EC2IntegrationTest",
+		"Ec2IntegrationTest",
 		"IntegrationTestBase",
 		"CWADockerImageBuilderX86",
 		"CWADockerImageBuilderARM64",

--- a/tool/clean/clean_host/clean_host.go
+++ b/tool/clean/clean_host/clean_host.go
@@ -42,12 +42,13 @@ func cleanHost() error {
 }
 
 func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
-	maxResults := int32(1000)
+	maxResults := *int32(1000)
 	nameFilter := types.Filter{Name: aws.String("tag:Name"), Values: []string{
 		"buildLinuxPackage",
 		"buildPKG",
 		"buildMSI",
 		"MSIUpgrade_*",
+		"EC2IntegrationTest",
 		"IntegrationTestBase",
 		"CWADockerImageBuilderX86",
 		"CWADockerImageBuilderARM64",

--- a/tool/clean/clean_host/clean_host.go
+++ b/tool/clean/clean_host/clean_host.go
@@ -42,7 +42,7 @@ func cleanHost() error {
 }
 
 func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
-	maxResults := *int32(1000)
+	maxResults := int32(1000)
 	nameFilter := types.Filter{Name: aws.String("tag:Name"), Values: []string{
 		"buildLinuxPackage",
 		"buildPKG",
@@ -64,7 +64,7 @@ func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
 			nameFilter,
 			{Name: aws.String("instance-state-name"),
 				Values: []string{"running"}}},
-		MaxResults: maxResults}
+		MaxResults: aws.Int32(maxResults)}
 	for {
 		instanceIds := make([]string, 0)
 		expirationDateInstance := time.Now().UTC().Add(clean.KeepDurationOneDay)

--- a/tool/clean/clean_host/clean_host.go
+++ b/tool/clean/clean_host/clean_host.go
@@ -71,7 +71,7 @@ func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
 		describeInstanceOutput, _ := ec2client.DescribeInstances(cxt, &instanceInput)
 		for _, reservation := range describeInstanceOutput.Reservations {
 			for _, instance := range reservation.Instances {
-				log.Printf("instance id %v experation date %v host creation date raw %v host state %v",
+				log.Printf("instance id %v expiration date %v host creation date raw %v host state %v",
 					*instance.InstanceId, expirationDateInstance, *instance.LaunchTime, instance.State)
 				if expirationDateInstance.After(*instance.LaunchTime) {
 					log.Printf("Try to delete instance %s tags %v launch-date %s", *instance.InstanceId, instance.Tags, *instance.LaunchTime)
@@ -84,7 +84,7 @@ func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
 			return
 		}
 
-		log.Printf("instances to temrinate %v", instanceIds)
+		log.Printf("instances to terminate %v", instanceIds)
 		terminateInstance := ec2.TerminateInstancesInput{InstanceIds: instanceIds}
 		_, err := ec2client.TerminateInstances(cxt, &terminateInstance)
 		if err != nil {


### PR DESCRIPTION
# Description of the issue
The host cleaner job has been failing repeatedly, leading to a gradual accumulation of unused, active hosts.

# Description of changes
* Fixes type mismatch with `MaxResults` field in the DescribeInstances input
* Adds `Ec2IntegrationTest` to the name filter

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Successful job execution: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/6007121747/job/16292796917

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




