### PR TITLE
Add agenthealth translator

### DIFF
--- a/service/defaultcomponents/components.go
+++ b/service/defaultcomponents/components.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatch"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger"
 )
@@ -61,7 +62,9 @@ func Factories() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 
-	if factories.Extensions, err = extension.MakeFactoryMap(); err != nil {
+	if factories.Extensions, err = extension.MakeFactoryMap(
+		agenthealth.NewFactory(),
+	); err != nil {
 		return otelcol.Factories{}, err
 	}
 

--- a/service/defaultcomponents/components_test.go
+++ b/service/defaultcomponents/components_test.go
@@ -13,7 +13,7 @@ const (
 	receiversCount  = 5
 	processorCount  = 5
 	exportersCount  = 5
-	extensionsCount = 0
+	extensionsCount = 1
 )
 
 func TestComponents(t *testing.T) {
@@ -45,4 +45,5 @@ func TestComponents(t *testing.T) {
 
 	extensions := factories.Extensions
 	assert.Len(t, extensions, extensionsCount)
+	assert.NotNil(t, extensions["agenthealth"])
 }

--- a/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
@@ -1,104 +1,112 @@
 connectors: {}
 exporters:
-  awscloudwatch:
-    force_flush_interval: 1m0s
-    max_datums_per_call: 1000
-    max_values_per_datum: 150
-    namespace: CWAgent
-    region: us-west-2
-    region_type: "ACJ"
-    mode: "EC2"
-    resource_to_telemetry_conversion:
-      enabled: true
-extensions: {}
+    awscloudwatch:
+        force_flush_interval: 1m0s
+        max_datums_per_call: 1000
+        max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
+        namespace: CWAgent
+        region: us-west-2
+        region_type: ACJ
+        resource_to_telemetry_conversion:
+            enabled: true
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
-  cumulativetodelta/hostDeltaMetrics:
-    exclude:
-      match_type: strict
-      metrics:
-        - iops_in_progress
-        - diskio_iops_in_progress
-      regexp: null
-    include:
-      match_type: ""
-      metrics: []
-      regexp: null
-    initial_value: 0
-    max_staleness: 0s
-  ec2tagger:
-    ec2_instance_tag_keys:
-      - AutoScalingGroupName
-    ec2_metadata_tags:
-      - ImageId
-      - InstanceId
-      - InstanceType
-    refresh_interval_seconds: 0s
-    imds_retries: 1
+    cumulativetodelta/hostDeltaMetrics:
+        exclude:
+            match_type: strict
+            metrics:
+                - iops_in_progress
+                - diskio_iops_in_progress
+            regexp: null
+        include:
+            match_type: ""
+            metrics: []
+            regexp: null
+        initial_value: 0
+        max_staleness: 0s
+    ec2tagger:
+        ec2_instance_tag_keys:
+            - AutoScalingGroupName
+        ec2_metadata_tags:
+            - ImageId
+            - InstanceId
+            - InstanceType
+        imds_retries: 1
+        refresh_interval_seconds: 0s
 receivers:
-  telegraf_cpu:
-    collection_interval: 1m0s
-    initial_delay: 1s
-    timeout: 0s
-  telegraf_disk:
-    collection_interval: 1m0s
-    initial_delay: 1s
-    timeout: 0s
-  telegraf_diskio:
-    collection_interval: 1m0s
-    initial_delay: 1s
-    timeout: 0s
-  telegraf_mem:
-    collection_interval: 1m0s
-    initial_delay: 1s
-    timeout: 0s
-  telegraf_netstat:
-    collection_interval: 1m0s
-    initial_delay: 1s
-    timeout: 0s
-  telegraf_swap:
-    collection_interval: 1m0s
-    initial_delay: 1s
-    timeout: 0s
+    telegraf_cpu:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
+    telegraf_disk:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
+    telegraf_diskio:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
+    telegraf_mem:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
+    telegraf_netstat:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
+    telegraf_swap:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
 service:
-  extensions: []
-  pipelines:
-    metrics/host:
-      exporters:
-        - awscloudwatch
-      processors:
-        - ec2tagger
-      receivers:
-        - telegraf_cpu
-        - telegraf_disk
-        - telegraf_mem
-        - telegraf_netstat
-        - telegraf_swap
-    metrics/hostDeltaMetrics:
-      exporters:
-        - awscloudwatch
-      processors:
-        - cumulativetodelta/hostDeltaMetrics
-        - ec2tagger
-      receivers:
-        - telegraf_diskio
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/metrics
+    pipelines:
+        metrics/host:
+            exporters:
+                - awscloudwatch
+            processors:
+                - ec2tagger
+            receivers:
+                - telegraf_mem
+                - telegraf_netstat
+                - telegraf_swap
+                - telegraf_cpu
+                - telegraf_disk
+        metrics/hostDeltaMetrics:
+            exporters:
+                - awscloudwatch
+            processors:
+                - cumulativetodelta/hostDeltaMetrics
+                - ec2tagger
+            receivers:
+                - telegraf_diskio
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
@@ -4,13 +4,19 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:
@@ -29,46 +35,47 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - ImageId
             - InstanceId
             - InstanceType
-            - ImageId
-        refresh_interval_seconds: 0s
         imds_retries: 1
+        refresh_interval_seconds: 0s
 receivers:
     telegraf_cpu:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_disk:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_diskio:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_ethtool:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_mem:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_netstat:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_nvidia_smi:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_swap:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -76,13 +83,13 @@ service:
             processors:
                 - ec2tagger
             receivers:
-                - telegraf_cpu
                 - telegraf_disk
-                - telegraf_ethtool
                 - telegraf_mem
                 - telegraf_netstat
-                - telegraf_nvidia_smi
                 - telegraf_swap
+                - telegraf_ethtool
+                - telegraf_nvidia_smi
+                - telegraf_cpu
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -100,7 +107,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/advanced_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_windows.yaml
@@ -4,13 +4,19 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     ec2tagger:
         ec2_instance_tag_keys:
@@ -19,46 +25,47 @@ processors:
             - ImageId
             - InstanceId
             - InstanceType
-        refresh_interval_seconds: 0s
         imds_retries: 1
+        refresh_interval_seconds: 0s
 receivers:
     telegraf_win_perf_counters/1492679118:
-        alias_name         : Memory
+        alias_name: Memory
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/2039663244:
-        alias_name         : TCPv6
+        alias_name: TCPv6
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/2073218482:
-        alias_name         : TCPv4
+        alias_name: TCPv4
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3446270237:
-        alias_name         : PhysicalDisk
+        alias_name: PhysicalDisk
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3610923661:
-        alias_name         : Paging File
+        alias_name: Paging File
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3762679655:
-        alias_name         : Processor
+        alias_name: Processor
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/4283769065:
-        alias_name         : LogicalDisk
+        alias_name: LogicalDisk
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -66,13 +73,13 @@ service:
             processors:
                 - ec2tagger
             receivers:
-                - telegraf_win_perf_counters/1492679118
-                - telegraf_win_perf_counters/2039663244
                 - telegraf_win_perf_counters/3446270237
-                - telegraf_win_perf_counters/2073218482
-                - telegraf_win_perf_counters/3610923661
                 - telegraf_win_perf_counters/3762679655
+                - telegraf_win_perf_counters/2073218482
+                - telegraf_win_perf_counters/2039663244
                 - telegraf_win_perf_counters/4283769065
+                - telegraf_win_perf_counters/1492679118
+                - telegraf_win_perf_counters/3610923661
     telemetry:
         logs:
             development: false
@@ -82,7 +89,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log]
+            output_paths:
+                - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
@@ -1,233 +1,270 @@
 connectors: {}
 exporters:
-  awscloudwatchlogs/emf_logs:
-    certificate_file_path: "/etc/test/ca_bundle.pem"
-    emf_only: true
-    endpoint: "https://fake_endpoint"
-    imds_retries: 1
-    local_mode: false
-    log_group_name: emf/logs/default
-    log_retention: 0
-    log_stream_name: host_name_from_env
-    max_retries: 2
-    no_verify_ssl: false
-    num_workers: 8
-    proxy_address: ""
-    raw_log: true
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_elapsed_time: 5m0s
-      max_interval: 30s
-      multiplier: 1.5
-      randomization_factor: 0.5
-    role_arn: ""
-    sending_queue:
-      queue_size: 1000
-    profile: ""
-    shared_credentials_file: []
-  awsemf/containerinsights:
-    namespace: ContainerInsights
-    log_group_name: '/aws/containerinsights/{ClusterName}/performance'
-    log_stream_name: '{NodeName}'
-    log_retention: 0
-    detailed_metrics: false
-    dimension_rollup_option: NoDimensionRollup
-    disable_metric_extraction: true
-    version: "0"
-    eks_fargate_container_insights_enabled: false
-    certificate_file_path: "/etc/test/ca_bundle.pem"
-    endpoint: "https://fake_endpoint"
-    enhanced_container_insights: false
-    imds_retries: 1
-    local_mode: false
-    retain_initial_value_of_delta_metric: false
-    parse_json_encoded_attr_values: [ Sources, kubernetes ]
-    max_retries: 2
-    resource_to_telemetry_conversion:
-      enabled: true
-    metric_declarations:
-      # pod metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_cpu_utilization
-          - pod_memory_utilization
-          - pod_network_rx_bytes
-          - pod_network_tx_bytes
-          - pod_cpu_utilization_over_pod_limit
-          - pod_memory_utilization_over_pod_limit
-      - dimensions: [ [ ClusterName, Namespace, PodName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_number_of_container_restarts
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_cpu_reserved_capacity
-          - pod_memory_reserved_capacity
-      # node metrics
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_cpu_utilization
-          - node_memory_utilization
-          - node_network_total_bytes
-          - node_cpu_reserved_capacity
-          - node_memory_reserved_capacity
-          - node_number_of_running_pods
-          - node_number_of_running_containers
-      - dimensions: [ [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_cpu_usage_total
-          - node_cpu_limit
-          - node_memory_working_set
-          - node_memory_limit
-      # node fs metrics
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_filesystem_utilization
-      # service metrics
-      - dimensions: [ [ ClusterName, Namespace, Service ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - service_number_of_running_pods
-      # namespace metrics
-      - dimensions: [ [ ClusterName, Namespace ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - namespace_number_of_running_pods
-      # cluster metrics
-      - dimensions: [ [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - cluster_node_count
-          - cluster_failed_node_count
-    metric_descriptors: [ ]
-    no_verify_ssl: false
-    num_workers: 8
-    output_destination: cloudwatch
-    proxy_address: ""
-    region: "us-east-1"
-    request_timeout_seconds: 30
-    resource_arn: ""
-    role_arn: ""
-    profile: ""
-    shared_credentials_file: [ ]
-extensions: {}
+    awscloudwatchlogs/emf_logs:
+        certificate_file_path: /etc/test/ca_bundle.pem
+        emf_only: true
+        endpoint: https://fake_endpoint
+        imds_retries: 1
+        local_mode: false
+        log_group_name: emf/logs/default
+        log_retention: 0
+        log_stream_name: host_name_from_env
+        max_retries: 2
+        middleware: agenthealth/logs
+        no_verify_ssl: false
+        num_workers: 8
+        profile: ""
+        proxy_address: ""
+        raw_log: true
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        role_arn: ""
+        sending_queue:
+            queue_size: 1000
+        shared_credentials_file: []
+    awsemf/containerinsights:
+        certificate_file_path: /etc/test/ca_bundle.pem
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: true
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: false
+        imds_retries: 1
+        local_mode: false
+        log_group_name: /aws/containerinsights/{ClusterName}/performance
+        log_retention: 0
+        log_stream_name: '{NodeName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+                  - Namespace
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_utilization
+                - pod_memory_utilization
+                - pod_network_rx_bytes
+                - pod_network_tx_bytes
+                - pod_cpu_utilization_over_pod_limit
+                - pod_memory_utilization_over_pod_limit
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_number_of_container_restarts
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_reserved_capacity
+                - pod_memory_reserved_capacity
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_cpu_utilization
+                - node_memory_utilization
+                - node_network_total_bytes
+                - node_cpu_reserved_capacity
+                - node_memory_reserved_capacity
+                - node_number_of_running_pods
+                - node_number_of_running_containers
+            - dimensions:
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_cpu_usage_total
+                - node_cpu_limit
+                - node_memory_working_set
+                - node_memory_limit
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_filesystem_utilization
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - service_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - namespace_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - cluster_node_count
+                - cluster_failed_node_count
+        metric_descriptors: []
+        middleware: agenthealth/logs
+        namespace: ContainerInsights
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        parse_json_encoded_attr_values:
+            - Sources
+            - kubernetes
+        profile: ""
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file: []
+        version: "0"
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
 processors:
-  batch/emf_logs:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
-  batch/containerinsights:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
+    batch/containerinsights:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    batch/emf_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
 receivers:
-  awscontainerinsightreceiver:
-    add_container_name_metric_label: false
-    add_full_pod_name_metric_label: false
-    add_service_as_attribute: true
-    cluster_name: TestCluster
-    collection_interval: 30s
-    container_orchestrator: eks
-    enable_control_plane_metrics: false
-    certificate_file_path: ""
-    endpoint: ""
-    imds_retries: 1
-    prefer_full_pod_name: true
-    leader_lock_name: cwagent-clusterleader
-    leader_lock_using_config_map_only: true
-    local_mode: false
-    max_retries: 0
-    no_verify_ssl: false
-    num_workers: 0
-    proxy_address: ""
-    region: "us-east-1"
-    request_timeout_seconds: 0
-    resource_arn: ""
-    role_arn: ""
-    profile: ""
-    shared_credentials_file: [ ]
-  tcplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: tcp_input
-    listen_address: 0.0.0.0:25888
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: tcp_input
-  udplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: udp_input
-    listen_address: 0.0.0.0:25888
-    multiline:
-      line_end_pattern: .^
-      line_start_pattern: ""
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: udp_input
+    awscontainerinsightreceiver:
+        add_container_name_metric_label: false
+        add_full_pod_name_metric_label: false
+        add_service_as_attribute: true
+        certificate_file_path: ""
+        cluster_name: TestCluster
+        collection_interval: 30s
+        container_orchestrator: eks
+        enable_control_plane_metrics: false
+        endpoint: ""
+        imds_retries: 1
+        leader_lock_name: cwagent-clusterleader
+        leader_lock_using_config_map_only: true
+        local_mode: false
+        max_retries: 0
+        no_verify_ssl: false
+        num_workers: 0
+        prefer_full_pod_name: true
+        profile: ""
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 0
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file: []
+    tcplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: tcp_input
+        listen_address: 0.0.0.0:25888
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: tcp_input
+    udplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: udp_input
+        listen_address: 0.0.0.0:25888
+        multiline:
+            line_end_pattern: .^
+            line_start_pattern: ""
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: udp_input
 service:
-  extensions: []
-  pipelines:
-    logs/emf_logs:
-      exporters:
-        - awscloudwatchlogs/emf_logs
-      processors:
-        - batch/emf_logs
-      receivers:
-        - tcplog/emf_logs
-        - udplog/emf_logs
-    metrics/containerinsights:
-      exporters:
-        - awsemf/containerinsights
-      processors:
-        - batch/containerinsights
-      receivers:
-        - awscontainerinsightreceiver
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: []
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        logs/emf_logs:
+            exporters:
+                - awscloudwatchlogs/emf_logs
+            processors:
+                - batch/emf_logs
+            receivers:
+                - tcplog/emf_logs
+                - udplog/emf_logs
+        metrics/containerinsights:
+            exporters:
+                - awsemf/containerinsights
+            processors:
+                - batch/containerinsights
+            receivers:
+                - awscontainerinsightreceiver
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths: []
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/basic_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/basic_config_linux.yaml
@@ -4,34 +4,41 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-east-1
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     ec2tagger:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - InstanceType
             - ImageId
             - InstanceId
-            - InstanceType
         imds_retries: 1
         refresh_interval_seconds: 0s
 receivers:
     telegraf_disk:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_mem:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -39,8 +46,8 @@ service:
             processors:
                 - ec2tagger
             receivers:
-                - telegraf_disk
                 - telegraf_mem
+                - telegraf_disk
     telemetry:
         logs:
             development: false
@@ -50,7 +57,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/basic_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/basic_config_windows.yaml
@@ -4,13 +4,19 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     ec2tagger:
         ec2_instance_tag_keys:
@@ -19,21 +25,22 @@ processors:
             - ImageId
             - InstanceId
             - InstanceType
-        refresh_interval_seconds: 0s
         imds_retries: 1
+        refresh_interval_seconds: 0s
 receivers:
     telegraf_win_perf_counters/1492679118:
-        alias_name         : Memory
+        alias_name: Memory
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/4283769065:
-        alias_name         : LogicalDisk
+        alias_name: LogicalDisk
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -52,7 +59,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log]
+            output_paths:
+                - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/collectd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/collectd_config_linux.yaml
@@ -4,21 +4,28 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors: {}
 receivers:
     telegraf_socket_listener:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -35,7 +42,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -5,10 +5,11 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 5000
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test
@@ -19,20 +20,22 @@ exporters:
             - - d1
             - []
     awscloudwatchlogs/emf_logs:
-        emf_only: true
         certificate_file_path: ""
-        endpoint: "https://logs-fips.us-west-2.amazonaws.com"
+        emf_only: true
+        endpoint: https://logs-fips.us-west-2.amazonaws.com
         imds_retries: 1
         local_mode: false
         log_group_name: emf/logs/default
         log_retention: 0
         log_stream_name: LOG_STREAM_NAME
         max_retries: 2
+        middleware: agenthealth/logs
         no_verify_ssl: false
         num_workers: 8
+        profile: ""
         proxy_address: ""
         raw_log: true
-        region: "us-west-2"
+        region: us-west-2
         request_timeout_seconds: 30
         resource_arn: ""
         retry_on_failure:
@@ -45,8 +48,7 @@ exporters:
         role_arn: log_role_arn_value_test
         sending_queue:
             queue_size: 1000
-        profile: ""
-        shared_credentials_file: [ ]
+        shared_credentials_file: []
     awsxray:
         aws_log_groups: []
         certificate_file_path: ""
@@ -56,19 +58,35 @@ exporters:
         indexed_attributes: []
         local_mode: true
         max_retries: 2
+        middleware: agenthealth/traces
         no_verify_ssl: true
         num_workers: 1
+        profile: ""
         proxy_address: https://proxy.proxy.com
         region: us-west-2
         request_timeout_seconds: 30
         resource_arn: arn:aws:iam::account:resource
         role_arn: trace_role_arn_value_test
-        profile: ""
-        shared_credentials_file: [ ]
+        shared_credentials_file: []
         telemetry:
             enabled: true
             include_metadata: true
-extensions: {}
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
+    agenthealth/traces:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutTraceSegments
 processors:
     batch/emf_logs:
         metadata_cardinality_limit: 1000
@@ -99,11 +117,11 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - ImageId
             - InstanceId
             - InstanceType
-            - ImageId
-        refresh_interval_seconds: 0s
         imds_retries: 1
+        refresh_interval_seconds: 0s
     transform:
         error_mode: propagate
         log_statements: []
@@ -128,13 +146,13 @@ receivers:
             role_arn: trace_role_arn_value_test
             tls:
                 ca_file: ""
-                ca_pem: "[REDACTED]"
+                ca_pem: '[REDACTED]'
                 cert_file: ""
-                cert_pem: "[REDACTED]"
+                cert_pem: '[REDACTED]'
                 insecure: true
                 insecure_skip_verify: false
                 key_file: ""
-                key_pem: "[REDACTED]"
+                key_pem: '[REDACTED]'
                 max_version: ""
                 min_version: ""
                 reload_interval: 0s
@@ -166,48 +184,48 @@ receivers:
                 traces_url_path: /v1/traces
     telegraf_cpu:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_disk:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_diskio:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_mem:
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_net:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_netstat:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_processes:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_procstat/1917393364:
         alias_name: /var/run/example1.pid
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_socket_listener:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_statsd:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_swap:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     udplog/emf_logs:
         attributes: {}
@@ -228,7 +246,10 @@ receivers:
         storage: null
         type: udp_input
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
+        - agenthealth/logs
+        - agenthealth/traces
     pipelines:
         logs/emf_logs:
             exporters:

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -8,10 +8,11 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 5000
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test
@@ -22,20 +23,22 @@ exporters:
             - - d1
             - []
     awscloudwatchlogs/emf_logs:
-        emf_only: true
         certificate_file_path: ""
-        endpoint: "https://logs-fips.us-west-2.amazonaws.com"
+        emf_only: true
+        endpoint: https://logs-fips.us-west-2.amazonaws.com
         imds_retries: 1
         local_mode: false
         log_group_name: emf/logs/default
         log_retention: 0
         log_stream_name: LOG_STREAM_NAME
         max_retries: 2
+        middleware: agenthealth/logs
         no_verify_ssl: false
         num_workers: 8
+        profile: ""
         proxy_address: ""
         raw_log: true
-        region: "us-west-2"
+        region: us-west-2
         request_timeout_seconds: 30
         resource_arn: ""
         retry_on_failure:
@@ -48,8 +51,7 @@ exporters:
         role_arn: log_role_arn_value_test
         sending_queue:
             queue_size: 1000
-        profile: ""
-        shared_credentials_file: [ ]
+        shared_credentials_file: []
     awsxray:
         aws_log_groups: []
         certificate_file_path: ""
@@ -59,19 +61,35 @@ exporters:
         indexed_attributes: []
         local_mode: true
         max_retries: 2
+        middleware: agenthealth/traces
         no_verify_ssl: true
         num_workers: 1
+        profile: ""
         proxy_address: https://proxy.proxy.com
         region: us-west-2
         request_timeout_seconds: 30
         resource_arn: arn:aws:iam::account:resource
         role_arn: trace_role_arn_value_test
-        profile: ""
-        shared_credentials_file: [ ]
+        shared_credentials_file: []
         telemetry:
             enabled: true
             include_metadata: true
-extensions: {}
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
+    agenthealth/traces:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutTraceSegments
 processors:
     batch/emf_logs:
         metadata_cardinality_limit: 1000
@@ -105,19 +123,19 @@ processors:
             - ImageId
             - InstanceId
             - InstanceType
-        refresh_interval_seconds: 0s
         imds_retries: 1
+        refresh_interval_seconds: 0s
     transform:
         error_mode: propagate
         log_statements: []
         metric_statements:
             - context: metric
               statements:
-                  - set(unit, "unit") where name == "cpu_usage_idle"
-                  - set(name, "CPU_USAGE_IDLE") where name == "cpu_usage_idle"
-                  - set(unit, "unit") where name == "cpu_usage_nice"
-                  - set(unit, "unit") where name == "disk_free"
-                  - set(name, "DISK_FREE") where name == "disk_free"
+                - set(unit, "unit") where name == "disk_free"
+                - set(name, "DISK_FREE") where name == "disk_free"
+                - set(unit, "unit") where name == "cpu_usage_idle"
+                - set(name, "CPU_USAGE_IDLE") where name == "cpu_usage_idle"
+                - set(unit, "unit") where name == "cpu_usage_nice"
         trace_statements: []
 receivers:
     awsxray:
@@ -131,13 +149,13 @@ receivers:
             role_arn: trace_role_arn_value_test
             tls:
                 ca_file: ""
-                ca_pem: "[REDACTED]"
+                ca_pem: '[REDACTED]'
                 cert_file: ""
-                cert_pem: "[REDACTED]"
+                cert_pem: '[REDACTED]'
                 insecure: true
                 insecure_skip_verify: false
                 key_file: ""
-                key_pem: "[REDACTED]"
+                key_pem: '[REDACTED]'
                 max_version: ""
                 min_version: ""
                 reload_interval: 0s
@@ -169,48 +187,48 @@ receivers:
                 traces_url_path: /v1/traces
     telegraf_cpu:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_disk:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_diskio:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_mem:
         collection_interval: 1s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_net:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_netstat:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_processes:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_procstat/1917393364:
         alias_name: /var/run/example1.pid
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_socket_listener:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_statsd:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_swap:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     udplog/emf_logs:
         attributes: {}
@@ -231,7 +249,10 @@ receivers:
         storage: null
         type: udp_input
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
+        - agenthealth/logs
+        - agenthealth/traces
     pipelines:
         logs/emf_logs:
             exporters:
@@ -247,15 +268,15 @@ service:
                 - ec2tagger
                 - transform
             receivers:
-                - telegraf_procstat/1917393364
                 - telegraf_mem
-                - telegraf_cpu
                 - telegraf_disk
-                - telegraf_swap
-                - telegraf_statsd
                 - telegraf_socket_listener
-                - telegraf_processes
+                - telegraf_cpu
+                - telegraf_procstat/1917393364
+                - telegraf_swap
                 - telegraf_netstat
+                - telegraf_processes
+                - telegraf_statsd
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -264,8 +285,8 @@ service:
                 - ec2tagger
                 - transform
             receivers:
-                - telegraf_diskio
                 - telegraf_net
+                - telegraf_diskio
         traces/xray:
             exporters:
                 - awsxray

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
@@ -5,10 +5,11 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 5000
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test
@@ -21,18 +22,20 @@ exporters:
     awscloudwatchlogs/emf_logs:
         certificate_file_path: ""
         emf_only: true
-        endpoint: "https://logs-fips.us-west-2.amazonaws.com"
+        endpoint: https://logs-fips.us-west-2.amazonaws.com
         imds_retries: 1
         local_mode: false
         log_group_name: emf/logs/default
         log_retention: 0
         log_stream_name: LOG_STREAM_NAME
         max_retries: 2
+        middleware: agenthealth/logs
         no_verify_ssl: false
         num_workers: 8
+        profile: ""
         proxy_address: ""
         raw_log: true
-        region: "us-west-2"
+        region: us-west-2
         request_timeout_seconds: 30
         resource_arn: ""
         retry_on_failure:
@@ -45,8 +48,7 @@ exporters:
         role_arn: log_role_arn_value_test
         sending_queue:
             queue_size: 1000
-        profile: ""
-        shared_credentials_file: [ ]
+        shared_credentials_file: []
     awsxray:
         aws_log_groups: []
         certificate_file_path: ""
@@ -56,19 +58,35 @@ exporters:
         indexed_attributes: []
         local_mode: true
         max_retries: 2
+        middleware: agenthealth/traces
         no_verify_ssl: true
         num_workers: 1
+        profile: ""
         proxy_address: https://proxy.proxy.com
         region: us-west-2
         request_timeout_seconds: 30
         resource_arn: arn:aws:iam::account:resource
         role_arn: trace_role_arn_value_test
-        profile: ""
-        shared_credentials_file: [ ]
+        shared_credentials_file: []
         telemetry:
             enabled: true
             include_metadata: true
-extensions: {}
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
+    agenthealth/traces:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutTraceSegments
 processors:
     batch/emf_logs:
         metadata_cardinality_limit: 1000
@@ -212,7 +230,10 @@ receivers:
         storage: null
         type: udp_input
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
+        - agenthealth/logs
+        - agenthealth/traces
     pipelines:
         logs/emf_logs:
             exporters:

--- a/translator/tocwconfig/sampleConfig/config_with_env.yaml
+++ b/translator/tocwconfig/sampleConfig/config_with_env.yaml
@@ -1,106 +1,113 @@
 connectors: {}
 exporters:
-  awscloudwatchlogs/emf_logs:
-    certificate_file_path: ""
-    emf_only: true
-    endpoint: ""
-    imds_retries: 1
-    local_mode: false
-    log_group_name: emf/logs/default
-    log_retention: 0
-    log_stream_name: ${ENV_LOG_STREAM_NAME}
-    max_retries: 2
-    no_verify_ssl: false
-    num_workers: 8
-    profile: ""
-    proxy_address: ""
-    raw_log: true
-    region: ${ENV_REGION}
-    request_timeout_seconds: 30
-    resource_arn: ""
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_elapsed_time: 5m0s
-      max_interval: 30s
-      multiplier: 1.5
-      randomization_factor: 0.5
-    role_arn: ${ENV_CREDENTIALS_ROLE_ARN}
-    sending_queue:
-      queue_size: 1000
-    shared_credentials_file: []
-extensions: {}
+    awscloudwatchlogs/emf_logs:
+        certificate_file_path: ""
+        emf_only: true
+        endpoint: ""
+        imds_retries: 1
+        local_mode: false
+        log_group_name: emf/logs/default
+        log_retention: 0
+        log_stream_name: ${ENV_LOG_STREAM_NAME}
+        max_retries: 2
+        middleware: agenthealth/logs
+        no_verify_ssl: false
+        num_workers: 8
+        profile: ""
+        proxy_address: ""
+        raw_log: true
+        region: ${ENV_REGION}
+        request_timeout_seconds: 30
+        resource_arn: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        role_arn: ${ENV_CREDENTIALS_ROLE_ARN}
+        sending_queue:
+            queue_size: 1000
+        shared_credentials_file: []
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
 processors:
-  batch/emf_logs:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
+    batch/emf_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
 receivers:
-  tcplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: tcp_input
-    listen_address: 0.0.0.0:25888
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: tcp_input
-  udplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: udp_input
-    listen_address: 0.0.0.0:25888
-    multiline:
-      line_end_pattern: .^
-      line_start_pattern: ""
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: udp_input
+    tcplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: tcp_input
+        listen_address: 0.0.0.0:25888
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: tcp_input
+    udplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: udp_input
+        listen_address: 0.0.0.0:25888
+        multiline:
+            line_end_pattern: .^
+            line_start_pattern: ""
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: udp_input
 service:
-  extensions: []
-  pipelines:
-    logs/emf_logs:
-      exporters:
-        - awscloudwatchlogs/emf_logs
-      processors:
-        - batch/emf_logs
-      receivers:
-        - tcplog/emf_logs
-        - udplog/emf_logs
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths:
-        - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        logs/emf_logs:
+            exporters:
+                - awscloudwatchlogs/emf_logs
+            processors:
+                - batch/emf_logs
+            receivers:
+                - tcplog/emf_logs
+                - udplog/emf_logs
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
@@ -1,69 +1,76 @@
 connectors: {}
 exporters:
     awscloudwatch:
-      force_flush_interval: 1m0s
-      max_datums_per_call: 1000
-      max_values_per_datum: 150
-      namespace: CWAgent
-      region: us-east-1
-      region_type: "ACJ"
-      mode: "EC2"
-      resource_to_telemetry_conversion:
-        enabled: true
-extensions: {}
+        force_flush_interval: 1m0s
+        max_datums_per_call: 1000
+        max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
+        namespace: CWAgent
+        region: us-east-1
+        region_type: ACJ
+        resource_to_telemetry_conversion:
+            enabled: true
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
-  cumulativetodelta/hostDeltaMetrics:
-    exclude:
-      match_type: strict
-      metrics:
-        - iops_in_progress
-        - diskio_iops_in_progress
-      regexp: null
-    include:
-      match_type: ""
-      metrics: []
-      regexp: null
-    initial_value: 0
-    max_staleness: 0s
-  ec2tagger:
-    ec2_instance_tag_keys:
-      - AutoScalingGroupName
-    ec2_metadata_tags:
-      - ImageId
-      - InstanceId
-      - InstanceType
-    refresh_interval_seconds: 0s
-    imds_retries: 1
-  transform:
-    log_statements: [ ]
-    error_mode: "propagate"
-    metric_statements:
-      - context: metric
-        statements:
-          - set(unit, "Count") where name == "diskio_iops_in_progress"
-          - set(name, "DRIVER_DISKIO_IOPS_IN_PROGRESS") where name == "diskio_iops_in_progress"
-          - set(unit, "Milliseconds") where name == "diskio_read_time"
-          - set(name, "DRIVER_DISKIO_READ_TIME") where name == "diskio_read_time"
-          - set(unit, "Milliseconds") where name == "diskio_write_time"
-          - set(name, "DRIVER_DISKIO_WRITE_TIME") where name == "diskio_write_time"
-    trace_statements: []
+    cumulativetodelta/hostDeltaMetrics:
+        exclude:
+            match_type: strict
+            metrics:
+                - iops_in_progress
+                - diskio_iops_in_progress
+            regexp: null
+        include:
+            match_type: ""
+            metrics: []
+            regexp: null
+        initial_value: 0
+        max_staleness: 0s
+    ec2tagger:
+        ec2_instance_tag_keys:
+            - AutoScalingGroupName
+        ec2_metadata_tags:
+            - InstanceId
+            - InstanceType
+            - ImageId
+        imds_retries: 1
+        refresh_interval_seconds: 0s
+    transform:
+        error_mode: propagate
+        log_statements: []
+        metric_statements:
+            - context: metric
+              statements:
+                - set(unit, "Count") where name == "diskio_iops_in_progress"
+                - set(name, "DRIVER_DISKIO_IOPS_IN_PROGRESS") where name == "diskio_iops_in_progress"
+                - set(unit, "Milliseconds") where name == "diskio_read_time"
+                - set(name, "DRIVER_DISKIO_READ_TIME") where name == "diskio_read_time"
+                - set(unit, "Milliseconds") where name == "diskio_write_time"
+                - set(name, "DRIVER_DISKIO_WRITE_TIME") where name == "diskio_write_time"
+        trace_statements: []
 receivers:
     telegraf_diskio:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
-      metrics/hostDeltaMetrics:
-        exporters:
-          - awscloudwatch
-        processors:
-          - cumulativetodelta/hostDeltaMetrics
-          - ec2tagger
-          - transform
-        receivers:
-          - telegraf_diskio
+        metrics/hostDeltaMetrics:
+            exporters:
+                - awscloudwatch
+            processors:
+                - cumulativetodelta/hostDeltaMetrics
+                - ec2tagger
+                - transform
+            receivers:
+                - telegraf_diskio
     telemetry:
         logs:
             development: false
@@ -73,7 +80,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
@@ -1,53 +1,60 @@
 connectors: {}
 exporters:
     awscloudwatch:
-      force_flush_interval: 1m0s
-      max_datums_per_call: 1000
-      max_values_per_datum: 150
-      namespace: CWAgent
-      region: us-east-1
-      region_type: "ACJ"
-      mode: "EC2"
-      resource_to_telemetry_conversion:
-        enabled: true
-extensions: {}
+        force_flush_interval: 1m0s
+        max_datums_per_call: 1000
+        max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
+        namespace: CWAgent
+        region: us-east-1
+        region_type: ACJ
+        resource_to_telemetry_conversion:
+            enabled: true
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
-  cumulativetodelta/hostDeltaMetrics:
-    exclude:
-      match_type: ""
-      metrics: [ ]
-      regexp: null
-    include:
-      match_type: ""
-      metrics: []
-      regexp: null
-    initial_value: 0
-    max_staleness: 0s
-  ec2tagger:
-    ec2_instance_tag_keys:
-      - AutoScalingGroupName
-    ec2_metadata_tags:
-      - ImageId
-      - InstanceId
-      - InstanceType
-    refresh_interval_seconds: 0s
-    imds_retries: 1
+    cumulativetodelta/hostDeltaMetrics:
+        exclude:
+            match_type: ""
+            metrics: []
+            regexp: null
+        include:
+            match_type: ""
+            metrics: []
+            regexp: null
+        initial_value: 0
+        max_staleness: 0s
+    ec2tagger:
+        ec2_instance_tag_keys:
+            - AutoScalingGroupName
+        ec2_metadata_tags:
+            - ImageId
+            - InstanceId
+            - InstanceType
+        imds_retries: 1
+        refresh_interval_seconds: 0s
 receivers:
     telegraf_net:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
-      metrics/hostDeltaMetrics:
-        exporters:
-          - awscloudwatch
-        processors:
-          - cumulativetodelta/hostDeltaMetrics
-          - ec2tagger
-        receivers:
-          - telegraf_net
+        metrics/hostDeltaMetrics:
+            exporters:
+                - awscloudwatch
+            processors:
+                - cumulativetodelta/hostDeltaMetrics
+                - ec2tagger
+            receivers:
+                - telegraf_net
     telemetry:
         logs:
             development: false
@@ -57,7 +64,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/drop_origin_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/drop_origin_linux.yaml
@@ -4,53 +4,60 @@ exporters:
         drop_original_metrics:
             CPU_USAGE_IDLE: true
             cpu_time_active: true
-            nvidia_smi_utilization_gpu: true
             nvidia_smi_temperature_gpu: true
+            nvidia_smi_utilization_gpu: true
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     ec2tagger:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - InstanceType
             - ImageId
             - InstanceId
-            - InstanceType
-        refresh_interval_seconds: 0s
         imds_retries: 1
+        refresh_interval_seconds: 0s
     transform:
+        error_mode: propagate
         log_statements: []
-        error_mode: "propagate"
         metric_statements:
             - context: metric
               statements:
-                  - set(unit, "unit") where name == "cpu_usage_idle"
-                  - set(name, "CPU_USAGE_IDLE") where name == "cpu_usage_idle"
-                  - set(unit, "unit") where name == "cpu_usage_nice"
+                - set(unit, "unit") where name == "cpu_usage_idle"
+                - set(name, "CPU_USAGE_IDLE") where name == "cpu_usage_idle"
+                - set(unit, "unit") where name == "cpu_usage_nice"
         trace_statements: []
 receivers:
     telegraf_cpu:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_disk:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_nvidia_smi:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -71,7 +78,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -1,430 +1,539 @@
 connectors: {}
 exporters:
-  awscloudwatchlogs/emf_logs:
-    emf_only: true
-    certificate_file_path: ""
-    endpoint: "https://fake_endpoint"
-    imds_retries: 2
-    local_mode: false
-    log_group_name: emf/logs/default
-    log_retention: 0
-    log_stream_name: host_name_from_env
-    max_retries: 2
-    no_verify_ssl: false
-    num_workers: 8
-    profile: "default"
-    proxy_address: ""
-    raw_log: true
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_elapsed_time: 5m0s
-      max_interval: 30s
-      multiplier: 1.5
-      randomization_factor: 0.5
-    role_arn: ""
-    sending_queue:
-      queue_size: 1000
-    shared_credentials_file: [ "/root/.aws/credentials" ]
-  awsemf/containerinsights:
-    detailed_metrics: false
-    dimension_rollup_option: NoDimensionRollup
-    disable_metric_extraction: true
-    eks_fargate_container_insights_enabled: false
-    certificate_file_path: ""
-    endpoint: "https://fake_endpoint"
-    enhanced_container_insights: true
-    imds_retries: 2
-    local_mode: false
-    log_group_name: /aws/containerinsights/{ClusterName}/performance
-    log_retention: 0
-    log_stream_name: '{NodeName}'
-    max_retries: 2
-    metric_declarations:
-      # container metrics
-      - dimensions: [ [ ClusterName ], [ ClusterName, ContainerName, FullPodName, Namespace, PodName ], [ ClusterName, ContainerName, Namespace, PodName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - container_cpu_utilization
-          - container_cpu_utilization_over_container_limit
-          - container_cpu_limit
-          - container_cpu_request
-          - container_memory_utilization
-          - container_memory_utilization_over_container_limit
-          - container_memory_failures_total
-          - container_memory_limit
-          - container_memory_request
-          - container_filesystem_usage
-          - container_filesystem_available
-          - container_filesystem_utilization
-      # pod metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_cpu_utilization
-          - pod_memory_utilization
-          - pod_network_rx_bytes
-          - pod_network_tx_bytes
-          - pod_cpu_utilization_over_pod_limit
-          - pod_memory_utilization_over_pod_limit
-      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_interface_network_rx_dropped
-          - pod_interface_network_tx_dropped
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, Service ] ]
-        label_matchers: []
-        metric_name_selectors:
-          - pod_cpu_reserved_capacity
-          - pod_memory_reserved_capacity
-          - pod_number_of_container_restarts
-          - pod_number_of_containers
-          - pod_number_of_running_containers
-          - pod_status_ready
-          - pod_status_scheduled
-          - pod_status_running
-          - pod_status_pending
-          - pod_status_failed
-          - pod_status_unknown
-          - pod_status_succeeded
-          - pod_memory_request
-          - pod_memory_limit
-          - pod_cpu_limit
-          - pod_cpu_request
-          - pod_container_status_running
-          - pod_container_status_terminated
-          - pod_container_status_waiting
-          - pod_container_status_waiting_reason_crash_loop_back_off
-          - pod_container_status_waiting_reason_image_pull_error
-          - pod_container_status_waiting_reason_start_error
-          - pod_container_status_waiting_reason_create_container_error
-          - pod_container_status_waiting_reason_create_container_config_error
-          - pod_container_status_terminated_reason_oom_killed
-      # node metrics
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_cpu_utilization
-          - node_memory_utilization
-          - node_network_total_bytes
-          - node_cpu_reserved_capacity
-          - node_memory_reserved_capacity
-          - node_number_of_running_pods
-          - node_number_of_running_containers
-          - node_cpu_usage_total
-          - node_cpu_limit
-          - node_memory_working_set
-          - node_memory_limit
-          - node_status_condition_ready
-          - node_status_condition_disk_pressure
-          - node_status_condition_memory_pressure
-          - node_status_condition_pid_pressure
-          - node_status_condition_network_unavailable
-          - node_status_condition_unknown
-          - node_status_capacity_pods
-          - node_status_allocatable_pods
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_interface_network_rx_dropped
-          - node_interface_network_tx_dropped
-          - node_diskio_io_service_bytes_total
-          - node_diskio_io_serviced_total
-      # node fs metrics
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_filesystem_utilization
-          - node_filesystem_inodes
-          - node_filesystem_inodes_free
-      # service metrics
-      - dimensions: [ [ ClusterName, Namespace, Service ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - service_number_of_running_pods
-      # deployment/stateful set/replica set metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - replicas_desired
-          - replicas_ready
-          - status_replicas_available
-          - status_replicas_unavailable
-      # daemon set metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - daemonset_status_number_available
-          - daemonset_status_number_unavailable
-      # namespace metrics
-      - dimensions: [ [ ClusterName, Namespace ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - namespace_number_of_running_pods
-      # cluster metrics
-      - dimensions: [ [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - cluster_node_count
-          - cluster_failed_node_count
-          - cluster_number_of_running_pods
-      # control plane metrics
-      - dimensions: [ [ClusterName, endpoint], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_size_bytes
-          - apiserver_storage_db_total_size_in_bytes
-          - etcd_db_total_size_in_bytes
-      - dimensions: [ [ClusterName, resource], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_list_duration_seconds
-          - apiserver_longrunning_requests
-          - apiserver_storage_objects
-      - dimensions: [ [ClusterName, verb], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_request_duration_seconds
-          - rest_client_request_duration_seconds
-      - dimensions: [ [ClusterName, code, verb], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_request_total
-          - apiserver_request_total_5xx
-      - dimensions: [ [ClusterName, operation], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_admission_controller_admission_duration_seconds
-          - apiserver_admission_step_admission_duration_seconds
-          - etcd_request_duration_seconds
-      - dimensions: [ [ClusterName, code, method], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - rest_client_requests_total
-      - dimensions: [ [ClusterName, request_kind], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_current_inflight_requests
-          - apiserver_current_inqueue_requests
-      - dimensions: [ [ClusterName, name], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_admission_webhook_admission_duration_seconds
-      - dimensions: [ [ClusterName, group], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_requested_deprecated_apis
-      - dimensions: [ [ClusterName, reason], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_flowcontrol_rejected_requests_total
-      - dimensions: [ [ ClusterName, priority_level ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_flowcontrol_request_concurrency_limit
-    metric_descriptors:
-          - metric_name: apiserver_admission_controller_admission_duration_seconds
-            unit: Seconds
-            overwrite: true
-          - metric_name: apiserver_admission_step_admission_duration_seconds
-            unit: Seconds
-            overwrite: true
-          - metric_name: apiserver_admission_webhook_admission_duration_seconds
-            unit: Seconds
-            overwrite: true
-          - metric_name: apiserver_current_inflight_requests
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_current_inqueue_requests
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_flowcontrol_rejected_requests_total
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_flowcontrol_request_concurrency_limit
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_longrunning_requests
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_request_duration_seconds
-            unit: Seconds
-            overwrite: true
-          - metric_name: apiserver_request_total
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_request_total_5xx
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_requested_deprecated_apis
-            unit: Count
-            overwrite: true
-          - metric_name: apiserver_storage_objects
-            unit: Count
-            overwrite: true
-          - metric_name: etcd_request_duration_seconds
-            unit: Seconds
-            overwrite: true
-          - metric_name: apiserver_storage_list_duration_seconds
-            unit: Seconds
-            overwrite: true
-          - metric_name: apiserver_storage_db_total_size_in_bytes
-            unit: Bytes
-            overwrite: true
-          - metric_name: apiserver_storage_size_bytes
-            unit: Bytes
-            overwrite: true
-          - metric_name: etcd_db_total_size_in_bytes
-            unit: Bytes
-            overwrite: true
-          - metric_name: rest_client_request_duration_seconds
-            unit: Seconds
-            overwrite: true
-          - metric_name: rest_client_requests_total
-            unit: Count
-            overwrite: true
-    namespace: ContainerInsights
-    no_verify_ssl: false
-    num_workers: 8
-    output_destination: cloudwatch
-    parse_json_encoded_attr_values:
-      - Sources
-      - kubernetes
-    proxy_address: ""
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    resource_to_telemetry_conversion:
-      enabled: true
-    retain_initial_value_of_delta_metric: false
-    role_arn: ""
-    profile: "default"
-    shared_credentials_file: [ "/root/.aws/credentials" ]
-    version: "0"
-extensions: {}
+    awscloudwatchlogs/emf_logs:
+        certificate_file_path: ""
+        emf_only: true
+        endpoint: https://fake_endpoint
+        imds_retries: 2
+        local_mode: false
+        log_group_name: emf/logs/default
+        log_retention: 0
+        log_stream_name: host_name_from_env
+        max_retries: 2
+        middleware: agenthealth/logs
+        no_verify_ssl: false
+        num_workers: 8
+        profile: default
+        proxy_address: ""
+        raw_log: true
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        role_arn: ""
+        sending_queue:
+            queue_size: 1000
+        shared_credentials_file:
+            - /root/.aws/credentials
+    awsemf/containerinsights:
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: true
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: true
+        imds_retries: 2
+        local_mode: false
+        log_group_name: /aws/containerinsights/{ClusterName}/performance
+        log_retention: 0
+        log_stream_name: '{NodeName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - container_cpu_utilization
+                - container_cpu_utilization_over_container_limit
+                - container_cpu_limit
+                - container_cpu_request
+                - container_memory_utilization
+                - container_memory_utilization_over_container_limit
+                - container_memory_failures_total
+                - container_memory_limit
+                - container_memory_request
+                - container_filesystem_usage
+                - container_filesystem_available
+                - container_filesystem_utilization
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_utilization
+                - pod_memory_utilization
+                - pod_network_rx_bytes
+                - pod_network_tx_bytes
+                - pod_cpu_utilization_over_pod_limit
+                - pod_memory_utilization_over_pod_limit
+            - dimensions:
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_interface_network_rx_dropped
+                - pod_interface_network_tx_dropped
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                  - Service
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_reserved_capacity
+                - pod_memory_reserved_capacity
+                - pod_number_of_container_restarts
+                - pod_number_of_containers
+                - pod_number_of_running_containers
+                - pod_status_ready
+                - pod_status_scheduled
+                - pod_status_running
+                - pod_status_pending
+                - pod_status_failed
+                - pod_status_unknown
+                - pod_status_succeeded
+                - pod_memory_request
+                - pod_memory_limit
+                - pod_cpu_limit
+                - pod_cpu_request
+                - pod_container_status_running
+                - pod_container_status_terminated
+                - pod_container_status_waiting
+                - pod_container_status_waiting_reason_crash_loop_back_off
+                - pod_container_status_waiting_reason_image_pull_error
+                - pod_container_status_waiting_reason_start_error
+                - pod_container_status_waiting_reason_create_container_error
+                - pod_container_status_waiting_reason_create_container_config_error
+                - pod_container_status_terminated_reason_oom_killed
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_cpu_utilization
+                - node_memory_utilization
+                - node_network_total_bytes
+                - node_cpu_reserved_capacity
+                - node_memory_reserved_capacity
+                - node_number_of_running_pods
+                - node_number_of_running_containers
+                - node_cpu_usage_total
+                - node_cpu_limit
+                - node_memory_working_set
+                - node_memory_limit
+                - node_status_condition_ready
+                - node_status_condition_disk_pressure
+                - node_status_condition_memory_pressure
+                - node_status_condition_pid_pressure
+                - node_status_condition_network_unavailable
+                - node_status_condition_unknown
+                - node_status_capacity_pods
+                - node_status_allocatable_pods
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_interface_network_rx_dropped
+                - node_interface_network_tx_dropped
+                - node_diskio_io_service_bytes_total
+                - node_diskio_io_serviced_total
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_filesystem_utilization
+                - node_filesystem_inodes
+                - node_filesystem_inodes_free
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - service_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - replicas_desired
+                - replicas_ready
+                - status_replicas_available
+                - status_replicas_unavailable
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - daemonset_status_number_available
+                - daemonset_status_number_unavailable
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - namespace_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - cluster_node_count
+                - cluster_failed_node_count
+                - cluster_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - endpoint
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_storage_size_bytes
+                - apiserver_storage_db_total_size_in_bytes
+                - etcd_db_total_size_in_bytes
+            - dimensions:
+                - - ClusterName
+                  - resource
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_storage_list_duration_seconds
+                - apiserver_longrunning_requests
+                - apiserver_storage_objects
+            - dimensions:
+                - - ClusterName
+                  - verb
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_request_duration_seconds
+                - rest_client_request_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - code
+                  - verb
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_request_total
+                - apiserver_request_total_5xx
+            - dimensions:
+                - - ClusterName
+                  - operation
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_admission_controller_admission_duration_seconds
+                - apiserver_admission_step_admission_duration_seconds
+                - etcd_request_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - code
+                  - method
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - rest_client_requests_total
+            - dimensions:
+                - - ClusterName
+                  - request_kind
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_current_inflight_requests
+                - apiserver_current_inqueue_requests
+            - dimensions:
+                - - ClusterName
+                  - name
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_admission_webhook_admission_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - group
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_requested_deprecated_apis
+            - dimensions:
+                - - ClusterName
+                  - reason
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_flowcontrol_rejected_requests_total
+            - dimensions:
+                - - ClusterName
+                  - priority_level
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_flowcontrol_request_concurrency_limit
+        metric_descriptors:
+            - metric_name: apiserver_admission_controller_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_admission_step_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_admission_webhook_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_current_inflight_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_current_inqueue_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_flowcontrol_rejected_requests_total
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_flowcontrol_request_concurrency_limit
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_longrunning_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_request_total
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_request_total_5xx
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_requested_deprecated_apis
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_storage_objects
+              overwrite: true
+              unit: Count
+            - metric_name: etcd_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_storage_list_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_storage_db_total_size_in_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: apiserver_storage_size_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: etcd_db_total_size_in_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: rest_client_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: rest_client_requests_total
+              overwrite: true
+              unit: Count
+        middleware: agenthealth/logs
+        namespace: ContainerInsights
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        parse_json_encoded_attr_values:
+            - Sources
+            - kubernetes
+        profile: default
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file:
+            - /root/.aws/credentials
+        version: "0"
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
 processors:
-  metricstransform/containerinsights:
-    transforms:
-      - include: apiserver_request_total
-        match_type: regexp
-        experimental_match_labels: { "code": "^5.*" }
-        action: insert
-        new_name: apiserver_request_total_5xx
-        aggregation_type: ""
-        group_resource_labels: { }
-        operations: [ ]
-        submatch_case: ""
-  batch/containerinsights:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
-  batch/emf_logs:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
+    batch/containerinsights:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    batch/emf_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    metricstransform/containerinsights:
+        transforms:
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                code: ^5.*
+              group_resource_labels: {}
+              include: apiserver_request_total
+              match_type: regexp
+              new_name: apiserver_request_total_5xx
+              operations: []
+              submatch_case: ""
 receivers:
-  awscontainerinsightreceiver:
-    add_container_name_metric_label: true
-    add_full_pod_name_metric_label: true
-    add_service_as_attribute: true
-    cluster_name: TestCluster
-    collection_interval: 30s
-    container_orchestrator: eks
-    enable_control_plane_metrics: true
-    certificate_file_path: ""
-    endpoint: ""
-    imds_retries: 2
-    leader_lock_name: cwagent-clusterleader
-    leader_lock_using_config_map_only: true
-    local_mode: false
-    max_retries: 0
-    no_verify_ssl: false
-    num_workers: 0
-    prefer_full_pod_name: true
-    proxy_address: ""
-    region: "us-east-1"
-    request_timeout_seconds: 0
-    resource_arn: ""
-    role_arn: ""
-    profile: "default"
-    shared_credentials_file: [ "/root/.aws/credentials" ]
-  tcplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: tcp_input
-    listen_address: 0.0.0.0:25888
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: tcp_input
-  udplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: udp_input
-    listen_address: 0.0.0.0:25888
-    multiline:
-      line_end_pattern: .^
-      line_start_pattern: ""
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: udp_input
+    awscontainerinsightreceiver:
+        add_container_name_metric_label: true
+        add_full_pod_name_metric_label: true
+        add_service_as_attribute: true
+        certificate_file_path: ""
+        cluster_name: TestCluster
+        collection_interval: 30s
+        container_orchestrator: eks
+        enable_control_plane_metrics: true
+        endpoint: ""
+        imds_retries: 2
+        leader_lock_name: cwagent-clusterleader
+        leader_lock_using_config_map_only: true
+        local_mode: false
+        max_retries: 0
+        no_verify_ssl: false
+        num_workers: 0
+        prefer_full_pod_name: true
+        profile: default
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 0
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file:
+            - /root/.aws/credentials
+    tcplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: tcp_input
+        listen_address: 0.0.0.0:25888
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: tcp_input
+    udplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: udp_input
+        listen_address: 0.0.0.0:25888
+        multiline:
+            line_end_pattern: .^
+            line_start_pattern: ""
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: udp_input
 service:
-  extensions: []
-  pipelines:
-    logs/emf_logs:
-      exporters:
-        - awscloudwatchlogs/emf_logs
-      processors:
-        - batch/emf_logs
-      receivers:
-        - tcplog/emf_logs
-        - udplog/emf_logs
-    metrics/containerinsights:
-      exporters:
-        - awsemf/containerinsights
-      processors:
-        - metricstransform/containerinsights
-        - batch/containerinsights
-      receivers:
-        - awscontainerinsightreceiver
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: []
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        logs/emf_logs:
+            exporters:
+                - awscloudwatchlogs/emf_logs
+            processors:
+                - batch/emf_logs
+            receivers:
+                - tcplog/emf_logs
+                - udplog/emf_logs
+        metrics/containerinsights:
+            exporters:
+                - awsemf/containerinsights
+            processors:
+                - metricstransform/containerinsights
+                - batch/containerinsights
+            receivers:
+                - awscontainerinsightreceiver
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths: []
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/ignore_append_dimensions.yaml
+++ b/translator/tocwconfig/sampleConfig/ignore_append_dimensions.yaml
@@ -1,60 +1,68 @@
 connectors: {}
 exporters:
-  awscloudwatch:
-    force_flush_interval: 1m0s
-    max_datums_per_call: 1000
-    max_values_per_datum: 150
-    namespace: CWAgent
-    region: us-east-1
-    region_type: "ACJ"
-    mode: "EC2"
-    resource_to_telemetry_conversion:
-      enabled: true
-extensions: {}
+    awscloudwatch:
+        force_flush_interval: 1m0s
+        max_datums_per_call: 1000
+        max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
+        namespace: CWAgent
+        region: us-east-1
+        region_type: ACJ
+        resource_to_telemetry_conversion:
+            enabled: true
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
-  ec2tagger:
-    ec2_instance_tag_keys: []
-    ec2_metadata_tags: []
-    refresh_interval_seconds: 0s
-    imds_retries: 1
+    ec2tagger:
+        ec2_instance_tag_keys: []
+        ec2_metadata_tags: []
+        imds_retries: 1
+        refresh_interval_seconds: 0s
 receivers:
-  telegraf_disk:
-    collection_interval: 1m0s
-    initial_delay: "1s"
-    timeout: 0s
-  telegraf_mem:
-    collection_interval: 1m0s
-    initial_delay: "1s"
-    timeout: 0s
+    telegraf_disk:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
+    telegraf_mem:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
 service:
-  extensions: []
-  pipelines:
-    metrics/host:
-      exporters:
-        - awscloudwatch
-      processors:
-        - ec2tagger
-      receivers:
-        - telegraf_disk
-        - telegraf_mem
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/metrics
+    pipelines:
+        metrics/host:
+            exporters:
+                - awscloudwatch
+            processors:
+                - ec2tagger
+            receivers:
+                - telegraf_mem
+                - telegraf_disk
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/invalid_input_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/invalid_input_linux.yaml
@@ -4,13 +4,19 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-east-1
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     ec2tagger:
         ec2_instance_tag_keys:
@@ -19,19 +25,20 @@ processors:
             - ImageId
             - InstanceId
             - InstanceType
-        refresh_interval_seconds: 0s
         imds_retries: 1
+        refresh_interval_seconds: 0s
 receivers:
     telegraf_disk:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_mem:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -50,7 +57,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -1,354 +1,461 @@
 connectors: {}
 exporters:
-  awsemf/containerinsights:
-    certificate_file_path: ""
-    detailed_metrics: false
-    dimension_rollup_option: NoDimensionRollup
-    disable_metric_extraction: true
-    eks_fargate_container_insights_enabled: false
-    endpoint: "https://fake_endpoint"
-    enhanced_container_insights: true
-    imds_retries: 1
-    local_mode: false
-    log_group_name: /aws/containerinsights/{ClusterName}/performance
-    log_retention: 0
-    log_stream_name: '{NodeName}'
-    max_retries: 2
-    metric_declarations:
-      # container metrics
-      - dimensions: [ [ ClusterName ], [ ClusterName, ContainerName, FullPodName, Namespace, PodName ], [ ClusterName, ContainerName, Namespace, PodName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - container_cpu_utilization
-          - container_cpu_utilization_over_container_limit
-          - container_cpu_limit
-          - container_cpu_request
-          - container_memory_utilization
-          - container_memory_utilization_over_container_limit
-          - container_memory_failures_total
-          - container_memory_limit
-          - container_memory_request
-          - container_filesystem_usage
-          - container_filesystem_available
-          - container_filesystem_utilization
-      # pod metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_cpu_utilization
-          - pod_memory_utilization
-          - pod_network_rx_bytes
-          - pod_network_tx_bytes
-          - pod_cpu_utilization_over_pod_limit
-          - pod_memory_utilization_over_pod_limit
-      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_interface_network_rx_dropped
-          - pod_interface_network_tx_dropped
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, Service ] ]
-        label_matchers: []
-        metric_name_selectors:
-          - pod_cpu_reserved_capacity
-          - pod_memory_reserved_capacity
-          - pod_number_of_container_restarts
-          - pod_number_of_containers
-          - pod_number_of_running_containers
-          - pod_status_ready
-          - pod_status_scheduled
-          - pod_status_running
-          - pod_status_pending
-          - pod_status_failed
-          - pod_status_unknown
-          - pod_status_succeeded
-          - pod_memory_request
-          - pod_memory_limit
-          - pod_cpu_limit
-          - pod_cpu_request
-          - pod_container_status_running
-          - pod_container_status_terminated
-          - pod_container_status_waiting
-          - pod_container_status_waiting_reason_crash_loop_back_off
-          - pod_container_status_waiting_reason_image_pull_error
-          - pod_container_status_waiting_reason_start_error
-          - pod_container_status_waiting_reason_create_container_error
-          - pod_container_status_waiting_reason_create_container_config_error
-          - pod_container_status_terminated_reason_oom_killed
-      # node metrics
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_cpu_utilization
-          - node_memory_utilization
-          - node_network_total_bytes
-          - node_cpu_reserved_capacity
-          - node_memory_reserved_capacity
-          - node_number_of_running_pods
-          - node_number_of_running_containers
-          - node_cpu_usage_total
-          - node_cpu_limit
-          - node_memory_working_set
-          - node_memory_limit
-          - node_status_condition_ready
-          - node_status_condition_disk_pressure
-          - node_status_condition_memory_pressure
-          - node_status_condition_pid_pressure
-          - node_status_condition_network_unavailable
-          - node_status_condition_unknown
-          - node_status_capacity_pods
-          - node_status_allocatable_pods
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_interface_network_rx_dropped
-          - node_interface_network_tx_dropped
-          - node_diskio_io_service_bytes_total
-          - node_diskio_io_serviced_total
-      # node fs metrics
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_filesystem_utilization
-          - node_filesystem_inodes
-          - node_filesystem_inodes_free
-      # service metrics
-      - dimensions: [ [ ClusterName, Namespace, Service ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - service_number_of_running_pods
-      # deployment/stateful set/replica set metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - replicas_desired
-          - replicas_ready
-          - status_replicas_available
-          - status_replicas_unavailable
-      # daemon set metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - daemonset_status_number_available
-          - daemonset_status_number_unavailable
-      # namespace metrics
-      - dimensions: [ [ ClusterName, Namespace ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - namespace_number_of_running_pods
-      # cluster metrics
-      - dimensions: [ [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - cluster_node_count
-          - cluster_failed_node_count
-          - cluster_number_of_running_pods
-      # control plane metrics
-      - dimensions: [ [ ClusterName, endpoint ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_size_bytes
-          - apiserver_storage_db_total_size_in_bytes
-          - etcd_db_total_size_in_bytes
-      - dimensions: [ [ ClusterName, resource ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_list_duration_seconds
-          - apiserver_longrunning_requests
-          - apiserver_storage_objects
-      - dimensions: [ [ ClusterName, verb ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_request_duration_seconds
-          - rest_client_request_duration_seconds
-      - dimensions: [ [ ClusterName, code, verb ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_request_total
-          - apiserver_request_total_5xx
-      - dimensions: [ [ ClusterName, operation ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_admission_controller_admission_duration_seconds
-          - apiserver_admission_step_admission_duration_seconds
-          - etcd_request_duration_seconds
-      - dimensions: [ [ ClusterName, code, method ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - rest_client_requests_total
-      - dimensions: [ [ ClusterName, request_kind ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_current_inflight_requests
-          - apiserver_current_inqueue_requests
-      - dimensions: [ [ ClusterName, name ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_admission_webhook_admission_duration_seconds
-      - dimensions: [ [ ClusterName, group ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_requested_deprecated_apis
-      - dimensions: [ [ ClusterName, reason ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_flowcontrol_rejected_requests_total
-      - dimensions: [ [ ClusterName, priority_level ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_flowcontrol_request_concurrency_limit
-    metric_descriptors:
-      - metric_name: apiserver_admission_controller_admission_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_admission_step_admission_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_admission_webhook_admission_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_current_inflight_requests
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_current_inqueue_requests
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_flowcontrol_rejected_requests_total
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_flowcontrol_request_concurrency_limit
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_longrunning_requests
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_request_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_request_total
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_request_total_5xx
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_requested_deprecated_apis
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_storage_objects
-        unit: Count
-        overwrite: true
-      - metric_name: etcd_request_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_storage_list_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_storage_db_total_size_in_bytes
-        unit: Bytes
-        overwrite: true
-      - metric_name: apiserver_storage_size_bytes
-        unit: Bytes
-        overwrite: true
-      - metric_name: etcd_db_total_size_in_bytes
-        unit: Bytes
-        overwrite: true
-      - metric_name: rest_client_request_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: rest_client_requests_total
-        unit: Count
-        overwrite: true
-    namespace: ContainerInsights
-    no_verify_ssl: false
-    num_workers: 8
-    output_destination: cloudwatch
-    parse_json_encoded_attr_values:
-      - Sources
-      - kubernetes
-    proxy_address: ""
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    resource_to_telemetry_conversion:
-      enabled: true
-    retain_initial_value_of_delta_metric: false
-    role_arn: ""
-    profile: "AmazonCloudWatchAgent"
-    shared_credentials_file: ["fake-path"]
-    version: "0"
-extensions: {}
+    awsemf/containerinsights:
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: true
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: true
+        imds_retries: 1
+        local_mode: false
+        log_group_name: /aws/containerinsights/{ClusterName}/performance
+        log_retention: 0
+        log_stream_name: '{NodeName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - container_cpu_utilization
+                - container_cpu_utilization_over_container_limit
+                - container_cpu_limit
+                - container_cpu_request
+                - container_memory_utilization
+                - container_memory_utilization_over_container_limit
+                - container_memory_failures_total
+                - container_memory_limit
+                - container_memory_request
+                - container_filesystem_usage
+                - container_filesystem_available
+                - container_filesystem_utilization
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_utilization
+                - pod_memory_utilization
+                - pod_network_rx_bytes
+                - pod_network_tx_bytes
+                - pod_cpu_utilization_over_pod_limit
+                - pod_memory_utilization_over_pod_limit
+            - dimensions:
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_interface_network_rx_dropped
+                - pod_interface_network_tx_dropped
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                  - Service
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_reserved_capacity
+                - pod_memory_reserved_capacity
+                - pod_number_of_container_restarts
+                - pod_number_of_containers
+                - pod_number_of_running_containers
+                - pod_status_ready
+                - pod_status_scheduled
+                - pod_status_running
+                - pod_status_pending
+                - pod_status_failed
+                - pod_status_unknown
+                - pod_status_succeeded
+                - pod_memory_request
+                - pod_memory_limit
+                - pod_cpu_limit
+                - pod_cpu_request
+                - pod_container_status_running
+                - pod_container_status_terminated
+                - pod_container_status_waiting
+                - pod_container_status_waiting_reason_crash_loop_back_off
+                - pod_container_status_waiting_reason_image_pull_error
+                - pod_container_status_waiting_reason_start_error
+                - pod_container_status_waiting_reason_create_container_error
+                - pod_container_status_waiting_reason_create_container_config_error
+                - pod_container_status_terminated_reason_oom_killed
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_cpu_utilization
+                - node_memory_utilization
+                - node_network_total_bytes
+                - node_cpu_reserved_capacity
+                - node_memory_reserved_capacity
+                - node_number_of_running_pods
+                - node_number_of_running_containers
+                - node_cpu_usage_total
+                - node_cpu_limit
+                - node_memory_working_set
+                - node_memory_limit
+                - node_status_condition_ready
+                - node_status_condition_disk_pressure
+                - node_status_condition_memory_pressure
+                - node_status_condition_pid_pressure
+                - node_status_condition_network_unavailable
+                - node_status_condition_unknown
+                - node_status_capacity_pods
+                - node_status_allocatable_pods
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_interface_network_rx_dropped
+                - node_interface_network_tx_dropped
+                - node_diskio_io_service_bytes_total
+                - node_diskio_io_serviced_total
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_filesystem_utilization
+                - node_filesystem_inodes
+                - node_filesystem_inodes_free
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - service_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - replicas_desired
+                - replicas_ready
+                - status_replicas_available
+                - status_replicas_unavailable
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - daemonset_status_number_available
+                - daemonset_status_number_unavailable
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - namespace_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - cluster_node_count
+                - cluster_failed_node_count
+                - cluster_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - endpoint
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_storage_size_bytes
+                - apiserver_storage_db_total_size_in_bytes
+                - etcd_db_total_size_in_bytes
+            - dimensions:
+                - - ClusterName
+                  - resource
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_storage_list_duration_seconds
+                - apiserver_longrunning_requests
+                - apiserver_storage_objects
+            - dimensions:
+                - - ClusterName
+                  - verb
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_request_duration_seconds
+                - rest_client_request_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - code
+                  - verb
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_request_total
+                - apiserver_request_total_5xx
+            - dimensions:
+                - - ClusterName
+                  - operation
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_admission_controller_admission_duration_seconds
+                - apiserver_admission_step_admission_duration_seconds
+                - etcd_request_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - code
+                  - method
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - rest_client_requests_total
+            - dimensions:
+                - - ClusterName
+                  - request_kind
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_current_inflight_requests
+                - apiserver_current_inqueue_requests
+            - dimensions:
+                - - ClusterName
+                  - name
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_admission_webhook_admission_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - group
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_requested_deprecated_apis
+            - dimensions:
+                - - ClusterName
+                  - reason
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_flowcontrol_rejected_requests_total
+            - dimensions:
+                - - ClusterName
+                  - priority_level
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_flowcontrol_request_concurrency_limit
+        metric_descriptors:
+            - metric_name: apiserver_admission_controller_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_admission_step_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_admission_webhook_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_current_inflight_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_current_inqueue_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_flowcontrol_rejected_requests_total
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_flowcontrol_request_concurrency_limit
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_longrunning_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_request_total
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_request_total_5xx
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_requested_deprecated_apis
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_storage_objects
+              overwrite: true
+              unit: Count
+            - metric_name: etcd_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_storage_list_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_storage_db_total_size_in_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: apiserver_storage_size_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: etcd_db_total_size_in_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: rest_client_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: rest_client_requests_total
+              overwrite: true
+              unit: Count
+        middleware: agenthealth/logs
+        namespace: ContainerInsights
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        parse_json_encoded_attr_values:
+            - Sources
+            - kubernetes
+        profile: AmazonCloudWatchAgent
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file:
+            - fake-path
+        version: "0"
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
 processors:
-  metricstransform/containerinsights:
-    transforms:
-      - include: apiserver_request_total
-        match_type: regexp
-        experimental_match_labels: { "code": "^5.*" }
-        action: insert
-        new_name: apiserver_request_total_5xx
-        aggregation_type: ""
-        group_resource_labels: { }
-        operations: [ ]
-        submatch_case: ""
-  batch/containerinsights:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
+    batch/containerinsights:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    metricstransform/containerinsights:
+        transforms:
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                code: ^5.*
+              group_resource_labels: {}
+              include: apiserver_request_total
+              match_type: regexp
+              new_name: apiserver_request_total_5xx
+              operations: []
+              submatch_case: ""
 receivers:
-  awscontainerinsightreceiver:
-    certificate_file_path: ""
-    add_container_name_metric_label: true
-    add_full_pod_name_metric_label: true
-    add_service_as_attribute: true
-    cluster_name: TestCluster
-    collection_interval: 30s
-    container_orchestrator: eks
-    enable_control_plane_metrics: true
-    endpoint: ""
-    imds_retries: 1
-    leader_lock_name: cwagent-clusterleader
-    leader_lock_using_config_map_only: true
-    local_mode: true
-    max_retries: 0
-    no_verify_ssl: false
-    num_workers: 0
-    prefer_full_pod_name: true
-    proxy_address: ""
-    region: "us-east-1"
-    request_timeout_seconds: 0
-    resource_arn: ""
-    role_arn: ""
-    profile: "AmazonCloudWatchAgent"
-    shared_credentials_file: [ "fake-path" ]
+    awscontainerinsightreceiver:
+        add_container_name_metric_label: true
+        add_full_pod_name_metric_label: true
+        add_service_as_attribute: true
+        certificate_file_path: ""
+        cluster_name: TestCluster
+        collection_interval: 30s
+        container_orchestrator: eks
+        enable_control_plane_metrics: true
+        endpoint: ""
+        imds_retries: 1
+        leader_lock_name: cwagent-clusterleader
+        leader_lock_using_config_map_only: true
+        local_mode: true
+        max_retries: 0
+        no_verify_ssl: false
+        num_workers: 0
+        prefer_full_pod_name: true
+        profile: AmazonCloudWatchAgent
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 0
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file:
+            - fake-path
 service:
-  extensions: []
-  pipelines:
-    metrics/containerinsights:
-      exporters:
-        - awsemf/containerinsights
-      processors:
-        - metricstransform/containerinsights
-        - batch/containerinsights
-      receivers:
-        - awscontainerinsightreceiver
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: []
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        metrics/containerinsights:
+            exporters:
+                - awsemf/containerinsights
+            processors:
+                - metricstransform/containerinsights
+                - batch/containerinsights
+            receivers:
+                - awscontainerinsightreceiver
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths: []
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
+++ b/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
@@ -1,204 +1,212 @@
 connectors: {}
 exporters:
-  awscloudwatchlogs/emf_logs:
-    emf_only: true
-    certificate_file_path: ""
-    endpoint: "https://fake_endpoint"
-    imds_retries: 1
-    local_mode: false
-    log_group_name: emf/logs/default
-    log_retention: 0
-    log_stream_name: fake-host-name
-    max_retries: 2
-    no_verify_ssl: false
-    num_workers: 8
-    proxy_address: ""
-    raw_log: true
-    region: us-west-2
-    request_timeout_seconds: 30
-    resource_arn: ""
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_elapsed_time: 5m0s
-      max_interval: 30s
-      multiplier: 1.5
-      randomization_factor: 0.5
-    role_arn: ""
-    sending_queue:
-      queue_size: 1000
-    profile: ""
-    shared_credentials_file: [ ]
-  awsemf/containerinsights:
-    detailed_metrics: false
-    dimension_rollup_option: NoDimensionRollup
-    disable_metric_extraction: false
-    eks_fargate_container_insights_enabled: false
-    certificate_file_path: ""
-    endpoint: "https://fake_endpoint"
-    "imds_retries": 1
-    enhanced_container_insights: false
-    local_mode: false
-    log_group_name: /aws/ecs/containerinsights/{ClusterName}/performance
-    log_retention: 0
-    log_stream_name: NodeTelemetry-{ContainerInstanceId}
-    max_retries: 2
-    metric_declarations:
-      - dimensions:
-          - - ClusterName
-            - ContainerInstanceId
-            - InstanceId
-        label_matchers: []
-        metric_name_selectors:
-          - instance_cpu_reserved_capacity
-          - instance_cpu_utilization
-          - instance_filesystem_utilization
-          - instance_memory_reserved_capacity
-          - instance_memory_utilization
-          - instance_network_total_bytes
-          - instance_number_of_running_tasks
-      - dimensions:
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - instance_cpu_limit
-          - instance_cpu_reserved_capacity
-          - instance_cpu_usage_total
-          - instance_cpu_utilization
-          - instance_filesystem_utilization
-          - instance_memory_limit
-          - instance_memory_reserved_capacity
-          - instance_memory_utilization
-          - instance_memory_working_set
-          - instance_network_total_bytes
-          - instance_number_of_running_tasks
-    metric_descriptors: []
-    namespace: ECS/ContainerInsights
-    no_verify_ssl: false
-    num_workers: 8
-    output_destination: cloudwatch
-    parse_json_encoded_attr_values:
-      - Sources
-    proxy_address: ""
-    region: us-west-2
-    request_timeout_seconds: 30
-    resource_arn: ""
-    resource_to_telemetry_conversion:
-      enabled: true
-    retain_initial_value_of_delta_metric: false
-    role_arn: ""
-    profile: ""
-    shared_credentials_file: [ ]
-    version: "0"
-extensions: {}
+    awscloudwatchlogs/emf_logs:
+        certificate_file_path: ""
+        emf_only: true
+        endpoint: https://fake_endpoint
+        imds_retries: 1
+        local_mode: false
+        log_group_name: emf/logs/default
+        log_retention: 0
+        log_stream_name: fake-host-name
+        max_retries: 2
+        middleware: agenthealth/logs
+        no_verify_ssl: false
+        num_workers: 8
+        profile: ""
+        proxy_address: ""
+        raw_log: true
+        region: us-west-2
+        request_timeout_seconds: 30
+        resource_arn: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        role_arn: ""
+        sending_queue:
+            queue_size: 1000
+        shared_credentials_file: []
+    awsemf/containerinsights:
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: false
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: false
+        imds_retries: 1
+        local_mode: false
+        log_group_name: /aws/ecs/containerinsights/{ClusterName}/performance
+        log_retention: 0
+        log_stream_name: NodeTelemetry-{ContainerInstanceId}
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - ClusterName
+                  - ContainerInstanceId
+                  - InstanceId
+              label_matchers: []
+              metric_name_selectors:
+                - instance_cpu_reserved_capacity
+                - instance_cpu_utilization
+                - instance_filesystem_utilization
+                - instance_memory_reserved_capacity
+                - instance_memory_utilization
+                - instance_network_total_bytes
+                - instance_number_of_running_tasks
+            - dimensions:
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - instance_cpu_limit
+                - instance_cpu_reserved_capacity
+                - instance_cpu_usage_total
+                - instance_cpu_utilization
+                - instance_filesystem_utilization
+                - instance_memory_limit
+                - instance_memory_reserved_capacity
+                - instance_memory_utilization
+                - instance_memory_working_set
+                - instance_network_total_bytes
+                - instance_number_of_running_tasks
+        metric_descriptors: []
+        middleware: agenthealth/logs
+        namespace: ECS/ContainerInsights
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        parse_json_encoded_attr_values:
+            - Sources
+        profile: ""
+        proxy_address: ""
+        region: us-west-2
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file: []
+        version: "0"
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
 processors:
-  batch/containerinsights:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
-  batch/emf_logs:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
+    batch/containerinsights:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    batch/emf_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
 receivers:
-  awscontainerinsightreceiver:
-    add_container_name_metric_label: false
-    add_full_pod_name_metric_label: false
-    add_service_as_attribute: true
-    cluster_name: ""
-    collection_interval: 30s
-    container_orchestrator: ecs
-    enable_control_plane_metrics: false
-    certificate_file_path: ""
-    endpoint: ""
-    imds_retries: 1
-    leader_lock_name: otel-container-insight-clusterleader
-    leader_lock_using_config_map_only: false
-    local_mode: false
-    max_retries: 0
-    no_verify_ssl: false
-    num_workers: 0
-    prefer_full_pod_name: false
-    proxy_address: ""
-    region: "us-west-2"
-    request_timeout_seconds: 0
-    resource_arn: ""
-    role_arn: ""
-    profile: ""
-    shared_credentials_file: [ ]
-  tcplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: tcp_input
-    listen_address: 0.0.0.0:25888
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: tcp_input
-  udplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: udp_input
-    listen_address: 0.0.0.0:25888
-    multiline:
-      line_end_pattern: .^
-      line_start_pattern: ""
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: udp_input
+    awscontainerinsightreceiver:
+        add_container_name_metric_label: false
+        add_full_pod_name_metric_label: false
+        add_service_as_attribute: true
+        certificate_file_path: ""
+        cluster_name: ""
+        collection_interval: 30s
+        container_orchestrator: ecs
+        enable_control_plane_metrics: false
+        endpoint: ""
+        imds_retries: 1
+        leader_lock_name: otel-container-insight-clusterleader
+        leader_lock_using_config_map_only: false
+        local_mode: false
+        max_retries: 0
+        no_verify_ssl: false
+        num_workers: 0
+        prefer_full_pod_name: false
+        profile: ""
+        proxy_address: ""
+        region: us-west-2
+        request_timeout_seconds: 0
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file: []
+    tcplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: tcp_input
+        listen_address: 0.0.0.0:25888
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: tcp_input
+    udplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: udp_input
+        listen_address: 0.0.0.0:25888
+        multiline:
+            line_end_pattern: .^
+            line_start_pattern: ""
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: udp_input
 service:
-  extensions: []
-  pipelines:
-    logs/emf_logs:
-      exporters:
-        - awscloudwatchlogs/emf_logs
-      processors:
-        - batch/emf_logs
-      receivers:
-        - tcplog/emf_logs
-        - udplog/emf_logs
-    metrics/containerinsights:
-      exporters:
-        - awsemf/containerinsights
-      processors:
-        - batch/containerinsights
-      receivers:
-        - awscontainerinsightreceiver
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: []
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        logs/emf_logs:
+            exporters:
+                - awscloudwatchlogs/emf_logs
+            processors:
+                - batch/emf_logs
+            receivers:
+                - tcplog/emf_logs
+                - udplog/emf_logs
+        metrics/containerinsights:
+            exporters:
+                - awsemf/containerinsights
+            processors:
+                - batch/containerinsights
+            receivers:
+                - awscontainerinsightreceiver
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths: []
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -1,430 +1,536 @@
 connectors: {}
 exporters:
-  awscloudwatchlogs/emf_logs:
-    certificate_file_path: ""
-    emf_only: true
-    endpoint: "https://fake_endpoint"
-    imds_retries: 0
-    local_mode: false
-    log_group_name: emf/logs/default
-    log_retention: 0
-    log_stream_name: host_name_from_env
-    max_retries: 2
-    no_verify_ssl: false
-    num_workers: 8
-    proxy_address: ""
-    raw_log: true
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_elapsed_time: 5m0s
-      max_interval: 30s
-      multiplier: 1.5
-      randomization_factor: 0.5
-    role_arn: ""
-    sending_queue:
-      queue_size: 1000
-    profile: ""
-    shared_credentials_file: [ ]
-  awsemf/containerinsights:
-    certificate_file_path: ""
-    detailed_metrics: false
-    dimension_rollup_option: NoDimensionRollup
-    disable_metric_extraction: false
-    eks_fargate_container_insights_enabled: false
-    endpoint: "https://fake_endpoint"
-    imds_retries: 0
-    enhanced_container_insights: true
-    local_mode: false
-    log_group_name: /aws/containerinsights/{ClusterName}/performance
-    log_retention: 0
-    log_stream_name: '{NodeName}'
-    max_retries: 2
-    metric_declarations:
-      # container metrics
-      - dimensions: [ [ ClusterName ], [ ClusterName, ContainerName, FullPodName, Namespace, PodName ], [ ClusterName, ContainerName, Namespace, PodName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - container_cpu_utilization
-          - container_cpu_utilization_over_container_limit
-          - container_cpu_limit
-          - container_cpu_request
-          - container_memory_utilization
-          - container_memory_utilization_over_container_limit
-          - container_memory_failures_total
-          - container_memory_limit
-          - container_memory_request
-          - container_filesystem_usage
-          - container_filesystem_available
-          - container_filesystem_utilization
-      # pod metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, Namespace, Service ], [ ClusterName, Namespace ], [ ClusterName, FullPodName, Namespace, PodName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_cpu_utilization
-          - pod_memory_utilization
-          - pod_network_rx_bytes
-          - pod_network_tx_bytes
-          - pod_cpu_utilization_over_pod_limit
-          - pod_memory_utilization_over_pod_limit
-      - dimensions: [ [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, PodName ], [ ClusterName, Namespace ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - pod_interface_network_rx_dropped
-          - pod_interface_network_tx_dropped
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ], [ ClusterName, FullPodName, Namespace, PodName ], [ ClusterName, Namespace, Service ] ]
-        label_matchers: []
-        metric_name_selectors:
-          - pod_cpu_reserved_capacity
-          - pod_memory_reserved_capacity
-          - pod_number_of_container_restarts
-          - pod_number_of_containers
-          - pod_number_of_running_containers
-          - pod_status_ready
-          - pod_status_scheduled
-          - pod_status_running
-          - pod_status_pending
-          - pod_status_failed
-          - pod_status_unknown
-          - pod_status_succeeded
-          - pod_memory_request
-          - pod_memory_limit
-          - pod_cpu_limit
-          - pod_cpu_request
-          - pod_container_status_running
-          - pod_container_status_terminated
-          - pod_container_status_waiting
-          - pod_container_status_waiting_reason_crash_loop_back_off
-          - pod_container_status_waiting_reason_image_pull_error
-          - pod_container_status_waiting_reason_start_error
-          - pod_container_status_waiting_reason_create_container_error
-          - pod_container_status_waiting_reason_create_container_config_error
-          - pod_container_status_terminated_reason_oom_killed
-      # node metrics
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_cpu_utilization
-          - node_memory_utilization
-          - node_network_total_bytes
-          - node_cpu_reserved_capacity
-          - node_memory_reserved_capacity
-          - node_number_of_running_pods
-          - node_number_of_running_containers
-          - node_cpu_usage_total
-          - node_cpu_limit
-          - node_memory_working_set
-          - node_memory_limit
-          - node_status_condition_ready
-          - node_status_condition_disk_pressure
-          - node_status_condition_memory_pressure
-          - node_status_condition_pid_pressure
-          - node_status_condition_network_unavailable
-          - node_status_condition_unknown
-          - node_status_capacity_pods
-          - node_status_allocatable_pods
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_interface_network_rx_dropped
-          - node_interface_network_tx_dropped
-          - node_diskio_io_service_bytes_total
-          - node_diskio_io_serviced_total
-      # node fs metrics
-      - dimensions: [ [ ClusterName, InstanceId, NodeName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - node_filesystem_utilization
-          - node_filesystem_inodes
-          - node_filesystem_inodes_free
-      # service metrics
-      - dimensions: [ [ ClusterName, Namespace, Service ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - service_number_of_running_pods
-      # deployment/stateful set/replica set metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - replicas_desired
-          - replicas_ready
-          - status_replicas_available
-          - status_replicas_unavailable
-      # daemon set metrics
-      - dimensions: [ [ ClusterName, Namespace, PodName ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - daemonset_status_number_available
-          - daemonset_status_number_unavailable
-      # namespace metrics
-      - dimensions: [ [ ClusterName, Namespace ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - namespace_number_of_running_pods
-      # cluster metrics
-      - dimensions: [ [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - cluster_node_count
-          - cluster_failed_node_count
-          - cluster_number_of_running_pods
-      # control plane metrics
-      - dimensions: [ [ ClusterName, endpoint ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_size_bytes
-          - apiserver_storage_db_total_size_in_bytes
-          - etcd_db_total_size_in_bytes
-      - dimensions: [ [ ClusterName, resource ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_storage_list_duration_seconds
-          - apiserver_longrunning_requests
-          - apiserver_storage_objects
-      - dimensions: [ [ ClusterName, verb ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_request_duration_seconds
-          - rest_client_request_duration_seconds
-      - dimensions: [ [ ClusterName, code, verb ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_request_total
-          - apiserver_request_total_5xx
-      - dimensions: [ [ ClusterName, operation ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_admission_controller_admission_duration_seconds
-          - apiserver_admission_step_admission_duration_seconds
-          - etcd_request_duration_seconds
-      - dimensions: [ [ ClusterName, code, method ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - rest_client_requests_total
-      - dimensions: [ [ ClusterName, request_kind ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_current_inflight_requests
-          - apiserver_current_inqueue_requests
-      - dimensions: [ [ ClusterName, name ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_admission_webhook_admission_duration_seconds
-      - dimensions: [ [ ClusterName, group ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_requested_deprecated_apis
-      - dimensions: [ [ ClusterName, reason ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_flowcontrol_rejected_requests_total
-      - dimensions: [ [ ClusterName, priority_level ], [ ClusterName ] ]
-        label_matchers: [ ]
-        metric_name_selectors:
-          - apiserver_flowcontrol_request_concurrency_limit
-    metric_descriptors:
-      - metric_name: apiserver_admission_controller_admission_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_admission_step_admission_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_admission_webhook_admission_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_current_inflight_requests
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_current_inqueue_requests
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_flowcontrol_rejected_requests_total
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_flowcontrol_request_concurrency_limit
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_longrunning_requests
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_request_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_request_total
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_request_total_5xx
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_requested_deprecated_apis
-        unit: Count
-        overwrite: true
-      - metric_name: apiserver_storage_objects
-        unit: Count
-        overwrite: true
-      - metric_name: etcd_request_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_storage_list_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: apiserver_storage_db_total_size_in_bytes
-        unit: Bytes
-        overwrite: true
-      - metric_name: apiserver_storage_size_bytes
-        unit: Bytes
-        overwrite: true
-      - metric_name: etcd_db_total_size_in_bytes
-        unit: Bytes
-        overwrite: true
-      - metric_name: rest_client_request_duration_seconds
-        unit: Seconds
-        overwrite: true
-      - metric_name: rest_client_requests_total
-        unit: Count
-        overwrite: true
-    namespace: ContainerInsights
-    no_verify_ssl: false
-    num_workers: 8
-    output_destination: cloudwatch
-    parse_json_encoded_attr_values:
-      - Sources
-      - kubernetes
-    proxy_address: ""
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    resource_to_telemetry_conversion:
-      enabled: true
-    retain_initial_value_of_delta_metric: false
-    role_arn: ""
-    profile: ""
-    shared_credentials_file: [ ]
-    version: "0"
-extensions: {}
+    awscloudwatchlogs/emf_logs:
+        certificate_file_path: ""
+        emf_only: true
+        endpoint: https://fake_endpoint
+        imds_retries: 0
+        local_mode: false
+        log_group_name: emf/logs/default
+        log_retention: 0
+        log_stream_name: host_name_from_env
+        max_retries: 2
+        middleware: agenthealth/logs
+        no_verify_ssl: false
+        num_workers: 8
+        profile: ""
+        proxy_address: ""
+        raw_log: true
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        role_arn: ""
+        sending_queue:
+            queue_size: 1000
+        shared_credentials_file: []
+    awsemf/containerinsights:
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: false
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: true
+        imds_retries: 0
+        local_mode: false
+        log_group_name: /aws/containerinsights/{ClusterName}/performance
+        log_retention: 0
+        log_stream_name: '{NodeName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - container_cpu_utilization
+                - container_cpu_utilization_over_container_limit
+                - container_cpu_limit
+                - container_cpu_request
+                - container_memory_utilization
+                - container_memory_utilization_over_container_limit
+                - container_memory_failures_total
+                - container_memory_limit
+                - container_memory_request
+                - container_filesystem_usage
+                - container_filesystem_available
+                - container_filesystem_utilization
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_utilization
+                - pod_memory_utilization
+                - pod_network_rx_bytes
+                - pod_network_tx_bytes
+                - pod_cpu_utilization_over_pod_limit
+                - pod_memory_utilization_over_pod_limit
+            - dimensions:
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_interface_network_rx_dropped
+                - pod_interface_network_tx_dropped
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                  - Service
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_reserved_capacity
+                - pod_memory_reserved_capacity
+                - pod_number_of_container_restarts
+                - pod_number_of_containers
+                - pod_number_of_running_containers
+                - pod_status_ready
+                - pod_status_scheduled
+                - pod_status_running
+                - pod_status_pending
+                - pod_status_failed
+                - pod_status_unknown
+                - pod_status_succeeded
+                - pod_memory_request
+                - pod_memory_limit
+                - pod_cpu_limit
+                - pod_cpu_request
+                - pod_container_status_running
+                - pod_container_status_terminated
+                - pod_container_status_waiting
+                - pod_container_status_waiting_reason_crash_loop_back_off
+                - pod_container_status_waiting_reason_image_pull_error
+                - pod_container_status_waiting_reason_start_error
+                - pod_container_status_waiting_reason_create_container_error
+                - pod_container_status_waiting_reason_create_container_config_error
+                - pod_container_status_terminated_reason_oom_killed
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_cpu_utilization
+                - node_memory_utilization
+                - node_network_total_bytes
+                - node_cpu_reserved_capacity
+                - node_memory_reserved_capacity
+                - node_number_of_running_pods
+                - node_number_of_running_containers
+                - node_cpu_usage_total
+                - node_cpu_limit
+                - node_memory_working_set
+                - node_memory_limit
+                - node_status_condition_ready
+                - node_status_condition_disk_pressure
+                - node_status_condition_memory_pressure
+                - node_status_condition_pid_pressure
+                - node_status_condition_network_unavailable
+                - node_status_condition_unknown
+                - node_status_capacity_pods
+                - node_status_allocatable_pods
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_interface_network_rx_dropped
+                - node_interface_network_tx_dropped
+                - node_diskio_io_service_bytes_total
+                - node_diskio_io_serviced_total
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_filesystem_utilization
+                - node_filesystem_inodes
+                - node_filesystem_inodes_free
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - service_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - replicas_desired
+                - replicas_ready
+                - status_replicas_available
+                - status_replicas_unavailable
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - daemonset_status_number_available
+                - daemonset_status_number_unavailable
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - namespace_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - cluster_node_count
+                - cluster_failed_node_count
+                - cluster_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - endpoint
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_storage_size_bytes
+                - apiserver_storage_db_total_size_in_bytes
+                - etcd_db_total_size_in_bytes
+            - dimensions:
+                - - ClusterName
+                  - resource
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_storage_list_duration_seconds
+                - apiserver_longrunning_requests
+                - apiserver_storage_objects
+            - dimensions:
+                - - ClusterName
+                  - verb
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_request_duration_seconds
+                - rest_client_request_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - code
+                  - verb
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_request_total
+                - apiserver_request_total_5xx
+            - dimensions:
+                - - ClusterName
+                  - operation
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_admission_controller_admission_duration_seconds
+                - apiserver_admission_step_admission_duration_seconds
+                - etcd_request_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - code
+                  - method
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - rest_client_requests_total
+            - dimensions:
+                - - ClusterName
+                  - request_kind
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_current_inflight_requests
+                - apiserver_current_inqueue_requests
+            - dimensions:
+                - - ClusterName
+                  - name
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_admission_webhook_admission_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - group
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_requested_deprecated_apis
+            - dimensions:
+                - - ClusterName
+                  - reason
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_flowcontrol_rejected_requests_total
+            - dimensions:
+                - - ClusterName
+                  - priority_level
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_flowcontrol_request_concurrency_limit
+        metric_descriptors:
+            - metric_name: apiserver_admission_controller_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_admission_step_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_admission_webhook_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_current_inflight_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_current_inqueue_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_flowcontrol_rejected_requests_total
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_flowcontrol_request_concurrency_limit
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_longrunning_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_request_total
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_request_total_5xx
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_requested_deprecated_apis
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_storage_objects
+              overwrite: true
+              unit: Count
+            - metric_name: etcd_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_storage_list_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_storage_db_total_size_in_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: apiserver_storage_size_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: etcd_db_total_size_in_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: rest_client_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: rest_client_requests_total
+              overwrite: true
+              unit: Count
+        middleware: agenthealth/logs
+        namespace: ContainerInsights
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        parse_json_encoded_attr_values:
+            - Sources
+            - kubernetes
+        profile: ""
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file: []
+        version: "0"
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
 processors:
-  metricstransform/containerinsights:
-    transforms:
-      - include: apiserver_request_total
-        match_type: regexp
-        experimental_match_labels: { "code": "^5.*" }
-        action: insert
-        new_name: apiserver_request_total_5xx
-        aggregation_type: ""
-        group_resource_labels: { }
-        operations: [ ]
-        submatch_case: ""
-  batch/containerinsights:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
-  batch/emf_logs:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
+    batch/containerinsights:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    batch/emf_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    metricstransform/containerinsights:
+        transforms:
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                code: ^5.*
+              group_resource_labels: {}
+              include: apiserver_request_total
+              match_type: regexp
+              new_name: apiserver_request_total_5xx
+              operations: []
+              submatch_case: ""
 receivers:
-  awscontainerinsightreceiver:
-    certificate_file_path: ""
-    add_container_name_metric_label: true
-    add_full_pod_name_metric_label: true
-    add_service_as_attribute: true
-    cluster_name: TestCluster
-    collection_interval: 30s
-    container_orchestrator: eks
-    enable_control_plane_metrics: true
-    endpoint: ""
-    imds_retries: 0
-    leader_lock_name: cwagent-clusterleader
-    leader_lock_using_config_map_only: true
-    local_mode: false
-    max_retries: 0
-    no_verify_ssl: false
-    num_workers: 0
-    prefer_full_pod_name: true
-    proxy_address: ""
-    region: "us-east-1"
-    request_timeout_seconds: 0
-    resource_arn: ""
-    role_arn: ""
-    profile: ""
-    shared_credentials_file: [ ]
-  tcplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: tcp_input
-    listen_address: 0.0.0.0:25888
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: tcp_input
-  udplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: udp_input
-    listen_address: 0.0.0.0:25888
-    multiline:
-      line_end_pattern: .^
-      line_start_pattern: ""
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    storage: null
-    type: udp_input
+    awscontainerinsightreceiver:
+        add_container_name_metric_label: true
+        add_full_pod_name_metric_label: true
+        add_service_as_attribute: true
+        certificate_file_path: ""
+        cluster_name: TestCluster
+        collection_interval: 30s
+        container_orchestrator: eks
+        enable_control_plane_metrics: true
+        endpoint: ""
+        imds_retries: 0
+        leader_lock_name: cwagent-clusterleader
+        leader_lock_using_config_map_only: true
+        local_mode: false
+        max_retries: 0
+        no_verify_ssl: false
+        num_workers: 0
+        prefer_full_pod_name: true
+        profile: ""
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 0
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file: []
+    tcplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: tcp_input
+        listen_address: 0.0.0.0:25888
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: tcp_input
+    udplog/emf_logs:
+        attributes: {}
+        encoding: utf-8
+        id: udp_input
+        listen_address: 0.0.0.0:25888
+        multiline:
+            line_end_pattern: .^
+            line_start_pattern: ""
+        operators: []
+        output: []
+        resource: {}
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        storage: null
+        type: udp_input
 service:
-  extensions: []
-  pipelines:
-    logs/emf_logs:
-      exporters:
-        - awscloudwatchlogs/emf_logs
-      processors:
-        - batch/emf_logs
-      receivers:
-        - tcplog/emf_logs
-        - udplog/emf_logs
-    metrics/containerinsights:
-      exporters:
-        - awsemf/containerinsights
-      processors:
-        - metricstransform/containerinsights
-        - batch/containerinsights
-      receivers:
-        - awscontainerinsightreceiver
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: []
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        logs/emf_logs:
+            exporters:
+                - awscloudwatchlogs/emf_logs
+            processors:
+                - batch/emf_logs
+            receivers:
+                - tcplog/emf_logs
+                - udplog/emf_logs
+        metrics/containerinsights:
+            exporters:
+                - awsemf/containerinsights
+            processors:
+                - metricstransform/containerinsights
+                - batch/containerinsights
+            receivers:
+                - awscontainerinsightreceiver
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths: []
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/prometheus_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_config_linux.yaml
@@ -1,118 +1,123 @@
 connectors: {}
 exporters:
-  awsemf/prometheus:
-    detailed_metrics: false
-    dimension_rollup_option: NoDimensionRollup
-    disable_metric_extraction: false
-    version: "0"
-    retain_initial_value_of_delta_metric: false
-    eks_fargate_container_insights_enabled: false
-    certificate_file_path: ""
-    endpoint: "https://fake_endpoint"
-    "imds_retries": 1
-    enhanced_container_insights: false
-    local_mode: false
-    log_group_name: /aws/ecs/containerinsights/TestCluster/prometheus
-    log_retention: 0
-    log_stream_name: '{JobName}'
-    max_retries: 2
-    metric_descriptors:
-      - metric_name: "nginx_request_count"
-        overwrite: false
-        unit: "Count"
-
-    metric_declarations:
-      - dimensions:
-          - - Service
-        label_matchers:
-          - label_names:
-              - Service
-            regex: nginx.*
-            separator: ;
-        metric_name_selectors:
-          - ^nginx_request_count$
-      - dimensions: []
-        label_matchers:
-          - label_names:
-              - Namespace
-            regex: default
-            separator: ;
-        metric_name_selectors:
-          - .*
-      - dimensions: [ ["name"] ]
-        label_matchers:
-          - label_names:
-              - name
-            regex: .*
-            separator: ;
-        metric_name_selectors:
-          - ^.*$
-      - dimensions: [ ["name"] ]
-        label_matchers:
-          - label_names:
-              - name
-            regex: .*
-            separator: ;
-        metric_name_selectors:
-          - ^node_cpu_guest_seconds_total$
-    namespace: CustomizedNamespace
-    no_verify_ssl: false
-    num_workers: 8
-    output_destination: cloudwatch
-    parse_json_encoded_attr_values: []
-    proxy_address: ""
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    resource_to_telemetry_conversion:
-      enabled: true
-    role_arn: ""
-    profile: ""
-    shared_credentials_file: [ ]
-
-extensions: {}
-
+    awsemf/prometheus:
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: false
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: false
+        imds_retries: 1
+        local_mode: false
+        log_group_name: /aws/ecs/containerinsights/TestCluster/prometheus
+        log_retention: 0
+        log_stream_name: '{JobName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - Service
+              label_matchers:
+                - label_names:
+                    - Service
+                  regex: nginx.*
+                  separator: ;
+              metric_name_selectors:
+                - ^nginx_request_count$
+            - dimensions: []
+              label_matchers:
+                - label_names:
+                    - Namespace
+                  regex: default
+                  separator: ;
+              metric_name_selectors:
+                - .*
+            - dimensions:
+                - - name
+              label_matchers:
+                - label_names:
+                    - name
+                  regex: .*
+                  separator: ;
+              metric_name_selectors:
+                - ^.*$
+            - dimensions:
+                - - name
+              label_matchers:
+                - label_names:
+                    - name
+                  regex: .*
+                  separator: ;
+              metric_name_selectors:
+                - ^node_cpu_guest_seconds_total$
+        metric_descriptors:
+            - metric_name: nginx_request_count
+              overwrite: false
+              unit: Count
+        middleware: agenthealth/logs
+        namespace: CustomizedNamespace
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        parse_json_encoded_attr_values: []
+        profile: ""
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file: []
+        version: "0"
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
 processors:
-  batch/prometheus:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 30s
-
+    batch/prometheus:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 30s
 receivers:
-  telegraf_prometheus:
-    collection_interval: 1m0s
-    initial_delay: "1s"
-    timeout: 0s
+    telegraf_prometheus:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
 service:
-  extensions: []
-  pipelines:
-    metrics/prometheus:
-      exporters:
-        - awsemf/prometheus
-      processors:
-        - batch/prometheus
-      receivers:
-        - telegraf_prometheus
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: []
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        metrics/prometheus:
+            exporters:
+                - awsemf/prometheus
+            processors:
+                - batch/prometheus
+            receivers:
+                - telegraf_prometheus
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths: []
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/prometheus_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_config_windows.yaml
@@ -1,86 +1,88 @@
 connectors: {}
 exporters:
-  awsemf/prometheus:
-    detailed_metrics: false
-    dimension_rollup_option: NoDimensionRollup
-    disable_metric_extraction: false
-    version: "0"
-    retain_initial_value_of_delta_metric: false
-    eks_fargate_container_insights_enabled: false
-    certificate_file_path: ""
-    endpoint: "https://fake_endpoint"
-    "imds_retries": 1
-    enhanced_container_insights: false
-    local_mode: false
-    log_group_name: /aws/ecs/containerinsights/TestCluster/prometheus
-    log_retention: 0
-    log_stream_name: '{JobName}'
-    max_retries: 2
-    metric_descriptors:
-      - metric_name: "nginx_request_count"
-        overwrite: false
-        unit: "Count"
-    metric_declarations:
-      - dimensions:
-          - - Service
-        label_matchers:
-          - label_names:
-              - Service
-            regex: nginx.*
-            separator: ;
-        metric_name_selectors:
-          - ^nginx_request_count$
-      - dimensions: []
-        label_matchers:
-          - label_names:
-              - Namespace
-            regex: default
-            separator: ;
-        metric_name_selectors:
-          - .*
-    namespace: CustomizedNamespace
-    no_verify_ssl: false
-    num_workers: 8
-    output_destination: cloudwatch
-    parse_json_encoded_attr_values: []
-    proxy_address: ""
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    resource_to_telemetry_conversion:
-      enabled: true
-    role_arn: ""
-    profile: ""
-    shared_credentials_file: [ ]
-
-extensions: {} 
-
+    awsemf/prometheus:
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: false
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: false
+        imds_retries: 1
+        local_mode: false
+        log_group_name: /aws/ecs/containerinsights/TestCluster/prometheus
+        log_retention: 0
+        log_stream_name: '{JobName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - Service
+              label_matchers:
+                - label_names:
+                    - Service
+                  regex: nginx.*
+                  separator: ;
+              metric_name_selectors:
+                - ^nginx_request_count$
+            - dimensions: []
+              label_matchers:
+                - label_names:
+                    - Namespace
+                  regex: default
+                  separator: ;
+              metric_name_selectors:
+                - .*
+        metric_descriptors:
+            - metric_name: nginx_request_count
+              overwrite: false
+              unit: Count
+        middleware: agenthealth/logs
+        namespace: CustomizedNamespace
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        parse_json_encoded_attr_values: []
+        profile: ""
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file: []
+        version: "0"
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
 processors:
-  batch/prometheus:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
-  
+    batch/prometheus:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
 receivers:
-  telegraf_prometheus:
-    collection_interval: 1m0s
-    initial_delay: "1s"
-    timeout: 0s
-
+    telegraf_prometheus:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
 service:
-  extensions: []
-  pipelines:
-    metrics/prometheus:
-      exporters:
-        - awsemf/prometheus
-      processors:
-        - batch/prometheus
-      receivers:
-        - telegraf_prometheus
-
-  telemetry:
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        metrics/prometheus:
+            exporters:
+                - awsemf/prometheus
+            processors:
+                - batch/prometheus
+            receivers:
+                - telegraf_prometheus
+    telemetry:
         logs:
             development: false
             disable_caller: false

--- a/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
@@ -4,13 +4,19 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:
@@ -36,26 +42,27 @@ processors:
 receivers:
     telegraf_cpu:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_disk:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_diskio:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_mem:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_swap:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -84,7 +91,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
@@ -4,15 +4,21 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         profile: AmazonCloudWatchAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         shared_credential_file: fake-path
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:
@@ -34,33 +40,34 @@ processors:
             - ImageId
             - InstanceId
             - InstanceType
+        imds_retries: 2
         profile: AmazonCloudWatchAgent
         refresh_interval_seconds: 0s
         shared_credential_file: fake-path
-        imds_retries: 2
 receivers:
     telegraf_cpu:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_disk:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_diskio:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_mem:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_swap:
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -89,7 +96,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/standard_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_windows.yaml
@@ -4,13 +4,19 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     ec2tagger:
         ec2_instance_tag_keys:
@@ -22,32 +28,33 @@ processors:
         refresh_interval_seconds: 0s
 receivers:
     telegraf_win_perf_counters/1492679118:
-        alias_name:          Memory
+        alias_name: Memory
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3446270237:
-        alias_name:          PhysicalDisk
+        alias_name: PhysicalDisk
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3610923661:
-        alias_name:          Paging File
+        alias_name: Paging File
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3762679655:
-        alias_name:          Processor
+        alias_name: Processor
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/4283769065:
-        alias_name:          LogicalDisk
+        alias_name: LogicalDisk
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -55,11 +62,11 @@ service:
             processors:
                 - ec2tagger
             receivers:
-                - telegraf_win_perf_counters/1492679118
-                - telegraf_win_perf_counters/3446270237
                 - telegraf_win_perf_counters/3610923661
+                - telegraf_win_perf_counters/3446270237
                 - telegraf_win_perf_counters/3762679655
                 - telegraf_win_perf_counters/4283769065
+                - telegraf_win_perf_counters/1492679118
     telemetry:
         logs:
             development: false
@@ -69,7 +76,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log]
+            output_paths:
+                - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/standard_config_windows_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_windows_with_common_config.yaml
@@ -4,15 +4,21 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         profile: AmazonCloudWatchAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         shared_credential_file: fake-path
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors:
     ec2tagger:
         ec2_instance_tag_keys:
@@ -21,38 +27,39 @@ processors:
             - ImageId
             - InstanceId
             - InstanceType
+        imds_retries: 2
         profile: AmazonCloudWatchAgent
         refresh_interval_seconds: 0s
         shared_credential_file: fake-path
-        imds_retries: 2
 receivers:
     telegraf_win_perf_counters/1492679118:
-        alias_name:          Memory
+        alias_name: Memory
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3446270237:
-        alias_name:          PhysicalDisk
+        alias_name: PhysicalDisk
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3610923661:
-        alias_name:          Paging File
+        alias_name: Paging File
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/3762679655:
-        alias_name:          Processor
+        alias_name: Processor
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
     telegraf_win_perf_counters/4283769065:
-        alias_name:          LogicalDisk
+        alias_name: LogicalDisk
         collection_interval: 1m0s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -60,11 +67,11 @@ service:
             processors:
                 - ec2tagger
             receivers:
-                - telegraf_win_perf_counters/1492679118
-                - telegraf_win_perf_counters/3446270237
                 - telegraf_win_perf_counters/3610923661
+                - telegraf_win_perf_counters/3446270237
                 - telegraf_win_perf_counters/3762679655
                 - telegraf_win_perf_counters/4283769065
+                - telegraf_win_perf_counters/1492679118
     telemetry:
         logs:
             development: false
@@ -74,7 +81,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log]
+            output_paths:
+                - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/statsd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/statsd_config_linux.yaml
@@ -1,25 +1,31 @@
 connectors: {}
-
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors: {}
 receivers:
     telegraf_statsd:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -36,7 +42,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/statsd_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/statsd_config_windows.yaml
@@ -4,21 +4,28 @@ exporters:
         force_flush_interval: 1m0s
         max_datums_per_call: 1000
         max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: "ACJ"
-        mode: "EC2"
+        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
-extensions: {}
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
 processors: {}
 receivers:
     telegraf_statsd:
         collection_interval: 10s
-        initial_delay: "1s"
+        initial_delay: 1s
         timeout: 0s
 service:
-    extensions: []
+    extensions:
+        - agenthealth/metrics
     pipelines:
         metrics/host:
             exporters:
@@ -35,7 +42,8 @@ service:
             error_output_paths: []
             initial_fields: {}
             level: info
-            output_paths: [c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log]
+            output_paths:
+                - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
             sampling:
                 initial: 2
                 thereafter: 500

--- a/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
@@ -1,99 +1,107 @@
 connectors: {}
 exporters:
-  awsxray:
-    aws_log_groups: []
-    certificate_file_path: ""
-    endpoint: ""
-    imds_retries: 2
-    index_all_attributes: false
-    indexed_attributes: []
-    local_mode: false
-    max_retries: 2
-    no_verify_ssl: false
-    num_workers: 8
-    proxy_address: ""
-    region: us-west-2
-    request_timeout_seconds: 30
-    resource_arn: ""
-    role_arn: ""
-    profile: "default"
-    shared_credentials_file: [ "/root/.aws/credentials" ]
-    telemetry:
-      enabled: true
-      include_metadata: true
-extensions: {}
+    awsxray:
+        aws_log_groups: []
+        certificate_file_path: ""
+        endpoint: ""
+        imds_retries: 2
+        index_all_attributes: false
+        indexed_attributes: []
+        local_mode: false
+        max_retries: 2
+        middleware: agenthealth/traces
+        no_verify_ssl: false
+        num_workers: 8
+        profile: default
+        proxy_address: ""
+        region: us-west-2
+        request_timeout_seconds: 30
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file:
+            - /root/.aws/credentials
+        telemetry:
+            enabled: true
+            include_metadata: true
+extensions:
+    agenthealth/traces:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutTraceSegments
 processors:
-  batch/xray:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 200ms
+    batch/xray:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 200ms
 receivers:
-  awsxray:
-    endpoint: 127.0.0.1:2000
-    proxy_server:
-      aws_endpoint: ""
-      endpoint: 127.0.0.1:2000
-      local_mode: false
-      proxy_address: ""
-      region: us-west-2
-      role_arn: ""
-    transport: udp
-  otlp:
-    protocols:
-      grpc:
-        auth: null
-        endpoint: 127.0.0.1:4317
-        include_metadata: false
-        keepalive: null
-        max_concurrent_streams: 0
-        max_recv_msg_size_mib: 0
-        read_buffer_size: 524288
-        tls: null
-        transport: tcp
-        write_buffer_size: 0
-      http:
-        auth: null
-        cors: null
-        endpoint: 127.0.0.1:4318
-        include_metadata: false
-        logs_url_path: /v1/logs
-        max_request_body_size: 0
-        metrics_url_path: /v1/metrics
-        response_headers: {}
-        tls: null
-        traces_url_path: /v1/traces
+    awsxray:
+        endpoint: 127.0.0.1:2000
+        proxy_server:
+            aws_endpoint: ""
+            endpoint: 127.0.0.1:2000
+            local_mode: false
+            proxy_address: ""
+            region: us-west-2
+            role_arn: ""
+        transport: udp
+    otlp:
+        protocols:
+            grpc:
+                auth: null
+                endpoint: 127.0.0.1:4317
+                include_metadata: false
+                keepalive: null
+                max_concurrent_streams: 0
+                max_recv_msg_size_mib: 0
+                read_buffer_size: 524288
+                tls: null
+                transport: tcp
+                write_buffer_size: 0
+            http:
+                auth: null
+                cors: null
+                endpoint: 127.0.0.1:4318
+                include_metadata: false
+                logs_url_path: /v1/logs
+                max_request_body_size: 0
+                metrics_url_path: /v1/metrics
+                response_headers: {}
+                tls: null
+                traces_url_path: /v1/traces
 service:
-  extensions: []
-  pipelines:
-    traces/xray:
-      exporters:
-        - awsxray
-      processors:
-        - batch/xray
-      receivers:
-        - awsxray
-        - otlp
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths:
-        - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/traces
+    pipelines:
+        traces/xray:
+            exporters:
+                - awsxray
+            processors:
+                - batch/xray
+            receivers:
+                - awsxray
+                - otlp
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
@@ -1,99 +1,107 @@
 connectors: {}
 exporters:
-  awsxray:
-    aws_log_groups: []
-    certificate_file_path: ""
-    endpoint: ""
-    imds_retries: 2
-    index_all_attributes: false
-    indexed_attributes: []
-    local_mode: false
-    max_retries: 2
-    no_verify_ssl: false
-    num_workers: 8
-    proxy_address: ""
-    region: us-west-2
-    request_timeout_seconds: 30
-    resource_arn: ""
-    role_arn: ""
-    profile: "default"
-    shared_credentials_file: [ "/root/.aws/credentials" ]
-    telemetry:
-      enabled: true
-      include_metadata: true
-extensions: {}
+    awsxray:
+        aws_log_groups: []
+        certificate_file_path: ""
+        endpoint: ""
+        imds_retries: 2
+        index_all_attributes: false
+        indexed_attributes: []
+        local_mode: false
+        max_retries: 2
+        middleware: agenthealth/traces
+        no_verify_ssl: false
+        num_workers: 8
+        profile: default
+        proxy_address: ""
+        region: us-west-2
+        request_timeout_seconds: 30
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file:
+            - /root/.aws/credentials
+        telemetry:
+            enabled: true
+            include_metadata: true
+extensions:
+    agenthealth/traces:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutTraceSegments
 processors:
-  batch/xray:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 200ms
+    batch/xray:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 200ms
 receivers:
-  awsxray:
-    endpoint: 127.0.0.1:2000
-    proxy_server:
-      aws_endpoint: ""
-      endpoint: 127.0.0.1:2000
-      local_mode: false
-      proxy_address: ""
-      region: us-west-2
-      role_arn: ""
-    transport: udp
-  otlp:
-    protocols:
-      grpc:
-        auth: null
-        endpoint: 127.0.0.1:4317
-        include_metadata: false
-        keepalive: null
-        max_concurrent_streams: 0
-        max_recv_msg_size_mib: 0
-        read_buffer_size: 524288
-        tls: null
-        transport: tcp
-        write_buffer_size: 0
-      http:
-        auth: null
-        cors: null
-        endpoint: 127.0.0.1:4318
-        include_metadata: false
-        logs_url_path: /v1/logs
-        max_request_body_size: 0
-        metrics_url_path: /v1/metrics
-        response_headers: {}
-        tls: null
-        traces_url_path: /v1/traces
+    awsxray:
+        endpoint: 127.0.0.1:2000
+        proxy_server:
+            aws_endpoint: ""
+            endpoint: 127.0.0.1:2000
+            local_mode: false
+            proxy_address: ""
+            region: us-west-2
+            role_arn: ""
+        transport: udp
+    otlp:
+        protocols:
+            grpc:
+                auth: null
+                endpoint: 127.0.0.1:4317
+                include_metadata: false
+                keepalive: null
+                max_concurrent_streams: 0
+                max_recv_msg_size_mib: 0
+                read_buffer_size: 524288
+                tls: null
+                transport: tcp
+                write_buffer_size: 0
+            http:
+                auth: null
+                cors: null
+                endpoint: 127.0.0.1:4318
+                include_metadata: false
+                logs_url_path: /v1/logs
+                max_request_body_size: 0
+                metrics_url_path: /v1/metrics
+                response_headers: {}
+                tls: null
+                traces_url_path: /v1/traces
 service:
-  extensions: []
-  pipelines:
-    traces/xray:
-      exporters:
-        - awsxray
-      processors:
-        - batch/xray
-      receivers:
-        - awsxray
-        - otlp
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths:
-        - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
-      sampling:
-        initial: 2
-        thereafter: 500
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/traces
+    pipelines:
+        traces/xray:
+            exporters:
+                - awsxray
+            processors:
+                - batch/xray
+            receivers:
+                - awsxray
+                - otlp
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            initial_fields: {}
+            level: info
+            output_paths:
+                - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
+            sampling:
+                initial: 2
+                thereafter: 500
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        resource: {}
+        traces:
+            processors: []
+            propagators: []

--- a/translator/translate/otel/exporter/awscloudwatch/translator.go
+++ b/translator/translate/otel/exporter/awscloudwatch/translator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/rollup_dimensions"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 )
 
 const (
@@ -78,6 +79,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	if dropOriginalMetrics := getDropOriginalMetrics(conf); len(dropOriginalMetrics) != 0 {
 		cfg.DropOriginalConfigs = dropOriginalMetrics
 	}
+	cfg.MiddlewareID = &agenthealth.MetricsID
 	return cfg, nil
 }
 
@@ -147,21 +149,21 @@ func getDropOriginalMetrics(conf *confmap.Conf) map[string]bool {
 		measurementCfgKey := common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, category, common.MeasurementKey)
 		dropOriginalCfgKey := common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, category, common.DropOriginalMetricsKey)
 		/* Drop original metrics does not support procstat since procstat can monitor multiple process
-				"procstat": [
-		        {
-		          "exe": "W3SVC",
-		          "measurement": [
-		            "pid_count"
-		          ]
-		        },
-		        {
-		          "exe": "IISADMIN",
-		          "measurement": [
-		            "pid_count"
-		          ]
-		        }]
-			Therefore, dropping the original metrics can conflict between these two processes (e.g customers can drop pid_count with the first
-			process but not the second process)
+		   		"procstat": [
+		           {
+		             "exe": "W3SVC",
+		             "measurement": [
+		               "pid_count"
+		             ]
+		           },
+		           {
+		             "exe": "IISADMIN",
+		             "measurement": [
+		               "pid_count"
+		             ]
+		           }]
+		   	Therefore, dropping the original metrics can conflict between these two processes (e.g customers can drop pid_count with the first
+		   	process but not the second process)
 		*/
 		if dropMetrics := common.GetArray[any](conf, dropOriginalCfgKey); dropMetrics != nil {
 			for _, dropMetric := range dropMetrics {

--- a/translator/translate/otel/exporter/awscloudwatch/translator_test.go
+++ b/translator/translate/otel/exporter/awscloudwatch/translator_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 
@@ -147,21 +148,23 @@ func TestTranslator(t *testing.T) {
 				require.NoError(t, err)
 				gotCfg, ok := got.(*cloudwatch.Config)
 				require.True(t, ok)
-				require.Equal(t, testCase.want.Namespace, gotCfg.Namespace)
-				require.Equal(t, testCase.want.Region, gotCfg.Region)
-				require.Equal(t, testCase.want.ForceFlushInterval, gotCfg.ForceFlushInterval)
-				require.Equal(t, testCase.want.RoleARN, gotCfg.RoleARN)
-				require.Equal(t, testCase.want.AccessKey, gotCfg.AccessKey)
-				require.Equal(t, testCase.want.SecretKey, gotCfg.SecretKey)
-				require.Equal(t, testCase.want.Token, gotCfg.Token)
-				require.Equal(t, testCase.want.Profile, gotCfg.Profile)
-				require.Equal(t, testCase.want.SharedCredentialFilename, gotCfg.SharedCredentialFilename)
-				require.Equal(t, testCase.want.MaxValuesPerDatum, gotCfg.MaxValuesPerDatum)
-				require.Equal(t, testCase.want.RollupDimensions, gotCfg.RollupDimensions)
+				assert.Equal(t, testCase.want.Namespace, gotCfg.Namespace)
+				assert.Equal(t, testCase.want.Region, gotCfg.Region)
+				assert.Equal(t, testCase.want.ForceFlushInterval, gotCfg.ForceFlushInterval)
+				assert.Equal(t, testCase.want.RoleARN, gotCfg.RoleARN)
+				assert.Equal(t, testCase.want.AccessKey, gotCfg.AccessKey)
+				assert.Equal(t, testCase.want.SecretKey, gotCfg.SecretKey)
+				assert.Equal(t, testCase.want.Token, gotCfg.Token)
+				assert.Equal(t, testCase.want.Profile, gotCfg.Profile)
+				assert.Equal(t, testCase.want.SharedCredentialFilename, gotCfg.SharedCredentialFilename)
+				assert.Equal(t, testCase.want.MaxValuesPerDatum, gotCfg.MaxValuesPerDatum)
+				assert.Equal(t, testCase.want.RollupDimensions, gotCfg.RollupDimensions)
+				assert.NotNil(t, gotCfg.MiddlewareID)
+				assert.Equal(t, "agenthealth/metrics", gotCfg.MiddlewareID.String())
 				if testCase.wantWindows != nil && runtime.GOOS == "windows" {
-					require.Equal(t, testCase.wantWindows.DropOriginalConfigs, gotCfg.DropOriginalConfigs)
+					assert.Equal(t, testCase.wantWindows.DropOriginalConfigs, gotCfg.DropOriginalConfigs)
 				} else {
-					require.Equal(t, testCase.want.DropOriginalConfigs, gotCfg.DropOriginalConfigs)
+					assert.Equal(t, testCase.want.DropOriginalConfigs, gotCfg.DropOriginalConfigs)
 				}
 			}
 		})

--- a/translator/translate/otel/exporter/awsemf/translator.go
+++ b/translator/translate/otel/exporter/awsemf/translator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/internal/retryer"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/awscontainerinsight"
 )
 
@@ -60,6 +61,7 @@ func (t *translator) ID() component.ID {
 // Translate creates an awsemf exporter config based on the input json config
 func (t *translator) Translate(c *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*awsemfexporter.Config)
+	cfg.MiddlewareID = &agenthealth.LogsID
 
 	var defaultConfig string
 	if isEcs(c) {

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 
@@ -666,20 +667,22 @@ func TestTranslator(t *testing.T) {
 				require.NotNil(t, got)
 				gotCfg, ok := got.(*awsemfexporter.Config)
 				require.True(t, ok)
-				require.Equal(t, testCase.want["namespace"], gotCfg.Namespace)
-				require.Equal(t, testCase.want["log_group_name"], gotCfg.LogGroupName)
-				require.Equal(t, testCase.want["log_stream_name"], gotCfg.LogStreamName)
-				require.Equal(t, testCase.want["dimension_rollup_option"], gotCfg.DimensionRollupOption)
-				require.Equal(t, testCase.want["disable_metric_extraction"], gotCfg.DisableMetricExtraction)
-				require.Equal(t, testCase.want["enhanced_container_insights"], gotCfg.EnhancedContainerInsights)
-				require.Equal(t, testCase.want["parse_json_encoded_attr_values"], gotCfg.ParseJSONEncodedAttributeValues)
-				require.Equal(t, testCase.want["output_destination"], gotCfg.OutputDestination)
-				require.Equal(t, testCase.want["eks_fargate_container_insights_enabled"], gotCfg.EKSFargateContainerInsightsEnabled)
-				require.Equal(t, testCase.want["resource_to_telemetry_conversion"], gotCfg.ResourceToTelemetrySettings)
-				require.ElementsMatch(t, testCase.want["metric_declarations"], gotCfg.MetricDeclarations)
-				require.ElementsMatch(t, testCase.want["metric_descriptors"], gotCfg.MetricDescriptors)
-				require.Equal(t, "global_arn", gotCfg.RoleARN)
-				require.Equal(t, "us-east-1", gotCfg.Region)
+				assert.Equal(t, testCase.want["namespace"], gotCfg.Namespace)
+				assert.Equal(t, testCase.want["log_group_name"], gotCfg.LogGroupName)
+				assert.Equal(t, testCase.want["log_stream_name"], gotCfg.LogStreamName)
+				assert.Equal(t, testCase.want["dimension_rollup_option"], gotCfg.DimensionRollupOption)
+				assert.Equal(t, testCase.want["disable_metric_extraction"], gotCfg.DisableMetricExtraction)
+				assert.Equal(t, testCase.want["enhanced_container_insights"], gotCfg.EnhancedContainerInsights)
+				assert.Equal(t, testCase.want["parse_json_encoded_attr_values"], gotCfg.ParseJSONEncodedAttributeValues)
+				assert.Equal(t, testCase.want["output_destination"], gotCfg.OutputDestination)
+				assert.Equal(t, testCase.want["eks_fargate_container_insights_enabled"], gotCfg.EKSFargateContainerInsightsEnabled)
+				assert.Equal(t, testCase.want["resource_to_telemetry_conversion"], gotCfg.ResourceToTelemetrySettings)
+				assert.ElementsMatch(t, testCase.want["metric_declarations"], gotCfg.MetricDeclarations)
+				assert.ElementsMatch(t, testCase.want["metric_descriptors"], gotCfg.MetricDescriptors)
+				assert.Equal(t, "global_arn", gotCfg.RoleARN)
+				assert.Equal(t, "us-east-1", gotCfg.Region)
+				assert.NotNil(t, gotCfg.MiddlewareID)
+				assert.Equal(t, "agenthealth/logs", gotCfg.MiddlewareID.String())
 			}
 		})
 	}

--- a/translator/translate/otel/exporter/awsxray/testdata/config.yaml
+++ b/translator/translate/otel/exporter/awsxray/testdata/config.yaml
@@ -10,3 +10,4 @@ proxy_address: https://proxy.proxy.com
 telemetry:
   enabled: true
   include_metadata: true
+middleware: agenthealth/traces

--- a/translator/translate/otel/exporter/awsxray/translator.go
+++ b/translator/translate/otel/exporter/awsxray/translator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/internal/retryer"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 )
 
 const (
@@ -84,6 +85,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		cfg.ProxyAddress = proxyAddress
 	}
 	cfg.AWSSessionSettings.IMDSRetries = retryer.GetDefaultRetryNumber()
+	cfg.MiddlewareID = &agenthealth.TracesID
 	return cfg, nil
 }
 

--- a/translator/translate/otel/exporter/awsxray/translator_test.go
+++ b/translator/translate/otel/exporter/awsxray/translator_test.go
@@ -45,6 +45,7 @@ func TestTranslator(t *testing.T) {
 					"enabled":          true,
 					"include_metadata": true,
 				},
+				"middleware": "agenthealth/traces",
 			}),
 		},
 		"WithCompleteConfig": {

--- a/translator/translate/otel/exporter/otel_aws_cloudwatch_logs/translator.go
+++ b/translator/translate/otel/exporter/otel_aws_cloudwatch_logs/translator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 )
 
 //go:embed aws_cloudwatch_logs_default.yaml
@@ -49,6 +50,7 @@ func (t *translator) ID() component.ID {
 // Translate creates an awscloudwatchlogsexporter exporter config based on the input json config
 func (t *translator) Translate(c *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*awscloudwatchlogsexporter.Config)
+	cfg.MiddlewareID = &agenthealth.LogsID
 
 	var defaultConfig string
 	// Add more else if when otel supports log reading

--- a/translator/translate/otel/exporter/otel_aws_cloudwatch_logs/translator_test.go
+++ b/translator/translate/otel/exporter/otel_aws_cloudwatch_logs/translator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 
@@ -49,10 +50,12 @@ func TestTranslator(t *testing.T) {
 				require.NotNil(t, got)
 				gotCfg, ok := got.(*awscloudwatchlogsexporter.Config)
 				require.True(t, ok)
-				require.Equal(t, testCase.want.LogGroupName, gotCfg.LogGroupName)
-				require.Equal(t, testCase.want.LogStreamName, gotCfg.LogStreamName)
-				require.Equal(t, testCase.want.RawLog, gotCfg.RawLog)
-				require.Equal(t, testCase.want.Region, gotCfg.Region)
+				assert.Equal(t, testCase.want.LogGroupName, gotCfg.LogGroupName)
+				assert.Equal(t, testCase.want.LogStreamName, gotCfg.LogStreamName)
+				assert.Equal(t, testCase.want.RawLog, gotCfg.RawLog)
+				assert.Equal(t, testCase.want.Region, gotCfg.Region)
+				assert.NotNil(t, gotCfg.MiddlewareID)
+				assert.Equal(t, "agenthealth/logs", gotCfg.MiddlewareID.String())
 			}
 		})
 	}

--- a/translator/translate/otel/extension/agenthealth/translator.go
+++ b/translator/translate/otel/extension/agenthealth/translator.go
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agenthealth
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/extension"
+
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+const (
+	OperationPutMetricData    = "PutMetricData"
+	OperationPutLogEvents     = "PutLogEvents"
+	OperationPutTraceSegments = "PutTraceSegments"
+)
+
+var (
+	MetricsID = component.NewIDWithName(agenthealth.TypeStr, string(component.DataTypeMetrics))
+	LogsID    = component.NewIDWithName(agenthealth.TypeStr, string(component.DataTypeLogs))
+	TracesID  = component.NewIDWithName(agenthealth.TypeStr, string(component.DataTypeTraces))
+)
+
+type translator struct {
+	name               string
+	operations         []string
+	isUsageDataEnabled bool
+	factory            extension.Factory
+}
+
+var _ common.Translator[component.Config] = (*translator)(nil)
+
+func NewTranslator(name component.DataType, operations []string) common.Translator[component.Config] {
+	return &translator{
+		name:               string(name),
+		operations:         operations,
+		factory:            agenthealth.NewFactory(),
+		isUsageDataEnabled: envconfig.IsUsageDataEnabled(),
+	}
+}
+
+func (t *translator) ID() component.ID {
+	return component.NewIDWithName(t.factory.Type(), t.name)
+}
+
+// Translate creates an extension configuration.
+func (t *translator) Translate(*confmap.Conf) (component.Config, error) {
+	cfg := t.factory.CreateDefaultConfig().(*agenthealth.Config)
+	cfg.IsUsageDataEnabled = t.isUsageDataEnabled
+	cfg.Stats = agent.StatsConfig{Operations: t.operations}
+	return cfg, nil
+}

--- a/translator/translate/otel/extension/agenthealth/translator_test.go
+++ b/translator/translate/otel/extension/agenthealth/translator_test.go
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agenthealth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
+)
+
+func TestTranslate(t *testing.T) {
+	operations := []string{OperationPutLogEvents}
+	tt := NewTranslator("test", operations).(*translator)
+	assert.Equal(t, "agenthealth/test", tt.ID().String())
+	tt.isUsageDataEnabled = true
+	got, err := tt.Translate(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, &agenthealth.Config{IsUsageDataEnabled: true, Stats: agent.StatsConfig{Operations: operations}}, got)
+	tt.isUsageDataEnabled = false
+	got, err = tt.Translate(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, &agenthealth.Config{IsUsageDataEnabled: false, Stats: agent.StatsConfig{Operations: operations}}, got)
+}

--- a/translator/translate/otel/pipeline/containerinsights/translator.go
+++ b/translator/translate/otel/pipeline/containerinsights/translator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awsemf"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/metricstransformprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/awscontainerinsight"
@@ -53,6 +54,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 			Receivers:  common.NewTranslatorMap(awscontainerinsight.NewTranslator()),
 			Processors: common.NewTranslatorMap(metricstransformprocessor.NewTranslatorWithName(pipelineName), batchprocessor.NewTranslatorWithNameAndSection(pipelineName, common.LogsKey)), // EKS & ECS CI sit under metrics_collected in "logs"
 			Exporters:  common.NewTranslatorMap(awsemf.NewTranslatorWithName(pipelineName)),
+			Extensions: common.NewTranslatorMap(agenthealth.NewTranslator(component.DataTypeLogs, []string{agenthealth.OperationPutLogEvents})),
 		}, nil
 	}
 
@@ -60,5 +62,6 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		Receivers:  common.NewTranslatorMap(awscontainerinsight.NewTranslator()),
 		Processors: common.NewTranslatorMap(batchprocessor.NewTranslatorWithNameAndSection(pipelineName, common.LogsKey)), // EKS & ECS CI sit under metrics_collected in "logs"
 		Exporters:  common.NewTranslatorMap(awsemf.NewTranslatorWithName(pipelineName)),
+		Extensions: common.NewTranslatorMap(agenthealth.NewTranslator(component.DataTypeLogs, []string{agenthealth.OperationPutLogEvents})),
 	}, nil
 }

--- a/translator/translate/otel/pipeline/containerinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/containerinsights/translator_test.go
@@ -22,6 +22,7 @@ func TestTranslator(t *testing.T) {
 		receivers    []string
 		processors   []string
 		exporters    []string
+		extensions   []string
 	}
 	cit := NewTranslator()
 	require.EqualValues(t, "metrics/containerinsights", cit.ID().String())
@@ -47,6 +48,7 @@ func TestTranslator(t *testing.T) {
 				receivers:    []string{"awscontainerinsightreceiver"},
 				processors:   []string{"batch/containerinsights"},
 				exporters:    []string{"awsemf/containerinsights"},
+				extensions:   []string{"agenthealth/logs"},
 			},
 		},
 		"WithKubernetesKey": {
@@ -62,6 +64,7 @@ func TestTranslator(t *testing.T) {
 				receivers:    []string{"awscontainerinsightreceiver"},
 				processors:   []string{"batch/containerinsights"},
 				exporters:    []string{"awsemf/containerinsights"},
+				extensions:   []string{"agenthealth/logs"},
 			},
 		},
 		"WithKubernetes/WithEnhancedContainerInsights": {
@@ -80,6 +83,7 @@ func TestTranslator(t *testing.T) {
 				receivers:    []string{"awscontainerinsightreceiver"},
 				processors:   []string{"metricstransform/containerinsights", "batch/containerinsights"},
 				exporters:    []string{"awsemf/containerinsights"},
+				extensions:   []string{"agenthealth/logs"},
 			},
 		},
 	}
@@ -95,6 +99,7 @@ func TestTranslator(t *testing.T) {
 				assert.Equal(t, testCase.want.receivers, collections.MapSlice(got.Receivers.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.processors, collections.MapSlice(got.Processors.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.exporters, collections.MapSlice(got.Exporters.Keys(), component.ID.String))
+				assert.Equal(t, testCase.want.extensions, collections.MapSlice(got.Extensions.Keys(), component.ID.String))
 			}
 		})
 	}

--- a/translator/translate/otel/pipeline/emf_logs/translator.go
+++ b/translator/translate/otel/pipeline/emf_logs/translator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/otel_aws_cloudwatch_logs"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/tcp_logs"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/udp_logs"
@@ -49,6 +50,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		Receivers:  common.NewTranslatorMap[component.Config](),
 		Processors: common.NewTranslatorMap(batchprocessor.NewTranslatorWithNameAndSection(common.PipelineNameEmfLogs, common.LogsKey)), // EMF logs sit under metrics_collected in "logs"
 		Exporters:  common.NewTranslatorMap(otel_aws_cloudwatch_logs.NewTranslatorWithName(common.PipelineNameEmfLogs)),
+		Extensions: common.NewTranslatorMap(agenthealth.NewTranslator(component.DataTypeLogs, []string{agenthealth.OperationPutLogEvents})),
 	}
 	if serviceAddress, ok := common.GetString(conf, serviceAddressEMFKey); ok {
 		if strings.Contains(serviceAddress, common.Udp) {

--- a/translator/translate/otel/pipeline/emf_logs/translator_test.go
+++ b/translator/translate/otel/pipeline/emf_logs/translator_test.go
@@ -22,6 +22,7 @@ func TestTranslator(t *testing.T) {
 		receivers    []string
 		processors   []string
 		exporters    []string
+		extensions   []string
 	}
 	cit := NewTranslator()
 	require.EqualValues(t, "logs/emf_logs", cit.ID().String())
@@ -47,6 +48,7 @@ func TestTranslator(t *testing.T) {
 				receivers:    []string{"tcplog/emf_logs", "udplog/emf_logs"},
 				processors:   []string{"batch/emf_logs"},
 				exporters:    []string{"awscloudwatchlogs/emf_logs"},
+				extensions:   []string{"agenthealth/logs"},
 			},
 		},
 		"WithStructuredLogKey": {
@@ -62,6 +64,7 @@ func TestTranslator(t *testing.T) {
 				receivers:    []string{"tcplog/emf_logs", "udplog/emf_logs"},
 				processors:   []string{"batch/emf_logs"},
 				exporters:    []string{"awscloudwatchlogs/emf_logs"},
+				extensions:   []string{"agenthealth/logs"},
 			},
 		},
 		"WithUdpServiceAddress": {
@@ -79,6 +82,7 @@ func TestTranslator(t *testing.T) {
 				receivers:    []string{"udplog/emf_logs"},
 				processors:   []string{"batch/emf_logs"},
 				exporters:    []string{"awscloudwatchlogs/emf_logs"},
+				extensions:   []string{"agenthealth/logs"},
 			},
 		},
 		"WithTcpServiceAddress": {
@@ -96,6 +100,7 @@ func TestTranslator(t *testing.T) {
 				receivers:    []string{"tcplog/emf_logs"},
 				processors:   []string{"batch/emf_logs"},
 				exporters:    []string{"awscloudwatchlogs/emf_logs"},
+				extensions:   []string{"agenthealth/logs"},
 			},
 		},
 	}
@@ -111,6 +116,7 @@ func TestTranslator(t *testing.T) {
 				assert.Equal(t, testCase.want.receivers, collections.MapSlice(got.Receivers.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.processors, collections.MapSlice(got.Processors.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.exporters, collections.MapSlice(got.Exporters.Keys(), component.ID.String))
+				assert.Equal(t, testCase.want.extensions, collections.MapSlice(got.Extensions.Keys(), component.ID.String))
 			}
 		})
 	}

--- a/translator/translate/otel/pipeline/host/translator.go
+++ b/translator/translate/otel/pipeline/host/translator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awscloudwatch"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/cumulativetodeltaprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/ec2taggerprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/metricsdecorator"
@@ -50,6 +51,7 @@ func (t translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators,
 		Receivers:  t.receivers,
 		Processors: common.NewTranslatorMap[component.Config](),
 		Exporters:  common.NewTranslatorMap(awscloudwatch.NewTranslator()),
+		Extensions: common.NewTranslatorMap(agenthealth.NewTranslator(component.DataTypeMetrics, []string{agenthealth.OperationPutMetricData})),
 	}
 
 	// we need to add delta processor because (only) diskio and net input plugins report delta metric

--- a/translator/translate/otel/pipeline/host/translator_test.go
+++ b/translator/translate/otel/pipeline/host/translator_test.go
@@ -35,6 +35,7 @@ func TestTranslator(t *testing.T) {
 		receivers  []string
 		processors []string
 		exporters  []string
+		extensions []string
 	}
 	testCases := map[string]struct {
 		input        map[string]interface{}
@@ -60,6 +61,7 @@ func TestTranslator(t *testing.T) {
 				receivers:  []string{"nop", "other"},
 				processors: []string{},
 				exporters:  []string{"awscloudwatch"},
+				extensions: []string{"agenthealth/metrics"},
 			},
 		},
 		"WithMetricsKeyNet": {
@@ -76,6 +78,7 @@ func TestTranslator(t *testing.T) {
 				receivers:  []string{"nop", "other"},
 				processors: []string{"cumulativetodelta/hostDeltaMetrics"},
 				exporters:  []string{"awscloudwatch"},
+				extensions: []string{"agenthealth/metrics"},
 			},
 		},
 		"WithMetricDecoration": {
@@ -99,6 +102,7 @@ func TestTranslator(t *testing.T) {
 				receivers:  []string{"nop", "other"},
 				processors: []string{"transform"},
 				exporters:  []string{"awscloudwatch"},
+				extensions: []string{"agenthealth/metrics"},
 			},
 		},
 		"WithoutMetricDecoration": {
@@ -119,6 +123,7 @@ func TestTranslator(t *testing.T) {
 				receivers:  []string{"nop", "other"},
 				processors: []string{},
 				exporters:  []string{"awscloudwatch"},
+				extensions: []string{"agenthealth/metrics"},
 			},
 		},
 	}
@@ -139,6 +144,7 @@ func TestTranslator(t *testing.T) {
 				assert.Equal(t, testCase.want.receivers, collections.MapSlice(got.Receivers.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.processors, collections.MapSlice(got.Processors.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.exporters, collections.MapSlice(got.Exporters.Keys(), component.ID.String))
+				assert.Equal(t, testCase.want.extensions, collections.MapSlice(got.Extensions.Keys(), component.ID.String))
 			}
 		})
 	}

--- a/translator/translate/otel/pipeline/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/prometheus/translator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/metrics_collected/prometheus"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awsemf"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/adapter"
 )
@@ -45,6 +46,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		Processors: common.NewTranslatorMap(
 			batchprocessor.NewTranslatorWithNameAndSection(pipelineName, common.LogsKey), // prometheus sits under metrics_collected in "logs"
 		),
-		Exporters: common.NewTranslatorMap(awsemf.NewTranslatorWithName(pipelineName)),
+		Exporters:  common.NewTranslatorMap(awsemf.NewTranslatorWithName(pipelineName)),
+		Extensions: common.NewTranslatorMap(agenthealth.NewTranslator(component.DataTypeLogs, []string{agenthealth.OperationPutLogEvents})),
 	}, nil
 }

--- a/translator/translate/otel/pipeline/prometheus/translator_test.go
+++ b/translator/translate/otel/pipeline/prometheus/translator_test.go
@@ -45,6 +45,7 @@ func TestTranslator(t *testing.T) {
 				receivers:  []string{"telegraf_prometheus"},
 				processors: []string{"batch/prometheus"},
 				exporters:  []string{"awsemf/prometheus"},
+				extensions: []string{"agenthealth/logs"},
 			},
 		},
 	}
@@ -60,6 +61,7 @@ func TestTranslator(t *testing.T) {
 				assert.Equal(t, testCase.want.receivers, collections.MapSlice(got.Receivers.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.processors, collections.MapSlice(got.Processors.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.exporters, collections.MapSlice(got.Exporters.Keys(), component.ID.String))
+				assert.Equal(t, testCase.want.extensions, collections.MapSlice(got.Extensions.Keys(), component.ID.String))
 			}
 		})
 	}

--- a/translator/translate/otel/pipeline/xray/translator.go
+++ b/translator/translate/otel/pipeline/xray/translator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	awsxrayexporter "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awsxray"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor"
 	awsxrayreceiver "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/awsxray"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/otlp"
@@ -47,6 +48,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		Receivers:  common.NewTranslatorMap[component.Config](),
 		Processors: common.NewTranslatorMap(processor.NewDefaultTranslatorWithName(pipelineName, batchprocessor.NewFactory())),
 		Exporters:  common.NewTranslatorMap(awsxrayexporter.NewTranslator()),
+		Extensions: common.NewTranslatorMap(agenthealth.NewTranslator(component.DataTypeTraces, []string{agenthealth.OperationPutTraceSegments})),
 	}
 	if conf.IsSet(xrayKey) {
 		translators.Receivers.Set(awsxrayreceiver.NewTranslator())

--- a/translator/translate/otel/pipeline/xray/translator_test.go
+++ b/translator/translate/otel/pipeline/xray/translator_test.go
@@ -21,6 +21,7 @@ func TestTranslator(t *testing.T) {
 		receivers  []string
 		processors []string
 		exporters  []string
+		extensions []string
 	}
 	tt := NewTranslator()
 	assert.EqualValues(t, "traces/xray", tt.ID().String())
@@ -45,6 +46,7 @@ func TestTranslator(t *testing.T) {
 				receivers:  []string{"awsxray"},
 				processors: []string{"batch/xray"},
 				exporters:  []string{"awsxray"},
+				extensions: []string{"agenthealth/traces"},
 			},
 		},
 		"WithOtlpKey": {
@@ -59,6 +61,7 @@ func TestTranslator(t *testing.T) {
 				receivers:  []string{"otlp"},
 				processors: []string{"batch/xray"},
 				exporters:  []string{"awsxray"},
+				extensions: []string{"agenthealth/traces"},
 			},
 		},
 		"WithXrayAndOtlpKey": {
@@ -74,6 +77,7 @@ func TestTranslator(t *testing.T) {
 				receivers:  []string{"awsxray", "otlp"},
 				processors: []string{"batch/xray"},
 				exporters:  []string{"awsxray"},
+				extensions: []string{"agenthealth/traces"},
 			},
 		},
 	}
@@ -89,6 +93,7 @@ func TestTranslator(t *testing.T) {
 				assert.Equal(t, testCase.want.receivers, collections.MapSlice(got.Receivers.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.processors, collections.MapSlice(got.Processors.Keys(), component.ID.String))
 				assert.Equal(t, testCase.want.exporters, collections.MapSlice(got.Exporters.Keys(), component.ID.String))
+				assert.Equal(t, testCase.want.extensions, collections.MapSlice(got.Extensions.Keys(), component.ID.String))
 			}
 		})
 	}


### PR DESCRIPTION
# Description of the issue
The translator needs to add the agenthealth extension to the YAML so it can be used.

# Description of changes
Each pipeline adds the agenthealth extension that its exporter correlates to. There are 3 possible extensions (one each for metrics, logs, and traces). Add the agenthealth extension factory to the default components.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated the expected results for the sample configs.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




