### PR TITLE
add missing apiserver_current_inqueue_requests declaration

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -208,6 +208,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_current_inflight_requests
+          - apiserver_current_inqueue_requests
       - dimensions: [ [ClusterName, name], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -179,6 +179,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_current_inflight_requests
+          - apiserver_current_inqueue_requests
       - dimensions: [ [ ClusterName, name ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -208,6 +208,7 @@ exporters:
         label_matchers: [ ]
         metric_name_selectors:
           - apiserver_current_inflight_requests
+          - apiserver_current_inqueue_requests
       - dimensions: [ [ ClusterName, name ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -315,6 +315,7 @@ func getControlPlaneMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Met
 				Dimensions: [][]string{{"ClusterName", "request_kind"}, {"ClusterName"}},
 				MetricNameSelectors: []string{
 					"apiserver_current_inflight_requests",
+					"apiserver_current_inqueue_requests",
 				},
 			},
 			{

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -365,7 +365,7 @@ func TestTranslator(t *testing.T) {
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "request_kind"}, {"ClusterName"}},
-						MetricNameSelectors: []string{"apiserver_current_inflight_requests"},
+						MetricNameSelectors: []string{"apiserver_current_inflight_requests", "apiserver_current_inqueue_requests"},
 					},
 					{
 						Dimensions:          [][]string{{"ClusterName", "name"}, {"ClusterName"}},


### PR DESCRIPTION
# Description of the issue
`apiserver_current_inqueue_requests` was missing

# Description of changes
adds `apiserver_current_inqueue_requests` to the declarations

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
tested end to end

![Screenshot 2023-10-06 at 4 36 04 PM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/95b40a61-0430-47ad-8bbb-11ae924efe85)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




