### PR TITLE
Fix windows event logs to only starts once

### DIFF
--- a/plugins/inputs/windows_event_log/windows_event_log_test.go
+++ b/plugins/inputs/windows_event_log/windows_event_log_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestGetStateFilePathGood tests getStateFilePath with good input.
@@ -100,4 +102,22 @@ func TestGetStateFilePathSpecialChars(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected non-nil")
 	}
+}
+
+func TestWindowsDuplicateStart(t *testing.T) {
+	fileStateFolder := filepath.Join(t.TempDir(), "CloudWatchAgentTest")
+	plugin := Plugin{
+		FileStateFolder: fileStateFolder,
+	}
+	ec := EventConfig{
+		LogGroupName:  "My  Group/:::",
+		LogStreamName: "My::Stream//  ",
+		Name:          "System  Event//Log::",
+	}
+	plugin.Events = append(plugin.Events, ec)
+	require.Equal(t, 0, len(plugin.newEvents), "Start should be ran only once so there should be only 1 new event")
+	plugin.Start(nil)
+	require.Equal(t, 1, len(plugin.newEvents), "Start should be ran only once so there should be only 1 new event")
+	plugin.Start(nil)
+	require.Equal(t, 1, len(plugin.newEvents), "Start should be ran only once so there should be only 1 new event")
 }


### PR DESCRIPTION
# Description of the issue
Currently, when the agent start in windows both log agent and telegraf start the windows log event plugin. As a result, the the plugins generates duplicate logs.

# Description of changes
Changed the start function of the plugin to be exclusively ran once to avoid any duplicate plugin calls to be started.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Created and ran a units test this can be seen in  [TestWindowsDuplicateStart](https://github.com/aws/amazon-cloudwatch-agent/blob/95e3f82cafd164ddae91c9e30246187af8bb8484/plugins/inputs/windows_event_log/windows_event_log_test.go#L106)
Also ran integration test:  [this is the instance where there is only logs](https://github.com/aws/amazon-cloudwatch-agent-test/pull/346)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




