### PR TITLE
Replace stanza package to include concurrent decode bug fix.

### DIFF
--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -64,6 +64,8 @@ jobs:
           go mod tidy
           go mod edit -replace github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws=github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws@${{ steps.get-latest-commit.outputs.sha }}
           go mod tidy
+          go mod edit -replace github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/stanza=github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/stanza@${{ steps.get-latest-commit.outputs.sha }}
+          go mod tidy
           git commit -am "Update OTel fork components to https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${{ steps.get-latest-commit.outputs.sha }}"
           git push -u origin HEAD
           git config --global --unset user.name

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/c
 // Replace with contrib to revert upstream change https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20519
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus => github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/translator/prometheus v0.0.0-20230906164155-ced73ba61d63
 
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20230906164155-ced73ba61d63
+
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20230906164155-ced73ba61d63
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-20230906164155-ced73ba61d63

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/xray
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/xray v0.0.0-20230906164155-ced73ba61d63/go.mod h1:6Vwl/+yXrD21CtE1emsNFeaAW0cq5GbY+HlXaILADh4=
 github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws v0.0.0-20230906164155-ced73ba61d63 h1:fcaOqpQRygoR24gQMXtowm3OHKCuiySr590OHii30oA=
 github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws v0.0.0-20230906164155-ced73ba61d63/go.mod h1:F5l/VuHtB8418NLJEsHeYz/pni6sWtOMR/SM6mgarhQ=
+github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20230906164155-ced73ba61d63 h1:/1L3AJjyZpGnKE0imFd2smlvm4rumtGBYhGccgK4KrA=
+github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20230906164155-ced73ba61d63/go.mod h1:nENVAU79yHGHoCe+pUHvYUy5LR+CHeFvhBkfRcNjRZ8=
 github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/translator/prometheus v0.0.0-20230906164155-ced73ba61d63 h1:LwzRYmnc6iErbspiZfUExezibLNDIe4Rff4CdhmyH0k=
 github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/translator/prometheus v0.0.0-20230906164155-ced73ba61d63/go.mod h1:UHT79wwd4bjA5Z7hQ9Cx6vbr5Pr7HK+PNLeOMt15+m8=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20230906164155-ced73ba61d63 h1:ADezb0grCo4h3Qe7RBivN3pDLq9oZDZ1lhnzRgwrIzs=
@@ -974,8 +976,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.79.0 
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.79.0/go.mod h1:/wfeJfzu3oAkC2boitFR3dZcnwNtwzryI/SW1LIhDLo=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.79.0 h1:R9lB4lMuDaCJP9l6SiOA9u0GPJm5nV5Fefb9cPo9gZQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.79.0/go.mod h1:KBcxvUZWwgSPwdH3oOub7NGNnwu673UdMDXtgn9xjvU=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.77.0 h1:UGgb2bYSrRTbCcLNEOc4ZCbKx2H1uwkKR+FpffQ7d0o=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.77.0/go.mod h1:nENVAU79yHGHoCe+pUHvYUy5LR+CHeFvhBkfRcNjRZ8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.77.0 h1:0YjNtrlIwAi4YQ5uznZbgZytsO7eTPB1NZGh/Xuv6dU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.77.0 h1:CFTeCIKxPyypJcH5ZhthAfV93pbi5huF44NEftABnjk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.77.0 h1:/6aMxOY14YS3xbm+HuxXI8NFxTnmRHwLf5CARLEzzDw=


### PR DESCRIPTION
# Description of the issue
We made the fix for the concurrent decode bug in `pkg/stanza` as part of https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/72, but never added a replace directive in our go.mod to include the change in the agent.

# Description of changes
Adds the replace in the go.mod and added it to the `otel-fork-replace.yml` workflow.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran an EMF generator with 10 connections/10 threads/~500ms between messages.

`v1.300026.3` saw corrupted messages after a couple minutes.

![image](https://github.com/aws/amazon-cloudwatch-agent/assets/84729962/fa326251-eaa2-4bb8-94f7-29b247351443)

Built the agent and ran the generator for over an hour. No longer saw corrupted messages.

![image](https://github.com/aws/amazon-cloudwatch-agent/assets/84729962/a6111f09-1ad0-4d68-9575-1f935c6b4936)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




