### PR TITLE
Skip Timestamp For Agent Log

### DIFF
--- a/translator/tocwconfig/sampleConfig/no_skip_log_timestamp.conf
+++ b/translator/tocwconfig/sampleConfig/no_skip_log_timestamp.conf
@@ -1,0 +1,37 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.logfile]]
+    destination = "cloudwatchlogs"
+    file_state_folder = "/opt/aws/amazon-cloudwatch-agent/logs/state"
+
+    [[inputs.logfile.file_config]]
+      file_path = "/tmp/not-amazon-cloudwatch-agent.log"
+      from_beginning = true
+      log_group_name = "amazon-cloudwatch-agent.log"
+      pipe = false
+      retention_in_days = -1
+      timestamp_layout = "15:04:05 06 Jan 02"
+      timestamp_regex = "(d{2}:d{2}:d{2} d{2} w{3} d{2})"
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    force_flush_interval = "5s"
+    log_stream_name = "i-UNKNOWN"
+    region = "us-west-2"

--- a/translator/tocwconfig/sampleConfig/no_skip_log_timestamp.json
+++ b/translator/tocwconfig/sampleConfig/no_skip_log_timestamp.json
@@ -1,0 +1,15 @@
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/tmp/not-amazon-cloudwatch-agent.log",
+            "log_group_name": "amazon-cloudwatch-agent.log",
+            "timestamp_format": "%H:%M:%S %y %b %d"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/no_skip_log_timestamp_windows.conf
+++ b/translator/tocwconfig/sampleConfig/no_skip_log_timestamp_windows.conf
@@ -1,0 +1,37 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.logfile]]
+    destination = "cloudwatchlogs"
+    file_state_folder = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\state"
+
+    [[inputs.logfile.file_config]]
+      file_path = "c:\\tmp\\not-amazon-cloudwatch-agent.log"
+      from_beginning = true
+      log_group_name = "amazon-cloudwatch-agent.log"
+      pipe = false
+      retention_in_days = -1
+      timestamp_layout = "15:04:05 06 Jan 02"
+      timestamp_regex = "(d{2}:d{2}:d{2} d{2} w{3} d{2})"
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    force_flush_interval = "5s"
+    log_stream_name = "i-UNKNOWN"
+    region = "us-west-2"

--- a/translator/tocwconfig/sampleConfig/no_skip_log_timestamp_windows.json
+++ b/translator/tocwconfig/sampleConfig/no_skip_log_timestamp_windows.json
@@ -1,0 +1,16 @@
+{
+
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "c:\\tmp\\not-amazon-cloudwatch-agent.log",
+            "log_group_name": "amazon-cloudwatch-agent.log",
+            "timestamp_format": "%H:%M:%S %y %b %d"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/skip_log_timestamp.conf
+++ b/translator/tocwconfig/sampleConfig/skip_log_timestamp.conf
@@ -1,0 +1,35 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/tmp/a.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.logfile]]
+    destination = "cloudwatchlogs"
+    file_state_folder = "/opt/aws/amazon-cloudwatch-agent/logs/state"
+
+    [[inputs.logfile.file_config]]
+      file_path = "/opt/tmp/a.log"
+      from_beginning = true
+      log_group_name = "amazon-cloudwatch-agent.log"
+      pipe = false
+      retention_in_days = -1
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    force_flush_interval = "5s"
+    log_stream_name = "i-UNKNOWN"
+    region = "us-west-2"

