### PR TITLE
update enhanced CI metrics and tests for pod_container_status metrics

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -60,15 +60,6 @@ exporters:
           - container_filesystem_usage
           - container_filesystem_available
           - container_filesystem_utilization
-          - container_status_running
-          - container_status_terminated
-          - container_status_waiting
-          - container_status_waiting_reason_crash_loop_back_off
-          - container_status_waiting_reason_image_pull_error
-          - container_status_waiting_reason_start_error
-          - container_status_waiting_reason_create_container_error
-          - container_status_waiting_reason_create_container_config_error
-          - container_status_terminated_reason_oom_killed
       # pod metrics
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
         label_matchers: [ ]
@@ -103,6 +94,15 @@ exporters:
           - pod_memory_limit
           - pod_cpu_limit
           - pod_cpu_request
+          - pod_container_status_running
+          - pod_container_status_terminated
+          - pod_container_status_waiting
+          - pod_container_status_waiting_reason_crash_loop_back_off
+          - pod_container_status_waiting_reason_image_pull_error
+          - pod_container_status_waiting_reason_start_error
+          - pod_container_status_waiting_reason_create_container_error
+          - pod_container_status_waiting_reason_create_container_config_error
+          - pod_container_status_terminated_reason_oom_killed
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -31,15 +31,6 @@ exporters:
           - container_filesystem_usage
           - container_filesystem_available
           - container_filesystem_utilization
-          - container_status_running
-          - container_status_terminated
-          - container_status_waiting
-          - container_status_waiting_reason_crash_loop_back_off
-          - container_status_waiting_reason_image_pull_error
-          - container_status_waiting_reason_start_error
-          - container_status_waiting_reason_create_container_error
-          - container_status_waiting_reason_create_container_config_error
-          - container_status_terminated_reason_oom_killed
       # pod metrics
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
         label_matchers: [ ]
@@ -56,7 +47,7 @@ exporters:
           - pod_interface_network_rx_dropped
           - pod_interface_network_tx_dropped
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, Service ] ]
-        label_matchers: [ ]
+        label_matchers: []
         metric_name_selectors:
           - pod_cpu_reserved_capacity
           - pod_memory_reserved_capacity
@@ -74,6 +65,15 @@ exporters:
           - pod_memory_limit
           - pod_cpu_limit
           - pod_cpu_request
+          - pod_container_status_running
+          - pod_container_status_terminated
+          - pod_container_status_waiting
+          - pod_container_status_waiting_reason_crash_loop_back_off
+          - pod_container_status_waiting_reason_image_pull_error
+          - pod_container_status_waiting_reason_start_error
+          - pod_container_status_waiting_reason_create_container_error
+          - pod_container_status_waiting_reason_create_container_config_error
+          - pod_container_status_terminated_reason_oom_killed
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -60,15 +60,6 @@ exporters:
           - container_filesystem_usage
           - container_filesystem_available
           - container_filesystem_utilization
-          - container_status_running
-          - container_status_terminated
-          - container_status_waiting
-          - container_status_waiting_reason_crash_loop_back_off
-          - container_status_waiting_reason_image_pull_error
-          - container_status_waiting_reason_start_error
-          - container_status_waiting_reason_create_container_error
-          - container_status_waiting_reason_create_container_config_error
-          - container_status_terminated_reason_oom_killed
       # pod metrics
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
         label_matchers: [ ]
@@ -85,7 +76,7 @@ exporters:
           - pod_interface_network_rx_dropped
           - pod_interface_network_tx_dropped
       - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, Service ] ]
-        label_matchers: [ ]
+        label_matchers: []
         metric_name_selectors:
           - pod_cpu_reserved_capacity
           - pod_memory_reserved_capacity
@@ -103,6 +94,15 @@ exporters:
           - pod_memory_limit
           - pod_cpu_limit
           - pod_cpu_request
