### PR TITLE
Use default value when -otelconfig option not given

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -259,6 +259,7 @@ func runAgent(ctx context.Context,
 	logger.SetupLogging(logConfig)
 
 	log.Printf("I! Starting AmazonCloudWatchAgent %s\n", agentinfo.FullVersion())
+	log.Printf("I! config: %v, %v",*fConfig, *fOtelConfig)
 	// Need to set SDK log level before plugins get loaded.
 	// Some aws.Config objects get created early and live forever which means
 	// we cannot change the sdk log level without restarting the Agent.

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -259,7 +259,6 @@ func runAgent(ctx context.Context,
 	logger.SetupLogging(logConfig)
 
 	log.Printf("I! Starting AmazonCloudWatchAgent %s\n", agentinfo.FullVersion())
-	log.Printf("I! config: %v, %v",*fConfig, *fOtelConfig)
 	// Need to set SDK log level before plugins get loaded.
 	// Some aws.Config objects get created early and live forever which means
 	// we cannot change the sdk log level without restarting the Agent.

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -58,7 +58,7 @@ var fQuiet = flag.Bool("quiet", false,
 var fTest = flag.Bool("test", false, "enable test mode: gather metrics, print them out, and exit")
 var fTestWait = flag.Int("test-wait", 0, "wait up to this many seconds for service inputs to complete in test mode")
 var fSchemaTest = flag.Bool("schematest", false, "validate the toml file schema")
-var fConfig = flag.String("config", "", "configuration file to load")
+var fTomlConfig = flag.String("config", "", "configuration file to load")
 var fOtelConfig = flag.String("otelconfig", paths.YamlConfigPath, "YAML configuration file to run OTel pipeline")
 var fEnvConfig = flag.String("envconfig", "", "env configuration file to load")
 var fConfigDirectory = flag.String("config-directory", "",
@@ -136,7 +136,7 @@ func reloadLoop(
 			}
 		}(ctx)
 
-		if envConfigPath, err := getEnvConfigPath(*fConfig, *fEnvConfig); err == nil {
+		if envConfigPath, err := getEnvConfigPath(*fTomlConfig, *fEnvConfig); err == nil {
 			// Reloads environment variables when file is changed
 			go func(ctx context.Context, envConfigPath string) {
 				var previousModTime time.Time
@@ -216,7 +216,7 @@ func runAgent(ctx context.Context,
 	inputFilters []string,
 	outputFilters []string,
 ) error {
-	envConfigPath, err := getEnvConfigPath(*fConfig, *fEnvConfig)
+	envConfigPath, err := getEnvConfigPath(*fTomlConfig, *fEnvConfig)
 	if err != nil {
 		return err
 	}
@@ -555,8 +555,8 @@ func main() {
 		// Handle the --service flag here to prevent any issues with tooling that
 		// may not have an interactive session, e.g. installing from Ansible.
 		if *fService != "" {
-			if *fConfig != "" {
-				svcConfig.Arguments = []string{"--config", *fConfig}
+			if *fTomlConfig != "" {
+				svcConfig.Arguments = []string{"--config", *fTomlConfig}
 			}
 			if *fConfigDirectory != "" {
 				svcConfig.Arguments = append(svcConfig.Arguments, "--config-directory", *fConfigDirectory)
@@ -607,7 +607,7 @@ func windowsRunAsService() bool {
 }
 
 func loadTomlConfigIntoAgent(c *config.Config) error {
-	err := c.LoadConfig(*fConfig)
+	err := c.LoadConfig(*fTomlConfig)
 	if err != nil {
 		return err
 	}
@@ -638,7 +638,7 @@ func validateAgentFinalConfigAndPlugins(c *config.Config) error {
 	if *fSchemaTest {
 		//up to this point, the given config file must be valid
 		fmt.Println(agentinfo.FullVersion())
-		fmt.Printf("The given config: %v is valid\n", *fConfig)
+		fmt.Printf("The given config: %v is valid\n", *fTomlConfig)
 		os.Exit(0)
 	}
 

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -42,6 +42,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/service/configprovider"
 	"github.com/aws/amazon-cloudwatch-agent/service/defaultcomponents"
 	"github.com/aws/amazon-cloudwatch-agent/service/registry"
+	"github.com/aws/amazon-cloudwatch-agent/tool/paths"
 )
 
 const (
@@ -58,7 +59,7 @@ var fTest = flag.Bool("test", false, "enable test mode: gather metrics, print th
 var fTestWait = flag.Int("test-wait", 0, "wait up to this many seconds for service inputs to complete in test mode")
 var fSchemaTest = flag.Bool("schematest", false, "validate the toml file schema")
 var fConfig = flag.String("config", "", "configuration file to load")
-var fOtelConfig = flag.String("otelconfig", "", "YAML configuration file to run OTel pipeline")
+var fOtelConfig = flag.String("otelconfig", paths.YamlConfigPath, "YAML configuration file to run OTel pipeline")
 var fEnvConfig = flag.String("envconfig", "", "env configuration file to load")
 var fConfigDirectory = flag.String("config-directory", "",
 	"directory containing additional *.conf files")

--- a/cmd/start-amazon-cloudwatch-agent/path.go
+++ b/cmd/start-amazon-cloudwatch-agent/path.go
@@ -27,7 +27,6 @@ func startAgent(writer io.WriteCloser) error {
 			paths.AgentBinaryPath, // when using syscall.Exec, must pass binary name as args[0]
 			"-config", paths.TomlConfigPath,
 			"-envconfig", paths.EnvConfigPath,
-			"-otelconfig", paths.YamlConfigPath,
 			"-pidfile", paths.AgentDir + "/var/amazon-cloudwatch-agent.pid",
 		}
 		if err := syscall.Exec(paths.AgentBinaryPath, execArgs, os.Environ()); err != nil {
@@ -65,7 +64,6 @@ func startAgent(writer io.WriteCloser) error {
 		paths.AgentBinaryPath,
 		"-config", paths.TomlConfigPath,
 		"-envconfig", paths.EnvConfigPath,
-		"-otelconfig", paths.YamlConfigPath,
 		"-pidfile", paths.AgentDir + "/var/amazon-cloudwatch-agent.pid",
 	}
 	if err = syscall.Exec(name, agentCmd, os.Environ()); err != nil {

--- a/cmd/start-amazon-cloudwatch-agent/path.go
+++ b/cmd/start-amazon-cloudwatch-agent/path.go
@@ -27,6 +27,7 @@ func startAgent(writer io.WriteCloser) error {
 			paths.AgentBinaryPath, // when using syscall.Exec, must pass binary name as args[0]
 			"-config", paths.TomlConfigPath,
 			"-envconfig", paths.EnvConfigPath,
+			"-otelconfig", paths.YamlConfigPath,
 			"-pidfile", paths.AgentDir + "/var/amazon-cloudwatch-agent.pid",
 		}
 		if err := syscall.Exec(paths.AgentBinaryPath, execArgs, os.Environ()); err != nil {
@@ -64,6 +65,7 @@ func startAgent(writer io.WriteCloser) error {
 		paths.AgentBinaryPath,
 		"-config", paths.TomlConfigPath,
 		"-envconfig", paths.EnvConfigPath,
+		"-otelconfig", paths.YamlConfigPath,
 		"-pidfile", paths.AgentDir + "/var/amazon-cloudwatch-agent.pid",
 	}
 	if err = syscall.Exec(name, agentCmd, os.Environ()); err != nil {

--- a/cmd/start-amazon-cloudwatch-agent/path_windows.go
+++ b/cmd/start-amazon-cloudwatch-agent/path_windows.go
@@ -10,10 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"os/exec"
-
-	"github.com/aws/amazon-cloudwatch-agent/tool/paths"
 )
 
 func startAgent(writer io.WriteCloser) error {
@@ -32,31 +29,4 @@ func startAgent(writer io.WriteCloser) error {
 	// log file is closed, so use fmt here
 	fmt.Printf("%s \n", stdoutStderr)
 	return err
-}
-
-func init() {
-	programFiles := os.Getenv("ProgramFiles")
-	var programData string
-	if _, ok := os.LookupEnv("ProgramData"); ok {
-		programData = os.Getenv("ProgramData")
-	} else {
-		// Windows 2003
-		programData = os.Getenv("ALLUSERSPROFILE") + "\\Application Data"
-	}
-
-	agentRootDir := programFiles + paths.AgentDir
-	agentConfigDir := programData + paths.AgentDir
-
-	jsonConfigPath = agentConfigDir + "\\" + JSON
-	jsonDirPath = agentConfigDir + paths.JsonDir
-	envConfigPath = agentConfigDir + "\\" + ENV
-	tomlConfigPath = agentConfigDir + "\\" + TOML
-	yamlConfigPath = agentConfigDir + "\\" + YAML
-
-	commonConfigPath = agentConfigDir + "\\" + COMMON_CONFIG
-
-	agentLogFilePath = agentConfigDir + "\\Logs\\" + AGENT_LOG_FILE
-
-	translatorBinaryPath = agentRootDir + "\\" + paths.TranslatorBinaryName
-	agentBinaryPath = agentRootDir + "\\" + paths.AgentBinaryName
 }

--- a/cmd/start-amazon-cloudwatch-agent/path_windows.go
+++ b/cmd/start-amazon-cloudwatch-agent/path_windows.go
@@ -25,6 +25,7 @@ func startAgent(writer io.WriteCloser) error {
 		paths.AgentBinaryPath,
 		"-config", paths.TomlConfigPath,
 		"-envconfig", paths.EnvConfigPath,
+		"-otelconfig", paths.YamlConfigPath,
 	)
 	stdoutStderr, err := cmd.CombinedOutput()
 	// log file is closed, so use fmt here

--- a/cmd/start-amazon-cloudwatch-agent/path_windows.go
+++ b/cmd/start-amazon-cloudwatch-agent/path_windows.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"log"
 	"os/exec"
+
+	"github.com/aws/amazon-cloudwatch-agent/tool/paths"
 )
 
 func startAgent(writer io.WriteCloser) error {
@@ -20,10 +22,9 @@ func startAgent(writer io.WriteCloser) error {
 	}
 
 	cmd := exec.Command(
-		agentBinaryPath,
-		"-config", tomlConfigPath,
-		"-envconfig", envConfigPath,
-		"-otelconfig", yamlConfigPath,
+		paths.AgentBinaryPath,
+		"-config", paths.TomlConfigPath,
+		"-envconfig", paths.EnvConfigPath,
 	)
 	stdoutStderr, err := cmd.CombinedOutput()
 	// log file is closed, so use fmt here

--- a/tool/paths/paths.go
+++ b/tool/paths/paths.go
@@ -4,24 +4,24 @@
 package paths
 
 const (
-	COMMON_CONFIG = "common-config.toml"
-	JSON          = "amazon-cloudwatch-agent.json"
-	TOML          = "amazon-cloudwatch-agent.toml"
-	YAML          = "amazon-cloudwatch-agent.yaml"
-	ENV           = "env-config.json"
+	COMMON_CONFIG  = "common-config.toml"
+	JSON           = "amazon-cloudwatch-agent.json"
+	TOML           = "amazon-cloudwatch-agent.toml"
+	YAML           = "amazon-cloudwatch-agent.yaml"
+	ENV            = "env-config.json"
 	AGENT_LOG_FILE = "amazon-cloudwatch-agent.log"
 	//TODO this CONFIG_DIR_IN_CONTAINER should change to something indicate dir, keep it for now to avoid break testing
 	CONFIG_DIR_IN_CONTAINER = "/etc/cwagentconfig"
 )
 
 var (
-	JsonConfigPath   string
-	JsonDirPath      string
-	EnvConfigPath    string
-	TomlConfigPath   string
-	CommonConfigPath string
-	YamlConfigPath   string
-	AgentLogFilePath string
+	JsonConfigPath       string
+	JsonDirPath          string
+	EnvConfigPath        string
+	TomlConfigPath       string
+	CommonConfigPath     string
+	YamlConfigPath       string
+	AgentLogFilePath     string
 	TranslatorBinaryPath string
 	AgentBinaryPath      string
 )

--- a/tool/paths/paths.go
+++ b/tool/paths/paths.go
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package paths
+
+const (
+	COMMON_CONFIG = "common-config.toml"
+	JSON          = "amazon-cloudwatch-agent.json"
+	TOML          = "amazon-cloudwatch-agent.toml"
+	YAML          = "amazon-cloudwatch-agent.yaml"
+	ENV           = "env-config.json"
+	AGENT_LOG_FILE = "amazon-cloudwatch-agent.log"
+	//TODO this CONFIG_DIR_IN_CONTAINER should change to something indicate dir, keep it for now to avoid break testing
+	CONFIG_DIR_IN_CONTAINER = "/etc/cwagentconfig"
+)
+
+var (
+	JsonConfigPath   string
+	JsonDirPath      string
+	EnvConfigPath    string
+	TomlConfigPath   string
+	CommonConfigPath string
+	YamlConfigPath   string
+	AgentLogFilePath string
+	TranslatorBinaryPath string
+	AgentBinaryPath      string
+)

--- a/tool/paths/paths_unix.go
+++ b/tool/paths/paths_unix.go
@@ -6,6 +6,8 @@
 
 package paths
 
+import "path/filepath"
+
 const (
 	AgentDir             = "/opt/aws/amazon-cloudwatch-agent"
 	BinaryDir            = "bin"
@@ -17,15 +19,13 @@ const (
 )
 
 func init() {
-	JsonConfigPath = AgentDir + "/etc/" + JSON
-	JsonDirPath = AgentDir + "/etc/" + JsonDir
-	EnvConfigPath = AgentDir + "/etc/" + ENV
-	TomlConfigPath = AgentDir + "/etc/" + TOML
-	CommonConfigPath = AgentDir + "/etc/" + COMMON_CONFIG
-	YamlConfigPath = AgentDir + "/etc/" + YAML
-
-	AgentLogFilePath = AgentDir + "/logs/" + AGENT_LOG_FILE
-
-	TranslatorBinaryPath = AgentDir + "/bin/" + TranslatorBinaryName
-	AgentBinaryPath = AgentDir + "/bin/" + AgentBinaryName
+	JsonConfigPath = filepath.Join(AgentDir, "etc", JSON)
+	JsonDirPath = filepath.Join(AgentDir, "etc", JsonDir)
+	EnvConfigPath = filepath.Join(AgentDir, "etc", ENV)
+	TomlConfigPath = filepath.Join(AgentDir, "etc", TOML)
+	CommonConfigPath = filepath.Join(AgentDir, "etc", COMMON_CONFIG)
+	YamlConfigPath = filepath.Join(AgentDir, "etc", YAML)
+	AgentLogFilePath = filepath.Join(AgentDir, "logs", AGENT_LOG_FILE)
+	TranslatorBinaryPath = filepath.Join(AgentDir, "bin", TranslatorBinaryName)
+	AgentBinaryPath = filepath.Join(AgentDir, "bin", AgentBinaryName)
 }

--- a/tool/paths/paths_unix.go
+++ b/tool/paths/paths_unix.go
@@ -7,13 +7,13 @@
 package paths
 
 const (
-	AgentDir = "/opt/aws/amazon-cloudwatch-agent"
-	BinaryDir = "bin"
-	JsonDir = "amazon-cloudwatch-agent.d"
+	AgentDir             = "/opt/aws/amazon-cloudwatch-agent"
+	BinaryDir            = "bin"
+	JsonDir              = "amazon-cloudwatch-agent.d"
 	TranslatorBinaryName = "config-translator"
-	AgentBinaryName = "amazon-cloudwatch-agent"
-	WizardBinaryName = "amazon-cloudwatch-agent-config-wizard"
-	AgentStartName = "amazon-cloudwatch-agent-ctl"
+	AgentBinaryName      = "amazon-cloudwatch-agent"
+	WizardBinaryName     = "amazon-cloudwatch-agent-config-wizard"
+	AgentStartName       = "amazon-cloudwatch-agent-ctl"
 )
 
 func init() {

--- a/tool/paths/paths_unix.go
+++ b/tool/paths/paths_unix.go
@@ -7,11 +7,25 @@
 package paths
 
 const (
-	AgentDir             = "/opt/aws/amazon-cloudwatch-agent"
-	BinaryDir            = "bin"
-	JsonDir              = "amazon-cloudwatch-agent.d"
+	AgentDir = "/opt/aws/amazon-cloudwatch-agent"
+	BinaryDir = "bin"
+	JsonDir = "amazon-cloudwatch-agent.d"
 	TranslatorBinaryName = "config-translator"
-	AgentBinaryName      = "amazon-cloudwatch-agent"
-	WizardBinaryName     = "amazon-cloudwatch-agent-config-wizard"
-	AgentStartName       = "amazon-cloudwatch-agent-ctl"
+	AgentBinaryName = "amazon-cloudwatch-agent"
+	WizardBinaryName = "amazon-cloudwatch-agent-config-wizard"
+	AgentStartName = "amazon-cloudwatch-agent-ctl"
 )
+
+func init() {
+	JsonConfigPath = AgentDir + "/etc/" + JSON
+	JsonDirPath = AgentDir + "/etc/" + JsonDir
+	EnvConfigPath = AgentDir + "/etc/" + ENV
+	TomlConfigPath = AgentDir + "/etc/" + TOML
+	CommonConfigPath = AgentDir + "/etc/" + COMMON_CONFIG
+	YamlConfigPath = AgentDir + "/etc/" + YAML
+
+	AgentLogFilePath = AgentDir + "/logs/" + AGENT_LOG_FILE
+
+	TranslatorBinaryPath = AgentDir + "/bin/" + TranslatorBinaryName
+	AgentBinaryPath = AgentDir + "/bin/" + AgentBinaryName
+}

--- a/tool/paths/paths_windows.go
+++ b/tool/paths/paths_windows.go
@@ -6,12 +6,38 @@
 
 package paths
 
+import "os"
+
 const (
-	AgentDir             = "\\Amazon\\AmazonCloudWatchAgent\\"
-	JsonDir              = "\\Configs"
-	BinaryDir            = "bin"
+	AgentDir = "\\Amazon\\AmazonCloudWatchAgent\\"
+	JsonDir = "\\Configs"
+	BinaryDir = "bin"
 	TranslatorBinaryName = "config-translator.exe"
-	AgentBinaryName      = "amazon-cloudwatch-agent.exe"
-	WizardBinaryName     = "amazon-cloudwatch-agent-config-wizard.exe"
-	AgentStartName       = "amazon-cloudwatch-agent-ctl.ps1"
+	AgentBinaryName = "amazon-cloudwatch-agent.exe"
+	WizardBinaryName = "amazon-cloudwatch-agent-config-wizard.exe"
+	AgentStartName = "amazon-cloudwatch-agent-ctl.ps1"
 )
+
+func init() {
+	programFiles := os.Getenv("ProgramFiles")
+	var programData string
+	if _, ok := os.LookupEnv("ProgramData"); ok {
+		programData = os.Getenv("ProgramData")
+	} else {
+		// Windows 2003
+		programData = os.Getenv("ALLUSERSPROFILE") + "\\Application Data"
+	}
+
+	AgentRootDir := programFiles + paths.AgentDir
+	AgentConfigDir := programData + paths.AgentDir
+
+	JsonConfigPath = agentConfigDir + "\\" + JSON
+	JsonDirPath = agentConfigDir + paths.JsonDir
+	EnvConfigPath = agentConfigDir + "\\" + ENV
+	TomlConfigPath = agentConfigDir + "\\" + TOML
+	YamlConfigPath = agentConfigDir + "\\" + YAML
+	CommonConfigPath = agentConfigDir + "\\" + COMMON_CONFIG
+	AgentLogFilePath = agentConfigDir + "\\Logs\\" + AGENT_LOG_FILE
+	TranslatorBinaryPath = agentRootDir + "\\" + paths.TranslatorBinaryName
+	AgentBinaryPath = agentRootDir + "\\" + paths.AgentBinaryName
+}

--- a/tool/paths/paths_windows.go
+++ b/tool/paths/paths_windows.go
@@ -31,8 +31,8 @@ func init() {
 		programData = filepath.Join(os.Getenv("ALLUSERSPROFILE"), "Application Data")
 	}
 
-	AgentRootDir := programFiles + AgentDir
-	AgentConfigDir := programData + AgentDir
+	AgentRootDir := filepath.Join(programFiles, AgentDir)
+	AgentConfigDir := filepath.Join(programData, AgentDir)
 	JsonConfigPath = filepath.Join(AgentConfigDir, JSON)
 	JsonDirPath = filepath.Join(AgentConfigDir, JsonDir)
 	EnvConfigPath = filepath.Join(AgentConfigDir, ENV)

--- a/tool/paths/paths_windows.go
+++ b/tool/paths/paths_windows.go
@@ -9,13 +9,13 @@ package paths
 import "os"
 
 const (
-	AgentDir = "\\Amazon\\AmazonCloudWatchAgent\\"
-	JsonDir = "\\Configs"
-	BinaryDir = "bin"
+	AgentDir             = "\\Amazon\\AmazonCloudWatchAgent\\"
+	JsonDir              = "\\Configs"
+	BinaryDir            = "bin"
 	TranslatorBinaryName = "config-translator.exe"
-	AgentBinaryName = "amazon-cloudwatch-agent.exe"
-	WizardBinaryName = "amazon-cloudwatch-agent-config-wizard.exe"
-	AgentStartName = "amazon-cloudwatch-agent-ctl.ps1"
+	AgentBinaryName      = "amazon-cloudwatch-agent.exe"
+	WizardBinaryName     = "amazon-cloudwatch-agent-config-wizard.exe"
+	AgentStartName       = "amazon-cloudwatch-agent-ctl.ps1"
 )
 
 func init() {
@@ -28,16 +28,16 @@ func init() {
 		programData = os.Getenv("ALLUSERSPROFILE") + "\\Application Data"
 	}
 
-	AgentRootDir := programFiles + paths.AgentDir
-	AgentConfigDir := programData + paths.AgentDir
+	AgentRootDir := programFiles + AgentDir
+	AgentConfigDir := programData + AgentDir
 
-	JsonConfigPath = agentConfigDir + "\\" + JSON
-	JsonDirPath = agentConfigDir + paths.JsonDir
-	EnvConfigPath = agentConfigDir + "\\" + ENV
-	TomlConfigPath = agentConfigDir + "\\" + TOML
-	YamlConfigPath = agentConfigDir + "\\" + YAML
-	CommonConfigPath = agentConfigDir + "\\" + COMMON_CONFIG
-	AgentLogFilePath = agentConfigDir + "\\Logs\\" + AGENT_LOG_FILE
-	TranslatorBinaryPath = agentRootDir + "\\" + paths.TranslatorBinaryName
-	AgentBinaryPath = agentRootDir + "\\" + paths.AgentBinaryName
+	JsonConfigPath = AgentConfigDir + "\\" + JSON
+	JsonDirPath = AgentConfigDir + JsonDir
+	EnvConfigPath = AgentConfigDir + "\\" + ENV
+	TomlConfigPath = AgentConfigDir + "\\" + TOML
+	YamlConfigPath = AgentConfigDir + "\\" + YAML
+	CommonConfigPath = AgentConfigDir + "\\" + COMMON_CONFIG
+	AgentLogFilePath = AgentConfigDir + "\\Logs\\" + AGENT_LOG_FILE
+	TranslatorBinaryPath = AgentRootDir + "\\" + TranslatorBinaryName
+	AgentBinaryPath = AgentRootDir + "\\" + AgentBinaryName
 }

--- a/tool/paths/paths_windows.go
+++ b/tool/paths/paths_windows.go
@@ -6,7 +6,10 @@
 
 package paths
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 const (
 	AgentDir             = "\\Amazon\\AmazonCloudWatchAgent\\"
@@ -25,19 +28,18 @@ func init() {
 		programData = os.Getenv("ProgramData")
 	} else {
 		// Windows 2003
-		programData = os.Getenv("ALLUSERSPROFILE") + "\\Application Data"
+		programData = filepath.Join(os.Getenv("ALLUSERSPROFILE"), "Application Data")
 	}
 
 	AgentRootDir := programFiles + AgentDir
 	AgentConfigDir := programData + AgentDir
-
-	JsonConfigPath = AgentConfigDir + "\\" + JSON
-	JsonDirPath = AgentConfigDir + JsonDir
-	EnvConfigPath = AgentConfigDir + "\\" + ENV
-	TomlConfigPath = AgentConfigDir + "\\" + TOML
-	YamlConfigPath = AgentConfigDir + "\\" + YAML
-	CommonConfigPath = AgentConfigDir + "\\" + COMMON_CONFIG
-	AgentLogFilePath = AgentConfigDir + "\\Logs\\" + AGENT_LOG_FILE
-	TranslatorBinaryPath = AgentRootDir + "\\" + TranslatorBinaryName
-	AgentBinaryPath = AgentRootDir + "\\" + AgentBinaryName
+	JsonConfigPath = filepath.Join(AgentConfigDir, JSON)
+	JsonDirPath = filepath.Join(AgentConfigDir, JsonDir)
+	EnvConfigPath = filepath.Join(AgentConfigDir, ENV)
+	TomlConfigPath = filepath.Join(AgentConfigDir, TOML)
+	YamlConfigPath = filepath.Join(AgentConfigDir, YAML)
+	CommonConfigPath = filepath.Join(AgentConfigDir, COMMON_CONFIG)
+	AgentLogFilePath = filepath.Join(AgentConfigDir, AGENT_LOG_FILE)
+	TranslatorBinaryPath = filepath.Join(AgentRootDir, TranslatorBinaryName)
+	AgentBinaryPath = filepath.Join(AgentRootDir, AgentBinaryName)
 }


### PR DESCRIPTION
# Description of the issue
The problem is some users directly start the `amazon-cloudwatch-agent` program.
Until recently there was no `-otelconfig` option.
Now there is, and it is breaking some users (missing metrics).

# Description of changes
Most of the changes are refactoring some common code from `start-amazon-cloudwatch-agent` into `tools/paths` package. Ultimately I just want to reuse the same variable the `start-amazon-cloudwatch-agent` program uses when it generates the YAML config.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- `make build`, `make test`
- Manually copied the linux_amd64 binaries to a test host and started the agent with the default linux config.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




