### PR TITLE
update enhanced CI metrics and aggregations and update tests

### DIFF
--- a/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
@@ -4,7 +4,7 @@ exporters:
     certificate_file_path: ""
     emf_only: true
     endpoint: "https://fake_endpoint"
-    "imds_retries": 1
+    imds_retries: 1
     local_mode: false
     log_group_name: emf/logs/default
     log_retention: 0
@@ -42,7 +42,7 @@ exporters:
     certificate_file_path: ""
     endpoint: ""
     enhanced_container_insights: false
-    "imds_retries": 1
+    imds_retries: 1
     local_mode: false
     retain_initial_value_of_delta_metric: false
     parse_json_encoded_attr_values: [ Sources, kubernetes ]
@@ -144,7 +144,7 @@ receivers:
     enable_control_plane_metrics: false
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 1
+    imds_retries: 1
     prefer_full_pod_name: true
     leader_lock_name: cwagent-clusterleader
     leader_lock_using_config_map_only: true

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -20,7 +20,7 @@ exporters:
         emf_only: true
         certificate_file_path: ""
         endpoint: "https://logs-fips.us-west-2.amazonaws.com"
-        "imds_retries": 1
+        imds_retries: 1
         local_mode: false
         log_group_name: emf/logs/default
         log_retention: 0
@@ -49,7 +49,7 @@ exporters:
         aws_log_groups: []
         certificate_file_path: ""
         endpoint: https://x-ray-endpoint.us-west-2.amazonaws.com
-        "imds_retries": 1
+        imds_retries: 1
         index_all_attributes: false
         indexed_attributes: []
         local_mode: true

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -23,7 +23,7 @@ exporters:
         emf_only: true
         certificate_file_path: ""
         endpoint: "https://logs-fips.us-west-2.amazonaws.com"
-        "imds_retries": 1
+        imds_retries: 1
         local_mode: false
         log_group_name: emf/logs/default
         log_retention: 0
@@ -52,7 +52,7 @@ exporters:
         aws_log_groups: []
         certificate_file_path: ""
         endpoint: https://x-ray-endpoint.us-west-2.amazonaws.com
-        "imds_retries": 1
+        imds_retries: 1
         index_all_attributes: false
         indexed_attributes: []
         local_mode: true

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
@@ -20,7 +20,7 @@ exporters:
         certificate_file_path: ""
         emf_only: true
         endpoint: "https://logs-fips.us-west-2.amazonaws.com"
-        "imds_retries": 1
+        imds_retries: 1
         local_mode: false
         log_group_name: emf/logs/default
         log_retention: 0
@@ -49,7 +49,7 @@ exporters:
         aws_log_groups: []
         certificate_file_path: ""
         endpoint: https://x-ray-endpoint.us-west-2.amazonaws.com
-        "imds_retries": 1
+        imds_retries: 1
         index_all_attributes: false
         indexed_attributes: []
         local_mode: true

--- a/translator/tocwconfig/sampleConfig/config_with_env.yaml
+++ b/translator/tocwconfig/sampleConfig/config_with_env.yaml
@@ -4,7 +4,7 @@ exporters:
     certificate_file_path: ""
     emf_only: true
     endpoint: ""
-    "imds_retries": 1
+    imds_retries: 1
     local_mode: false
     log_group_name: emf/logs/default
     log_retention: 0

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -4,7 +4,7 @@ exporters:
     emf_only: true
     certificate_file_path: ""
     endpoint: "https://fake_endpoint"
-    "imds_retries": 2
+    imds_retries: 2
     local_mode: false
     log_group_name: emf/logs/default
     log_retention: 0
@@ -36,8 +36,8 @@ exporters:
     eks_fargate_container_insights_enabled: false
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 2
     enhanced_container_insights: true
+    imds_retries: 2
     local_mode: false
     log_group_name: /aws/containerinsights/{ClusterName}/performance
     log_retention: 0
@@ -53,11 +53,20 @@ exporters:
           - container_memory_utilization
           - container_memory_utilization_over_container_limit
           - container_memory_failures_total
+          - container_memory_limit
+          - container_memory_request
           - container_filesystem_usage
+          - container_filesystem_available
+          - container_filesystem_utilization
           - container_status_running
           - container_status_terminated
           - container_status_waiting
