### PR TITLE
Add New Metrics For Where Customer Are Using The Agent

### DIFF
--- a/cmd/config-downloader/downloader.go
+++ b/cmd/config-downloader/downloader.go
@@ -143,7 +143,7 @@ func main() {
 
 	mode = sdkutil.DetectAgentMode(mode)
 
-	region = util.DetectRegion(mode, cc.CredentialsMap())
+	region, _ = util.DetectRegion(mode, cc.CredentialsMap())
 
 	if region == "" && downloadLocation != locationDefault {
 		fmt.Println("Unable to determine aws-region.")

--- a/handlers/agentinfo/info_test.go
+++ b/handlers/agentinfo/info_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	ai := New("")
+	ai := New("", "", "")
 	expectedUserAgentRegex := `^CWAgent/Unknown \(.*\) ` +
 		`ID/[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$`
 
@@ -37,7 +37,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestRecordOpData(t *testing.T) {
-	ai := newAgentInfo("")
+	ai := newAgentInfo("", "", "")
 
 	stats := ai.StatsHeader()
 	actual := agentStats{}
@@ -124,8 +124,20 @@ func TestGetAgentStats(t *testing.T) {
 		PayloadBytes:        aws.Int(5678),
 		StatusCode:          aws.Int(200),
 		ImdsFallbackSucceed: aws.Int(1),
+		RunInContainer:      aws.Int(0),
+		RegionType:          aws.String(EC2Metadata),
+		Mode:                aws.String(ModeWithIRSA),
 	}
 
+	assert.Equal(t, "\"cpu\":1.2,\"mem\":123,\"fd\":456,\"th\":789,\"lat\":1234,\"load\":5678,\"code\":200,\"ifs\":1,\"ric\":0,\"rt\":\"EC2M\",\"m\":\"WI\"", getAgentStats(stats))
+
+	stats.Mode = nil
+	assert.Equal(t, "\"cpu\":1.2,\"mem\":123,\"fd\":456,\"th\":789,\"lat\":1234,\"load\":5678,\"code\":200,\"ifs\":1,\"ric\":0,\"rt\":\"EC2M\"", getAgentStats(stats))
+
+	stats.RegionType = nil
+	assert.Equal(t, "\"cpu\":1.2,\"mem\":123,\"fd\":456,\"th\":789,\"lat\":1234,\"load\":5678,\"code\":200,\"ifs\":1,\"ric\":0", getAgentStats(stats))
+
+	stats.RunInContainer = nil
 	assert.Equal(t, "\"cpu\":1.2,\"mem\":123,\"fd\":456,\"th\":789,\"lat\":1234,\"load\":5678,\"code\":200,\"ifs\":1", getAgentStats(stats))
 
 	stats.ImdsFallbackSucceed = nil

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -81,7 +81,7 @@ func (c *CloudWatch) Capabilities() consumer.Capabilities {
 }
 
 func (c *CloudWatch) Start(_ context.Context, host component.Host) error {
-	c.agentInfo = agentinfo.New("")
+	c.agentInfo = agentinfo.New("", c.config.RegionType, c.config.Mode)
 	c.publisher, _ = publisher.NewPublisher(
 		publisher.NewNonBlockingFifoQueue(metricChanBufferSize),
 		maxConcurrentPublisher,

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -382,7 +382,7 @@ func newCloudWatchClient(
 			MaxDatumsPerCall:   defaultMaxDatumsPerCall,
 			MaxValuesPerDatum:  defaultMaxValuesPerDatum,
 		},
-		agentInfo: agentinfo.New(""),
+		agentInfo: agentinfo.New("", "", ""),
 	}
 	cloudwatch.startRoutines()
 	return cloudwatch

--- a/plugins/outputs/cloudwatch/config.go
+++ b/plugins/outputs/cloudwatch/config.go
@@ -11,13 +11,15 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-// Config represent a configuration for the CloudWatch logs exporter.
+// Config represent a configuration for the CloudWatch metrics exporter.
 type Config struct {
 	Region                   string          `mapstructure:"region"`
 	EndpointOverride         string          `mapstructure:"endpoint_override,omitempty"`
 	AccessKey                string          `mapstructure:"access_key,omitempty"`
 	SecretKey                string          `mapstructure:"secret_key,omitempty"`
 	RoleARN                  string          `mapstructure:"role_arn,omitempty"`
+	RegionType               string          `mapstructure:"region_type,omitempty"`
+	Mode                     string          `mapstructure:"mode,omitempty"`
 	Profile                  string          `mapstructure:"profile,omitempty"`
 	SharedCredentialFilename string          `mapstructure:"shared_credential_file,omitempty"`
 	Token                    string          `mapstructure:"token,omitempty"`

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -31,7 +31,7 @@ const (
 	LogEntryField     = "value"
 
 	defaultFlushTimeout = 5 * time.Second
-	eventHeaderSize     = 26
+	eventHeaderSize     = 200
 	truncatedSuffix     = "[Truncated...]"
 	msgSizeLimit        = 256*1024 - eventHeaderSize
 
@@ -43,6 +43,8 @@ const (
 
 type CloudWatchLogs struct {
 	Region           string `toml:"region"`
+	RegionType       string `toml:"region_type"`
+	Mode             string `toml:"mode"`
 	EndpointOverride string `toml:"endpoint_override"`
 	AccessKey        string `toml:"access_key"`
 	SecretKey        string `toml:"secret_key"`
@@ -133,7 +135,7 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 			Logger:   configaws.SDKLogger{},
 		},
 	)
-	agentInfo := agentinfo.New(t.Group)
+	agentInfo := agentinfo.New(t.Group, c.RegionType, c.Mode)
 	client.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{"PutLogEvents"}))
 	client.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentInfo.UserAgent()))
 	client.Handlers.Build.PushBackNamed(handlers.NewDynamicCustomHeaderHandler("X-Amz-Agent-Stats", agentInfo.StatsHeader))

--- a/plugins/outputs/cloudwatchlogs/pusher_test.go
+++ b/plugins/outputs/cloudwatchlogs/pusher_test.go
@@ -765,6 +765,6 @@ func TestResendWouldStopAfterExhaustedRetries(t *testing.T) {
 
 func testPreparation(retention int, s *svcMock, flushTimeout time.Duration, retryDuration time.Duration) (chan struct{}, *pusher) {
 	stop := make(chan struct{})
-	p := NewPusher(Target{"G", "S", retention}, s, flushTimeout, retryDuration, models.NewLogger("cloudwatchlogs", "test", ""), stop, &wg, agentinfo.New(""))
+	p := NewPusher(Target{"G", "S", retention}, s, flushTimeout, retryDuration, models.NewLogger("cloudwatchlogs", "test", ""), stop, &wg, agentinfo.New("", "", ""))
 	return stop, p
 }

--- a/translator/context/context.go
+++ b/translator/context/context.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/aws/amazon-cloudwatch-agent/handlers/agentinfo"
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 )
 
@@ -41,6 +42,7 @@ type Context struct {
 	multiConfig         string
 	outputTomlFilePath  string
 	mode                string
+	shortMode           string
 	credentials         map[string]string
 	proxy               map[string]string
 	ssl                 map[string]string
@@ -96,6 +98,10 @@ func (ctx *Context) Mode() string {
 	return ctx.mode
 }
 
+func (ctx *Context) ShortMode() string {
+	return ctx.shortMode
+}
+
 func (ctx *Context) Credentials() map[string]string {
 	return ctx.credentials
 }
@@ -112,12 +118,16 @@ func (ctx *Context) SetMode(mode string) {
 	switch mode {
 	case config.ModeEC2:
 		ctx.mode = config.ModeEC2
+		ctx.shortMode = agentinfo.ModeEC2
 	case config.ModeOnPrem:
 		ctx.mode = config.ModeOnPrem
+		ctx.shortMode = agentinfo.ModeOnPrem
 	case config.ModeOnPremise:
 		ctx.mode = config.ModeOnPremise
+		ctx.shortMode = agentinfo.ModeOnPrem
 	case config.ModeWithIRSA:
 		ctx.mode = config.ModeWithIRSA
+		ctx.shortMode = agentinfo.ModeWithIRSA
 	default:
 		log.Panicf("Invalid mode %s. Valid mode values are %s, %s, %s and %s.", mode, config.ModeEC2, config.ModeOnPrem, config.ModeOnPremise, config.ModeWithIRSA)
 	}

--- a/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
@@ -6,6 +6,8 @@ exporters:
     max_values_per_datum: 150
     namespace: CWAgent
     region: us-west-2
+    region_type: "ACJ"
+    mode: "EC2"
     resource_to_telemetry_conversion:
       enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/advanced_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_windows.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/basic_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/basic_config_linux.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-east-1
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/basic_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/basic_config_windows.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/collectd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/collectd_config_linux.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.conf
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.conf
@@ -126,4 +126,6 @@
     force_flush_interval = "60s"
     log_stream_name = "LOG_STREAM_NAME"
     region = "us-west-2"
+    region_type = "ACJ"
+    mode = "EC2"
     role_arn = "log_role_arn_value_test"

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -7,6 +7,8 @@ exporters:
         max_values_per_datum: 5000
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.conf
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.conf
@@ -126,4 +126,6 @@
     force_flush_interval = "60s"
     log_stream_name = "LOG_STREAM_NAME"
     region = "us-west-2"
+    region_type = "ACJ"
+    mode = "EC2"
     role_arn = "log_role_arn_value_test"

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -10,6 +10,8 @@ exporters:
         max_values_per_datum: 5000
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.conf
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.conf
@@ -144,4 +144,6 @@
     force_flush_interval = "60s"
     log_stream_name = "LOG_STREAM_NAME"
     region = "us-west-2"
+    region_type = "ACJ"
+    mode = "EC2"
     role_arn = "log_role_arn_value_test"

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
@@ -7,6 +7,8 @@ exporters:
         max_values_per_datum: 5000
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test

--- a/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
@@ -6,6 +6,8 @@ exporters:
       max_values_per_datum: 150
       namespace: CWAgent
       region: us-east-1
+      region_type: "ACJ"
+      mode: "EC2"
       resource_to_telemetry_conversion:
         enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
@@ -6,6 +6,8 @@ exporters:
       max_values_per_datum: 150
       namespace: CWAgent
       region: us-east-1
+      region_type: "ACJ"
+      mode: "EC2"
       resource_to_telemetry_conversion:
         enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/drop_origin_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/drop_origin_linux.yaml
@@ -11,6 +11,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/ignore_append_dimensions.yaml
+++ b/translator/tocwconfig/sampleConfig/ignore_append_dimensions.yaml
@@ -6,6 +6,8 @@ exporters:
     max_values_per_datum: 150
     namespace: CWAgent
     region: us-east-1
+    region_type: "ACJ"
+    mode: "EC2"
     resource_to_telemetry_conversion:
       enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/invalid_input_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/invalid_input_linux.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-east-1
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
@@ -7,6 +7,8 @@ exporters:
         namespace: CWAgent
         profile: AmazonCloudWatchAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
         shared_credential_file: fake-path

--- a/translator/tocwconfig/sampleConfig/standard_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_windows.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/standard_config_windows_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_windows_with_common_config.yaml
@@ -7,6 +7,8 @@ exporters:
         namespace: CWAgent
         profile: AmazonCloudWatchAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
         shared_credential_file: fake-path

--- a/translator/tocwconfig/sampleConfig/statsd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/statsd_config_linux.yaml
@@ -7,6 +7,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/sampleConfig/statsd_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/statsd_config_windows.yaml
@@ -6,6 +6,8 @@ exporters:
         max_values_per_datum: 150
         namespace: CWAgent
         region: us-west-2
+        region_type: "ACJ"
+        mode: "EC2"
         resource_to_telemetry_conversion:
             enabled: true
 extensions: {}

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -134,6 +134,7 @@ func TestStatsDConfig(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			resetContext(t)
+			context.CurrentContext().SetMode(config.ModeEC2)
 			checkTranslation(t, testCase.filename, testCase.targetPlatform, testCase.expectedEnvVars, testCase.appendString)
 		})
 	}
@@ -142,6 +143,7 @@ func TestStatsDConfig(t *testing.T) {
 // Linux only for CollectD
 func TestCollectDConfig(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "collectd_config_linux", "linux", expectedEnvVars, "")
 	checkTranslation(t, "collectd_config_linux", "darwin", nil, "")
@@ -195,6 +197,7 @@ func TestBasicConfig(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			resetContext(t)
+			context.CurrentContext().SetMode(config.ModeEC2)
 			checkTranslation(t, testCase.filename, testCase.targetPlatform, testCase.expectedEnvVars, testCase.appendString)
 		})
 	}
@@ -202,6 +205,7 @@ func TestBasicConfig(t *testing.T) {
 
 func TestInvalidInputConfig(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "invalid_input_linux", "linux", expectedEnvVars, "")
 }
@@ -232,6 +236,7 @@ func TestStandardConfig(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			resetContext(t)
+			context.CurrentContext().SetMode(config.ModeEC2)
 			t.Setenv(envconfig.IMDS_NUMBER_RETRY, "0")
 			checkTranslation(t, testCase.filename, testCase.targetPlatform, testCase.expectedEnvVars, testCase.appendString)
 		})
