### PR TITLE
Use fmt.Printf Instead Of log.Printf On Start Up Because Of A Bug Wit…

### DIFF
--- a/internal/retryer/imdsretryer.go
+++ b/internal/retryer/imdsretryer.go
@@ -4,6 +4,7 @@
 package retryer
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -27,7 +28,7 @@ type IMDSRetryer struct {
 // otel component layer retries should come from aws config settings
 // translator layer should come from env vars see GetDefaultRetryNumber()
 func NewIMDSRetryer(imdsRetries int) IMDSRetryer {
-	log.Printf("I! imds retry client will retry %d times", imdsRetries)
+	fmt.Printf("I! imds retry client will retry %d times", imdsRetries)
 	return IMDSRetryer{
 		DefaultRetryer: client.DefaultRetryer{
 			NumMaxRetries: imdsRetries,


### PR DESCRIPTION
…h Windows User Data Causing Agent Not To Start

# Description of the issue
Due to an issue with user data in windows agent can't start when using log.Printf on start up. Agent can use log.Printf at runtime. This is because during user data win is now allowing writing to standard err. 

# Description of changes
Use fmt.Printf instead for start up logs. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Reproduction of issue
Manual test by starting agent (works)
Manual test use user data to start cwa (fail)

With the changes 
Manual test by starting agent (works)
Manual test use user data to start cwa (works)
Going to add automated tests, but we need this fix because of backwards compatibility, so this can be merged before the tests are done. 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




