### PR TITLE
Auto removal no block

### DIFF
--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -411,18 +411,18 @@ func getLogSrc(t *testing.T, logFile *LogFile) (*logs.LogSrc, chan logs.LogEvent
 	return &logSource, evts
 }
 
-func writeLines(t *testing.T, f *os.File, numLines int, msg string) {
-	t.Logf("start writing, %s", f.Name())
+func writeLines(t *testing.T, file *os.File, numLines int, msg string) {
+	t.Logf("start writing, %s", file.Name())
 	for i := 0; i < numLines; i++ {
-		_, err := f.WriteString(msg + "\n")
+		_, err := file.WriteString(msg + "\n")
 		require.NoError(t, err)
 	}
-	t.Logf("stop writing, %s", f.Name())
+	t.Logf("stop writing, %s", file.Name())
 }
 
 // createWriteRead creates a temp file, writes to it, then verifies events
 // are received. If isParent is true, then spawn a 2nd goroutine for createWriteRead.
-// Closes "done" channel when complete to let caller know it was successful.
+// Closes "done" when complete to let caller know it was successful.
 func createWriteRead(t *testing.T, prefix string, logFile *LogFile, done chan bool, isParent bool) {
 	// Let caller know when the goroutine is done.
 	defer close(done)
@@ -431,6 +431,7 @@ func createWriteRead(t *testing.T, prefix string, logFile *LogFile, done chan bo
 	file := makeTempFile(t, prefix)
 	logSrc, evts := getLogSrc(t, logFile)
 	defer (*logSrc).Stop()
+	defer close(evts)
 	// Choose a large enough number of lines so that even high-spec hosts will not
 	// complete receiving logEvents before the 2nd createWriteRead() goroutine begins.
 	const numLines int = 1000000

--- a/plugins/inputs/logfile/logfile_test.go
+++ b/plugins/inputs/logfile/logfile_test.go
@@ -371,11 +371,12 @@ func TestLogsFileRemove(t *testing.T) {
 	tt.Stop()
 }
 
-func setupLogFileForTest(t *testing.T, file *os.File, prefix string) *LogFile {
+func setupLogFileForTest(t *testing.T, monitorPath string) *LogFile {
 	logFile := NewLogFile()
 	logFile.Log = TestLogger{t}
+	t.Logf("create LogFile with FilePath = %s", monitorPath)
 	logFile.FileConfig = []FileConfig{{
-		FilePath:      filepath.Join(filepath.Dir(file.Name()), prefix+"*"),
+		FilePath:      monitorPath,
 		FromBeginning: true,
 		AutoRemoval:   true,
 	}}
@@ -394,8 +395,11 @@ func makeTempFile(t *testing.T, prefix string) *os.File {
 // getLogSrc returns a LogSrc from the given LogFile, and the channel for output.
 // Verifies 1 and only 1 LogSrc is discovered.
 func getLogSrc(t *testing.T, logFile *LogFile) (*logs.LogSrc, chan logs.LogEvent) {
+	start := time.Now()
 	logSources := logFile.FindLogSrc()
-	require.Equal(t, 1, len(logSources))
+	duration := time.Since(start)
+	require.Less(t, duration, time.Second)
+	require.Equal(t, 1, len(logSources), "FindLogSrc() expected 1, got %d", len(logSources))
 	logSource := logSources[0]
 	evts := make(chan logs.LogEvent)
 	logSource.SetOutput(func(e logs.LogEvent) {
@@ -406,49 +410,42 @@ func getLogSrc(t *testing.T, logFile *LogFile) (*logs.LogSrc, chan logs.LogEvent
 	return &logSource, evts
 }
 
-func writeLines(t *testing.T, file *os.File, numLines int, msg string) {
-	t.Log("Fill temp file with sufficient lines to be read.")
+func writeLines(t *testing.T, f *os.File, numLines int, msg string) {
+	t.Logf("start writing, %s", f.Name())
 	for i := 0; i < numLines; i++ {
-		_, err := file.WriteString(msg + "\n")
+		_, err := f.WriteString(msg + "\n")
 		require.NoError(t, err)
 	}
+	t.Logf("stop writing, %s", f.Name())
 }
 
 // createWriteRead creates a temp file, writes to it, then verifies events
 // are received. If isParent is true, then spawn a 2nd goroutine for createWriteRead.
-// Close the given channel when complete to let caller know it was successful.
+// Closes "done" channel when complete to let caller know it was successful.
 func createWriteRead(t *testing.T, prefix string, logFile *LogFile, done chan bool, isParent bool) {
 	// Let caller know when the goroutine is done.
 	defer close(done)
 	// done2 is only passed to child if this is the parent.
 	done2 := make(chan bool)
 	file := makeTempFile(t, prefix)
-	if isParent {
-		logFile = setupLogFileForTest(t, file, prefix)
-		defer logFile.Stop()
-	}
+	start := time.Now()
 	logSrc, evts := getLogSrc(t, logFile)
 	defer (*logSrc).Stop()
-	defer close(evts)
+	duration := time.Since(start)
+	// Verify LogFile.FindLogSrc() is not blocking until EOF on first file is reached.
+	assert.Less(t, duration, time.Millisecond*100)
 	// Choose a large enough number of lines so that even high-spec hosts will not
 	// complete receiving logEvents before the 2nd createWriteRead() goroutine begins.
-	const numLines int = 100000
+	const numLines int = 1000000
 	const msg string = "this is the best log line ever written to a file"
 	writeLines(t, file, numLines, msg)
 	file.Close()
-	if !isParent {
-		// Child creates 2nd temp file which is NOT auto removed.
-		defer os.Remove(file.Name())
-	}
 	t.Log("Verify every line written to the temp file is received.")
 	for i := 0; i < numLines; i++ {
 		logEvent := <-evts
 		require.Equal(t, msg, logEvent.Message())
-		if i != numLines/2 {
-			continue
-		}
-		// Halfway through start another goroutine to create another temp file.
-		if isParent {
+		if isParent && i == numLines/2 {
+			// Halfway through start child goroutine to create another temp file.
 			go createWriteRead(t, prefix, logFile, done2, false)
 		}
 	}
@@ -457,8 +454,8 @@ func createWriteRead(t *testing.T, prefix string, logFile *LogFile, done chan bo
 		t.Log("Verify child completed.")
 		select {
 		case <-done2:
-			t.Log("Completed before timeout (as expected)")
-		case <-time.After(time.Second * 5):
+			t.Log("Child completed before timeout (as expected)")
+		case <-time.After(time.Second * 10):
 			require.Fail(t, "timeout waiting for child")
 		}
 		t.Log("Verify 1st temp file was auto deleted.")
@@ -468,20 +465,36 @@ func createWriteRead(t *testing.T, prefix string, logFile *LogFile, done chan bo
 }
 
 // TestLogsFileAutoRemoval verifies when a new file matching the configured
-// FilePath is discovered, the old file will be automatically deleted after
-// being read to the end-of-file.
+// FilePath is discovered, the old file will be automatically deleted ONLY after
+// being read to the end-of-file. Also verifies the new log file is discovered
+// before finishing the old file.
 func TestLogsFileAutoRemoval(t *testing.T) {
 	// Override global in tailersrc.go.
 	multilineWaitPeriod = 10 * time.Millisecond
-	prefix := "file_auto_removal"
+	prefix := "TestLogsFileAutoRemoval*"
+	f1 := makeTempFile(t, prefix)
+	f1.Close()
+	os.Remove(f1.Name())
+	// Create the LogFile.
+	fileDirectoryPath := filepath.Dir(f1.Name())
+	monitorPath := filepath.Join(fileDirectoryPath, prefix)
+	logFile := setupLogFileForTest(t, monitorPath)
+	defer logFile.Stop()
+
 	done := make(chan bool)
-	createWriteRead(t, prefix, nil, done, true)
+	createWriteRead(t, prefix, logFile, done, true)
 	t.Log("Verify 1st tmp file created and discovered.")
 	select {
 	case <-done:
-		t.Log("Completed before timeout (as expected)")
-	case <-time.After(time.Second * 5):
+		t.Log("Parent completed before timeout (as expected)")
+	case <-time.After(time.Second * 10):
 		require.Fail(t, "timeout waiting for 2nd temp file.")
+	}
+	// Cleanup
+	files, _ := filepath.Glob(monitorPath)
+	for _, f := range files {
+		t.Logf("cleanup, %s", f)
+		os.Remove(f)
 	}
 }
 

--- a/plugins/inputs/logfile/tail/tail.go
+++ b/plugins/inputs/logfile/tail/tail.go
@@ -165,10 +165,9 @@ func (tail *Tail) Stop() error {
 }
 
 // StopAtEOF stops tailing as soon as the end of the file is reached.
-// Blocks until tailer is dead and returns reason for death.
-func (tail *Tail) StopAtEOF() error {
+// Does not wait until tailer is dead.
+func (tail *Tail) StopAtEOF() {
 	tail.Kill(errStopAtEOF)
-	return tail.Wait()
 }
 
 var errStopAtEOF = errors.New("tail: stop at eof")

--- a/plugins/inputs/logfile/tail/tail_test.go
+++ b/plugins/inputs/logfile/tail/tail_test.go
@@ -83,19 +83,20 @@ func TestStopAtEOF(t *testing.T) {
 
 	readThreelines(t, tail)
 
-	// Since StopAtEOF() will block until the EOF is reached, run it in a goroutine.
+	// Since tail.Wait() will block until the EOF is reached, run it in a goroutine.
 	done := make(chan bool)
 	go func() {
 		tail.StopAtEOF()
+		tail.Wait()
 		close(done)
 	}()
 
 	// Verify the goroutine is blocked indefinitely.
 	select {
 	case <-done:
-		t.Fatalf("StopAtEOF() completed unexpectedly")
+		t.Fatalf("tail.Wait() completed unexpectedly")
 	case <-time.After(time.Second * 1):
-		t.Log("timeout waiting for StopAtEOF() (as expected)")
+		t.Log("timeout waiting for tail.Wait() (as expected)")
 	}
 
 	assert.Equal(t, errStopAtEOF, tail.Err())
@@ -105,12 +106,12 @@ func TestStopAtEOF(t *testing.T) {
 		<-tail.Lines
 	}
 
-	// Verify StopAtEOF() has completed.
+	// Verify tail.Wait() has completed.
 	select {
 	case <-done:
-		t.Log("StopAtEOF() completed (as expected)")
+		t.Log("tail.Wait() completed (as expected)")
 	case <-time.After(time.Second * 1):
-		t.Fatalf("StopAtEOF() has not completed")
+		t.Fatalf("tail.Wait() has not completed")
 	}
 
 	// Then remove the tmpfile


### PR DESCRIPTION
# Description of the issue
Previously there this issue - https://github.com/aws/amazon-cloudwatch-agent/issues/381
Which was fixed by - https://github.com/aws/amazon-cloudwatch-agent/pull/452

But now instead of an edge case where the agent will DROP log lines, the issue is that the agent will BLOCK waiting to upload ALL log lines and potentially miss discovering and reporting on a new file.
Consider the following events:
1. File 1 is created, discovered, and reported
2. File 2 is created, and discovered, but the agent is not finished reading File 1, so `LogFile.FindLogSrc()` is blocking.
3. Before `LogFile.FindLogSrc()` completes, another 2 files matching the monitored pattern are created (File 3 and File 4)
4. When the agent is done reading FIle 1 it deletes it and begins monitoring File 2.
5. The Agent discovers FIle 4, but not File 3.

If this series of events repeats the host could be left with a bunch of unread, unreported, and not deleted files.

# Description of changes
- `LogFile.FindLogSrc()` will no longer block waiting for the tail to exit. This means there could be more than 1 tail running and reading LogEvents for a single log source. (This is already possible though)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Modified existing unit test case for auto removal.

BEFORE the fix:
```
adamym@88665a370425 amazon-cloudwatch-agent % go test -v -count=1  ./plugins/inputs/logfile/ -run TestLogsFileAutoRemoval
=== RUN   TestLogsFileAutoRemoval
    logfile_test.go:390: Created temp file, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval1899158973
    logfile_test.go:377: create LogFile with FilePath = /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval*
    logfile_test.go:390: Created temp file, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval33957811
2023/10/19 08:24:10 The state file  for /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval33957811 does not exist: stat : no such file or directory
    logfile_test.go:415: start writing, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval33957811
    logfile_test.go:420: stop writing, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval33957811
    logfile_test.go:440: Verify every line written to the temp file is received.
    logfile_test.go:390: Created temp file, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval1680826170
    logfile_test.go:451: Verify child completed.
2023/10/19 08:24:17 The state file  for /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval1680826170 does not exist: stat : no such file or directory
    logfile_test.go:402: 
        	Error Trace:	/Users/adamym/go/src/github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/logfile_test.go:402
        	            				/Users/adamym/go/src/github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/logfile_test.go:432
        	            				/usr/local/Cellar/go/1.21.1/libexec/src/runtime/asm_amd64.s:1650
        	Error:      	"1.437046513s" is not less than "100ms"
        	Test:       	TestLogsFileAutoRemoval
    logfile_test.go:454: Child completed before timeout (as expected)
    logfile_test.go:458: Verify 1st temp file was auto deleted.
2023/10/19 08:24:17 I! [logfile] Successfully removed file /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval33957811 with auto_removal feature
    logfile_test.go:460: 
        	Error Trace:	/Users/adamym/go/src/github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/logfile_test.go:460
        	            				/Users/adamym/go/src/github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/logfile_test.go:482
        	Error:      	Should be true
        	Test:       	TestLogsFileAutoRemoval
    logfile_test.go:483: Verify 1st tmp file created and discovered.
    logfile_test.go:486: Parent completed before timeout (as expected)
    logfile_test.go:493: cleanup, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval1680826170
--- FAIL: TestLogsFileAutoRemoval (6.52s)
FAIL
FAIL	github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile	7.098s
FAIL
```

AFTER THE FIX:
```
adamym@88665a370425 amazon-cloudwatch-agent % go test -v -count=1  ./plugins/inputs/logfile/ -run TestLogsFileAutoRemoval
=== RUN   TestLogsFileAutoRemoval
    logfile_test.go:390: Created temp file, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval48041360
    logfile_test.go:377: create LogFile with FilePath = /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval*
    logfile_test.go:390: Created temp file, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2879642736
2023/10/19 08:24:32 The state file  for /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2879642736 does not exist: stat : no such file or directory
    logfile_test.go:415: start writing, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2879642736
    logfile_test.go:420: stop writing, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2879642736
    logfile_test.go:440: Verify every line written to the temp file is received.
    logfile_test.go:390: Created temp file, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2728170068
2023/10/19 08:24:37 The state file  for /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2728170068 does not exist: stat : no such file or directory
    logfile_test.go:415: start writing, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2728170068
    logfile_test.go:451: Verify child completed.
2023/10/19 08:24:38 I! [logfile] Successfully removed file /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2879642736 with auto_removal feature
    logfile_test.go:420: stop writing, /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2728170068
    logfile_test.go:440: Verify every line written to the temp file is received.
    logfile_test.go:454: Child completed before timeout (as expected)
    logfile_test.go:458: Verify 1st temp file was auto deleted.
    logfile_test.go:483: Verify 1st tmp file created and discovered.
    logfile_test.go:486: Parent completed before timeout (as expected)
2023/10/19 08:24:44 I! [logfile] Successfully removed file /var/folders/7c/rx6r0v6n44j4pwnc_77gt46w0000gs/T/TestLogsFileAutoRemoval2728170068 with auto_removal feature
--- PASS: TestLogsFileAutoRemoval (11.89s)
PASS
ok  	github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile	12.466s
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




