### PR TITLE
Drop unsupported NaN, Inf, and out of range values.

### DIFF
--- a/internal/util/type_conversion.go
+++ b/internal/util/type_conversion.go
@@ -35,7 +35,7 @@ func ToOtelValue(value interface{}) interface{} {
 		return float64(v)
 	case float64:
 		if math.IsNaN(v) || math.IsInf(v, 0) {
-			return float64(0)
+			return nil
 		}
 		return v
 	case bool:

--- a/internal/util/type_conversion.go
+++ b/internal/util/type_conversion.go
@@ -3,7 +3,11 @@
 
 package util
 
-import "github.com/aws/amazon-cloudwatch-agent/metric/distribution"
+import (
+	"math"
+
+	"github.com/aws/amazon-cloudwatch-agent/metric/distribution"
+)
 
 func ToOtelValue(value interface{}) interface{} {
 	switch v := value.(type) {
@@ -30,6 +34,9 @@ func ToOtelValue(value interface{}) interface{} {
 	case float32:
 		return float64(v)
 	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return float64(0)
+		}
 		return v
 	case bool:
 		if v {

--- a/internal/util/type_conversion.go
+++ b/internal/util/type_conversion.go
@@ -4,49 +4,50 @@
 package util
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/aws/amazon-cloudwatch-agent/metric/distribution"
 )
 
-func ToOtelValue(value interface{}) interface{} {
+func ToOtelValue(value interface{}) (interface{}, error) {
 	switch v := value.(type) {
 	case int:
-		return int64(v)
+		return int64(v), nil
 	case int8:
-		return int64(v)
+		return int64(v), nil
 	case int16:
-		return int64(v)
+		return int64(v), nil
 	case int32:
-		return int64(v)
+		return int64(v), nil
 	case int64:
-		return v
+		return v, nil
 	case uint:
-		return int64(v)
+		return int64(v), nil
 	case uint8:
-		return int64(v)
+		return int64(v), nil
 	case uint16:
-		return int64(v)
+		return int64(v), nil
 	case uint32:
-		return int64(v)
+		return int64(v), nil
 	case uint64:
-		return int64(v)
+		return int64(v), nil
 	case float32:
-		return float64(v)
+		return float64(v), nil
 	case float64:
 		if math.IsNaN(v) || math.IsInf(v, 0) {
-			return nil
+			return nil, fmt.Errorf("unsupported value: %v", v)
 		}
-		return v
+		return v, nil
 	case bool:
 		if v {
-			return int64(1)
+			return int64(1), nil
 		} else {
-			return int64(0)
+			return int64(0), nil
 		}
 	case distribution.Distribution:
-		return v
+		return v, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unsupported type: %T", v)
 	}
 }

--- a/internal/util/type_conversion_test.go
+++ b/internal/util/type_conversion_test.go
@@ -15,9 +15,9 @@ func TestToOtelValue(t *testing.T) {
 		input interface{}
 		want  interface{}
 	}{
-		{input: math.NaN(), want: float64(0)},
-		{input: math.Inf(1), want: float64(0)},
-		{input: math.Inf(-1), want: float64(0)},
+		{input: math.NaN(), want: nil},
+		{input: math.Inf(1), want: nil},
+		{input: math.Inf(-1), want: nil},
 		{input: "test", want: nil},
 		{input: int32(3), want: int64(3)},
 		{input: 5.5, want: 5.5},

--- a/internal/util/type_conversion_test.go
+++ b/internal/util/type_conversion_test.go
@@ -8,19 +8,42 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/amazon-cloudwatch-agent/metric/distribution/regular"
 )
 
 func TestToOtelValue(t *testing.T) {
+	distribution := regular.NewRegularDistribution()
 	testCases := []struct {
 		input interface{}
 		want  interface{}
 	}{
+		// ints
+		{input: 5, want: int64(5)},
+		{input: int8(5), want: int64(5)},
+		{input: int16(5), want: int64(5)},
+		{input: int32(5), want: int64(5)},
+		{input: int64(5), want: int64(5)},
+		// uints
+		{input: uint(5), want: int64(5)},
+		{input: uint8(5), want: int64(5)},
+		{input: uint16(5), want: int64(5)},
+		{input: uint32(5), want: int64(5)},
+		{input: uint64(5), want: int64(5)},
+		// floats
+		{input: float32(5.5), want: 5.5},
+		{input: 5.5, want: 5.5},
+		// bool
+		{input: false, want: int64(0)},
+		{input: true, want: int64(1)},
+		// distribution
+		{input: distribution, want: distribution},
+		// unsupported floats
 		{input: math.NaN(), want: nil},
 		{input: math.Inf(1), want: nil},
 		{input: math.Inf(-1), want: nil},
+		// unsupported types
 		{input: "test", want: nil},
-		{input: int32(3), want: int64(3)},
-		{input: 5.5, want: 5.5},
 	}
 	for _, testCase := range testCases {
 		assert.Equal(t, testCase.want, ToOtelValue(testCase.input))

--- a/internal/util/type_conversion_test.go
+++ b/internal/util/type_conversion_test.go
@@ -4,6 +4,7 @@
 package util
 
 import (
+	"errors"
 	"math"
 	"testing"
 
@@ -15,8 +16,9 @@ import (
 func TestToOtelValue(t *testing.T) {
 	distribution := regular.NewRegularDistribution()
 	testCases := []struct {
-		input interface{}
-		want  interface{}
+		input   interface{}
+		want    interface{}
+		wantErr error
 	}{
 		// ints
 		{input: 5, want: int64(5)},
@@ -39,13 +41,15 @@ func TestToOtelValue(t *testing.T) {
 		// distribution
 		{input: distribution, want: distribution},
 		// unsupported floats
-		{input: math.NaN(), want: nil},
-		{input: math.Inf(1), want: nil},
-		{input: math.Inf(-1), want: nil},
+		{input: math.NaN(), want: nil, wantErr: errors.New("unsupported value: NaN")},
+		{input: math.Inf(1), want: nil, wantErr: errors.New("unsupported value: +Inf")},
+		{input: math.Inf(-1), want: nil, wantErr: errors.New("unsupported value: -Inf")},
 		// unsupported types
-		{input: "test", want: nil},
+		{input: "test", want: nil, wantErr: errors.New("unsupported type: string")},
 	}
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.want, ToOtelValue(testCase.input))
+		got, err := ToOtelValue(testCase.input)
+		assert.Equal(t, testCase.wantErr, err)
+		assert.Equal(t, testCase.want, got)
 	}
 }

--- a/internal/util/type_conversion_test.go
+++ b/internal/util/type_conversion_test.go
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToOtelValue(t *testing.T) {
+	testCases := []struct {
+		input interface{}
+		want  interface{}
+	}{
+		{input: math.NaN(), want: float64(0)},
+		{input: math.Inf(1), want: float64(0)},
+		{input: math.Inf(-1), want: float64(0)},
+		{input: "test", want: nil},
+		{input: int32(3), want: int64(3)},
+		{input: 5.5, want: 5.5},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.want, ToOtelValue(testCase.input))
+	}
+}

--- a/metric/distribution/distribution.go
+++ b/metric/distribution/distribution.go
@@ -3,7 +3,16 @@
 
 package distribution
 
-import "go.opentelemetry.io/collector/pdata/pmetric"
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+var (
+	ErrUnsupportedWeight = errors.New("weight must be larger than 0")
+	ErrUnsupportedValue  = errors.New("value cannot be negative, NaN, or Inf")
+)
 
 type Distribution interface {
 	Maximum() float64

--- a/metric/distribution/distribution.go
+++ b/metric/distribution/distribution.go
@@ -10,10 +10,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-const (
-	epsilon = 0.001
-)
-
 var (
 	ErrUnsupportedWeight = errors.New("weight must be larger than 0")
 	ErrUnsupportedValue  = errors.New("value cannot be negative, NaN, Inf, or greater than 2^360")
@@ -53,9 +49,9 @@ type Distribution interface {
 
 var NewDistribution func() Distribution
 
-// IsValueInRange checks to see if the metric is between -2^360 and 2^360.
+// IsSupportedValue checks to see if the metric is between the min value and 2^360 and not a NaN.
 // This matches the accepted range described in the MetricDatum documentation
 // https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
-func IsValueInRange(value float64) bool {
-	return value >= MinValue && value <= MaxValue
+func IsSupportedValue(value, min, max float64) bool {
+	return !math.IsNaN(value) && value >= min && value <= max
 }

--- a/metric/distribution/distribution.go
+++ b/metric/distribution/distribution.go
@@ -5,13 +5,20 @@ package distribution
 
 import (
 	"errors"
+	"math"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
+const (
+	epsilon = 0.001
+)
+
 var (
 	ErrUnsupportedWeight = errors.New("weight must be larger than 0")
-	ErrUnsupportedValue  = errors.New("value cannot be negative, NaN, or Inf")
+	ErrUnsupportedValue  = errors.New("value cannot be negative, NaN, Inf, or greater than 2^360")
+	MinValue             = -math.Pow(2, 360)
+	MaxValue             = math.Pow(2, 360)
 )
 
 type Distribution interface {
@@ -45,3 +52,10 @@ type Distribution interface {
 }
 
 var NewDistribution func() Distribution
+
+// IsValueInRange checks to see if the metric is between -2^360 and 2^360.
+// This matches the accepted range described in the MetricDatum documentation
+// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
+func IsValueInRange(value float64) bool {
+	return value >= MinValue && value <= MaxValue
+}

--- a/metric/distribution/distribution_test.go
+++ b/metric/distribution/distribution_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsValueInRange(t *testing.T) {
+func TestIsAcceptedValue(t *testing.T) {
 	testCases := []struct {
 		input float64
 		want  bool
@@ -20,8 +20,11 @@ func TestIsValueInRange(t *testing.T) {
 		{input: MaxValue, want: true},
 		{input: MaxValue * 1.0001, want: false},
 		{input: math.Pow(2, 300), want: true},
+		{input: math.NaN(), want: false},
+		{input: math.Inf(1), want: false},
+		{input: math.Inf(-1), want: false},
 	}
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.want, IsValueInRange(testCase.input))
+		assert.Equal(t, testCase.want, IsSupportedValue(testCase.input, MinValue, MaxValue))
 	}
 }

--- a/metric/distribution/distribution_test.go
+++ b/metric/distribution/distribution_test.go
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package distribution
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValueInRange(t *testing.T) {
+	testCases := []struct {
+		input float64
+		want  bool
+	}{
+		{input: MinValue * 1.0001, want: false},
+		{input: MinValue, want: true},
+		{input: MaxValue, want: true},
+		{input: MaxValue * 1.0001, want: false},
+		{input: math.Pow(2, 300), want: true},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.want, IsValueInRange(testCase.input))
+	}
+}

--- a/metric/distribution/regular/regular_distribution.go
+++ b/metric/distribution/regular/regular_distribution.go
@@ -4,7 +4,6 @@
 package regular
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -70,37 +69,33 @@ func (regularDist *RegularDistribution) Size() int {
 
 // weight is 1/samplingRate
 func (regularDist *RegularDistribution) AddEntryWithUnit(value float64, weight float64, unit string) error {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
-		return fmt.Errorf("unsupported value: %v", value)
+	if weight <= 0 {
+		return fmt.Errorf("weight must be larger than 0: %v", weight)
 	}
-	if weight > 0 {
-		if value < 0 {
-			return errors.New("negative value")
-		}
-		//sample count
-		regularDist.sampleCount += weight
-		//sum
-		regularDist.sum += value * weight
-		//min
-		if value < regularDist.minimum {
-			regularDist.minimum = value
-		}
-		//max
-		if value > regularDist.maximum {
-			regularDist.maximum = value
-		}
+	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("value cannot be negative, NaN, or Inf: %v", value)
+	}
+	//sample count
+	regularDist.sampleCount += weight
+	//sum
+	regularDist.sum += value * weight
+	//min
+	if value < regularDist.minimum {
+		regularDist.minimum = value
+	}
+	//max
+	if value > regularDist.maximum {
+		regularDist.maximum = value
+	}
 
-		//values and counts
-		regularDist.buckets[value] += weight
+	//values and counts
+	regularDist.buckets[value] += weight
 
-		//unit
-		if regularDist.unit == "" {
-			regularDist.unit = unit
-		} else if regularDist.unit != unit && unit != "" {
-			log.Printf("D! Multiple units are detected: %s, %s", regularDist.unit, unit)
-		}
-	} else {
-		log.Printf("D! Weight should be larger than 0: %v", weight)
+	//unit
+	if regularDist.unit == "" {
+		regularDist.unit = unit
+	} else if regularDist.unit != unit && unit != "" {
+		log.Printf("D! Multiple units are detected: %s, %s", regularDist.unit, unit)
 	}
 	return nil
 }

--- a/metric/distribution/regular/regular_distribution.go
+++ b/metric/distribution/regular/regular_distribution.go
@@ -5,6 +5,7 @@ package regular
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"math"
 
@@ -69,6 +70,9 @@ func (regularDist *RegularDistribution) Size() int {
 
 // weight is 1/samplingRate
 func (regularDist *RegularDistribution) AddEntryWithUnit(value float64, weight float64, unit string) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("unsupported value: %v", value)
+	}
 	if weight > 0 {
 		if value < 0 {
 			return errors.New("negative value")

--- a/metric/distribution/regular/regular_distribution.go
+++ b/metric/distribution/regular/regular_distribution.go
@@ -70,10 +70,10 @@ func (regularDist *RegularDistribution) Size() int {
 // weight is 1/samplingRate
 func (regularDist *RegularDistribution) AddEntryWithUnit(value float64, weight float64, unit string) error {
 	if weight <= 0 {
-		return fmt.Errorf("weight must be larger than 0: %v", weight)
+		return fmt.Errorf("unsupported weight %v: %w", weight, distribution.ErrUnsupportedWeight)
 	}
 	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
-		return fmt.Errorf("value cannot be negative, NaN, or Inf: %v", value)
+		return fmt.Errorf("unsupported value %v: %w", value, distribution.ErrUnsupportedValue)
 	}
 	//sample count
 	regularDist.sampleCount += weight

--- a/metric/distribution/regular/regular_distribution.go
+++ b/metric/distribution/regular/regular_distribution.go
@@ -72,7 +72,7 @@ func (regularDist *RegularDistribution) AddEntryWithUnit(value float64, weight f
 	if weight <= 0 {
 		return fmt.Errorf("unsupported weight %v: %w", weight, distribution.ErrUnsupportedWeight)
 	}
-	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) || !distribution.IsValueInRange(value) {
+	if !distribution.IsSupportedValue(value, 0, distribution.MaxValue) {
 		return fmt.Errorf("unsupported value %v: %w", value, distribution.ErrUnsupportedValue)
 	}
 	//sample count

--- a/metric/distribution/regular/regular_distribution.go
+++ b/metric/distribution/regular/regular_distribution.go
@@ -72,7 +72,7 @@ func (regularDist *RegularDistribution) AddEntryWithUnit(value float64, weight f
 	if weight <= 0 {
 		return fmt.Errorf("unsupported weight %v: %w", weight, distribution.ErrUnsupportedWeight)
 	}
-	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) || !distribution.IsValueInRange(value) {
 		return fmt.Errorf("unsupported value %v: %w", value, distribution.ErrUnsupportedValue)
 	}
 	//sample count

--- a/metric/distribution/regular/regular_distribution_test.go
+++ b/metric/distribution/regular/regular_distribution_test.go
@@ -78,9 +78,11 @@ func TestRegularDistribution(t *testing.T) {
 	anotherDist.AddDistribution(distClone)
 	assert.Equal(t, dist, anotherDist) //the direction of AddDistribution should not matter.
 
-	assert.Equal(t, errors.New("unsupported value: NaN"), anotherDist.AddEntry(math.NaN(), 1))
-	assert.Equal(t, errors.New("unsupported value: +Inf"), anotherDist.AddEntry(math.Inf(1), 1))
-	assert.Equal(t, errors.New("unsupported value: -Inf"), anotherDist.AddEntry(math.Inf(-1), 1))
+	assert.Equal(t, errors.New("weight must be larger than 0: 0"), anotherDist.AddEntry(1, 0))
+	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: -1"), anotherDist.AddEntry(-1, 1))
+	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: NaN"), anotherDist.AddEntry(math.NaN(), 1))
+	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: +Inf"), anotherDist.AddEntry(math.Inf(1), 1))
+	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: -Inf"), anotherDist.AddEntry(math.Inf(-1), 1))
 }
 
 func cloneRegularDistribution(dist *RegularDistribution) *RegularDistribution {

--- a/metric/distribution/regular/regular_distribution_test.go
+++ b/metric/distribution/regular/regular_distribution_test.go
@@ -4,11 +4,12 @@
 package regular
 
 import (
-	"errors"
 	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/amazon-cloudwatch-agent/metric/distribution"
 )
 
 func TestRegularDistribution(t *testing.T) {
@@ -78,11 +79,11 @@ func TestRegularDistribution(t *testing.T) {
 	anotherDist.AddDistribution(distClone)
 	assert.Equal(t, dist, anotherDist) //the direction of AddDistribution should not matter.
 
-	assert.Equal(t, errors.New("weight must be larger than 0: 0"), anotherDist.AddEntry(1, 0))
-	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: -1"), anotherDist.AddEntry(-1, 1))
-	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: NaN"), anotherDist.AddEntry(math.NaN(), 1))
-	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: +Inf"), anotherDist.AddEntry(math.Inf(1), 1))
-	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: -Inf"), anotherDist.AddEntry(math.Inf(-1), 1))
+	assert.ErrorIs(t, anotherDist.AddEntry(1, 0), distribution.ErrUnsupportedWeight)
+	assert.ErrorIs(t, anotherDist.AddEntry(-1, 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(math.NaN(), 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(math.Inf(1), 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(math.Inf(-1), 1), distribution.ErrUnsupportedValue)
 }
 
 func cloneRegularDistribution(dist *RegularDistribution) *RegularDistribution {

--- a/metric/distribution/regular/regular_distribution_test.go
+++ b/metric/distribution/regular/regular_distribution_test.go
@@ -84,6 +84,8 @@ func TestRegularDistribution(t *testing.T) {
 	assert.ErrorIs(t, anotherDist.AddEntry(math.NaN(), 1), distribution.ErrUnsupportedValue)
 	assert.ErrorIs(t, anotherDist.AddEntry(math.Inf(1), 1), distribution.ErrUnsupportedValue)
 	assert.ErrorIs(t, anotherDist.AddEntry(math.Inf(-1), 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(distribution.MaxValue*1.001, 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(distribution.MinValue*1.001, 1), distribution.ErrUnsupportedValue)
 }
 
 func cloneRegularDistribution(dist *RegularDistribution) *RegularDistribution {

--- a/metric/distribution/regular/regular_distribution_test.go
+++ b/metric/distribution/regular/regular_distribution_test.go
@@ -4,12 +4,14 @@
 package regular
 
 import (
+	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSEH1Distribution(t *testing.T) {
+func TestRegularDistribution(t *testing.T) {
 	//dist new and add entry
 	dist := NewRegularDistribution()
 
@@ -34,9 +36,9 @@ func TestSEH1Distribution(t *testing.T) {
 	//another dist new and add entry
 	anotherDist := NewRegularDistribution()
 
-	anotherDist.AddEntry(21, 1)
-	anotherDist.AddEntry(22, 1)
-	anotherDist.AddEntry(23, 2)
+	assert.NoError(t, anotherDist.AddEntry(21, 1))
+	assert.NoError(t, anotherDist.AddEntry(22, 1))
+	assert.NoError(t, anotherDist.AddEntry(23, 2))
 
 	assert.Equal(t, 89.0, anotherDist.Sum())
 	assert.Equal(t, 4.0, anotherDist.SampleCount())
@@ -75,6 +77,10 @@ func TestSEH1Distribution(t *testing.T) {
 	//add distClone into another dist
 	anotherDist.AddDistribution(distClone)
 	assert.Equal(t, dist, anotherDist) //the direction of AddDistribution should not matter.
+
+	assert.Equal(t, errors.New("unsupported value: NaN"), anotherDist.AddEntry(math.NaN(), 1))
+	assert.Equal(t, errors.New("unsupported value: +Inf"), anotherDist.AddEntry(math.Inf(1), 1))
+	assert.Equal(t, errors.New("unsupported value: -Inf"), anotherDist.AddEntry(math.Inf(-1), 1))
 }
 
 func cloneRegularDistribution(dist *RegularDistribution) *RegularDistribution {

--- a/metric/distribution/seh1/seh1_distribution.go
+++ b/metric/distribution/seh1/seh1_distribution.go
@@ -5,6 +5,7 @@ package seh1
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"math"
 
@@ -79,6 +80,9 @@ func (seh1Distribution *SEH1Distribution) Size() int {
 
 // weight is 1/samplingRate
 func (seh1Distribution *SEH1Distribution) AddEntryWithUnit(value float64, weight float64, unit string) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("unsupported value: %v", value)
+	}
 	if weight > 0 {
 		if value < 0 {
 			return errors.New("negative value")

--- a/metric/distribution/seh1/seh1_distribution.go
+++ b/metric/distribution/seh1/seh1_distribution.go
@@ -82,7 +82,7 @@ func (seh1Distribution *SEH1Distribution) AddEntryWithUnit(value float64, weight
 	if weight <= 0 {
 		return fmt.Errorf("unsupported weight %v: %w", weight, distribution.ErrUnsupportedWeight)
 	}
-	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) || !distribution.IsValueInRange(value) {
+	if !distribution.IsSupportedValue(value, 0, distribution.MaxValue) {
 		return fmt.Errorf("unsupported value %v: %w", value, distribution.ErrUnsupportedValue)
 	}
 	//sample count

--- a/metric/distribution/seh1/seh1_distribution.go
+++ b/metric/distribution/seh1/seh1_distribution.go
@@ -82,7 +82,7 @@ func (seh1Distribution *SEH1Distribution) AddEntryWithUnit(value float64, weight
 	if weight <= 0 {
 		return fmt.Errorf("unsupported weight %v: %w", weight, distribution.ErrUnsupportedWeight)
 	}
-	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) || !distribution.IsValueInRange(value) {
 		return fmt.Errorf("unsupported value %v: %w", value, distribution.ErrUnsupportedValue)
 	}
 	//sample count

--- a/metric/distribution/seh1/seh1_distribution.go
+++ b/metric/distribution/seh1/seh1_distribution.go
@@ -150,7 +150,7 @@ func (seh1Distribution *SEH1Distribution) AddDistributionWithWeight(distribution
 		if seh1Distribution.unit == "" {
 			seh1Distribution.unit = distribution.Unit()
 		} else if seh1Distribution.unit != distribution.Unit() && distribution.Unit() != "" {
-			log.Printf("D! Multiple units are dected: %s, %s", seh1Distribution.unit, distribution.Unit())
+			log.Printf("D! Multiple units are detected: %s, %s", seh1Distribution.unit, distribution.Unit())
 		}
 	} else {
 		log.Printf("D! SampleCount * Weight should be larger than 0: %v, %v", distribution.SampleCount(), weight)

--- a/metric/distribution/seh1/seh1_distribution.go
+++ b/metric/distribution/seh1/seh1_distribution.go
@@ -4,7 +4,6 @@
 package seh1
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -80,38 +79,34 @@ func (seh1Distribution *SEH1Distribution) Size() int {
 
 // weight is 1/samplingRate
 func (seh1Distribution *SEH1Distribution) AddEntryWithUnit(value float64, weight float64, unit string) error {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
-		return fmt.Errorf("unsupported value: %v", value)
+	if weight <= 0 {
+		return fmt.Errorf("weight must be larger than 0: %v", weight)
 	}
-	if weight > 0 {
-		if value < 0 {
-			return errors.New("negative value")
-		}
-		//sample count
-		seh1Distribution.sampleCount += weight
-		//sum
-		seh1Distribution.sum += value * weight
-		//min
-		if value < seh1Distribution.minimum {
-			seh1Distribution.minimum = value
-		}
-		//max
-		if value > seh1Distribution.maximum {
-			seh1Distribution.maximum = value
-		}
+	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("value cannot be negative, NaN, or Inf: %v", value)
+	}
+	//sample count
+	seh1Distribution.sampleCount += weight
+	//sum
+	seh1Distribution.sum += value * weight
+	//min
+	if value < seh1Distribution.minimum {
+		seh1Distribution.minimum = value
+	}
+	//max
+	if value > seh1Distribution.maximum {
+		seh1Distribution.maximum = value
+	}
 
-		//seh
-		bucketNumber := bucketNumber(value)
-		seh1Distribution.buckets[bucketNumber] += weight
+	//seh
+	bucketNumber := bucketNumber(value)
+	seh1Distribution.buckets[bucketNumber] += weight
 
-		//unit
-		if seh1Distribution.unit == "" {
-			seh1Distribution.unit = unit
-		} else if seh1Distribution.unit != unit && unit != "" {
-			log.Printf("D! Multiple units are detected: %s, %s", seh1Distribution.unit, unit)
-		}
-	} else {
-		log.Printf("D! Weight should be larger than 0: %v", weight)
+	//unit
+	if seh1Distribution.unit == "" {
+		seh1Distribution.unit = unit
+	} else if seh1Distribution.unit != unit && unit != "" {
+		log.Printf("D! Multiple units are detected: %s, %s", seh1Distribution.unit, unit)
 	}
 	return nil
 }

--- a/metric/distribution/seh1/seh1_distribution.go
+++ b/metric/distribution/seh1/seh1_distribution.go
@@ -80,10 +80,10 @@ func (seh1Distribution *SEH1Distribution) Size() int {
 // weight is 1/samplingRate
 func (seh1Distribution *SEH1Distribution) AddEntryWithUnit(value float64, weight float64, unit string) error {
 	if weight <= 0 {
-		return fmt.Errorf("weight must be larger than 0: %v", weight)
+		return fmt.Errorf("unsupported weight %v: %w", weight, distribution.ErrUnsupportedWeight)
 	}
 	if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
-		return fmt.Errorf("value cannot be negative, NaN, or Inf: %v", value)
+		return fmt.Errorf("unsupported value %v: %w", value, distribution.ErrUnsupportedValue)
 	}
 	//sample count
 	seh1Distribution.sampleCount += weight

--- a/metric/distribution/seh1/seh1_distribution_test.go
+++ b/metric/distribution/seh1/seh1_distribution_test.go
@@ -4,6 +4,8 @@
 package seh1
 
 import (
+	"errors"
+	"math"
 	"math/big"
 	"testing"
 
@@ -77,6 +79,10 @@ func TestSEH1Distribution(t *testing.T) {
 	//add distClone into another dist
 	anotherDist.AddDistribution(distClone)
 	assert.Equal(t, dist, anotherDist) //the direction of AddDistribution should not matter.
+
+	assert.Equal(t, errors.New("unsupported value: NaN"), anotherDist.AddEntry(math.NaN(), 1))
+	assert.Equal(t, errors.New("unsupported value: +Inf"), anotherDist.AddEntry(math.Inf(1), 1))
+	assert.Equal(t, errors.New("unsupported value: -Inf"), anotherDist.AddEntry(math.Inf(-1), 1))
 }
 
 func cloneSEH1Distribution(dist *SEH1Distribution) *SEH1Distribution {

--- a/metric/distribution/seh1/seh1_distribution_test.go
+++ b/metric/distribution/seh1/seh1_distribution_test.go
@@ -86,6 +86,8 @@ func TestSEH1Distribution(t *testing.T) {
 	assert.ErrorIs(t, anotherDist.AddEntry(math.NaN(), 1), distribution.ErrUnsupportedValue)
 	assert.ErrorIs(t, anotherDist.AddEntry(math.Inf(1), 1), distribution.ErrUnsupportedValue)
 	assert.ErrorIs(t, anotherDist.AddEntry(math.Inf(-1), 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(distribution.MaxValue*1.001, 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(distribution.MinValue*1.001, 1), distribution.ErrUnsupportedValue)
 }
 
 func cloneSEH1Distribution(dist *SEH1Distribution) *SEH1Distribution {

--- a/metric/distribution/seh1/seh1_distribution_test.go
+++ b/metric/distribution/seh1/seh1_distribution_test.go
@@ -80,9 +80,11 @@ func TestSEH1Distribution(t *testing.T) {
 	anotherDist.AddDistribution(distClone)
 	assert.Equal(t, dist, anotherDist) //the direction of AddDistribution should not matter.
 
-	assert.Equal(t, errors.New("unsupported value: NaN"), anotherDist.AddEntry(math.NaN(), 1))
-	assert.Equal(t, errors.New("unsupported value: +Inf"), anotherDist.AddEntry(math.Inf(1), 1))
-	assert.Equal(t, errors.New("unsupported value: -Inf"), anotherDist.AddEntry(math.Inf(-1), 1))
+	assert.Equal(t, errors.New("weight must be larger than 0: 0"), anotherDist.AddEntry(1, 0))
+	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: -1"), anotherDist.AddEntry(-1, 1))
+	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: NaN"), anotherDist.AddEntry(math.NaN(), 1))
+	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: +Inf"), anotherDist.AddEntry(math.Inf(1), 1))
+	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: -Inf"), anotherDist.AddEntry(math.Inf(-1), 1))
 }
 
 func cloneSEH1Distribution(dist *SEH1Distribution) *SEH1Distribution {

--- a/metric/distribution/seh1/seh1_distribution_test.go
+++ b/metric/distribution/seh1/seh1_distribution_test.go
@@ -4,12 +4,13 @@
 package seh1
 
 import (
-	"errors"
 	"math"
 	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/amazon-cloudwatch-agent/metric/distribution"
 )
 
 func TestSEH1Distribution(t *testing.T) {
@@ -80,11 +81,11 @@ func TestSEH1Distribution(t *testing.T) {
 	anotherDist.AddDistribution(distClone)
 	assert.Equal(t, dist, anotherDist) //the direction of AddDistribution should not matter.
 
-	assert.Equal(t, errors.New("weight must be larger than 0: 0"), anotherDist.AddEntry(1, 0))
-	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: -1"), anotherDist.AddEntry(-1, 1))
-	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: NaN"), anotherDist.AddEntry(math.NaN(), 1))
-	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: +Inf"), anotherDist.AddEntry(math.Inf(1), 1))
-	assert.Equal(t, errors.New("value cannot be negative, NaN, or Inf: -Inf"), anotherDist.AddEntry(math.Inf(-1), 1))
+	assert.ErrorIs(t, anotherDist.AddEntry(1, 0), distribution.ErrUnsupportedWeight)
+	assert.ErrorIs(t, anotherDist.AddEntry(-1, 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(math.NaN(), 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(math.Inf(1), 1), distribution.ErrUnsupportedValue)
+	assert.ErrorIs(t, anotherDist.AddEntry(math.Inf(-1), 1), distribution.ErrUnsupportedValue)
 }
 
 func cloneSEH1Distribution(dist *SEH1Distribution) *SEH1Distribution {

--- a/plugins/outputs/cloudwatch/aggregator.go
+++ b/plugins/outputs/cloudwatch/aggregator.go
@@ -147,7 +147,7 @@ func (durationAgg *durationAggregator) aggregating() {
 					if err != nil {
 						if errors.Is(err, distribution.ErrUnsupportedValue) {
 							log.Printf("W! err %s, metric %s", err, *m.MetricName)
-						} else if errors.Is(err, distribution.ErrUnsupportedWeight) {
+						} else {
 							log.Printf("D! err %s, metric %s", err, *m.MetricName)
 						}
 					}

--- a/plugins/outputs/cloudwatch/aggregator.go
+++ b/plugins/outputs/cloudwatch/aggregator.go
@@ -4,6 +4,7 @@
 package cloudwatch
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -144,7 +145,11 @@ func (durationAgg *durationAggregator) aggregating() {
 					m.distribution = distribution.NewDistribution()
 					err := m.distribution.AddEntryWithUnit(*m.Value, 1, *m.Unit)
 					if err != nil {
-						log.Printf("W! err %s, metric %s", err, *m.MetricName)
+						if errors.Is(err, distribution.ErrUnsupportedValue) {
+							log.Printf("W! err %s, metric %s", err, *m.MetricName)
+						} else if errors.Is(err, distribution.ErrUnsupportedWeight) {
+							log.Printf("D! err %s, metric %s", err, *m.MetricName)
+						}
 					}
 				}
 				// Else the first entry has a distribution, so do nothing.

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -399,7 +399,7 @@ func (c *CloudWatch) BuildMetricDatum(metric *aggregationDatum) []*cloudwatch.Me
 			continue
 		}
 		if len(distList) == 0 {
-			if math.IsNaN(*metric.Value) || math.IsInf(*metric.Value, 0) {
+			if math.IsNaN(*metric.Value) || math.IsInf(*metric.Value, 0) || !distribution.IsValueInRange(*metric.Value) {
 				log.Printf("E! metric (%s) has an unsupported value: %v, dropping it", *metric.MetricName, *metric.Value)
 				continue
 			}

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -6,7 +6,6 @@ package cloudwatch
 import (
 	"context"
 	"log"
-	"math"
 	"reflect"
 	"sort"
 	"sync"
@@ -399,7 +398,7 @@ func (c *CloudWatch) BuildMetricDatum(metric *aggregationDatum) []*cloudwatch.Me
 			continue
 		}
 		if len(distList) == 0 {
-			if math.IsNaN(*metric.Value) || math.IsInf(*metric.Value, 0) || !distribution.IsValueInRange(*metric.Value) {
+			if !distribution.IsSupportedValue(*metric.Value, distribution.MinValue, distribution.MaxValue) {
 				log.Printf("E! metric (%s) has an unsupported value: %v, dropping it", *metric.MetricName, *metric.Value)
 				continue
 			}

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -399,10 +399,9 @@ func (c *CloudWatch) BuildMetricDatum(metric *aggregationDatum) []*cloudwatch.Me
 			continue
 		}
 		if len(distList) == 0 {
-			value := *metric.Value
-			if math.IsNaN(value) || math.IsInf(value, 0) {
-				log.Printf("W! metric (%s) has an unsupported value: %v, setting it to 0", *metric.MetricName, value)
-				value = 0
+			if math.IsNaN(*metric.Value) || math.IsInf(*metric.Value, 0) {
+				log.Printf("E! metric (%s) has an unsupported value: %v, dropping it", *metric.MetricName, *metric.Value)
+				continue
 			}
 			// Not a distribution.
 			datum := &cloudwatch.MetricDatum{
@@ -411,7 +410,7 @@ func (c *CloudWatch) BuildMetricDatum(metric *aggregationDatum) []*cloudwatch.Me
 				Timestamp:         metric.Timestamp,
 				Unit:              metric.Unit,
 				StorageResolution: metric.StorageResolution,
-				Value:             aws.Float64(value),
+				Value:             metric.Value,
 			}
 			datums = append(datums, datum)
 		} else {

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -246,11 +246,7 @@ func TestBuildMetricDatum(t *testing.T) {
 				Value:      aws.Float64(testCase),
 			},
 		})
-		assert.Len(t, got, 1)
-		assert.Equal(t, &cloudwatch.MetricDatum{
-			MetricName: aws.String("test"),
-			Value:      aws.Float64(0),
-		}, got[0])
+		assert.Empty(t, got)
 	}
 }
 

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -235,10 +235,14 @@ func TestProcessRollup(t *testing.T) {
 	cw.Shutdown(context.Background())
 }
 
-func TestBuildMetricDatum(t *testing.T) {
+func TestBuildMetricDatumDropUnsupported(t *testing.T) {
 	svc := new(mockCloudWatchClient)
 	cw := newCloudWatchClient(svc, time.Second)
-	testCases := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
+	testCases := []float64{
+		math.NaN(),
+		math.Inf(1),
+		math.Inf(-1),
+	}
 	for _, testCase := range testCases {
 		got := cw.BuildMetricDatum(&aggregationDatum{
 			MetricDatum: cloudwatch.MetricDatum{

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/handlers/agentinfo"
 	"github.com/aws/amazon-cloudwatch-agent/internal/publisher"
+	"github.com/aws/amazon-cloudwatch-agent/metric/distribution"
 )
 
 // Return true if found.
@@ -242,6 +243,8 @@ func TestBuildMetricDatumDropUnsupported(t *testing.T) {
 		math.NaN(),
 		math.Inf(1),
 		math.Inf(-1),
+		distribution.MaxValue * 1.001,
+		distribution.MinValue * 1.001,
 	}
 	for _, testCase := range testCases {
 		got := cw.BuildMetricDatum(&aggregationDatum{

--- a/receiver/adapter/accumulator/accumulator.go
+++ b/receiver/adapter/accumulator/accumulator.go
@@ -190,7 +190,7 @@ func (o *otelAccumulator) modifyMetricAndConvertToOtelValue(m telegraf.Metric) (
 		// Convert all int,uint to int64 and float to float64 and bool to int.
 		otelValue, err := util.ToOtelValue(value)
 		if err != nil {
-			errs = multierr.Append(errs, fmt.Errorf("field (%s): %w", field, err))
+			errs = multierr.Append(errs, fmt.Errorf("field (%q): %w", field, err))
 		}
 
 		if otelValue == nil {

--- a/receiver/adapter/accumulator/accumulator_test.go
+++ b/receiver/adapter/accumulator/accumulator_test.go
@@ -235,13 +235,12 @@ func Test_ModifyMetricAndConvertMetricValue(t *testing.T) {
 				"cpu",
 				map[string]string{},
 				map[string]interface{}{
-					"client": "redis",
-					"nan":    math.NaN(),
+					"nan": math.NaN(),
 				},
 				time.Now(),
 				telegraf.Gauge,
 			),
-			wantErr: errors.New("empty metrics after converting fields: [client nan]"),
+			wantErr: errors.New("empty metrics after converting fields: [nan]"),
 		},
 		"WithValid": {
 			metric: testutil.MustMetric(

--- a/receiver/adapter/accumulator/accumulator_test.go
+++ b/receiver/adapter/accumulator/accumulator_test.go
@@ -4,7 +4,9 @@
 package accumulator
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"runtime"
 	"testing"
@@ -234,11 +236,12 @@ func Test_ModifyMetricAndConvertMetricValue(t *testing.T) {
 				map[string]string{},
 				map[string]interface{}{
 					"client": "redis",
+					"nan":    math.NaN(),
 				},
 				time.Now(),
 				telegraf.Gauge,
 			),
-			wantErr: errEmptyAfterConvert,
+			wantErr: errors.New("empty metrics after converting fields: [client nan]"),
 		},
 		"WithValid": {
 			metric: testutil.MustMetric(

--- a/receiver/adapter/accumulator/metrics_test.go
+++ b/receiver/adapter/accumulator/metrics_test.go
@@ -244,7 +244,8 @@ func Test_PopulateNumberDataPoint_WithDifferentValueType(t *testing.T) {
 	for _, tc := range test_cases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			otelValue := util.ToOtelValue(tc.telegrafDataPointValue)
+			otelValue, err := util.ToOtelValue(tc.telegrafDataPointValue)
+			as.NoError(err)
 			as.NotNil(otelValue)
 
 			switch v := tc.expectedOtelDataPointValue.(type) {


### PR DESCRIPTION
# Description of the issue
The CloudWatch Agent doesn't currently account for NaN or Inf values. When we have aggregation enabled, we will add these metrics to the distribution. When the regular distribution is [converted](https://github.com/aws/amazon-cloudwatch-agent/blob/main/plugins/outputs/cloudwatch/util.go#L87) into an SEH one, we're unable to retrieve the counts for the NaN value due to the way GoLang handles NaN lookups. This leads to an empty distribution list and the CloudWatch Agent creates the individual metric datum instead of the aggregate. CloudWatch does not support NaN values.

# Description of changes
- Drop NaN/Inf/Out of range values during OTEL conversion.
- Rejects NaN/Inf/Out of range values when they reach the distributions.
- Drop individual MetricDatums with NaN/Inf/Out of range values.

Matches https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html values restrictions.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