+          - pod_container_status_running
+          - pod_container_status_terminated
+          - pod_container_status_waiting
+          - pod_container_status_waiting_reason_crash_loop_back_off
+          - pod_container_status_waiting_reason_image_pull_error
+          - pod_container_status_waiting_reason_start_error
+          - pod_container_status_waiting_reason_create_container_error
+          - pod_container_status_waiting_reason_create_container_config_error
+          - pod_container_status_terminated_reason_oom_killed
       # node metrics
       - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
         label_matchers: [ ]

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -63,9 +63,6 @@ func getContainerMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.Metric
 				"container_cpu_utilization", "container_cpu_utilization_over_container_limit", "container_cpu_limit", "container_cpu_request",
 				"container_memory_utilization", "container_memory_utilization_over_container_limit", "container_memory_failures_total", "container_memory_limit", "container_memory_request",
 				"container_filesystem_usage", "container_filesystem_available", "container_filesystem_utilization",
-				"container_status_running", "container_status_terminated", "container_status_waiting", "container_status_waiting_reason_crash_loop_back_off",
-				"container_status_waiting_reason_image_pull_error", "container_status_waiting_reason_start_error", "container_status_waiting_reason_create_container_error",
-				"container_status_waiting_reason_create_container_config_error", "container_status_terminated_reason_oom_killed",
 			},
 		}
 
@@ -95,6 +92,9 @@ func getPodMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 		selectors = append(selectors, []string{"pod_number_of_container_restarts", "pod_number_of_containers", "pod_number_of_running_containers",
 			"pod_status_ready", "pod_status_scheduled", "pod_status_running", "pod_status_pending", "pod_status_failed", "pod_status_unknown",
 			"pod_status_succeeded", "pod_memory_request", "pod_memory_limit", "pod_cpu_limit", "pod_cpu_request",
+			"pod_container_status_running", "pod_container_status_terminated", "pod_container_status_waiting", "pod_container_status_waiting_reason_crash_loop_back_off",
+			"pod_container_status_waiting_reason_image_pull_error", "pod_container_status_waiting_reason_start_error", "pod_container_status_waiting_reason_create_container_error",
+			"pod_container_status_waiting_reason_create_container_config_error", "pod_container_status_terminated_reason_oom_killed",
 		}...)
 
 	}

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -270,9 +270,6 @@ func TestTranslator(t *testing.T) {
 							"container_cpu_utilization", "container_cpu_utilization_over_container_limit", "container_cpu_limit", "container_cpu_request",
 							"container_memory_utilization", "container_memory_utilization_over_container_limit", "container_memory_failures_total", "container_memory_limit", "container_memory_request",
 							"container_filesystem_usage", "container_filesystem_available", "container_filesystem_utilization",
-							"container_status_running", "container_status_terminated", "container_status_waiting", "container_status_waiting_reason_crash_loop_back_off",
-							"container_status_waiting_reason_image_pull_error", "container_status_waiting_reason_start_error", "container_status_waiting_reason_create_container_error",
-							"container_status_waiting_reason_create_container_config_error", "container_status_terminated_reason_oom_killed",
 						},
 					},
 					{
@@ -295,6 +292,9 @@ func TestTranslator(t *testing.T) {
 						MetricNameSelectors: []string{"pod_cpu_reserved_capacity", "pod_memory_reserved_capacity", "pod_number_of_container_restarts", "pod_number_of_containers", "pod_number_of_running_containers",
 							"pod_status_ready", "pod_status_scheduled", "pod_status_running", "pod_status_pending", "pod_status_failed", "pod_status_unknown",
 							"pod_status_succeeded", "pod_memory_request", "pod_memory_limit", "pod_cpu_limit", "pod_cpu_request",
+							"pod_container_status_running", "pod_container_status_terminated", "pod_container_status_waiting", "pod_container_status_waiting_reason_crash_loop_back_off",
+							"pod_container_status_waiting_reason_image_pull_error", "pod_container_status_waiting_reason_start_error", "pod_container_status_waiting_reason_create_container_error",
+							"pod_container_status_waiting_reason_create_container_config_error", "pod_container_status_terminated_reason_oom_killed",
 						},
 					},
 					{


### PR DESCRIPTION
# Description of the issue
Move to container status metrics
See https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/109

# Description of changes
Updated metrics/units:
![Screenshot 2023-10-10 at 2 16 10 PM](https://github.com/aws/amazon-cloudwatch-agent/assets/5192710/d455ba5f-f7ec-4a53-a5c0-9328d18b75f7)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
tested end to end, see screenshots aove

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




