### PR TITLE
restrict pprof-addr to localhost

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -435,8 +435,7 @@ func main() {
 			parts := strings.Split(pprofHostPort, ":")
 			if len(parts) == 2 && parts[0] == "" {
 				pprofHostPort = fmt.Sprintf("localhost:%s", parts[1])
-			}
-			if !strings.Contains(pprofHostPort, "localhost") {
+			} else if parts[0] != "localhost" {
 				log.Printf("W! Not starting pprof, it is restricted to localhost:nnnn")
 				return
 			}
@@ -517,7 +516,10 @@ func main() {
 					log.Fatalf("E! Failed to unmarshal env config: %v", err)
 				}
 				envVars[parts[0]] = parts[1]
-				bytes, _ = json.MarshalIndent(envVars, "", "\t")
+				bytes, err = json.MarshalIndent(envVars, "", "\t")
+				if err != nil {
+					log.Fatalf("E! Failed to marshal env config: %v", err)
+				}
 				if err = os.WriteFile(*fEnvConfig, bytes, 0644); err != nil {
 					log.Fatalf("E! Failed to update env config: %v", err)
 				}

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -51,7 +51,7 @@ const (
 var fDebug = flag.Bool("debug", false,
 	"turn on debug logging")
 var pprofAddr = flag.String("pprof-addr", "",
-	"pprof address to listen on, not activate pprof if empty")
+	"pprof address to listen on, disabled by default, examples: 'localhost:1234', ':4567' (restricted to localhost)")
 var fQuiet = flag.Bool("quiet", false,
 	"run in quiet mode")
 var fTest = flag.Bool("test", false, "enable test mode: gather metrics, print them out, and exit")
@@ -80,8 +80,6 @@ var fAggregatorFilters = flag.String("aggregator-filter", "",
 	"filter the aggregators to enable, separator is :")
 var fProcessorFilters = flag.String("processor-filter", "",
 	"filter the processors to enable, separator is :")
-var fUsage = flag.String("usage", "",
-	"print usage for a plugin, ie, 'telegraf --usage mysql'")
 var fService = flag.String("service", "",
 	"operate on the service (windows only)")
 var fServiceName = flag.String("service-name", "telegraf", "service name (windows only)")
@@ -181,17 +179,17 @@ func reloadLoop(
 // The "config-translator" program populates that file.
 func loadEnvironmentVariables(path string) error {
 	if path == "" {
-		return fmt.Errorf("No env config file specified")
+		return fmt.Errorf("no env config file specified")
 	}
 
 	bytes, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("Can't read env config file %s due to: %s", path, err.Error())
+		return fmt.Errorf("cannot read env config file %s due to: %s", path, err.Error())
 	}
 	envVars := map[string]string{}
 	err = json.Unmarshal(bytes, &envVars)
 	if err != nil {
-		return fmt.Errorf("Can't create env config due to: %s", err.Error())
+		return fmt.Errorf("cannot create env config due to: %s", err.Error())
 	}
 
 	for key, val := range envVars {
@@ -203,7 +201,7 @@ func loadEnvironmentVariables(path string) error {
 
 func getEnvConfigPath(configPath, envConfigPath string) (string, error) {
 	if configPath == "" {
-		return "", fmt.Errorf("No config file specified")
+		return "", fmt.Errorf("no config file specified")
 	}
 	//load the environment variables that's saved in json env config file
 	if envConfigPath == "" {
@@ -438,6 +436,10 @@ func main() {
 			if len(parts) == 2 && parts[0] == "" {
 				pprofHostPort = fmt.Sprintf("localhost:%s", parts[1])
 			}
+			if !strings.Contains(pprofHostPort, "localhost") {
+				log.Printf("W! Not starting pprof, it is restricted to localhost:nnnn")
+				return
+			}
 			pprofHostPort = "http://" + pprofHostPort + "/debug/pprof"
 
 			log.Printf("I! Starting pprof HTTP server at: %s\n", pprofHostPort)
@@ -515,7 +517,7 @@ func main() {
 					log.Fatalf("E! Failed to unmarshal env config: %v", err)
 				}
 				envVars[parts[0]] = parts[1]
-				bytes, err = json.MarshalIndent(envVars, "", "\t")
+				bytes, _ = json.MarshalIndent(envVars, "", "\t")
 				if err = os.WriteFile(*fEnvConfig, bytes, 0644); err != nil {
 					log.Fatalf("E! Failed to update env config: %v", err)
 				}


### PR DESCRIPTION
# Description of the issue
Avoid potential misconfiguration exposing agent debug info externally.

# Description of changes
Improved the `--help` text for the `--prof-addr` option.
Added a check to ensure that the address is `localhost:nnnn`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Manual testing:
```
amazon-cloudwatch-agent --pprof-addr 123
2023-10-06T14:46:12Z W! Not starting pprof, it is restricted to localhost:nnnn
2023-10-06T14:46:12Z E! [telegraf] Error running agent: no config file specified

amazon-cloudwatch-agent --pprof-addr localhost
2023-10-06T14:46:18Z I! Starting pprof HTTP server at: http://localhost/debug/pprof
2023-10-06T14:46:18Z E! [telegraf] Error running agent: no config file specified
2023-10-06T14:46:18Z E! listen tcp: address localhost: missing port in address

amazon-cloudwatch-agent --pprof-addr localhost:123
2023-10-06T14:46:26Z I! Starting pprof HTTP server at: http://localhost:123/debug/pprof
2023-10-06T14:46:26Z E! [telegraf] Error running agent: no config file specified

amazon-cloudwatch-agent --pprof-addr :123         
2023-10-06T14:46:39Z I! Starting pprof HTTP server at: http://localhost:123/debug/pprof
2023-10-06T14:46:39Z E! [telegraf] Error running agent: no config file specified

amazon-cloudwatch-agent --pprof-addr lokalhost:8090
2023-10-06T14:47:04Z W! Not starting pprof, it is restricted to localhost:nnnn
2023-10-06T14:47:04Z E! [telegraf] Error running agent: no config file specified
```

`--help` output looks like this:
```
  -otelconfig string
    	YAML configuration file to run OTel pipeline
  -output-filter string
    	filter the outputs to enable, separator is :
  -output-list
    	print available output plugins.
  -pidfile string
    	file to write our pid to
  -pprof-addr string
    	pprof address to listen on, disabled by default, examples: 'localhost:1234', ':4567' (restricted to localhost)
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




