### PR TITLE
Add agenthealth extension with user agent handler.

### DIFF
--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -3,6 +3,12 @@
 
 package envconfig
 
+import (
+	"os"
+	"strconv"
+	"sync"
+)
+
 const (
 	//the following are the names of environment variables
 	HTTP_PROXY         = "HTTP_PROXY"
@@ -15,3 +21,22 @@ const (
 	CWAGENT_USAGE_DATA = "CWAGENT_USAGE_DATA"
 	IMDS_NUMBER_RETRY  = "IMDS_NUMBER_RETRY"
 )
+
+var (
+	usageDataEnabled bool
+	onceUsageData    sync.Once
+)
+
+// getUsageDataEnabled returns true for true or invalid
+// examples of invalid are not set env var, "", "invalid"
+func getUsageDataEnabled() bool {
+	ok, err := strconv.ParseBool(os.Getenv(CWAGENT_USAGE_DATA))
+	return ok || err != nil
+}
+
+func IsUsageDataEnabled() bool {
+	onceUsageData.Do(func() {
+		usageDataEnabled = getUsageDataEnabled()
+	})
+	return usageDataEnabled
+}

--- a/cfg/envconfig/envconfig_test.go
+++ b/cfg/envconfig/envconfig_test.go
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package envconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUsageDataEnabled(t *testing.T) {
+	assert.True(t, getUsageDataEnabled())
+
+	t.Setenv(CWAGENT_USAGE_DATA, "TRUE")
+	assert.True(t, getUsageDataEnabled())
+
+	t.Setenv(CWAGENT_USAGE_DATA, "INVALID")
+	assert.True(t, getUsageDataEnabled())
+
+	t.Setenv(CWAGENT_USAGE_DATA, "FALSE")
+	assert.False(t, getUsageDataEnabled())
+}

--- a/extension/agenthealth/config.go
+++ b/extension/agenthealth/config.go
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agenthealth
+
+import "go.opentelemetry.io/collector/component"
+
+type Config struct {
+	IsUsageDataEnabled bool `mapstructure:"is_usage_data_enabled"`
+}
+
+var _ component.Config = (*Config)(nil)

--- a/extension/agenthealth/config_test.go
+++ b/extension/agenthealth/config_test.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agenthealth
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	testCases := []struct {
+		id   component.ID
+		want component.Config
+	}{
+		{
+			id:   component.NewID(TypeStr),
+			want: NewFactory().CreateDefaultConfig(),
+		},
+		{
+			id:   component.NewIDWithName(TypeStr, "1"),
+			want: &Config{IsUsageDataEnabled: false},
+		},
+	}
+	for _, testCase := range testCases {
+		conf, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+		require.NoError(t, err)
+		cfg := NewFactory().CreateDefaultConfig()
+		sub, err := conf.Sub(testCase.id.String())
+		require.NoError(t, err)
+		require.NoError(t, component.UnmarshalConfig(sub, cfg))
+
+		assert.NoError(t, component.ValidateConfig(cfg))
+		assert.Equal(t, testCase.want, cfg)
+	}
+}

--- a/extension/agenthealth/extension.go
+++ b/extension/agenthealth/extension.go
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agenthealth
+
+import (
+	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/useragent"
+)
+
+type agentHealth struct {
+	logger *zap.Logger
+	cfg    *Config
+	component.StartFunc
+	component.ShutdownFunc
+}
+
+var _ awsmiddleware.Extension = (*agentHealth)(nil)
+
+func (ah *agentHealth) Handlers() ([]awsmiddleware.RequestHandler, []awsmiddleware.ResponseHandler) {
+	var responsesHandlers []awsmiddleware.ResponseHandler
+	requestsHandlers := []awsmiddleware.RequestHandler{useragent.NewHandler(ah.cfg.IsUsageDataEnabled)}
+	return requestsHandlers, responsesHandlers
+}
+
+func newAgentHealth(logger *zap.Logger, cfg *Config) (*agentHealth, error) {
+	return &agentHealth{logger: logger, cfg: cfg}, nil
+}

