### PR TITLE
Use GZIP 6 RPM Compression To Fix Install On AL2 Without Kernel Patch

### DIFF
--- a/packaging/linux/amazon-cloudwatch-agent.spec
+++ b/packaging/linux/amazon-cloudwatch-agent.spec
@@ -10,6 +10,8 @@ Source:     amazon-cloudwatch-agent.tar.gz
 
 %define _enable_debug_packages 0
 %define debug_package %{nil}
+%define _source_payload w6.gzdio
+%define _binary_payload w6.gzdio
 
 %prep
 %setup -c %{name}-%{version}


### PR DESCRIPTION
# Description of the issue
Can't install rpm on the kernel patchless version of al2 

# Description of changes
Use Gzip 6 RPM Compression for rpm build spec
Current binary size 76mb new binary size 96mb 
Current install time 11 seconds new install time 5 seconds 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manually build on al2 with kernel patch.
Install on al2 without kernel patch. 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




