### PR TITLE
fix apiserver_storage_db_total_size_in_bytes

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -172,7 +172,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_size_bytes
-          - apiserver_storage_size_bytes
+          - apiserver_storage_db_total_size_in_bytes
           - etcd_db_total_size_in_bytes
           - etcd_request_duration_seconds
       - dimensions: [ [ClusterName, resource], [ ClusterName ] ]

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -143,7 +143,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_size_bytes
-          - apiserver_storage_size_bytes
+          - apiserver_storage_db_total_size_in_bytes
           - etcd_db_total_size_in_bytes
           - etcd_request_duration_seconds
       - dimensions: [ [ ClusterName, resource ], [ ClusterName ] ]

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -172,7 +172,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_storage_size_bytes
-          - apiserver_storage_size_bytes
+          - apiserver_storage_db_total_size_in_bytes
           - etcd_db_total_size_in_bytes
           - etcd_request_duration_seconds
       - dimensions: [ [ ClusterName, resource ], [ ClusterName ] ]

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -270,7 +270,7 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 				Dimensions: [][]string{{"ClusterName", "endpoint"}, {"ClusterName"}},
 				MetricNameSelectors: []string{
 					"apiserver_storage_size_bytes",
-					"apiserver_storage_size_bytes",
+					"apiserver_storage_db_total_size_in_bytes",
 					"etcd_db_total_size_in_bytes",
 					"etcd_request_duration_seconds",
 				},

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -341,7 +341,7 @@ func TestTranslator(t *testing.T) {
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "endpoint"}, {"ClusterName"}},
-						MetricNameSelectors: []string{"apiserver_storage_size_bytes", "apiserver_storage_size_bytes", "etcd_db_total_size_in_bytes", "etcd_request_duration_seconds"},
+						MetricNameSelectors: []string{"apiserver_storage_size_bytes", "apiserver_storage_db_total_size_in_bytes", "etcd_db_total_size_in_bytes", "etcd_request_duration_seconds"},
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "resource"}, {"ClusterName"}},


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._
`apiserver_storage_size_bytes is duplicated, one of the instances should be `apiserver_storage_db_total_size_in_bytes`

# Description of changes
replaced the duplicate instance

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
unit tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