--- a/extension/agenthealth/extension.go
+++ b/extension/agenthealth/extension.go
@@ -21,9 +21,9 @@ type agentHealth struct {
 var _ awsmiddleware.Extension = (*agentHealth)(nil)
 
 func (ah *agentHealth) Handlers() ([]awsmiddleware.RequestHandler, []awsmiddleware.ResponseHandler) {
-	var responsesHandlers []awsmiddleware.ResponseHandler
-	requestsHandlers := []awsmiddleware.RequestHandler{useragent.NewHandler(ah.cfg.IsUsageDataEnabled)}
-	return requestsHandlers, responsesHandlers
+	var responseHandlers []awsmiddleware.ResponseHandler
+	requestHandlers := []awsmiddleware.RequestHandler{useragent.NewHandler(ah.cfg.IsUsageDataEnabled)}
+	return requestHandlers, responseHandlers
 }
 
 func newAgentHealth(logger *zap.Logger, cfg *Config) (*agentHealth, error) {

--- a/extension/agenthealth/extension_test.go
+++ b/extension/agenthealth/extension_test.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agenthealth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap"
+)
+
+func TestExtension(t *testing.T) {
+	ctx := context.Background()
+	extension, err := newAgentHealth(zap.NewNop(), &Config{IsUsageDataEnabled: true})
+	assert.NoError(t, err)
+	assert.NotNil(t, extension)
+	assert.NoError(t, extension.Start(ctx, componenttest.NewNopHost()))
+	requests, responses := extension.Handlers()
+	assert.Len(t, requests, 1)
+	assert.Len(t, responses, 0)
+	extension.cfg.IsUsageDataEnabled = false
+	extension.Handlers()
+	requests, responses = extension.Handlers()
+	assert.Len(t, requests, 1)
+	assert.Len(t, responses, 0)
+	assert.NoError(t, extension.Shutdown(ctx))
+}

--- a/extension/agenthealth/factory.go
+++ b/extension/agenthealth/factory.go
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agenthealth
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
+)
+
+const (
+	TypeStr = "agenthealth"
+)
+
+func NewFactory() extension.Factory {
+	return extension.NewFactory(
+		TypeStr,
+		createDefaultConfig,
+		createExtension,
+		component.StabilityLevelAlpha,
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{
+		IsUsageDataEnabled: true,
+	}
+}
+
+func createExtension(_ context.Context, settings extension.CreateSettings, cfg component.Config) (extension.Extension, error) {
+	return newAgentHealth(settings.Logger, cfg.(*Config))
+}

--- a/extension/agenthealth/factory_test.go
+++ b/extension/agenthealth/factory_test.go
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agenthealth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/extension/extensiontest"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	cfg := NewFactory().CreateDefaultConfig()
+	assert.Equal(t, &Config{IsUsageDataEnabled: true}, cfg)
+	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+}
+
+func TestCreateExtension(t *testing.T) {
+	cfg := &Config{}
+	got, err := NewFactory().CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+}