-          - container_status_waiting_reason_crashed
+          - container_status_waiting_reason_crash_loop_back_off
+          - container_status_waiting_reason_image_pull_error
+          - container_status_waiting_reason_start_error
+          - container_status_waiting_reason_create_container_error
+          - container_status_waiting_reason_create_container_config_error
+          - container_status_terminated_reason_oom_killed
       # pod metrics
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
         label_matchers: [ ]
@@ -72,9 +81,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - pod_interface_network_rx_dropped
-          - pod_interface_network_rx_errors
           - pod_interface_network_tx_dropped
-          - pod_interface_network_tx_errors
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, Service ] ]
         label_matchers: []
         metric_name_selectors:
@@ -90,6 +97,8 @@ exporters:
           - pod_status_failed
           - pod_status_unknown
           - pod_status_succeeded
+          - pod_memory_request
+          - pod_memory_limit
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]
@@ -117,9 +126,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - node_interface_network_rx_dropped
-          - node_interface_network_rx_errors
           - node_interface_network_tx_dropped
-          - node_interface_network_tx_errors
           - node_diskio_io_service_bytes_total
           - node_diskio_io_serviced_total
       # node fs metrics
@@ -164,30 +171,83 @@ exporters:
       - dimensions: [ [ClusterName, endpoint], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
+          - apiserver_storage_size_bytes
+          - apiserver_storage_size_bytes
           - etcd_db_total_size_in_bytes
+          - etcd_request_duration_seconds
       - dimensions: [ [ClusterName, resource], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_list_duration_seconds
-      - dimensions: [ [ClusterName, priority_level], [ ClusterName ] ]
+          - apiserver_longrunning_requests
+          - apiserver_storage_objects
+      - dimensions: [ [ClusterName, verb], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_request_duration_seconds
+          - rest_client_request_duration_seconds
+      - dimensions: [ [ClusterName, code, verb], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_request_total
+          - apiserver_request_total_5xx
+      - dimensions: [ [ClusterName, operation], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_admission_controller_admission_duration_seconds
+          - apiserver_admission_step_admission_duration_seconds
+          - etcd_request_duration_seconds
+      - dimensions: [ [ClusterName, code, method], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - rest_client_requests_total
+      - dimensions: [ [ClusterName, request_kind], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_current_inflight_requests
+      - dimensions: [ [ClusterName, name], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_admission_webhook_admission_duration_seconds
+      - dimensions: [ [ClusterName, group], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_requested_deprecated_apis
+      - dimensions: [ [ClusterName, reason], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_flowcontrol_rejected_requests_total
+      - dimensions: [ [ ClusterName, priority_level ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_flowcontrol_request_concurrency_limit
-      - dimensions: [ [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_objects
-          - apiserver_request_total
-          - apiserver_request_total_5xx
-          - apiserver_request_duration_seconds
-          - apiserver_admission_controller_admission_duration_seconds
-          - rest_client_request_duration_seconds
-          - rest_client_requests_total
-          - etcd_request_duration_seconds
-          - apiserver_flowcontrol_rejected_requests_total
     metric_descriptors:
-          - metric_name: apiserver_storage_objects
+          - metric_name: apiserver_admission_controller_admission_duration_seconds
+            unit: Seconds
+            overwrite: true
+          - metric_name: apiserver_admission_step_admission_duration_seconds
+            unit: Seconds
+            overwrite: true
+          - metric_name: apiserver_admission_webhook_admission_duration_seconds
+            unit: Seconds
+            overwrite: true
+          - metric_name: apiserver_current_inflight_requests
             unit: Count
+            overwrite: true
+          - metric_name: apiserver_current_inqueue_requests
+            unit: Count
+            overwrite: true
+          - metric_name: apiserver_flowcontrol_rejected_requests_total
+            unit: Count
+            overwrite: true
+          - metric_name: apiserver_flowcontrol_request_concurrency_limit
+            unit: Count
+            overwrite: true
+          - metric_name: apiserver_longrunning_requests
+            unit: Count
+            overwrite: true
+          - metric_name: apiserver_request_duration_seconds
+            unit: Seconds
             overwrite: true
           - metric_name: apiserver_request_total
             unit: Count
@@ -195,25 +255,34 @@ exporters:
           - metric_name: apiserver_request_total_5xx
             unit: Count
             overwrite: true
-          - metric_name: apiserver_request_duration_seconds
+          - metric_name: apiserver_storage_objects
+            unit: Count
+            overwrite: true
+          - metric_name: etcd_request_duration_seconds
             unit: Seconds
             overwrite: true
-          - metric_name: apiserver_admission_controller_admission_duration_seconds
+          - metric_name: apiserver_storage_list_duration_seconds
+            unit: Seconds
+            overwrite: true
+          - metric_name: apiserver_storage_objects
+            unit: Count
+            overwrite: true
+          - metric_name: apiserver_storage_db_total_size_in_bytes
+            unit: Bytes
+            overwrite: true
+          - metric_name: apiserver_storage_size_bytes
+            unit: Bytes
+            overwrite: true
+          - metric_name: etcd_db_total_size_in_bytes
+            unit: Bytes
+            overwrite: true
+          - metric_name: etcd_request_duration_seconds
             unit: Seconds
             overwrite: true
           - metric_name: rest_client_request_duration_seconds
             unit: Seconds
             overwrite: true
           - metric_name: rest_client_requests_total
-            unit: Count
-            overwrite: true
-          - metric_name: etcd_request_duration_seconds
-            unit: Seconds
-            overwrite: true
-          - metric_name: apiserver_flowcontrol_rejected_requests_total
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_flowcontrol_request_concurrency_limit
             unit: Count
             overwrite: true
     namespace: ContainerInsights
@@ -270,7 +339,7 @@ receivers:
     enable_control_plane_metrics: true
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 2
+    imds_retries: 2
     leader_lock_name: cwagent-clusterleader
     leader_lock_using_config_map_only: true
     local_mode: false

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -7,8 +7,8 @@ exporters:
     disable_metric_extraction: true
     eks_fargate_container_insights_enabled: false
     endpoint: ""
-    "imds_retries": 1
     enhanced_container_insights: true
+    imds_retries: 1
     local_mode: false
     log_group_name: /aws/containerinsights/{ClusterName}/performance
     log_retention: 0
@@ -24,11 +24,20 @@ exporters:
           - container_memory_utilization
           - container_memory_utilization_over_container_limit
           - container_memory_failures_total
+          - container_memory_limit
+          - container_memory_request
           - container_filesystem_usage
+          - container_filesystem_available
+          - container_filesystem_utilization
           - container_status_running
           - container_status_terminated
           - container_status_waiting
-          - container_status_waiting_reason_crashed
+          - container_status_waiting_reason_crash_loop_back_off
+          - container_status_waiting_reason_image_pull_error
+          - container_status_waiting_reason_start_error
+          - container_status_waiting_reason_create_container_error
+          - container_status_waiting_reason_create_container_config_error
+          - container_status_terminated_reason_oom_killed
       # pod metrics
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
         label_matchers: [ ]
@@ -43,11 +52,9 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - pod_interface_network_rx_dropped
-          - pod_interface_network_rx_errors
           - pod_interface_network_tx_dropped
-          - pod_interface_network_tx_errors
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, Service ] ]
-        label_matchers: []
+        label_matchers: [ ]
         metric_name_selectors:
           - pod_cpu_reserved_capacity
           - pod_memory_reserved_capacity
@@ -61,6 +68,8 @@ exporters:
           - pod_status_failed
           - pod_status_unknown
           - pod_status_succeeded
+          - pod_memory_request
+          - pod_memory_limit
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]
@@ -88,9 +97,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - node_interface_network_rx_dropped
-          - node_interface_network_rx_errors
           - node_interface_network_tx_dropped
-          - node_interface_network_tx_errors
           - node_diskio_io_service_bytes_total
           - node_diskio_io_serviced_total
       # node fs metrics
@@ -132,33 +139,86 @@ exporters:
           - cluster_failed_node_count
           - cluster_number_of_running_pods
       # control plane metrics
-      - dimensions: [ [ClusterName, endpoint], [ ClusterName ] ]
+      - dimensions: [ [ ClusterName, endpoint ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
+          - apiserver_storage_size_bytes
+          - apiserver_storage_size_bytes
           - etcd_db_total_size_in_bytes
-      - dimensions: [ [ClusterName, resource], [ ClusterName ] ]
+          - etcd_request_duration_seconds
+      - dimensions: [ [ ClusterName, resource ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_list_duration_seconds
-      - dimensions: [ [ClusterName, priority_level], [ ClusterName ] ]
+          - apiserver_longrunning_requests
+          - apiserver_storage_objects
+      - dimensions: [ [ ClusterName, verb ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_request_duration_seconds
+          - rest_client_request_duration_seconds
+      - dimensions: [ [ ClusterName, code, verb ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_request_total
+          - apiserver_request_total_5xx
+      - dimensions: [ [ ClusterName, operation ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_admission_controller_admission_duration_seconds
+          - apiserver_admission_step_admission_duration_seconds
+          - etcd_request_duration_seconds
+      - dimensions: [ [ ClusterName, code, method ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - rest_client_requests_total
+      - dimensions: [ [ ClusterName, request_kind ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_current_inflight_requests
+      - dimensions: [ [ ClusterName, name ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_admission_webhook_admission_duration_seconds
+      - dimensions: [ [ ClusterName, group ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_requested_deprecated_apis
+      - dimensions: [ [ ClusterName, reason ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_flowcontrol_rejected_requests_total
+      - dimensions: [ [ ClusterName, priority_level ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_flowcontrol_request_concurrency_limit
-      - dimensions: [ [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_objects
-          - apiserver_request_total
-          - apiserver_request_total_5xx
-          - apiserver_request_duration_seconds
-          - apiserver_admission_controller_admission_duration_seconds
-          - rest_client_request_duration_seconds
-          - rest_client_requests_total
-          - etcd_request_duration_seconds
-          - apiserver_flowcontrol_rejected_requests_total
     metric_descriptors:
-      - metric_name: apiserver_storage_objects
+      - metric_name: apiserver_admission_controller_admission_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_admission_step_admission_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_admission_webhook_admission_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_current_inflight_requests
         unit: Count
+        overwrite: true
+      - metric_name: apiserver_current_inqueue_requests
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_flowcontrol_rejected_requests_total
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_flowcontrol_request_concurrency_limit
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_longrunning_requests
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_request_duration_seconds
+        unit: Seconds
         overwrite: true
       - metric_name: apiserver_request_total
         unit: Count
@@ -166,25 +226,34 @@ exporters:
       - metric_name: apiserver_request_total_5xx
         unit: Count
         overwrite: true
-      - metric_name: apiserver_request_duration_seconds
+      - metric_name: apiserver_storage_objects
+        unit: Count
+        overwrite: true
+      - metric_name: etcd_request_duration_seconds
         unit: Seconds
         overwrite: true
-      - metric_name: apiserver_admission_controller_admission_duration_seconds
+      - metric_name: apiserver_storage_list_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_storage_objects
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_storage_db_total_size_in_bytes
+        unit: Bytes
+        overwrite: true
+      - metric_name: apiserver_storage_size_bytes
+        unit: Bytes
+        overwrite: true
+      - metric_name: etcd_db_total_size_in_bytes
+        unit: Bytes
+        overwrite: true
+      - metric_name: etcd_request_duration_seconds
         unit: Seconds
         overwrite: true
       - metric_name: rest_client_request_duration_seconds
         unit: Seconds
         overwrite: true
       - metric_name: rest_client_requests_total
-        unit: Count
-        overwrite: true
-      - metric_name: etcd_request_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_flowcontrol_rejected_requests_total
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_flowcontrol_request_concurrency_limit
         unit: Count
         overwrite: true
     namespace: ContainerInsights
@@ -235,7 +304,7 @@ receivers:
     container_orchestrator: eks
     enable_control_plane_metrics: true
     endpoint: ""
-    "imds_retries": 1
+    imds_retries: 1
     leader_lock_name: cwagent-clusterleader
     leader_lock_using_config_map_only: true
     local_mode: true

--- a/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
+++ b/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
@@ -4,7 +4,7 @@ exporters:
     emf_only: true
     certificate_file_path: ""
     endpoint: "https://fake_endpoint"
-    "imds_retries": 1
+    imds_retries: 1
     local_mode: false
     log_group_name: emf/logs/default
     log_retention: 0
@@ -36,7 +36,7 @@ exporters:
     eks_fargate_container_insights_enabled: false
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 1
+    imds_retries: 1
     enhanced_container_insights: false
     local_mode: false
     log_group_name: /aws/ecs/containerinsights/{ClusterName}/performance
@@ -115,7 +115,7 @@ receivers:
     enable_control_plane_metrics: false
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 1
+    imds_retries: 1
     leader_lock_name: otel-container-insight-clusterleader
     leader_lock_using_config_map_only: false
     local_mode: false

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -53,11 +53,20 @@ exporters:
           - container_memory_utilization
           - container_memory_utilization_over_container_limit
           - container_memory_failures_total
+          - container_memory_limit
+          - container_memory_request
           - container_filesystem_usage
+          - container_filesystem_available
+          - container_filesystem_utilization
           - container_status_running
           - container_status_terminated
           - container_status_waiting
-          - container_status_waiting_reason_crashed
+          - container_status_waiting_reason_crash_loop_back_off
+          - container_status_waiting_reason_image_pull_error
+          - container_status_waiting_reason_start_error
+          - container_status_waiting_reason_create_container_error
+          - container_status_waiting_reason_create_container_config_error
+          - container_status_terminated_reason_oom_killed
       # pod metrics
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
         label_matchers: [ ]
@@ -72,11 +81,9 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - pod_interface_network_rx_dropped
-          - pod_interface_network_rx_errors
           - pod_interface_network_tx_dropped
-          - pod_interface_network_tx_errors
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, Service ] ]
-        label_matchers: []
+        label_matchers: [ ]
         metric_name_selectors:
           - pod_cpu_reserved_capacity
           - pod_memory_reserved_capacity
@@ -90,6 +97,8 @@ exporters:
           - pod_status_failed
           - pod_status_unknown
           - pod_status_succeeded
+          - pod_memory_request
+          - pod_memory_limit
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]
@@ -117,9 +126,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - node_interface_network_rx_dropped
-          - node_interface_network_rx_errors
           - node_interface_network_tx_dropped
-          - node_interface_network_tx_errors
           - node_diskio_io_service_bytes_total
           - node_diskio_io_serviced_total
       # node fs metrics
@@ -161,33 +168,86 @@ exporters:
           - cluster_failed_node_count
           - cluster_number_of_running_pods
       # control plane metrics
-      - dimensions: [ [ClusterName, endpoint], [ ClusterName ] ]
+      - dimensions: [ [ ClusterName, endpoint ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
+          - apiserver_storage_size_bytes
+          - apiserver_storage_size_bytes
           - etcd_db_total_size_in_bytes
-      - dimensions: [ [ClusterName, resource], [ ClusterName ] ]
+          - etcd_request_duration_seconds
+      - dimensions: [ [ ClusterName, resource ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_list_duration_seconds
-      - dimensions: [ [ClusterName, priority_level], [ ClusterName ] ]
+          - apiserver_longrunning_requests
+          - apiserver_storage_objects
+      - dimensions: [ [ ClusterName, verb ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_request_duration_seconds
+          - rest_client_request_duration_seconds
+      - dimensions: [ [ ClusterName, code, verb ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_request_total
+          - apiserver_request_total_5xx
+      - dimensions: [ [ ClusterName, operation ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_admission_controller_admission_duration_seconds
+          - apiserver_admission_step_admission_duration_seconds
+          - etcd_request_duration_seconds
+      - dimensions: [ [ ClusterName, code, method ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - rest_client_requests_total
+      - dimensions: [ [ ClusterName, request_kind ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_current_inflight_requests
+      - dimensions: [ [ ClusterName, name ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_admission_webhook_admission_duration_seconds
+      - dimensions: [ [ ClusterName, group ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_requested_deprecated_apis
+      - dimensions: [ [ ClusterName, reason ], [ ClusterName ] ]
+        label_matchers: [ ]
+        metric_name_selectors:
+          - apiserver_flowcontrol_rejected_requests_total
+      - dimensions: [ [ ClusterName, priority_level ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_flowcontrol_request_concurrency_limit
-      - dimensions: [ [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_objects
-          - apiserver_request_total
-          - apiserver_request_total_5xx
-          - apiserver_request_duration_seconds
-          - apiserver_admission_controller_admission_duration_seconds
-          - rest_client_request_duration_seconds
-          - rest_client_requests_total
-          - etcd_request_duration_seconds
-          - apiserver_flowcontrol_rejected_requests_total
     metric_descriptors:
-      - metric_name: apiserver_storage_objects
+      - metric_name: apiserver_admission_controller_admission_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_admission_step_admission_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_admission_webhook_admission_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_current_inflight_requests
         unit: Count
+        overwrite: true
+      - metric_name: apiserver_current_inqueue_requests
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_flowcontrol_rejected_requests_total
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_flowcontrol_request_concurrency_limit
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_longrunning_requests
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_request_duration_seconds
+        unit: Seconds
         overwrite: true
       - metric_name: apiserver_request_total
         unit: Count
@@ -195,25 +255,34 @@ exporters:
       - metric_name: apiserver_request_total_5xx
         unit: Count
         overwrite: true
-      - metric_name: apiserver_request_duration_seconds
+      - metric_name: apiserver_storage_objects
+        unit: Count
+        overwrite: true
+      - metric_name: etcd_request_duration_seconds
         unit: Seconds
         overwrite: true
-      - metric_name: apiserver_admission_controller_admission_duration_seconds
+      - metric_name: apiserver_storage_list_duration_seconds
+        unit: Seconds
+        overwrite: true
+      - metric_name: apiserver_storage_objects
+        unit: Count
+        overwrite: true
+      - metric_name: apiserver_storage_db_total_size_in_bytes
+        unit: Bytes
+        overwrite: true
+      - metric_name: apiserver_storage_size_bytes
+        unit: Bytes
+        overwrite: true
+      - metric_name: etcd_db_total_size_in_bytes
+        unit: Bytes
+        overwrite: true
+      - metric_name: etcd_request_duration_seconds
         unit: Seconds
         overwrite: true
       - metric_name: rest_client_request_duration_seconds
         unit: Seconds
         overwrite: true
       - metric_name: rest_client_requests_total
-        unit: Count
-        overwrite: true
-      - metric_name: etcd_request_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_flowcontrol_rejected_requests_total
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_flowcontrol_request_concurrency_limit
         unit: Count
         overwrite: true
     namespace: ContainerInsights

--- a/translator/tocwconfig/sampleConfig/prometheus_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_config_linux.yaml
@@ -9,7 +9,7 @@ exporters:
     eks_fargate_container_insights_enabled: false
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 1
+    imds_retries: 1
     enhanced_container_insights: false
     local_mode: false
     log_group_name: /aws/ecs/containerinsights/TestCluster/prometheus

--- a/translator/tocwconfig/sampleConfig/prometheus_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_config_windows.yaml
@@ -9,7 +9,7 @@ exporters:
     eks_fargate_container_insights_enabled: false
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 1
+    imds_retries: 1
     enhanced_container_insights: false
     local_mode: false
     log_group_name: /aws/ecs/containerinsights/TestCluster/prometheus

--- a/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
@@ -4,7 +4,7 @@ exporters:
     aws_log_groups: []
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 2
+    imds_retries: 2
     index_all_attributes: false
     indexed_attributes: []
     local_mode: false

--- a/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
@@ -4,7 +4,7 @@ exporters:
     aws_log_groups: []
     certificate_file_path: ""
     endpoint: ""
-    "imds_retries": 2
+    imds_retries: 2
     index_all_attributes: false
     indexed_attributes: []
     local_mode: false

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -350,6 +350,7 @@ func verifyToYamlTranslation(t *testing.T, input interface{}, expectedYamlFilePa
 			return pretty.Sprint(x) < pretty.Sprint(y)
 		})
 		// assert.Equal(t, expected, actual) // this is useful for debugging differences between the YAML
+
 		require.True(t, cmp.Equal(expected, actual, opt), "D! YAML diff: %s", cmp.Diff(expected, actual))
 	}
 }

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -268,8 +268,12 @@ func TestTranslator(t *testing.T) {
 						Dimensions: [][]string{{"ClusterName"}, {"ContainerName", "FullPodName", "PodName", "Namespace", "ClusterName"}, {"ContainerName", "PodName", "Namespace", "ClusterName"}},
 						MetricNameSelectors: []string{
 							"container_cpu_utilization", "container_cpu_utilization_over_container_limit",
-							"container_memory_utilization", "container_memory_utilization_over_container_limit", "container_memory_failures_total",
-							"container_filesystem_usage", "container_status_running", "container_status_terminated", "container_status_waiting", "container_status_waiting_reason_crashed"},
+							"container_memory_utilization", "container_memory_utilization_over_container_limit", "container_memory_failures_total", "container_memory_limit", "container_memory_request",
+							"container_filesystem_usage", "container_filesystem_available", "container_filesystem_utilization",
+							"container_status_running", "container_status_terminated", "container_status_waiting", "container_status_waiting_reason_crash_loop_back_off",
+							"container_status_waiting_reason_image_pull_error", "container_status_waiting_reason_start_error", "container_status_waiting_reason_create_container_error",
+							"container_status_waiting_reason_create_container_config_error", "container_status_terminated_reason_oom_killed",
+						},
 					},
 					{
 						Dimensions: [][]string{{"PodName", "Namespace", "ClusterName"}, {"ClusterName"}, {"Service", "Namespace", "ClusterName"}, {"ClusterName", "Namespace"}, {"FullPodName", "PodName", "Namespace", "ClusterName"}},
@@ -278,22 +282,20 @@ func TestTranslator(t *testing.T) {
 							"pod_memory_utilization_over_pod_limit"},
 					},
 					{
-						Dimensions: [][]string{{"PodName", "Namespace", "ClusterName"}, {"ClusterName"}, {"FullPodName", "PodName", "Namespace", "ClusterName"}, {"Service", "Namespace", "ClusterName"}},
-						MetricNameSelectors: []string{"pod_cpu_reserved_capacity", "pod_memory_reserved_capacity", "pod_number_of_container_restarts",
-							"pod_number_of_containers", "pod_number_of_running_containers",
-							"pod_status_ready", "pod_status_scheduled",
-							"pod_status_running", "pod_status_pending",
-							"pod_status_failed", "pod_status_unknown",
-							"pod_status_succeeded"},
-					},
-					{
 						Dimensions: [][]string{
 							{"FullPodName", "PodName", "Namespace", "ClusterName"},
 							{"PodName", "Namespace", "ClusterName"},
 							{"Service", "Namespace", "ClusterName"},
 							{"ClusterName"},
 						},
-						MetricNameSelectors: []string{"pod_interface_network_rx_dropped", "pod_interface_network_rx_errors", "pod_interface_network_tx_dropped", "pod_interface_network_tx_errors"},
+						MetricNameSelectors: []string{"pod_interface_network_rx_dropped", "pod_interface_network_tx_dropped"},
+					},
+					{
+						Dimensions: [][]string{{"PodName", "Namespace", "ClusterName"}, {"ClusterName"}, {"FullPodName", "PodName", "Namespace", "ClusterName"}, {"Service", "Namespace", "ClusterName"}},
+						MetricNameSelectors: []string{"pod_cpu_reserved_capacity", "pod_memory_reserved_capacity", "pod_number_of_container_restarts", "pod_number_of_containers", "pod_number_of_running_containers",
+							"pod_status_ready", "pod_status_scheduled", "pod_status_running", "pod_status_pending", "pod_status_failed", "pod_status_unknown",
+							"pod_status_succeeded", "pod_memory_request", "pod_memory_limit",
+						},
 					},
 					{
 						Dimensions: [][]string{{"NodeName", "InstanceId", "ClusterName"}, {"ClusterName"}},
@@ -310,8 +312,7 @@ func TestTranslator(t *testing.T) {
 							{"ClusterName"},
 						},
 						MetricNameSelectors: []string{
-							"node_interface_network_rx_dropped", "node_interface_network_rx_errors",
-							"node_interface_network_tx_dropped", "node_interface_network_tx_errors",
+							"node_interface_network_rx_dropped", "node_interface_network_tx_dropped",
 							"node_diskio_io_service_bytes_total", "node_diskio_io_serviced_total"},
 					},
 					{
@@ -340,29 +341,47 @@ func TestTranslator(t *testing.T) {
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "endpoint"}, {"ClusterName"}},
-						MetricNameSelectors: []string{"etcd_db_total_size_in_bytes"},
+						MetricNameSelectors: []string{"apiserver_storage_size_bytes", "apiserver_storage_size_bytes", "etcd_db_total_size_in_bytes", "etcd_request_duration_seconds"},
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "resource"}, {"ClusterName"}},
-						MetricNameSelectors: []string{"apiserver_storage_list_duration_seconds"},
+						MetricNameSelectors: []string{"apiserver_storage_list_duration_seconds", "apiserver_longrunning_requests", "apiserver_storage_objects"},
+					},
+					{
+						Dimensions:          [][]string{{"ClusterName", "verb"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"apiserver_request_duration_seconds", "rest_client_request_duration_seconds"},
+					},
+					{
+						Dimensions:          [][]string{{"ClusterName", "code", "verb"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"apiserver_request_total", "apiserver_request_total_5xx"},
+					},
+					{
+						Dimensions:          [][]string{{"ClusterName", "operation"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"apiserver_admission_controller_admission_duration_seconds", "apiserver_admission_step_admission_duration_seconds", "etcd_request_duration_seconds"},
+					},
+					{
+						Dimensions:          [][]string{{"ClusterName", "code", "method"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"rest_client_requests_total"},
+					},
+					{
+						Dimensions:          [][]string{{"ClusterName", "request_kind"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"apiserver_current_inflight_requests"},
+					},
+					{
+						Dimensions:          [][]string{{"ClusterName", "name"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"apiserver_admission_webhook_admission_duration_seconds"},
+					},
+					{
+						Dimensions:          [][]string{{"ClusterName", "group"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"apiserver_requested_deprecated_apis"},
+					},
+					{
+						Dimensions:          [][]string{{"ClusterName", "reason"}, {"ClusterName"}},
+						MetricNameSelectors: []string{"apiserver_flowcontrol_rejected_requests_total"},
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "priority_level"}, {"ClusterName"}},
 						MetricNameSelectors: []string{"apiserver_flowcontrol_request_concurrency_limit"},
-					},
-					{
-						Dimensions: [][]string{{"ClusterName"}},
-						MetricNameSelectors: []string{
-							"apiserver_admission_controller_admission_duration_seconds",
-							"apiserver_flowcontrol_rejected_requests_total",
-							"apiserver_request_duration_seconds",
-							"apiserver_request_total",
-							"apiserver_request_total_5xx",
-							"apiserver_storage_objects",
-							"etcd_request_duration_seconds",
-							"rest_client_request_duration_seconds",
-							"rest_client_requests_total",
-						},
 					},
 				},
 				"metric_descriptors": []awsemfexporter.MetricDescriptor{
@@ -372,12 +391,37 @@ func TestTranslator(t *testing.T) {
 						Overwrite:  true,
 					},
 					{
-						MetricName: "apiserver_flowcontrol_request_concurrency_limit",
+						MetricName: "apiserver_admission_step_admission_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_admission_webhook_admission_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_current_inflight_requests",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_current_inqueue_requests",
 						Unit:       "Count",
 						Overwrite:  true,
 					},
 					{
 						MetricName: "apiserver_flowcontrol_rejected_requests_total",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_flowcontrol_request_concurrency_limit",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_longrunning_requests",
 						Unit:       "Count",
 						Overwrite:  true,
 					},
@@ -399,6 +443,36 @@ func TestTranslator(t *testing.T) {
 					{
 						MetricName: "apiserver_storage_objects",
 						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "etcd_request_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_storage_list_duration_seconds",
+						Unit:       "Seconds",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_storage_objects",
+						Unit:       "Count",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_storage_db_total_size_in_bytes",
+						Unit:       "Bytes",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "apiserver_storage_size_bytes",
+						Unit:       "Bytes",
+						Overwrite:  true,
+					},
+					{
+						MetricName: "etcd_db_total_size_in_bytes",
+						Unit:       "Bytes",
 						Overwrite:  true,
 					},
 					{


### PR DESCRIPTION
# Description of the issue
`amazon-cloudawtch-agent` update for this PR: https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/96

# Description of changes
1. implement requested aggregations
2. updated tests to pass, and also style fixes like unquoting imds_retries

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested end to end

Crash:
![Screenshot 2023-09-20 at 2 22 51 PM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/7c314254-ef4b-4e1d-a295-63f84c5bec9b)

No crashes:
![Screenshot 2023-09-20 at 10 18 55 AM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/b3a40be2-e1eb-4653-8117-b4b333eabc4e)

New kube-apiserver metrics
![Screenshot 2023-09-20 at 2 54 57 PM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/6bce510d-e5a5-455-a47b-c302768167c9)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
3. Run `make lint`




