### PR TITLE
Add the from_beginning property value to schema.json

### DIFF
--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -645,6 +645,9 @@
                   "auto_removal": {
                     "type": "boolean"
                   },
+                  "from_beginning": {
+                    "type": "boolean"
+                  },
                   "blacklist": {
                     "type": "string",
                     "minLength": 1,


### PR DESCRIPTION
# Description of the issue
Error 'Additional property from_beginning is not allowed' in fetch-config after adding `from_beginning` property value to `logs.logs_collected.files.collect_list` field in amazon-cloudwatch-agent.json file

### *Expected Behaviour*
After adding the from_beginning value to the `logs.logs_collected.files.collect_list` field, fetch-config should validate the property value and work correctly.

### *Actual Behaviour*
Error 'Additional property from_beginning is not allowed'.    
```bash
I! Trying to detect region from ec2 D! [EC2] Found active network interface Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_amazon-cloudwatch-agent.json.tmp
Start configuration validation...
2023/09/22 16:11:12 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_amazon-cloudwatch-agent.json.tmp ...
2023/09/22 16:11:12 E! Invalid Json input schema.
2023/09/22 16:11:12 E! Invalid Json input schema.
2023/09/22 16:11:12 Under path : /logs/logs_collected/files/collect_list/1 | Error : Additional property from_beginning is not allowed
2023/09/22 16:11:12 Configuration validation first phase failed. Agent version: 1.0. Verify the JSON input is only using features supported by this version.
```

# Description of changes
Add a map to the `translator/config/schema.json` file to recognize the value of the from_beginning property

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. modify schema.json    
2. build
    ```bash
    make amazon-cloudwatch-agent-linux package-rpm
    ```
    
3. install the package
    
    ```bash
    cd ./build/bin/linux/amd64/
    rpm -Uvh amazon-cloudwatch-agent.rpm
    ```
    
4. add `from_beginning` property and restart
    
    ```bash
    > cat <<EOF > /home/ec2-user/amazon-cloudwatch-agent.json
    {
      "logs": {
        "logs_collected": {
          "files": {
            "collect_list": [
              {
                "file_path": "/home/ec2-user/logs/*.log",
                "log_group_name": "/example",
                "from_beginning": False,
                "retention_in_days": 30
              }
            ]
          }
        }
      }
    }
    EOF
    
    > sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/home/ec2-user/amazon-cloudwatch-agent.json
    ```
    
5. verify the toml file
    
    ```toml
    > cd /opt/aws/amazon-cloudwatch-agent/etc
    > cat amazon-cloudwatch-agent.toml
    
    (omit...)
    [inputs]
    
      [[inputs.logfile]]
        destination = "cloudwatchlogs"
        file_state_folder = "/opt/aws/amazon-cloudwatch-agent/logs/state"
    
        [[inputs.logfile.file_config]]
          file_path = "/home/ec2-user/logs/*.log"
          from_beginning = false
          log_group_name = "/example"
          pipe = false
          retention_in_days = 30
    ```
    
 Make sure the from_beginning value is applied as `false` instead of the default `true`.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