--- a/extension/agenthealth/handler/useragent/handler.go
+++ b/extension/agenthealth/handler/useragent/handler.go
@@ -4,6 +4,7 @@
 package useragent
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
@@ -28,7 +29,7 @@ func (uah *userAgentHandler) Position() awsmiddleware.HandlerPosition {
 
 // HandleRequest prepends the User-Agent header with the CloudWatch Agent's
 // user agent string.
-func (uah *userAgentHandler) HandleRequest(_ string, r *http.Request) {
+func (uah *userAgentHandler) HandleRequest(_ context.Context, r *http.Request) {
 	newHeader := uah.Header()
 	current := r.Header.Get(headerKeyUserAgent)
 	if current != "" {

--- a/extension/agenthealth/handler/useragent/handler.go
+++ b/extension/agenthealth/handler/useragent/handler.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package useragent
+
+import (
+	"net/http"
+
+	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
+	"go.uber.org/atomic"
+)
+
+type userAgentHandler struct {
+	userAgent          UserAgent
+	isUsageDataEnabled bool
+	header             *atomic.String
+}
+
+var _ awsmiddleware.RequestHandler = (*userAgentHandler)(nil)
+
+func (uah *userAgentHandler) ID() string {
+	return handlerID
+}
+
+func (uah *userAgentHandler) Position() awsmiddleware.HandlerPosition {
+	return awsmiddleware.After
+}
+
+// HandleRequest prepends the User-Agent header with the CloudWatch Agent's
+// user agent string.
+func (uah *userAgentHandler) HandleRequest(_ string, r *http.Request) {
+	newHeader := uah.Header()
+	current := r.Header.Get(headerKeyUserAgent)
+	if current != "" {
+		newHeader += separator + current
+	}
+	r.Header.Set(headerKeyUserAgent, newHeader)
+}
+
+func (uah *userAgentHandler) Header() string {
+	return uah.header.Load()
+}
+
+func (uah *userAgentHandler) refreshHeader() {
+	uah.header.Store(uah.userAgent.Header(uah.isUsageDataEnabled))
+}
+
+func newHandler(userAgent UserAgent, isUsageDataEnabled bool) *userAgentHandler {
+	handler := &userAgentHandler{
+		userAgent:          userAgent,
+		header:             &atomic.String{},
+		isUsageDataEnabled: isUsageDataEnabled,
+	}
+	handler.refreshHeader()
+	userAgent.Listen(handler.refreshHeader)
+	return handler
+}
+
+func NewHandler(isUsageDataEnabled bool) awsmiddleware.RequestHandler {
+	return newHandler(Get(), isUsageDataEnabled)
+}

--- a/extension/agenthealth/handler/useragent/handler_test.go
+++ b/extension/agenthealth/handler/useragent/handler_test.go
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package useragent
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+)
+
+func TestUserAgentHandler(t *testing.T) {
+	t.Setenv(envconfig.CWAGENT_USER_AGENT, "FirstUA")
+	ua := newUserAgent()
+	handler := newHandler(ua, true)
+	assert.Equal(t, handlerID, handler.ID())
+	assert.Equal(t, awsmiddleware.After, handler.Position())
+	req, err := http.NewRequest("", "localhost", nil)
+	require.NoError(t, err)
+	handler.HandleRequest("", req)
+	assert.Equal(t, "FirstUA", req.Header.Get(headerKeyUserAgent))
+	t.Setenv(envconfig.CWAGENT_USER_AGENT, "SecondUA")
+	ua.notify()
+	handler.HandleRequest("", req)
+	assert.Equal(t, "SecondUA FirstUA", req.Header.Get(headerKeyUserAgent))
+}

--- a/extension/agenthealth/handler/useragent/handler_test.go
+++ b/extension/agenthealth/handler/useragent/handler_test.go
@@ -4,6 +4,7 @@
 package useragent
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -22,10 +23,10 @@ func TestUserAgentHandler(t *testing.T) {
 	assert.Equal(t, awsmiddleware.After, handler.Position())
 	req, err := http.NewRequest("", "localhost", nil)
 	require.NoError(t, err)
-	handler.HandleRequest("", req)
+	handler.HandleRequest(context.Background(), req)
 	assert.Equal(t, "FirstUA", req.Header.Get(headerKeyUserAgent))
 	t.Setenv(envconfig.CWAGENT_USER_AGENT, "SecondUA")
 	ua.notify()
-	handler.HandleRequest("", req)
+	handler.HandleRequest(context.Background(), req)
 	assert.Equal(t, "SecondUA FirstUA", req.Header.Get(headerKeyUserAgent))
 }

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -1,0 +1,193 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package useragent
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	telegraf "github.com/influxdata/telegraf/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
+	"go.opentelemetry.io/collector/otelcol"
+	"go.uber.org/atomic"
+	"golang.org/x/exp/maps"
+
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/aws/amazon-cloudwatch-agent/internal/util/collections"
+	"github.com/aws/amazon-cloudwatch-agent/internal/version"
+	"github.com/aws/amazon-cloudwatch-agent/receiver/adapter"
+)
+
+const (
+	handlerID          = "cloudwatchagent.UserAgentHandler"
+	headerKeyUserAgent = "User-Agent"
+
+	flagRunAsUser                 = "run_as_user"
+	flagContainerInsights         = "container_insights"
+	flagPulse                     = "pulse"
+	flagEnhancedContainerInsights = "enhanced_container_insights"
+	separator                     = " "
+
+	typeInputs     = "inputs"
+	typeProcessors = "processors"
+	typeOutputs    = "outputs"
+)
+
+var (
+	singleton UserAgent
+	once      sync.Once
+)
+
+type UserAgent interface {
+	SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegraf.Config)
+	SetContainerInsightsFlag()
+	Header(isUsageDataEnabled bool) string
+	Listen(listener func())
+}
+
+type userAgent struct {
+	dataLock sync.Mutex
+	id       string
+
+	listenerLock sync.Mutex
+	listeners    []func()
+	isRoot       bool
+
+	inputs     collections.Set[string]
+	processors collections.Set[string]
+	outputs    collections.Set[string]
+
+	inputsStr     atomic.String
+	processorsStr atomic.String
+	outputsStr    atomic.String
+}
+
+var _ UserAgent = (*userAgent)(nil)
+
+func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegraf.Config) {
+	ua.dataLock.Lock()
+	defer ua.dataLock.Unlock()
+	for _, input := range telegrafCfg.Inputs {
+		ua.inputs.Add(input.Config.Name)
+	}
+	for _, output := range telegrafCfg.Outputs {
+		ua.outputs.Add(output.Config.Name)
+	}
+
+	for _, pipeline := range otelCfg.Service.Pipelines {
+		for _, receiver := range pipeline.Receivers {
+			// trim the adapter prefix from adapted Telegraf plugins
+			name := strings.TrimPrefix(string(receiver.Type()), adapter.TelegrafPrefix)
+			ua.inputs.Add(name)
+		}
+		for _, processor := range pipeline.Processors {
+			ua.processors.Add(string(processor.Type()))
+		}
+		for _, exporter := range pipeline.Exporters {
+			ua.outputs.Add(string(exporter.Type()))
+			if exporter.Type() == "awsemf" {
+				cfg := otelCfg.Exporters[exporter].(*awsemfexporter.Config)
+				if cfg.IsPulseApmEnabled() {
+					ua.outputs.Add(flagPulse)
+				}
+				if cfg.IsEnhancedContainerInsights() {
+					ua.outputs.Add(flagEnhancedContainerInsights)
+				}
+			}
+		}
+	}
+
+	if !ua.isRoot {
+		ua.inputs.Add(flagRunAsUser)
+	}
+
+	ua.inputsStr.Store(componentsStr(typeInputs, ua.inputs))
+	ua.processorsStr.Store(componentsStr(typeProcessors, ua.processors))
+	ua.outputsStr.Store(componentsStr(typeOutputs, ua.outputs))
+	ua.notify()
+}
+
+func (ua *userAgent) SetContainerInsightsFlag() {
+	ua.dataLock.Lock()
+	defer ua.dataLock.Unlock()
+	if !ua.outputs.Contains(flagContainerInsights) {
+		ua.outputs.Add(flagContainerInsights)
+		ua.outputsStr.Store(componentsStr(typeOutputs, ua.outputs))
+		ua.notify()
+	}
+}
+
+func (ua *userAgent) Listen(listener func()) {
+	ua.listenerLock.Lock()
+	defer ua.listenerLock.Unlock()
+	ua.listeners = append(ua.listeners, listener)
+}
+
+func (ua *userAgent) notify() {
+	ua.listenerLock.Lock()
+	defer ua.listenerLock.Unlock()
+	for _, listener := range ua.listeners {
+		listener()
+	}
+}
+
+func (ua *userAgent) Header(isUsageDataEnabled bool) string {
+	if envUserAgent := os.Getenv(envconfig.CWAGENT_USER_AGENT); envUserAgent != "" {
+		return envUserAgent
+	}
+	if !isUsageDataEnabled {
+		return version.Full()
+	}
+
+	var components []string
+	inputs := ua.inputsStr.Load()
+	if inputs != "" {
+		components = append(components, inputs)
+	}
+	processors := ua.processorsStr.Load()
+	if processors != "" {
+		components = append(components, processors)
+	}
+	outputs := ua.outputsStr.Load()
+	if outputs != "" {
+		components = append(components, outputs)
+	}
+
+	return strings.TrimSpace(fmt.Sprintf("%s ID/%s %s", version.Full(), ua.id, strings.Join(components, separator)))
+}
+
+func componentsStr(componentType string, componentSet collections.Set[string]) string {
+	if len(componentSet) == 0 {
+		return ""
+	}
+	components := maps.Keys(componentSet)
+	sort.Strings(components)
+	return fmt.Sprintf("%s:(%s)", componentType, strings.Join(components, separator))
+}
+
+func isRunningAsRoot() bool {
+	return os.Getuid() == 0
+}
+
+func newUserAgent() *userAgent {
+	uah := &userAgent{
+		id:         uuid.NewString(),
+		isRoot:     isRunningAsRoot(),
+		inputs:     collections.NewSet[string](),
+		processors: collections.NewSet[string](),
+		outputs:    collections.NewSet[string](),
+	}
+	return uah
+}
+
+func Get() UserAgent {
+	once.Do(func() {
+		singleton = newUserAgent()
+	})
+	return singleton
+}

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -70,8 +70,6 @@ type userAgent struct {
 var _ UserAgent = (*userAgent)(nil)
 
 func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegraf.Config) {
-	ua.dataLock.Lock()
-	defer ua.dataLock.Unlock()
 	for _, input := range telegrafCfg.Inputs {
 		ua.inputs.Add(input.Config.Name)
 	}

--- a/extension/agenthealth/handler/useragent/useragent_test.go
+++ b/extension/agenthealth/handler/useragent/useragent_test.go
@@ -1,0 +1,145 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package useragent
+
+import (
+	"sync"
+	"testing"
+
+	telegraf "github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/models"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/otelcol"
+	"go.opentelemetry.io/collector/service"
+	"go.opentelemetry.io/collector/service/pipelines"
+
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/aws/amazon-cloudwatch-agent/internal/version"
+	"github.com/aws/amazon-cloudwatch-agent/receiver/adapter"
+)
+
+func TestSetComponents(t *testing.T) {
+	otelCfg := &otelcol.Config{
+		Service: service.Config{
+			Pipelines: map[component.ID]*pipelines.PipelineConfig{
+				component.NewID("metrics"): {
+					Receivers: []component.ID{
+						component.NewID(adapter.TelegrafPrefix + "cpu"),
+						component.NewID("prometheus"),
+					},
+					Processors: []component.ID{
+						component.NewID("batch"),
+						component.NewID("filter"),
+					},
+					Exporters: []component.ID{
+						component.NewID("cloudwatch"),
+					},
+				},
+			},
+		},
+	}
+	telegrafCfg := &telegraf.Config{
+		Inputs: []*models.RunningInput{
+			{Config: &models.InputConfig{Name: "logs"}},
+			{Config: &models.InputConfig{Name: "cpu"}},
+		},
+		Outputs: []*models.RunningOutput{
+			{Config: &models.OutputConfig{Name: "cloudwatchlogs"}},
+		},
+	}
+
+	ua := newUserAgent()
+	ua.isRoot = true
+	ua.SetComponents(otelCfg, telegrafCfg)
+	assert.Len(t, ua.inputs, 3)
+	assert.Len(t, ua.processors, 2)
+	assert.Len(t, ua.outputs, 2)
+
+	assert.Equal(t, "inputs:(cpu logs prometheus)", ua.inputsStr.Load())
+	assert.Equal(t, "processors:(batch filter)", ua.processorsStr.Load())
+	assert.Equal(t, "outputs:(cloudwatch cloudwatchlogs)", ua.outputsStr.Load())
+	assert.Contains(t, ua.Header(true), "inputs:(cpu logs prometheus) processors:(batch filter) outputs:(cloudwatch cloudwatchlogs)")
+
+	ua.isRoot = false
+	ua.SetComponents(otelCfg, telegrafCfg)
+	assert.Len(t, ua.inputs, 4)
+	assert.Equal(t, "inputs:(cpu logs prometheus run_as_user)", ua.inputsStr.Load())
+}
+
+func TestSetComponentsEmpty(t *testing.T) {
+	ua := newUserAgent()
+	ua.SetComponents(&otelcol.Config{}, &telegraf.Config{})
+	assert.Len(t, ua.inputs, 1)
+	assert.Len(t, ua.processors, 0)
+	assert.Len(t, ua.outputs, 0)
+
+	assert.Equal(t, "inputs:(run_as_user)", ua.inputsStr.Load())
+	assert.Equal(t, "", ua.processorsStr.Load())
+	assert.Equal(t, "", ua.outputsStr.Load())
+}
+
+func TestContainerInsightsFlag(t *testing.T) {
+	ua := newUserAgent()
+	ua.outputs.Add("TEST_EXPORTER")
+	ua.SetContainerInsightsFlag()
+	assert.Equal(t, "outputs:(TEST_EXPORTER container_insights)", ua.outputsStr.Load())
+	// do not rebuild output string if flag already set
+	ua.outputs.Add("flag_already_set")
+	ua.SetContainerInsightsFlag()
+	assert.Equal(t, "outputs:(TEST_EXPORTER container_insights)", ua.outputsStr.Load())
+}
+
+func TestAlternateUserAgent(t *testing.T) {
+	t.Setenv(envconfig.CWAGENT_USER_AGENT, "TEST_AGENT")
+	ua := newUserAgent()
+	assert.Equal(t, "TEST_AGENT", ua.Header(false))
+	t.Setenv(envconfig.CWAGENT_USER_AGENT, "")
+	assert.Equal(t, version.Full(), ua.Header(false))
+}
+
+func TestEmf(t *testing.T) {
+	otelCfg := &otelcol.Config{
+		Service: service.Config{
+			Pipelines: map[component.ID]*pipelines.PipelineConfig{
+				component.NewID("metrics"): {
+					Receivers: []component.ID{
+						component.NewID("nop"),
+					},
+					Exporters: []component.ID{
+						component.NewID("awsemf"),
+					},
+				},
+			},
+		},
+		Exporters: map[component.ID]component.Config{
+			component.NewID("awsemf"): &awsemfexporter.Config{Namespace: "AWS/APM", LogGroupName: "/aws/apm/log/group"},
+		},
+	}
+	ua := newUserAgent()
+	ua.SetComponents(otelCfg, &telegraf.Config{})
+	assert.Len(t, ua.inputs, 2)
+	assert.Len(t, ua.processors, 0)
+	assert.Len(t, ua.outputs, 2)
+
+	assert.Equal(t, "inputs:(nop run_as_user)", ua.inputsStr.Load())
+	assert.Equal(t, "", ua.processorsStr.Load())
+	assert.Equal(t, "outputs:(awsemf pulse)", ua.outputsStr.Load())
+}
+
+func TestSingleton(t *testing.T) {
+	assert.Equal(t, Get().(*userAgent).id, Get().(*userAgent).id)
+}
+
+func TestListen(t *testing.T) {
+	var wg sync.WaitGroup
+	ua := newUserAgent()
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		ua.Listen(wg.Done)
+	}
+	ua.SetContainerInsightsFlag()
+	wg.Wait()
+}

