### PR TITLE
Removing service dimension for pod-net metrics

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -70,7 +70,7 @@ exporters:
           - pod_network_tx_bytes
           - pod_cpu_utilization_over_pod_limit
           - pod_memory_utilization_over_pod_limit
-      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace,  Service ], [ ClusterName ] ]
+      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - pod_interface_network_rx_dropped

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -41,7 +41,7 @@ exporters:
           - pod_network_tx_bytes
           - pod_cpu_utilization_over_pod_limit
           - pod_memory_utilization_over_pod_limit
-      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace,  Service ], [ ClusterName ] ]
+      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - pod_interface_network_rx_dropped

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -70,7 +70,7 @@ exporters:
           - pod_network_tx_bytes
           - pod_cpu_utilization_over_pod_limit
           - pod_memory_utilization_over_pod_limit
-      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace,  Service ], [ ClusterName ] ]
+      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace ], [ ClusterName ] ]
         label_matchers: [ ]
         metric_name_selectors:
           - pod_interface_network_rx_dropped

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -111,7 +111,7 @@ func getPodMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 				Dimensions: [][]string{
 					{"FullPodName", "PodName", "Namespace", "ClusterName"},
 					{"PodName", "Namespace", "ClusterName"},
-					{"Service", "Namespace", "ClusterName"},
+					{"Namespace", "ClusterName"},
 					{"ClusterName"},
 				},
 				MetricNameSelectors: []string{"pod_interface_network_rx_dropped", "pod_interface_network_tx_dropped"},

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -282,7 +282,7 @@ func TestTranslator(t *testing.T) {
 						Dimensions: [][]string{
 							{"FullPodName", "PodName", "Namespace", "ClusterName"},
 							{"PodName", "Namespace", "ClusterName"},
-							{"Service", "Namespace", "ClusterName"},
+							{"Namespace", "ClusterName"},
 							{"ClusterName"},
 						},
 						MetricNameSelectors: []string{"pod_interface_network_rx_dropped", "pod_interface_network_tx_dropped"},


### PR DESCRIPTION
# Description of the issue
pod_interface_network_rx_dropped  & pod_interface_network_tx_dropped will have dimensions of [ClusterName,Namespace] instead of [ClusterName,Namespace, Service]. The rest of the dimension sets are unaffected

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
![Screenshot 2023-10-20 at 12 00 03](https://github.com/aws/amazon-cloudwatch-agent/assets/44349099/c36a088f-5627-4b1d-943c-b2c95b3e6dc6)
![Screenshot 2023-10-20 at 11 59 37](https://github.com/aws/amazon-cloudwatch-agent/assets/44349099/295fa385-2476-4e57-a422-e31947440c44)


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