--- a/translator/tocwconfig/sampleConfig/skip_log_timestamp.json
+++ b/translator/tocwconfig/sampleConfig/skip_log_timestamp.json
@@ -1,0 +1,18 @@
+{
+  "agent": {
+    "logfile": "/opt/tmp/a.log"
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/opt/tmp/a.log",
+            "log_group_name": "amazon-cloudwatch-agent.log",
+            "timestamp_format": "%H:%M:%S %y %b %d"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/skip_log_timestamp_default.conf
+++ b/translator/tocwconfig/sampleConfig/skip_log_timestamp_default.conf
@@ -1,0 +1,35 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.logfile]]
+    destination = "cloudwatchlogs"
+    file_state_folder = "/opt/aws/amazon-cloudwatch-agent/logs/state"
+
+    [[inputs.logfile.file_config]]
+      file_path = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+      from_beginning = true
+      log_group_name = "amazon-cloudwatch-agent.log"
+      pipe = false
+      retention_in_days = -1
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    force_flush_interval = "5s"
+    log_stream_name = "i-UNKNOWN"
+    region = "us-west-2"

--- a/translator/tocwconfig/sampleConfig/skip_log_timestamp_default.json
+++ b/translator/tocwconfig/sampleConfig/skip_log_timestamp_default.json
@@ -1,0 +1,15 @@
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+            "log_group_name": "amazon-cloudwatch-agent.log",
+            "timestamp_format": "%H:%M:%S %y %b %d"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/skip_log_timestamp_default_windows.conf
+++ b/translator/tocwconfig/sampleConfig/skip_log_timestamp_default_windows.conf
@@ -1,0 +1,35 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.logfile]]
+    destination = "cloudwatchlogs"
+    file_state_folder = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\state"
+
+    [[inputs.logfile.file_config]]
+      file_path = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+      from_beginning = true
+      log_group_name = "amazon-cloudwatch-agent.log"
+      pipe = false
+      retention_in_days = -1
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    force_flush_interval = "5s"
+    log_stream_name = "i-UNKNOWN"
+    region = "us-west-2"

--- a/translator/tocwconfig/sampleConfig/skip_log_timestamp_default_windows.json
+++ b/translator/tocwconfig/sampleConfig/skip_log_timestamp_default_windows.json
@@ -1,0 +1,15 @@
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log",
+            "log_group_name": "amazon-cloudwatch-agent.log",
+            "timestamp_format": "%H:%M:%S %y %b %d"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/skip_log_timestamp_windows.conf
+++ b/translator/tocwconfig/sampleConfig/skip_log_timestamp_windows.conf
@@ -1,0 +1,35 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "c:\\tmp\\am.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.logfile]]
+    destination = "cloudwatchlogs"
+    file_state_folder = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\state"
+
+    [[inputs.logfile.file_config]]
+      file_path = "c:\\tmp\\am.log"
+      from_beginning = true
+      log_group_name = "amazon-cloudwatch-agent.log"
+      pipe = false
+      retention_in_days = -1
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    force_flush_interval = "5s"
+    log_stream_name = "i-UNKNOWN"
+    region = "us-west-2"