--- a/extension/agenthealth/testdata/config.yaml
+++ b/extension/agenthealth/testdata/config.yaml
@@ -1,0 +1,3 @@
+agenthealth:
+agenthealth/1:
+  is_usage_data_enabled: false

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Jeffail/gabs v1.4.0
+	github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware v0.0.0-20231023161526-9bd8785e9c2e
 	github.com/aws/aws-sdk-go v1.45.24
 	github.com/aws/aws-sdk-go-v2 v1.21.2
 	github.com/aws/aws-sdk-go-v2/config v1.18.25
@@ -130,14 +131,18 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/collector v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/component v0.84.1-0.20230908201109-ab3d6c5b6470
+	go.opentelemetry.io/collector/config/configtelemetry v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/confmap v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/consumer v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/exporter v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.84.0
+	go.opentelemetry.io/collector/extension v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0014.0.20230908201109-ab3d6c5b6470
+	go.opentelemetry.io/collector/processor v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/processor/batchprocessor v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/receiver v0.84.1-0.20230908201109-ab3d6c5b6470
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.84.0
+	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.25.0
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
@@ -154,12 +159,6 @@ require (
 	k8s.io/apimachinery v0.28.1
 	k8s.io/client-go v0.28.1
 	k8s.io/klog/v2 v2.100.1
-)
-
-require (
-	go.opentelemetry.io/collector/config/configtelemetry v0.84.1-0.20230908201109-ab3d6c5b6470
-	go.opentelemetry.io/collector/extension v0.84.1-0.20230908201109-ab3d6c5b6470
-	go.opentelemetry.io/collector/processor v0.84.1-0.20230908201109-ab3d6c5b6470
 )
 
 require (
@@ -181,7 +180,6 @@ require (
 	github.com/alecthomas/participle v0.4.1 // indirect
 	github.com/alecthomas/participle/v2 v2.0.0 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
-	github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware v0.0.0-20231023152757-c6e2437e6590 // indirect
 	github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws v0.0.0-20230928170322-0df38c533713 // indirect
 	github.com/antchfx/jsonquery v1.1.5 // indirect
 	github.com/antchfx/xmlquery v1.3.9 // indirect
@@ -394,7 +392,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.17.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
-	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/goleak v1.2.1 // indirect
 	golang.org/x/crypto v0.13.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awsemfex
 github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awsemfexporter v0.0.0-20231023161526-9bd8785e9c2e/go.mod h1:UAXcRSojI8I0Kb9iS9a2v7J/iPrQ1loJIsBprSaVdFo=
 github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.0.0-20231023161526-9bd8785e9c2e h1:wwkcWoKzZM1S92tSxSRxraQcUsJk+CS8UsKUR5Wcgow=
 github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.0.0-20231023161526-9bd8785e9c2e/go.mod h1:cr4dmBlfnMVYT+gyKUAKh39zQu5u/UAukxQj15MdZ18=
-github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware v0.0.0-20231023152757-c6e2437e6590 h1:uUCPnX2C5C36iyX46N1eUjmp4LRpSTGeexgUWmohv7c=
-github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware v0.0.0-20231023152757-c6e2437e6590/go.mod h1:uOQa5/9Jle9VADEdWCXL4AbJr35NJQil30tapcTHQlw=
+github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware v0.0.0-20231023161526-9bd8785e9c2e h1:tlA6NWgE+cKvBErHLl+oDAYG+oJ3TJV+N6jeJnYr5iI=
+github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware v0.0.0-20231023161526-9bd8785e9c2e/go.mod h1:uOQa5/9Jle9VADEdWCXL4AbJr35NJQil30tapcTHQlw=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-20231023161526-9bd8785e9c2e h1:uQk5BvFVNMNCQswMx3gilWwPiqikvWx3BBFwMs85Stw=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-20231023161526-9bd8785e9c2e/go.mod h1:9iAsO2SC8NIsa8/xCmC2Pj4MZPmYdvm+1/n89M74JS4=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/containerinsight v0.0.0-20231023161526-9bd8785e9c2e h1:FvMVzM0uAQmE1lPdKdmSCPpZnE0O3yg14J2oMwrBXt0=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	filename       = "CWAGENT_VERSION"
+	unknownVersion = "Unknown"
+)
+
+var (
+	version     = readVersionFile()
+	fullVersion = buildFullVersion(version)
+)
+
+func Number() string {
+	return version
+}
+
+func Full() string {
+	return fullVersion
+}
+
+func FilePath() (string, error) {
+	ex, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(ex), filename), nil
+}
+
+func buildFullVersion(version string) string {
+	return fmt.Sprintf("CWAgent/%s (%s; %s; %s)",
+		version,
+		runtime.Version(),
+		runtime.GOOS,
+		runtime.GOARCH)
+}
+
+func readVersionFile() string {
+	versionFilePath, err := FilePath()
+	if err != nil {
+		return unknownVersion
+	}
+	content, err := os.ReadFile(versionFilePath)
+	if err != nil {
+		return unknownVersion
+	}
+	return strings.Trim(string(content), " \n\r\t")
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion(t *testing.T) {
+	expectedVersion := "Unknown"
+	expectedFullVersion := fmt.Sprintf("CWAgent/%s (%s; %s; %s)",
+		expectedVersion,
+		runtime.Version(),
+		runtime.GOOS,
+		runtime.GOARCH)
+	assert.Equal(t, expectedVersion, Number())
+	assert.Equal(t, expectedFullVersion, Full())
+
+	expectedVersion = "TEST_VERSION"
+	expectedFullVersion = fmt.Sprintf("CWAgent/%s (%s; %s; %s)",
+		expectedVersion,
+		runtime.Version(),
+		runtime.GOOS,
+		runtime.GOARCH)
+	filePath, err := FilePath()
+	require.NoError(t, err)
+	err = os.WriteFile(filePath, []byte(expectedVersion), 0644)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Remove(filePath)
+	})
+
+	actualVersion := readVersionFile()
+	assert.Equal(t, expectedVersion, actualVersion)
+	assert.Equal(t, expectedFullVersion, buildFullVersion(actualVersion))
+}

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -17,6 +17,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 
 	configaws "github.com/aws/amazon-cloudwatch-agent/cfg/aws"
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/useragent"
 	"github.com/aws/amazon-cloudwatch-agent/handlers"
 	"github.com/aws/amazon-cloudwatch-agent/handlers/agentinfo"
 	"github.com/aws/amazon-cloudwatch-agent/internal"
@@ -135,7 +137,7 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 	)
 	agentInfo := agentinfo.New(t.Group)
 	client.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{"PutLogEvents"}))
-	client.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", agentInfo.UserAgent()))
+	client.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("User-Agent", useragent.Get().Header(envconfig.IsUsageDataEnabled())))
 	client.Handlers.Build.PushBackNamed(handlers.NewDynamicCustomHeaderHandler("X-Amz-Agent-Stats", agentInfo.StatsHeader))
 
 	pusher := NewPusher(t, client, c.ForceFlushInterval.Duration, maxRetryTimeout, c.Log, c.pusherStopChan, &c.pusherWaitGroup, agentInfo)


### PR DESCRIPTION
# Description of the issue
The agenthealth extension implements the `awsmiddleware.Extension` interface and provides the request/response handlers to configure on the AWS Clients. This allows the agent's user agent to be prepended on AWS requests.

# Description of changes
Adds the agenthealth extension scaffolding with a user agent handler. There's a singleton user agent that gets updated by its `Set*` functions. On each change, the handler is updated and on each requests, the user agent string is added.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Adds unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




