### PR TITLE
Add shared config fallback stat to agent info.

### DIFF
--- a/cfg/aws/credentials.go
+++ b/cfg/aws/credentials.go
@@ -18,6 +18,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+
+	"github.com/aws/amazon-cloudwatch-agent/handlers/agentinfo"
 )
 
 const (
@@ -114,6 +116,7 @@ func getSession(config *aws.Config) *session.Session {
 		if len(found) > 0 {
 			log.Printf("W! Unused shared config file(s) found: %v. If you would like to use them, "+
 				"please update your common-config.toml.", found)
+			agentinfo.RecordSharedConfigFallback()
 		}
 	}
 	return ses

--- a/handlers/agentinfo/info_test.go
+++ b/handlers/agentinfo/info_test.go
@@ -147,6 +147,9 @@ func TestGetAgentStats(t *testing.T) {
 
 	stats.StatusCode = nil
 	assert.Empty(t, getAgentStats(stats))
+
+	stats.SharedConfigFallback = aws.Int(1)
+	assert.Equal(t, "\"scfb\":1", getAgentStats(stats))
 }
 
 func TestGetStatusCode(t *testing.T) {
@@ -232,4 +235,14 @@ func TestIsUsageDataEnabled(t *testing.T) {
 
 	t.Setenv(envconfig.CWAGENT_USAGE_DATA, "FALSE")
 	assert.False(t, getUsageDataEnabled())
+}
+
+func TestSharedConfigFallback(t *testing.T) {
+	defer sharedConfigFallback.Store(false)
+	assert.Nil(t, getSharedConfigFallback())
+	RecordSharedConfigFallback()
+	assert.Equal(t, 1, *(getSharedConfigFallback()))
+	RecordSharedConfigFallback()
+	RecordSharedConfigFallback()
+	assert.Equal(t, 1, *(getSharedConfigFallback()))
 }


### PR DESCRIPTION
# Description of the issue
We want insight into the potential impact that removing the fallback override logic would have.

# Description of changes
Adds a shared config fallback stat to the agent info. Similar to https://github.com/aws/amazon-cloudwatch-agent/pull/838.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