--- a/translator/tocwconfig/sampleConfig/skip_log_timestamp_windows.json
+++ b/translator/tocwconfig/sampleConfig/skip_log_timestamp_windows.json
@@ -1,0 +1,18 @@
+{
+  "agent": {
+    "logfile": "c:\\tmp\\am.log"
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "c:\\tmp\\am.log",
+            "log_group_name": "amazon-cloudwatch-agent.log",
+            "timestamp_format": "%H:%M:%S %y %b %d"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/translate/agent/ruleLogFile.go
+++ b/translator/translate/agent/ruleLogFile.go
@@ -19,6 +19,7 @@ type Logfile struct {
 
 func (l *Logfile) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
 	returnKey, returnVal = translator.DefaultCase("logfile", GetDefaultValue(), input)
+	context.CurrentContext().SetAgentLogFile(returnVal.(string))
 	return
 }
 

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleTimestampFormat.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleTimestampFormat.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 )
 
 /*
@@ -138,13 +139,17 @@ func checkAndReplace(input string, timestampFormatMap map[string]string) string 
 type TimestampRegax struct {
 }
 
+// ApplyRule add timestamp regex
+// do not add timestamp check when viewing cwa logfile
 func (t *TimestampRegax) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
 	//Convert the input string into []rune and iterate the map and build the output []rune
 	m := input.(map[string]interface{})
 	//If user not specify the timestamp_format, then no config entry for "timestamp_layout" in TOML
 	if val, ok := m["timestamp_format"]; !ok {
-		returnKey = ""
-		returnVal = ""
+		return "", ""
+	} else if m["file_path"] == context.CurrentContext().GetAgentLogFile() {
+		fmt.Printf("timestamp_format set file_path : %s is the same as agent log file %s thus do not use timestamp_regex \n", m["file_path"], context.CurrentContext().GetAgentLogFile())
+		return "", ""
 	} else {
 		//If user provide with the specific timestamp_format, use the one that user provide
 		res := checkAndReplace(val.(string), TimeFormatRegexEscapeMap)
@@ -170,13 +175,17 @@ func (t *TimestampRegax) ApplyRule(input interface{}) (returnKey string, returnV
 type TimestampLayout struct {
 }
 
+// ApplyRule add timestamp layout
+// do not add timestamp check when viewing cwa logfile
 func (t *TimestampLayout) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
 	//Convert the input string into []rune and iterate the map and build the output []rune
 	m := input.(map[string]interface{})
 	//If user not specify the timestamp_format, then no config entry for "timestamp_layout" in TOML
 	if val, ok := m["timestamp_format"]; !ok {
-		returnKey = ""
-		returnVal = ""
+		return "", ""
+	} else if m["file_path"] == context.CurrentContext().GetAgentLogFile() {
+		fmt.Printf("timestamp_format set file_path : %s is the same as agent log file %s thus do not use timestamp_layout \n", m["file_path"], context.CurrentContext().GetAgentLogFile())
+		return "", ""
 	} else {
 		res := checkAndReplace(val.(string), TimeFormatMap)
 		//If user provide with the specific timestamp_format, use the one that user provide


### PR DESCRIPTION
# Description of the issue
The customer noticed the issue because we now log the toml output on start of agent. This includes a line with the date format that is old. 
We keep logging the same entry for a bad time stamp config when recording agent logs.

```
    {
      "agent": {
        "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
      },
      "logs": {
        "logs_collected": {
          "files": {
            "collect_list": [
          {
                "file_path": "/var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
                "log_group_name": "stage-InstanceLogGroup",
                "log_stream_name": "(v124-1) - /var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
                "timestamp_format": "%Y-%m-%d%H:%M:%S"
              }
            ]
          }
        },
        "force_flush_interval" : 15
      }
    }
```

If we have a valid timestamp in the log we will not keep logging the same log line. 

```
    {
      "agent": {
        "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
      },
      "logs": {
        "logs_collected": {
          "files": {
            "collect_list": [
          {
                "file_path": "/var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
                "log_group_name": "stage-InstanceLogGroup",
                "log_stream_name": "(v124-1) - /var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
                "timestamp_format": "%Y-%m-%dT%H:%M:%S"
              }
            ]
          }
        },
        "force_flush_interval" : 15
      }
    }
```

# Description of changes
Do not use timestamp when reading agent log file. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manual testing to see no log for invalid timestamp in logs with config 

log out if time stamp is skipped in translation layer 
```
timestamp_format set timesfile_path : /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log is the same as agent log file /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log thus do not use timestamp_regex
timestamp_format set file_path : /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log is the same as agent log file /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log thus do not use timestamp_layout
```
    {
      "agent": {
        "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
      },
      "logs": {
        "logs_collected": {
          "files": {
            "collect_list": [
          {
                "file_path": "/var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
                "log_group_name": "stage-InstanceLogGroup",
                "log_stream_name": "(v124-1) - /var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
                "timestamp_format": "%Y-%m-%dT%H:%M:%S"
              }
            ]
          }
        },
        "force_flush_interval" : 15
      }
    }
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




