### PR TITLE
If IMDSV2 Fails Log fmt.Printf Not log.Printf

### DIFF
--- a/internal/retryer/imdsretryer.go
+++ b/internal/retryer/imdsretryer.go
@@ -5,7 +5,6 @@ package retryer
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 
@@ -44,7 +43,7 @@ func (r IMDSRetryer) ShouldRetry(req *request.Request) bool {
 	if awsError, ok := req.Error.(awserr.Error); r.DefaultRetryer.ShouldRetry(req) || (ok && awsError != nil && awsError.Code() == "EC2MetadataError") {
 		shouldRetry = true
 	}
-	log.Printf("D! should retry %t for imds error : %v", shouldRetry, req.Error)
+	fmt.Printf("D! should retry %t for imds error : %v", shouldRetry, req.Error)
 	return shouldRetry
 }
 

--- a/translator/util/ec2util/ec2util.go
+++ b/translator/util/ec2util/ec2util.go
@@ -5,7 +5,6 @@ package ec2util
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -113,7 +112,7 @@ func (e *ec2Util) deriveEC2MetadataFromIMDS() error {
 	if hostname, err := mdDisableFallback.GetMetadata("hostname"); err == nil {
 		e.Hostname = hostname
 	} else {
-		log.Printf("D! could not get hostname without imds v1 fallback enable thus enable fallback")
+		fmt.Println("D! could not get hostname without imds v1 fallback enable thus enable fallback")
 		hostnameInner, errInner := mdEnableFallback.GetMetadata("hostname")
 		if errInner == nil {
 			e.Hostname = hostnameInner
@@ -130,7 +129,7 @@ func (e *ec2Util) deriveEC2MetadataFromIMDS() error {
 		e.PrivateIP = instanceIdentityDocument.PrivateIP
 		e.InstanceID = instanceIdentityDocument.InstanceID
 	} else {
-		log.Printf("D! could not get instance document without imds v1 fallback enable thus enable fallback")
+		fmt.Println("D! could not get instance document without imds v1 fallback enable thus enable fallback")
 		instanceIdentityDocumentInner, errInner := mdEnableFallback.GetInstanceIdentityDocument()
 		if errInner == nil {
 			e.Region = instanceIdentityDocumentInner.Region


### PR DESCRIPTION
# Description of the issue
If imdsv2 fails on windows starting with user data there will be a log line to standard error causing agent to fail. 

# Description of changes
Log imds failures to standard out instead so windows user data will not fail. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
None

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




