### PR TITLE
Prevent aggregate dimension duplicates.

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -502,13 +502,13 @@ func BuildDimensions(tagMap map[string]string) []*cloudwatch.Dimension {
 	return dimensions
 }
 
-func (c *CloudWatch) ProcessRollup(rawDimension []*cloudwatch.Dimension) [][]*cloudwatch.Dimension {
+func (c *CloudWatch) ProcessRollup(rawDimensions []*cloudwatch.Dimension) [][]*cloudwatch.Dimension {
 	rawDimensionMap := map[string]string{}
-	for _, v := range rawDimension {
+	for _, v := range rawDimensions {
 		rawDimensionMap[*v.Name] = *v.Value
 	}
 	targetDimensionsList := c.config.RollupDimensions
-	fullDimensionsList := [][]*cloudwatch.Dimension{rawDimension}
+	fullDimensionsList := [][]*cloudwatch.Dimension{rawDimensions}
 	for _, targetDimensions := range targetDimensionsList {
 		i := 0
 		extraDimensions := make([]*cloudwatch.Dimension, len(targetDimensions))
@@ -523,7 +523,7 @@ func (c *CloudWatch) ProcessRollup(rawDimension []*cloudwatch.Dimension) [][]*cl
 			}
 			i += 1
 		}
-		if i == len(targetDimensions) && !reflect.DeepEqual(rawDimension, extraDimensions) {
+		if i == len(targetDimensions) && len(targetDimensions) != len(rawDimensions) {
 			fullDimensionsList = append(fullDimensionsList, extraDimensions)
 		}
 	}

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -210,25 +210,41 @@ func TestBuildMetricDatumDropUnsupported(t *testing.T) {
 }
 
 func TestGetUniqueRollupList(t *testing.T) {
-	inputLists := [][]string{{"d1"}, {"d1"}, {"d2"}, {"d1"}}
-	actualLists := GetUniqueRollupList(inputLists)
-	expectedLists := [][]string{{"d1"}, {"d2"}}
-	assert.EqualValues(t, expectedLists, actualLists, "Duplicate list showed up")
-
-	inputLists = [][]string{{"d1", "d2", ""}}
-	actualLists = GetUniqueRollupList(inputLists)
-	expectedLists = [][]string{{"d1", "d2", ""}}
-	assert.EqualValues(t, expectedLists, actualLists, "Unique list should be same with input list")
-
-	inputLists = [][]string{{}, {}}
-	actualLists = GetUniqueRollupList(inputLists)
-	expectedLists = [][]string{{}}
-	assert.EqualValues(t, expectedLists, actualLists, "Unique list failed on empty list")
-
-	inputLists = [][]string{}
-	actualLists = GetUniqueRollupList(inputLists)
-	expectedLists = [][]string{}
-	assert.EqualValues(t, expectedLists, actualLists, "Unique list result should be empty")
+	testCases := map[string]struct {
+		input [][]string
+		want  [][]string
+	}{
+		"WithEmpty": {
+			input: [][]string{},
+			want:  [][]string{},
+		},
+		"WithSimple": {
+			input: [][]string{{"d1", "d2", ""}},
+			want:  [][]string{{"", "d1", "d2"}},
+		},
+		"WithDuplicates/NoDimension": {
+			input: [][]string{{}, {}},
+			want:  [][]string{{}},
+		},
+		"WithDuplicates/SingleDimension": {
+			input: [][]string{{"d1"}, {"d1"}, {"d2"}, {"d1"}},
+			want:  [][]string{{"d1"}, {"d2"}},
+		},
+		"WithDuplicates/DifferentOrder": {
+			input: [][]string{{"d2", "d1", "d3"}, {"d3", "d1", "d2"}, {"d3", "d2", "d1"}},
+			want:  [][]string{{"d1", "d2", "d3"}},
+		},
+		"WithDuplicates/WithinSets": {
+			input: [][]string{{"d1", "d1", "d2"}, {"d1", "d1"}, {"d2", "d1"}, {"d1"}},
+			want:  [][]string{{"d1", "d2"}, {"d1"}},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := GetUniqueRollupList(testCase.input)
+			assert.EqualValues(t, testCase.want, got)
+		})
+	}
 }
 
 func TestIsDropping(t *testing.T) {

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -100,10 +100,10 @@ func TestProcessRollup(t *testing.T) {
 		publisher.NewNonBlockingFifoQueue(10),
 		10,
 		2*time.Second,
-		cw.WriteToCloudWatch)
-	cw.config.RollupDimensions = [][]string{{"d1", "d2"}, {"d1"}, {}, {"d4"}}
+		cw.WriteToCloudWatch,
+	)
 
-	rawDimension := []*cloudwatch.Dimension{
+	testRawDimensions := []*cloudwatch.Dimension{
 		{
 			Name:  aws.String("d1"),
 			Value: aws.String("v1"),
@@ -118,122 +118,74 @@ func TestProcessRollup(t *testing.T) {
 		},
 	}
 
-	actualDimensionList := cw.ProcessRollup(rawDimension)
-	expectedDimensionList := [][]*cloudwatch.Dimension{
-		{
-			{
-				Name:  aws.String("d1"),
-				Value: aws.String("v1"),
-			},
-			{
-				Name:  aws.String("d2"),
-				Value: aws.String("v2"),
-			},
-			{
-				Name:  aws.String("d3"),
-				Value: aws.String("v3"),
-			},
-		},
-		{
-			{
-				Name:  aws.String("d1"),
-				Value: aws.String("v1"),
-			},
-			{
-				Name:  aws.String("d2"),
-				Value: aws.String("v2"),
-			},
-		},
-		{
-			{
-				Name:  aws.String("d1"),
-				Value: aws.String("v1"),
+	testCases := map[string]struct {
+		rollupDimensions [][]string
+		rawDimensions    []*cloudwatch.Dimension
+		want             [][]*cloudwatch.Dimension
+	}{
+		"WithSimpleRollup": {
+			rollupDimensions: [][]string{{"d1", "d2"}, {"d1"}, {}, {"d4"}},
+			rawDimensions:    testRawDimensions,
+			want: [][]*cloudwatch.Dimension{
+				testRawDimensions,
+				{
+					{
+						Name:  aws.String("d1"),
+						Value: aws.String("v1"),
+					},
+					{
+						Name:  aws.String("d2"),
+						Value: aws.String("v2"),
+					},
+				},
+				{
+					{
+						Name:  aws.String("d1"),
+						Value: aws.String("v1"),
+					},
+				},
+				{},
 			},
 		},
-		{},
-	}
-	assert.EqualValues(t, expectedDimensionList, actualDimensionList, "Unexpected dimension roll up list")
-
-	cw.config.RollupDimensions = [][]string{}
-	rawDimension = []*cloudwatch.Dimension{
-		{
-			Name:  aws.String("d1"),
-			Value: aws.String("v1"),
+		"WithNoRollupConfig": {
+			rollupDimensions: [][]string{},
+			rawDimensions:    testRawDimensions,
+			want:             [][]*cloudwatch.Dimension{testRawDimensions},
 		},
-		{
-			Name:  aws.String("d2"),
-			Value: aws.String("v2"),
+		"WithNoRawDimensions": {
+			rollupDimensions: [][]string{{"d1", "d2"}, {"d1"}, {}},
+			rawDimensions:    []*cloudwatch.Dimension{},
+			want:             [][]*cloudwatch.Dimension{{}},
 		},
-		{
-			Name:  aws.String("d3"),
-			Value: aws.String("v3"),
+		"WithDuplicate/SameOrder": {
+			rollupDimensions: [][]string{{"d1", "d2", "d3"}},
+			rawDimensions:    testRawDimensions,
+			want:             [][]*cloudwatch.Dimension{testRawDimensions},
 		},
-	}
-
-	actualDimensionList = cw.ProcessRollup(rawDimension)
-	expectedDimensionList = [][]*cloudwatch.Dimension{
-		{
-			{
-				Name:  aws.String("d1"),
-				Value: aws.String("v1"),
-			},
-			{
-				Name:  aws.String("d2"),
-				Value: aws.String("v2"),
-			},
-			{
-				Name:  aws.String("d3"),
-				Value: aws.String("v3"),
-			},
+		"WithDuplicate/DifferentOrder": {
+			rollupDimensions: [][]string{{"d2", "d1", "d3"}},
+			rawDimensions:    testRawDimensions,
+			want:             [][]*cloudwatch.Dimension{testRawDimensions},
+		},
+		"WithSameLength/DifferentNames": {
+			rollupDimensions: [][]string{{"d1", "d3", "d4"}},
+			rawDimensions:    testRawDimensions,
+			want:             [][]*cloudwatch.Dimension{testRawDimensions},
+		},
+		"WithExtraDimensions": {
+			rollupDimensions: [][]string{{"d1", "d2", "d3", "d4"}},
+			rawDimensions:    testRawDimensions,
+			want:             [][]*cloudwatch.Dimension{testRawDimensions},
 		},
 	}
-	assert.EqualValues(t, expectedDimensionList, actualDimensionList, "Unexpected dimension roll up list without rollup setting")
-
-	cw.config.RollupDimensions = [][]string{{"d1", "d2"}, {"d1"}, {}}
-	rawDimension = []*cloudwatch.Dimension{}
-
-	actualDimensionList = cw.ProcessRollup(rawDimension)
-	expectedDimensionList = [][]*cloudwatch.Dimension{
-		{},
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cw.config.RollupDimensions = testCase.rollupDimensions
+			got := cw.ProcessRollup(testCase.rawDimensions)
+			assert.EqualValues(t, testCase.want, got, "Unexpected dimension roll up list")
+		})
 	}
-	assert.EqualValues(t, expectedDimensionList, actualDimensionList, "Unexpected dimension roll up list with no raw dimensions")
-
-	cw.config.RollupDimensions = [][]string{{"d1", "d2", "d3"}}
-	rawDimension = []*cloudwatch.Dimension{
-		{
-			Name:  aws.String("d1"),
-			Value: aws.String("v1"),
-		},
-		{
-			Name:  aws.String("d2"),
-			Value: aws.String("v2"),
-		},
-		{
-			Name:  aws.String("d3"),
-			Value: aws.String("v3"),
-		},
-	}
-
-	actualDimensionList = cw.ProcessRollup(rawDimension)
-	expectedDimensionList = [][]*cloudwatch.Dimension{
-		{
-			{
-				Name:  aws.String("d1"),
-				Value: aws.String("v1"),
-			},
-			{
-				Name:  aws.String("d2"),
-				Value: aws.String("v2"),
-			},
-			{
-				Name:  aws.String("d3"),
-				Value: aws.String("v3"),
-			},
-		},
-	}
-	assert.EqualValues(t, expectedDimensionList, actualDimensionList,
-		"Unexpected dimension roll up list with duplicate roll up")
-	cw.Shutdown(context.Background())
+	assert.NoError(t, cw.Shutdown(context.Background()))
 }
 
 func TestBuildMetricDatumDropUnsupported(t *testing.T) {


### PR DESCRIPTION
# Description of the issue
Closes https://github.com/aws/amazon-cloudwatch-agent/issues/672

When we create the aggregate dimensions in `ProcessRollup`, we have a check to prevent duplicate dimension sets from occurring. The [reflect.DeepEqual](https://pkg.go.dev/reflect#DeepEqual) comparison requires the order to be the same.
> Slice values are deeply equal when all of the following are true: they are both nil or both non-nil, they have the same length, and either they point to the same initial entry of the same underlying array (that is, &x[0] == &y[0]) or their corresponding elements (up to length) are deeply equal. Note that a non-nil empty slice and a nil slice (for example, []byte{} and []byte(nil)) are not deeply equal. 

This means that if the metric has dimensions `[a, b, c]` and the configuration is `[[a, c, b]]`, then we'll get `[[a, b, c], [a, c, b]]` as the resulting aggregate dimensions (original and configured). This results in duplicate metrics/dimension combinations being sent to CloudWatch.

# Description of changes
Skip dimension aggregations that have the same number of dimensions as the original metric. There are two scenarios in this case: either the same dimensions have been specified in the aggregate dimensions or a dimension that does not exist for the metric is being specified. Either way, that combination can be dropped from the aggregation.

Update `GetUniqueRollupList` to also account for duplicates and ignore order within the dimension sets, so `[[a, a, b]]` and `[[b, a]]` is equivalent to `[[a, b]]`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added tests for different ordered aggregate dimensions configuration.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




