### PR TITLE
Remove misleading metric filter warning

### DIFF
--- a/receiver/adapter/accumulator/accumulator_test.go
+++ b/receiver/adapter/accumulator/accumulator_test.go
@@ -192,7 +192,7 @@ func Test_Accumulator_WithUnsupportedValueAndEmptyFields(t *testing.T) {
 	as.Equal(0, otelMetrics.ResourceMetrics().Len())
 }
 
-func Test_ModifyMetricandConvertMetricValue(t *testing.T) {
+func Test_ModifyMetricAndConvertMetricValue(t *testing.T) {
 	t.Helper()
 
 	as := assert.New(t)
@@ -214,7 +214,7 @@ func Test_ModifyMetricandConvertMetricValue(t *testing.T) {
 		telegraf.Gauge,
 	)
 
-	modifiedMetric, err := acc.modifyMetricandConvertToOtelValue(metric)
+	modifiedMetric, err := acc.modifyMetricAndConvertToOtelValue(metric)
 	as.NoError(err)
 
 	txMetricValue, txMetricExist := modifiedMetric.GetField("tx")

--- a/receiver/adapter/accumulator/accumulator_test.go
+++ b/receiver/adapter/accumulator/accumulator_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -193,45 +194,95 @@ func Test_Accumulator_WithUnsupportedValueAndEmptyFields(t *testing.T) {
 }
 
 func Test_ModifyMetricAndConvertMetricValue(t *testing.T) {
-	t.Helper()
-
 	as := assert.New(t)
-
-	acc := newOtelAccumulatorWithTestRunningInputs(as, nil, false)
-
-	metric := testutil.MustMetric(
-		"cpu",
-		map[string]string{
-			"instance_id": "mock",
+	cfg := &models.InputConfig{
+		Filter: models.Filter{
+			FieldDrop: []string{"filtered_field"},
 		},
-		map[string]interface{}{
-			"tx":     float64(4.5),
-			"rx":     int32(3),
-			"error":  false,
-			"client": "redis",
+	}
+	acc := newOtelAccumulatorWithConfig(as, nil, false, cfg)
+
+	testCases := map[string]struct {
+		metric            telegraf.Metric
+		wantErr           error
+		wantFields        map[string]interface{}
+		wantDroppedFields []string
+	}{
+		"WithEmpty": {
+			metric: testutil.MustMetric(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{},
+				time.Now(),
+				telegraf.Gauge,
+			),
 		},
-		time.Now(),
-		telegraf.Gauge,
-	)
+		"WithFiltered": {
+			metric: testutil.MustMetric(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"filtered_field": 1,
+				},
+				time.Now(),
+				telegraf.Gauge,
+			),
+		},
+		"WithInvalidConvert": {
+			metric: testutil.MustMetric(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"client": "redis",
+				},
+				time.Now(),
+				telegraf.Gauge,
+			),
+			wantErr: errEmptyAfterConvert,
+		},
+		"WithValid": {
+			metric: testutil.MustMetric(
+				"cpu",
+				map[string]string{
+					"instance_id": "mock",
+				},
+				map[string]interface{}{
+					"tx":     4.5,
+					"rx":     int32(3),
+					"error":  false,
+					"client": "redis",
+				},
+				time.Now(),
+				telegraf.Gauge,
+			),
+			wantFields: map[string]interface{}{
+				"tx":    4.5,
+				"rx":    int64(3),
+				"error": int64(0),
+			},
+			wantDroppedFields: []string{"client"},
+		},
+	}
 
-	modifiedMetric, err := acc.modifyMetricAndConvertToOtelValue(metric)
-	as.NoError(err)
-
-	txMetricValue, txMetricExist := modifiedMetric.GetField("tx")
-	as.True(txMetricExist)
-	as.Equal(float64(4.5), txMetricValue)
-
-	rxMetricValue, rxMetricExist := modifiedMetric.GetField("rx")
-	as.True(rxMetricExist)
-	as.Equal(int64(3), rxMetricValue)
-
-	errorMetricValue, errorMetricExist := modifiedMetric.GetField("error")
-	as.True(errorMetricExist)
-	as.Equal(int64(0), errorMetricValue)
-
-	_, clientMetricExist := modifiedMetric.GetField("client")
-	as.False(clientMetricExist)
-
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := acc.modifyMetricAndConvertToOtelValue(testCase.metric)
+			as.Equal(testCase.wantErr, err)
+			if len(testCase.wantFields) == 0 {
+				as.Nil(got)
+			} else {
+				for field, wantValue := range testCase.wantFields {
+					value, ok := got.GetField(field)
+					as.True(ok)
+					as.Equal(wantValue, value)
+				}
+				for _, field := range testCase.wantDroppedFields {
+					_, ok := got.GetField(field)
+					as.False(ok)
+				}
+			}
+		})
+	}
 }
 
 func Test_Accumulator_AddMetric(t *testing.T) {

--- a/receiver/adapter/accumulator/testutil.go
+++ b/receiver/adapter/accumulator/testutil.go
@@ -45,14 +45,17 @@ func generateExpectedAttributes() pcommon.Map {
 }
 
 func newOtelAccumulatorWithTestRunningInputs(as *assert.Assertions, consumer consumer.Metrics, isServiceInput bool) *otelAccumulator {
+	return newOtelAccumulatorWithConfig(as, consumer, isServiceInput, &models.InputConfig{})
+}
 
+func newOtelAccumulatorWithConfig(as *assert.Assertions, consumer consumer.Metrics, isServiceInput bool, cfg *models.InputConfig) *otelAccumulator {
 	var input telegraf.Input
 	if isServiceInput {
 		input = &TestServiceRunningInput{}
 	} else {
 		input = &TestRunningInput{}
 	}
-	ri := models.NewRunningInput(input, &models.InputConfig{})
+	ri := models.NewRunningInput(input, cfg)
 	as.NoError(ri.Config.Filter.Compile())
 
 	return &otelAccumulator{


### PR DESCRIPTION
# Description of the issue
We currently log a warning during metric filtering/conversion with "Filter and convert failed" even when filtering is valid. This is leading to confusion when doing log dives. Metric filtering is fine and is done using the same telegraf functions that we were using before.

# Description of changes
Changed the accumulator to only log the warning if the telegraf metric had fields and they were all dropped during our value conversion.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran unit tests. Add unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