@@ -262,6 +267,7 @@ func TestAdvancedConfig(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			resetContext(t)
+			context.CurrentContext().SetMode(config.ModeEC2)
 			checkTranslation(t, testCase.filename, testCase.targetPlatform, testCase.expectedEnvVars, testCase.appendString)
 		})
 	}
@@ -414,6 +420,7 @@ func TestStandardConfigWithCommonConfig(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			resetContext(t)
+			context.CurrentContext().SetMode(config.ModeEC2)
 			readCommonConfig(t, "./sampleConfig/commonConfig/withCredentialsProxySsl.toml")
 			checkTranslation(t, testCase.filename, testCase.targetPlatform, testCase.expectedEnvVars, testCase.appendString)
 		})
@@ -422,6 +429,7 @@ func TestStandardConfigWithCommonConfig(t *testing.T) {
 
 func TestDeltaNetConfigLinux(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "delta_net_config_linux", "linux", expectedEnvVars, "")
 	checkTranslation(t, "delta_net_config_linux", "darwin", nil, "")
@@ -445,6 +453,7 @@ func TestLogFilterConfig(t *testing.T) {
 
 func TestIgnoreInvalidAppendDimensions(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "ignore_append_dimensions", "linux", expectedEnvVars, "")
 }
@@ -499,8 +508,8 @@ func readCommonConfig(t *testing.T, commonConfigFilePath string) {
 
 func resetContext(t *testing.T) {
 	t.Setenv(envconfig.IMDS_NUMBER_RETRY, strconv.Itoa(retryer.DefaultImdsRetries))
-	util.DetectRegion = func(string, map[string]string) string {
-		return "us-west-2"
+	util.DetectRegion = func(string, map[string]string) (string, string) {
+		return "us-west-2", "ACJ"
 	}
 	util.DetectCredentialsPath = func() string {
 		return "fake-path"

--- a/translator/tocwconfig/tocwconfig_unix_test.go
+++ b/translator/tocwconfig/tocwconfig_unix_test.go
@@ -6,10 +6,16 @@
 
 package tocwconfig
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
+)
 
 func TestCompleteConfigUnix(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{
 		"CWAGENT_USER_AGENT": "CUSTOM USER AGENT VALUE",
 		"CWAGENT_LOG_LEVEL":  "DEBUG",
@@ -24,6 +30,7 @@ func TestCompleteConfigUnix(t *testing.T) {
 
 func TestDeltaConfigLinux(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "delta_config_linux", "linux", expectedEnvVars, "")
 	checkTranslation(t, "delta_config_linux", "darwin", nil, "")
@@ -31,6 +38,7 @@ func TestDeltaConfigLinux(t *testing.T) {
 
 func TestDropOriginConfig(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "drop_origin_linux", "linux", expectedEnvVars, "")
 }

--- a/translator/tocwconfig/tocwconfig_windows_test.go
+++ b/translator/tocwconfig/tocwconfig_windows_test.go
@@ -6,10 +6,16 @@
 
 package tocwconfig
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
+)
 
 func TestCompleteConfigWindows(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{
 		"CWAGENT_USER_AGENT": "CUSTOM USER AGENT VALUE",
 		"CWAGENT_LOG_LEVEL":  "DEBUG",

--- a/translator/translate/agent/agent.go
+++ b/translator/translate/agent/agent.go
@@ -13,6 +13,7 @@ var ChildRule = map[string]translator.Rule{}
 
 const (
 	SectionKey = "agent"
+	Mode       = "mode"
 )
 
 func GetCurPath() string {
@@ -27,6 +28,8 @@ type Agent struct {
 	Interval    string
 	Credentials map[string]interface{}
 	Region      string
+	RegionType  string
+	Mode        string
 	Internal    bool
 	Role_arn    string
 }

--- a/translator/translate/agent/ruleRegion.go
+++ b/translator/translate/agent/ruleRegion.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"fmt"
 
+	"github.com/aws/amazon-cloudwatch-agent/handlers/agentinfo"
 	"github.com/aws/amazon-cloudwatch-agent/translator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util"
@@ -15,20 +16,21 @@ type Region struct {
 }
 
 const (
-	RegionKey = "region"
+	RegionKey  = "region"
+	RegionType = "region_type"
 )
 
 // This region will be provided to the corresponding input and output plugins
 // This should be applied before interpreting other component.
 func (r *Region) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
-	var region string
 	ctx := context.CurrentContext()
 	_, inputRegion := translator.DefaultCase(RegionKey, "", input)
 	if inputRegion != "" {
 		Global_Config.Region = inputRegion.(string)
+		Global_Config.RegionType = agentinfo.AgentConfigJson
 		return
 	}
-	region = util.DetectRegion(ctx.Mode(), ctx.Credentials())
+	region, regionType := util.DetectRegion(ctx.Mode(), ctx.Credentials())
 
 	if region == "" {
 		translator.AddErrorMessages(GetCurPath()+"ruleRegion/", fmt.Sprintf("Region info is missing for mode: %s",
@@ -36,6 +38,7 @@ func (r *Region) ApplyRule(input interface{}) (returnKey string, returnVal inter
 	}
 
 	Global_Config.Region = region
+	Global_Config.RegionType = regionType
 	return
 }
 

--- a/translator/translate/logs/logs_test.go
+++ b/translator/translate/logs/logs_test.go
@@ -19,6 +19,7 @@ import (
 func TestLogs(t *testing.T) {
 	l := new(Logs)
 	agent.Global_Config.Region = "us-east-1"
+	agent.Global_Config.RegionType = "any"
 
 	var input interface{}
 	err := json.Unmarshal([]byte(`{"logs":{"log_stream_name":"LOG_STREAM_NAME"}}`), &input)
@@ -32,6 +33,8 @@ func TestLogs(t *testing.T) {
 			"cloudwatchlogs": []interface{}{
 				map[string]interface{}{
 					"region":               "us-east-1",
+					"region_type":          "any",
+					"mode":                 "",
 					"log_stream_name":      "LOG_STREAM_NAME",
 					"force_flush_interval": "5s",
 				},
@@ -44,6 +47,7 @@ func TestLogs(t *testing.T) {
 func TestLogs_LogStreamName(t *testing.T) {
 	l := new(Logs)
 	agent.Global_Config.Region = "us-east-1"
+	agent.Global_Config.RegionType = "any"
 
 	var input interface{}
 	err := json.Unmarshal([]byte(`{"logs":{}}`), &input)
@@ -61,6 +65,8 @@ func TestLogs_LogStreamName(t *testing.T) {
 			"cloudwatchlogs": []interface{}{
 				map[string]interface{}{
 					"region":               "us-east-1",
+					"region_type":          "any",
+					"mode":                 "OP",
 					"log_stream_name":      hostname,
 					"force_flush_interval": "5s",
 				},
@@ -86,6 +92,8 @@ func TestLogs_LogStreamName(t *testing.T) {
 			"cloudwatchlogs": []interface{}{
 				map[string]interface{}{
 					"region":               "us-east-1",
+					"region_type":          "any",
+					"mode":                 "",
 					"log_stream_name":      "arn_aws_ecs_us-east-2_012345678910_task/cluster-name/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
 					"force_flush_interval": "5s",
 				},
@@ -108,6 +116,8 @@ func TestLogs_LogStreamName(t *testing.T) {
 			"cloudwatchlogs": []interface{}{
 				map[string]interface{}{
 					"region":               "us-east-1",
+					"region_type":          "any",
+					"mode":                 "",
 					"log_stream_name":      "demo-app-5ffc89b95c-jgnf6",
 					"force_flush_interval": "5s",
 				},
@@ -123,6 +133,7 @@ func TestLogs_LogStreamName(t *testing.T) {
 func TestLogs_ForceFlushInterval(t *testing.T) {
 	l := new(Logs)
 	agent.Global_Config.Region = "us-east-1"
+	agent.Global_Config.RegionType = "any"
 
 	var input interface{}
 	err := json.Unmarshal([]byte(`{"logs":{"force_flush_interval":10}}`), &input)
@@ -140,6 +151,8 @@ func TestLogs_ForceFlushInterval(t *testing.T) {
 			"cloudwatchlogs": []interface{}{
 				map[string]interface{}{
 					"region":               "us-east-1",
+					"region_type":          "any",
+					"mode":                 "OP",
 					"log_stream_name":      hostname,
 					"force_flush_interval": "10s",
 				},
@@ -155,6 +168,7 @@ func TestLogs_ForceFlushInterval(t *testing.T) {
 func TestLogs_EndpointOverride(t *testing.T) {
 	l := new(Logs)
 	agent.Global_Config.Region = "us-east-1"
+	agent.Global_Config.RegionType = "any"
 
 	var input interface{}
 	err := json.Unmarshal([]byte(`{"logs":{"endpoint_override":"https://logs-fips.us-east-1.amazonaws.com"}}`), &input)
@@ -172,6 +186,8 @@ func TestLogs_EndpointOverride(t *testing.T) {
 			"cloudwatchlogs": []interface{}{
 				map[string]interface{}{
 					"region":               "us-east-1",
+					"region_type":          "any",
+					"mode":                 "OP",
 					"endpoint_override":    "https://logs-fips.us-east-1.amazonaws.com",
 					"log_stream_name":      hostname,
 					"force_flush_interval": "5s",

--- a/translator/translate/logs/ruleBasicLogConfig.go
+++ b/translator/translate/logs/ruleBasicLogConfig.go
@@ -5,6 +5,7 @@ package logs
 
 import (
 	"github.com/aws/amazon-cloudwatch-agent/translator"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 )
 
@@ -16,6 +17,8 @@ func (f *BasicLogConfig) ApplyRule(input interface{}) (returnKey string, returnV
 	// add creds
 	cloudwatchlogsConfig = translator.MergeTwoUniqueMaps(cloudwatchlogsConfig, agent.Global_Config.Credentials)
 	cloudwatchlogsConfig[agent.RegionKey] = agent.Global_Config.Region
+	cloudwatchlogsConfig[agent.RegionType] = agent.Global_Config.RegionType
+	cloudwatchlogsConfig[agent.Mode] = context.CurrentContext().ShortMode()
 
 	returnKey = Output_Cloudwatch_Logs
 	returnVal = cloudwatchlogsConfig

--- a/translator/translate/otel/exporter/awscloudwatch/translator.go
+++ b/translator/translate/otel/exporter/awscloudwatch/translator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/metric"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatch"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/rollup_dimensions"
@@ -57,6 +58,8 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	_ = credentials.Unmarshal(cfg)
 	cfg.RoleARN = getRoleARN(conf)
 	cfg.Region = agent.Global_Config.Region
+	cfg.RegionType = agent.Global_Config.RegionType
+	cfg.Mode = context.CurrentContext().ShortMode()
 	if namespace, ok := common.GetString(conf, common.ConfigKey(common.MetricsKey, namespaceKey)); ok {
 		cfg.Namespace = namespace
 	}


### PR DESCRIPTION
# Description of the issue
CloudWatch Agent wants to collect metrics on where the agent is being run. 

# Description of changes
Add metrics for CloudWatch Agent mode and region provider. I did this by creating global variables for these metrics and shoving them into the config layer to be picked up by the plugins. This is because this information is only known at translation time, but we need this information at plugin runtime. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




