### PR TITLE
fix some aggregations, fix some double counted stuff, add in some mis…

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -178,7 +178,6 @@ exporters:
           - apiserver_storage_size_bytes
           - apiserver_storage_db_total_size_in_bytes
           - etcd_db_total_size_in_bytes
-          - etcd_request_duration_seconds
       - dimensions: [ [ClusterName, resource], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -200,6 +199,7 @@ exporters:
         metric_name_selectors:
           - apiserver_admission_controller_admission_duration_seconds
           - apiserver_admission_step_admission_duration_seconds
+          - etcd_request_duration_seconds
       - dimensions: [ [ClusterName, code, method], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -50,6 +50,8 @@ exporters:
         metric_name_selectors:
           - container_cpu_utilization
           - container_cpu_utilization_over_container_limit
+          - container_cpu_limit
+          - container_cpu_request
           - container_memory_utilization
           - container_memory_utilization_over_container_limit
           - container_memory_failures_total
@@ -99,6 +101,8 @@ exporters:
           - pod_status_succeeded
           - pod_memory_request
           - pod_memory_limit
+          - pod_cpu_limit
+          - pod_cpu_request
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]
@@ -196,7 +200,6 @@ exporters:
         metric_name_selectors:
           - apiserver_admission_controller_admission_duration_seconds
           - apiserver_admission_step_admission_duration_seconds
-          - etcd_request_duration_seconds
       - dimensions: [ [ClusterName, code, method], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -255,6 +258,9 @@ exporters:
           - metric_name: apiserver_request_total_5xx
             unit: Count
             overwrite: true
+          - metric_name: apiserver_requested_deprecated_apis
+            unit: Count
+            overwrite: true
           - metric_name: apiserver_storage_objects
             unit: Count
             overwrite: true
@@ -264,9 +270,6 @@ exporters:
           - metric_name: apiserver_storage_list_duration_seconds
             unit: Seconds
             overwrite: true
-          - metric_name: apiserver_storage_objects
-            unit: Count
-            overwrite: true
           - metric_name: apiserver_storage_db_total_size_in_bytes
             unit: Bytes
             overwrite: true
@@ -275,9 +278,6 @@ exporters:
             overwrite: true
           - metric_name: etcd_db_total_size_in_bytes
             unit: Bytes
-            overwrite: true
-          - metric_name: etcd_request_duration_seconds
-            unit: Seconds
             overwrite: true
           - metric_name: rest_client_request_duration_seconds
             unit: Seconds

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -149,7 +149,6 @@ exporters:
           - apiserver_storage_size_bytes
           - apiserver_storage_db_total_size_in_bytes
           - etcd_db_total_size_in_bytes
-          - etcd_request_duration_seconds
       - dimensions: [ [ ClusterName, resource ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -171,6 +170,7 @@ exporters:
         metric_name_selectors:
           - apiserver_admission_controller_admission_duration_seconds
           - apiserver_admission_step_admission_duration_seconds
+          - etcd_request_duration_seconds
       - dimensions: [ [ ClusterName, code, method ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -21,6 +21,8 @@ exporters:
         metric_name_selectors:
           - container_cpu_utilization
           - container_cpu_utilization_over_container_limit
+          - container_cpu_limit
+          - container_cpu_request
           - container_memory_utilization
           - container_memory_utilization_over_container_limit
           - container_memory_failures_total
@@ -70,6 +72,8 @@ exporters:
           - pod_status_succeeded
           - pod_memory_request
           - pod_memory_limit
+          - pod_cpu_limit
+          - pod_cpu_request
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]
@@ -167,7 +171,6 @@ exporters:
         metric_name_selectors:
           - apiserver_admission_controller_admission_duration_seconds
           - apiserver_admission_step_admission_duration_seconds
-          - etcd_request_duration_seconds
       - dimensions: [ [ ClusterName, code, method ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -226,6 +229,9 @@ exporters:
       - metric_name: apiserver_request_total_5xx
         unit: Count
         overwrite: true
+      - metric_name: apiserver_requested_deprecated_apis
+        unit: Count
+        overwrite: true
       - metric_name: apiserver_storage_objects
         unit: Count
         overwrite: true
@@ -235,9 +241,6 @@ exporters:
       - metric_name: apiserver_storage_list_duration_seconds
         unit: Seconds
         overwrite: true
-      - metric_name: apiserver_storage_objects
-        unit: Count
-        overwrite: true
       - metric_name: apiserver_storage_db_total_size_in_bytes
         unit: Bytes
         overwrite: true
@@ -246,9 +249,6 @@ exporters:
         overwrite: true
       - metric_name: etcd_db_total_size_in_bytes
         unit: Bytes
-        overwrite: true
-      - metric_name: etcd_request_duration_seconds
-        unit: Seconds
         overwrite: true
       - metric_name: rest_client_request_duration_seconds
         unit: Seconds

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -178,7 +178,6 @@ exporters:
           - apiserver_storage_size_bytes
           - apiserver_storage_db_total_size_in_bytes
           - etcd_db_total_size_in_bytes
-          - etcd_request_duration_seconds
       - dimensions: [ [ ClusterName, resource ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -200,6 +199,7 @@ exporters:
         metric_name_selectors:
           - apiserver_admission_controller_admission_duration_seconds
           - apiserver_admission_step_admission_duration_seconds
+          - etcd_request_duration_seconds
       - dimensions: [ [ ClusterName, code, method ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -50,6 +50,8 @@ exporters:
         metric_name_selectors:
           - container_cpu_utilization
           - container_cpu_utilization_over_container_limit
+          - container_cpu_limit
+          - container_cpu_request
           - container_memory_utilization
           - container_memory_utilization_over_container_limit
           - container_memory_failures_total
@@ -99,6 +101,8 @@ exporters:
           - pod_status_succeeded
           - pod_memory_request
           - pod_memory_limit
+          - pod_cpu_limit
+          - pod_cpu_request
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]
@@ -196,7 +200,6 @@ exporters:
         metric_name_selectors:
           - apiserver_admission_controller_admission_duration_seconds
           - apiserver_admission_step_admission_duration_seconds
-          - etcd_request_duration_seconds
       - dimensions: [ [ ClusterName, code, method ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
@@ -255,6 +258,9 @@ exporters:
       - metric_name: apiserver_request_total_5xx
         unit: Count
         overwrite: true
+      - metric_name: apiserver_requested_deprecated_apis
+        unit: Count
+        overwrite: true
       - metric_name: apiserver_storage_objects
         unit: Count
         overwrite: true
@@ -264,9 +270,6 @@ exporters:
       - metric_name: apiserver_storage_list_duration_seconds
         unit: Seconds
         overwrite: true
-      - metric_name: apiserver_storage_objects
-        unit: Count
-        overwrite: true
       - metric_name: apiserver_storage_db_total_size_in_bytes
         unit: Bytes
         overwrite: true
@@ -275,9 +278,6 @@ exporters:
         overwrite: true
       - metric_name: etcd_db_total_size_in_bytes
         unit: Bytes
-        overwrite: true
-      - metric_name: etcd_request_duration_seconds
-        unit: Seconds
         overwrite: true
       - metric_name: rest_client_request_duration_seconds
         unit: Seconds

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -273,7 +273,6 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 					"apiserver_storage_size_bytes",
 					"apiserver_storage_db_total_size_in_bytes",
 					"etcd_db_total_size_in_bytes",
-					"etcd_request_duration_seconds",
 				},
 			},
 			{
@@ -303,6 +302,7 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 				MetricNameSelectors: []string{
 					"apiserver_admission_controller_admission_duration_seconds",
 					"apiserver_admission_step_admission_duration_seconds",
+					"etcd_request_duration_seconds",
 				},
 			},
 			{

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -60,7 +60,7 @@ func getContainerMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Metric
 		metricDeclaration := awsemfexporter.MetricDeclaration{
 			Dimensions: [][]string{{"ClusterName"}, {"ContainerName", "FullPodName", "PodName", "Namespace", "ClusterName"}, {"ContainerName", "PodName", "Namespace", "ClusterName"}},
 			MetricNameSelectors: []string{
-				"container_cpu_utilization", "container_cpu_utilization_over_container_limit",
+				"container_cpu_utilization", "container_cpu_utilization_over_container_limit", "container_cpu_limit", "container_cpu_request",
 				"container_memory_utilization", "container_memory_utilization_over_container_limit", "container_memory_failures_total", "container_memory_limit", "container_memory_request",
 				"container_filesystem_usage", "container_filesystem_available", "container_filesystem_utilization",
 				"container_status_running", "container_status_terminated", "container_status_waiting", "container_status_waiting_reason_crash_loop_back_off",
@@ -94,7 +94,8 @@ func getPodMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 		podMetricDeclarations[0].Dimensions = append(podMetricDeclarations[0].Dimensions, []string{"FullPodName", "PodName", "Namespace", "ClusterName"})
 		selectors = append(selectors, []string{"pod_number_of_container_restarts", "pod_number_of_containers", "pod_number_of_running_containers",
 			"pod_status_ready", "pod_status_scheduled", "pod_status_running", "pod_status_pending", "pod_status_failed", "pod_status_unknown",
-			"pod_status_succeeded", "pod_memory_request", "pod_memory_limit"}...)
+			"pod_status_succeeded", "pod_memory_request", "pod_memory_limit", "pod_cpu_limit", "pod_cpu_request",
+		}...)
 
 	}
 
@@ -302,7 +303,6 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 				MetricNameSelectors: []string{
 					"apiserver_admission_controller_admission_duration_seconds",
 					"apiserver_admission_step_admission_duration_seconds",
-					"etcd_request_duration_seconds",
 				},
 			},
 			{
@@ -407,6 +407,11 @@ func getControlPlaneMetricDescriptors(conf *confmap.Conf) []awsemfexporter.Metri
 				Overwrite:  true,
 			},
 			{
+				MetricName: "apiserver_requested_deprecated_apis",
+				Unit:       "Count",
+				Overwrite:  true,
+			},
+			{
 				MetricName: "apiserver_storage_objects",
 				Unit:       "Count",
 				Overwrite:  true,
@@ -422,11 +427,6 @@ func getControlPlaneMetricDescriptors(conf *confmap.Conf) []awsemfexporter.Metri
 				Overwrite:  true,
 			},
 			{
-				MetricName: "apiserver_storage_objects",
-				Unit:       "Count",
-				Overwrite:  true,
-			},
-			{
 				MetricName: "apiserver_storage_db_total_size_in_bytes",
 				Unit:       "Bytes",
 				Overwrite:  true,
@@ -439,11 +439,6 @@ func getControlPlaneMetricDescriptors(conf *confmap.Conf) []awsemfexporter.Metri
 			{
 				MetricName: "etcd_db_total_size_in_bytes",
 				Unit:       "Bytes",
-				Overwrite:  true,
-			},
-			{
-				MetricName: "etcd_request_duration_seconds",
-				Unit:       "Seconds",
 				Overwrite:  true,
 			},
 			{

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -267,7 +267,7 @@ func TestTranslator(t *testing.T) {
 					{
 						Dimensions: [][]string{{"ClusterName"}, {"ContainerName", "FullPodName", "PodName", "Namespace", "ClusterName"}, {"ContainerName", "PodName", "Namespace", "ClusterName"}},
 						MetricNameSelectors: []string{
-							"container_cpu_utilization", "container_cpu_utilization_over_container_limit",
+							"container_cpu_utilization", "container_cpu_utilization_over_container_limit", "container_cpu_limit", "container_cpu_request",
 							"container_memory_utilization", "container_memory_utilization_over_container_limit", "container_memory_failures_total", "container_memory_limit", "container_memory_request",
 							"container_filesystem_usage", "container_filesystem_available", "container_filesystem_utilization",
 							"container_status_running", "container_status_terminated", "container_status_waiting", "container_status_waiting_reason_crash_loop_back_off",
@@ -294,7 +294,7 @@ func TestTranslator(t *testing.T) {
 						Dimensions: [][]string{{"PodName", "Namespace", "ClusterName"}, {"ClusterName"}, {"FullPodName", "PodName", "Namespace", "ClusterName"}, {"Service", "Namespace", "ClusterName"}},
 						MetricNameSelectors: []string{"pod_cpu_reserved_capacity", "pod_memory_reserved_capacity", "pod_number_of_container_restarts", "pod_number_of_containers", "pod_number_of_running_containers",
 							"pod_status_ready", "pod_status_scheduled", "pod_status_running", "pod_status_pending", "pod_status_failed", "pod_status_unknown",
-							"pod_status_succeeded", "pod_memory_request", "pod_memory_limit",
+							"pod_status_succeeded", "pod_memory_request", "pod_memory_limit", "pod_cpu_limit", "pod_cpu_request",
 						},
 					},
 					{
@@ -357,7 +357,7 @@ func TestTranslator(t *testing.T) {
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "operation"}, {"ClusterName"}},
-						MetricNameSelectors: []string{"apiserver_admission_controller_admission_duration_seconds", "apiserver_admission_step_admission_duration_seconds", "etcd_request_duration_seconds"},
+						MetricNameSelectors: []string{"apiserver_admission_controller_admission_duration_seconds", "apiserver_admission_step_admission_duration_seconds"},
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "code", "method"}, {"ClusterName"}},
@@ -441,23 +441,18 @@ func TestTranslator(t *testing.T) {
 						Overwrite:  true,
 					},
 					{
-						MetricName: "apiserver_storage_objects",
+						MetricName: "apiserver_requested_deprecated_apis",
 						Unit:       "Count",
 						Overwrite:  true,
 					},
 					{
-						MetricName: "etcd_request_duration_seconds",
-						Unit:       "Seconds",
+						MetricName: "apiserver_storage_objects",
+						Unit:       "Count",
 						Overwrite:  true,
 					},
 					{
 						MetricName: "apiserver_storage_list_duration_seconds",
 						Unit:       "Seconds",
-						Overwrite:  true,
-					},
-					{
-						MetricName: "apiserver_storage_objects",
-						Unit:       "Count",
 						Overwrite:  true,
 					},
 					{

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -341,7 +341,7 @@ func TestTranslator(t *testing.T) {
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "endpoint"}, {"ClusterName"}},
-						MetricNameSelectors: []string{"apiserver_storage_size_bytes", "apiserver_storage_db_total_size_in_bytes", "etcd_db_total_size_in_bytes", "etcd_request_duration_seconds"},
+						MetricNameSelectors: []string{"apiserver_storage_size_bytes", "apiserver_storage_db_total_size_in_bytes", "etcd_db_total_size_in_bytes"},
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "resource"}, {"ClusterName"}},
@@ -357,7 +357,7 @@ func TestTranslator(t *testing.T) {
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "operation"}, {"ClusterName"}},
-						MetricNameSelectors: []string{"apiserver_admission_controller_admission_duration_seconds", "apiserver_admission_step_admission_duration_seconds"},
+						MetricNameSelectors: []string{"apiserver_admission_controller_admission_duration_seconds", "apiserver_admission_step_admission_duration_seconds", "etcd_request_duration_seconds"},
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "code", "method"}, {"ClusterName"}},


### PR DESCRIPTION
…sing stuff

# Description of the issue
A couple fixes
- add missing container/pod_cpu_limit, container/pod_cpu_request metrics
- remove duplicate entries of `etcd_request_duration_seconds`
- remove `etcd_request_duration_seconds` from `endpoint`, it should be `operation` only, this metric does not emit an endpoint
- `apiserver_requested_deprecated_apis` missing units
- `apiserver_storage_objects` duplicated

# Description of changes
See above

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested end to end

container/pod cpu limit/request.  No units is okay for CPU, kubernetes CPU limits are not a percentage or a well defined unit like bytes.  CI has historically published them without units.

![Screenshot 2023-10-05 at 10 21 06 AM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/dea0f9f8-2c74-400c-9ae9-aa4488fdd566)

![Screenshot 2023-10-05 at 10 15 35 AM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/c1b6aa0a-a8eb-4b92-9af2-341f024af92c)

`etcd_request_duration_seconds`:
![Screenshot 2023-10-05 at 10 21 44 AM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/8c398d82-b79c-4f8e-b30e-7fa635b31309)

`apiserver_storage_objects`:
![Screenshot 2023-10-05 at 10 10 17 AM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/e85c2766-df7b-48e3-8805-bf2468d8d4bb)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




