### PR TITLE
Fix client stats payload measurement

### DIFF
--- a/extension/agenthealth/handler/stats/agent/agent.go
+++ b/extension/agenthealth/handler/stats/agent/agent.go
@@ -67,6 +67,15 @@ func (s *Stats) Merge(other Stats) {
 	if other.EnhancedContainerInsights != nil {
 		s.EnhancedContainerInsights = other.EnhancedContainerInsights
 	}
+	if other.RunningInContainer != nil {
+		s.RunningInContainer = other.RunningInContainer
+	}
+	if other.RegionType != nil {
+		s.RegionType = other.RegionType
+	}
+	if other.Mode != nil {
+		s.Mode = other.Mode
+	}
 }
 
 func (s *Stats) Marshal() (string, error) {

--- a/extension/agenthealth/handler/stats/agent/agent_test.go
+++ b/extension/agenthealth/handler/stats/agent/agent_test.go
@@ -21,18 +21,23 @@ func TestMerge(t *testing.T) {
 	assert.EqualValues(t, 1.3, *stats.CpuPercent)
 	assert.EqualValues(t, 123, *stats.MemoryBytes)
 	stats.Merge(Stats{
+		CpuPercent:                aws.Float64(1.5),
+		MemoryBytes:               aws.Uint64(133),
 		FileDescriptorCount:       aws.Int32(456),
 		ThreadCount:               aws.Int32(789),
 		LatencyMillis:             aws.Int64(1234),
 		PayloadBytes:              aws.Int(5678),
 		StatusCode:                aws.Int(200),
-		ImdsFallbackSucceed:       aws.Int(1),
 		SharedConfigFallback:      aws.Int(1),
+		ImdsFallbackSucceed:       aws.Int(1),
 		AppSignals:                aws.Int(1),
 		EnhancedContainerInsights: aws.Int(1),
+		RunningInContainer:        aws.Int(0),
+		RegionType:                aws.String("RegionType"),
+		Mode:                      aws.String("Mode"),
 	})
-	assert.EqualValues(t, 1.3, *stats.CpuPercent)
-	assert.EqualValues(t, 123, *stats.MemoryBytes)
+	assert.EqualValues(t, 1.5, *stats.CpuPercent)
+	assert.EqualValues(t, 133, *stats.MemoryBytes)
 	assert.EqualValues(t, 456, *stats.FileDescriptorCount)
 	assert.EqualValues(t, 789, *stats.ThreadCount)
 	assert.EqualValues(t, 1234, *stats.LatencyMillis)
@@ -42,6 +47,9 @@ func TestMerge(t *testing.T) {
 	assert.EqualValues(t, 1, *stats.SharedConfigFallback)
 	assert.EqualValues(t, 1, *stats.AppSignals)
 	assert.EqualValues(t, 1, *stats.EnhancedContainerInsights)
+	assert.EqualValues(t, 0, *stats.RunningInContainer)
+	assert.EqualValues(t, "RegionType", *stats.RegionType)
+	assert.EqualValues(t, "Mode", *stats.Mode)
 }
 
 func TestMarshal(t *testing.T) {

--- a/extension/agenthealth/handler/stats/client/client_test.go
+++ b/extension/agenthealth/handler/stats/client/client_test.go
@@ -23,7 +23,7 @@ func TestHandle(t *testing.T) {
 	handler.(*clientStatsHandler).getOperationName = func(context.Context) string {
 		return operation
 	}
-	assert.Equal(t, awsmiddleware.Before, handler.Position())
+	assert.Equal(t, awsmiddleware.After, handler.Position())
 	assert.Equal(t, handlerID, handler.ID())
 	body := []byte("test payload size")
 	req, err := http.NewRequest("", "localhost", bytes.NewBuffer(body))

--- a/extension/agenthealth/handler/stats/handler.go
+++ b/extension/agenthealth/handler/stats/handler.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	handlerID           = "cloudwatchagent.StatsHandler"
+	handlerID           = "cloudwatchagent.AgentStats"
 	headerKeyAgentStats = "X-Amz-Agent-Stats"
 )
 
@@ -25,7 +25,7 @@ func NewHandlers(logger *zap.Logger, cfg agent.StatsConfig) ([]awsmiddleware.Req
 	filter := agent.NewOperationsFilter(cfg.Operations...)
 	clientStats := client.NewHandler(filter)
 	stats := newStatsHandler(logger, filter, []agent.StatsProvider{clientStats, provider.GetProcessStats(), provider.GetFlagsStats()})
-	return []awsmiddleware.RequestHandler{clientStats, stats}, []awsmiddleware.ResponseHandler{clientStats}
+	return []awsmiddleware.RequestHandler{stats, clientStats}, []awsmiddleware.ResponseHandler{clientStats}
 }
 
 type statsHandler struct {

--- a/extension/agenthealth/handler/stats/provider/flag_test.go
+++ b/extension/agenthealth/handler/stats/provider/flag_test.go
@@ -15,23 +15,23 @@ import (
 func TestFlagStats(t *testing.T) {
 	t.Setenv(envconfig.RunInContainer, envconfig.TrueValue)
 	provider := newFlagStats(time.Microsecond)
-	got := provider.stats
+	got := provider.getStats()
 	assert.Nil(t, got.ImdsFallbackSucceed)
 	assert.Nil(t, got.SharedConfigFallback)
 	assert.NotNil(t, got.RunningInContainer)
 	assert.Equal(t, 1, *got.RunningInContainer)
 	provider.SetFlag(FlagIMDSFallbackSucceed)
 	assert.Nil(t, got.ImdsFallbackSucceed)
-	got = provider.stats
+	got = provider.getStats()
 	assert.NotNil(t, got.ImdsFallbackSucceed)
 	assert.Equal(t, 1, *got.ImdsFallbackSucceed)
 	assert.Nil(t, got.SharedConfigFallback)
 	provider.SetFlag(FlagSharedConfigFallback)
-	got = provider.stats
+	got = provider.getStats()
 	assert.NotNil(t, got.SharedConfigFallback)
 	assert.Equal(t, 1, *got.SharedConfigFallback)
 	provider.SetFlagWithValue(FlagMode, "test")
-	got = provider.stats
+	got = provider.getStats()
 	assert.NotNil(t, got.Mode)
 	assert.Equal(t, "test", *got.Mode)
 }

--- a/extension/agenthealth/handler/stats/provider/interval.go
+++ b/extension/agenthealth/handler/stats/provider/interval.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
@@ -13,26 +14,34 @@ import (
 // intervalStats restricts the Stats get function to once
 // per interval.
 type intervalStats struct {
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	interval time.Duration
 
 	getOnce *sync.Once
 	lastGet time.Time
 
-	stats agent.Stats
+	stats atomic.Value
 }
 
 var _ agent.StatsProvider = (*intervalStats)(nil)
 
 func (p *intervalStats) Stats(string) agent.Stats {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	var stats agent.Stats
 	p.getOnce.Do(func() {
 		p.lastGet = time.Now()
-		stats = p.stats
+		stats = p.getStats()
 		go p.allowNextGetAfter(p.interval)
 	})
+	return stats
+}
+
+func (p *intervalStats) getStats() agent.Stats {
+	var stats agent.Stats
+	if value := p.stats.Load(); value != nil {
+		stats = value.(agent.Stats)
+	}
 	return stats
 }
 

--- a/extension/agenthealth/handler/stats/provider/interval_test.go
+++ b/extension/agenthealth/handler/stats/provider/interval_test.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
 )
 
 func TestIntervalStats(t *testing.T) {
 	s := newIntervalStats(time.Millisecond)
-	s.stats.ThreadCount = aws.Int32(2)
+	s.stats.Store(agent.Stats{
+		ThreadCount: aws.Int32(2),
+	})
 	got := s.Stats("")
 	assert.NotNil(t, got.ThreadCount)
 	got = s.Stats("")

--- a/extension/agenthealth/handler/stats/provider/process.go
+++ b/extension/agenthealth/handler/stats/provider/process.go
@@ -74,14 +74,12 @@ func (p *processStats) updateLoop() {
 }
 
 func (p *processStats) refresh() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.stats = agent.Stats{
+	p.stats.Store(agent.Stats{
 		CpuPercent:          p.cpuPercent(),
 		MemoryBytes:         p.memoryBytes(),
 		FileDescriptorCount: p.fileDescriptorCount(),
 		ThreadCount:         p.threadCount(),
-	}
+	})
 }
 
 func newProcessStats(proc processMetrics, interval time.Duration) *processStats {

--- a/extension/agenthealth/handler/stats/provider/process_test.go
+++ b/extension/agenthealth/handler/stats/provider/process_test.go
@@ -50,7 +50,7 @@ func TestProcessStats(t *testing.T) {
 	testErr := errors.New("test error")
 	mock := &mockProcessMetrics{}
 	provider := newProcessStats(mock, time.Millisecond)
-	got := provider.stats
+	got := provider.getStats()
 	assert.NotNil(t, got.CpuPercent)
 	assert.NotNil(t, got.MemoryBytes)
 	assert.NotNil(t, got.FileDescriptorCount)
@@ -61,7 +61,7 @@ func TestProcessStats(t *testing.T) {
 	assert.EqualValues(t, 4, *got.ThreadCount)
 	mock.err = testErr
 	time.Sleep(2 * time.Millisecond)
-	got = provider.stats
+	got = provider.getStats()
 	assert.Nil(t, got.CpuPercent)
 	assert.Nil(t, got.MemoryBytes)
 	assert.Nil(t, got.FileDescriptorCount)

--- a/extension/agenthealth/handler/useragent/handler.go
+++ b/extension/agenthealth/handler/useragent/handler.go
@@ -11,6 +11,11 @@ import (
 	"go.uber.org/atomic"
 )
 
+const (
+	handlerID          = "cloudwatchagent.UserAgent"
+	headerKeyUserAgent = "User-Agent"
+)
+
 type userAgentHandler struct {
 	userAgent          UserAgent
 	isUsageDataEnabled bool

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -25,9 +25,6 @@ import (
 )
 
 const (
-	handlerID          = "cloudwatchagent.UserAgentHandler"
-	headerKeyUserAgent = "User-Agent"
-
 	flagRunAsUser                 = "run_as_user"
 	flagContainerInsights         = "container_insights"
 	flagAppSignals                = "app_signals"


### PR DESCRIPTION
# Description of the issue
There are a couple of issues that these changes are addressing:
- The payload bytes for the client stats were always 0.
  - This was because the client stats were placed at the front of the build step instead of at the back, so the body had not been created yet.
- The new flag stats (RegionType, Mode, etc.) were not showing up.
  - This was because they weren't added to the `Stats.Merge` function, so they weren't being included.
- Client stats weren't always present.
  - This was due to lock contention.

# Description of changes
- Replace some locks with atomics. Change the mutex guarding the `sync.Once` to a `sync.RWMutex` since it is only changed once a minute, so the lock shouldn't block for reads.
- Fix payload measurement by moving the client stats handler to after the rest of the build step handlers.
- Add flag stats to `Stats.Merge`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated some unit tests. Built and ran the agent with some logging.

```
2023-10-26T17:06:55Z D! [agenthealth] stats header (PutLogEvents/b96f84b4-08e5-4244-9f41-ccd180dd1491): "lat":506,"load":2943,"code":200
2023-10-26T17:06:55Z D! [agenthealth] stats header time taken: 205.18µs
2023-10-26T17:07:11Z D! [agenthealth] stats header (PutLogEvents/1990185a-d2ee-4542-a600-a615f5f8cb88): "lat":487,"load":2405,"code":200
2023-10-26T17:07:11Z D! [agenthealth] stats header time taken: 239.297µs
2023-10-26T17:07:25Z D! [agenthealth] stats header (PutMetricData/e4550c88-0d52-4dcf-b54f-ff71f4460378): "cpu":0.4,"mem":83161088,"fd":11,"th":7,"lat":478,"load":2397,"code":200,"scfb":1,"ric":0,"rt":"ACJ","m":"EC2"
2023-10-26T17:07:25Z D! [agenthealth] stats header time taken: 212.226µs
2023-10-26T17:07:26Z D! [agenthealth] stats header (PutLogEvents/7ef80417-7c3a-4f21-b62e-6ecc93c60504): "lat":491,"load":2582,"code":200
2023-10-26T17:07:26Z D! [agenthealth] stats header time taken: 199.893µs
2023-10-26T17:07:42Z D! [agenthealth] stats header (PutLogEvents/5265e6f1-2a6b-4b22-8d1c-cca964b943d7): "lat":496,"load":3651,"code":200
2023-10-26T17:07:42Z D! [agenthealth] stats header time taken: 202.375µs
2023-10-26T17:07:57Z D! [agenthealth] stats header (PutLogEvents/8b6c51ae-778d-4e4e-9956-4c23217f4975): "lat":510,"load":2402,"code":200
2023-10-26T17:07:57Z D! [agenthealth] stats header time taken: 223.284µs
2023-10-26T17:08:13Z D! [agenthealth] stats header (PutLogEvents/3d85b784-505a-469d-acfd-3f387b15aac2): "lat":498,"load":2411,"code":200
2023-10-26T17:08:13Z D! [agenthealth] stats header time taken: 201.941µs
2023-10-26T17:08:25Z D! [agenthealth] stats header (PutMetricData/6808bd79-8035-4b41-8ce3-e45155ddb833): "cpu":0.4,"mem":83161088,"fd":13,"th":7,"lat":501,"load":4292,"code":200
2023-10-26T17:08:25Z D! [agenthealth] stats header time taken: 217.422µs
2023-10-26T17:08:28Z D! [agenthealth] stats header (PutLogEvents/6bd00216-4050-4c93-b113-fcf5a58a5e2d): "lat":491,"load":2584,"code":200
2023-10-26T17:08:28Z D! [agenthealth] stats header time taken: 198.479µs
2023-10-26T17:08:44Z D! [agenthealth] stats header (PutLogEvents/bbcd6889-1362-4193-8198-883a9a636c4d): "lat":482,"load":2960,"code":200
2023-10-26T17:08:44Z D! [agenthealth] stats header time taken: 252.67µs
2023-10-26T17:08:59Z D! [agenthealth] stats header (PutLogEvents/082de1cb-80c0-42d0-9d42-2ae865e8543a): "lat":531,"load":2398,"code":200
2023-10-26T17:08:59Z D! [agenthealth] stats header time taken: 203.221µs
2023-10-26T17:09:15Z D! [agenthealth] stats header (PutLogEvents/1cc4d031-dd18-483e-b7a0-30c827dfffe5): "lat":495,"load":2405,"code":200
2023-10-26T17:09:15Z D! [agenthealth] stats header time taken: 204.349µs
2023-10-26T17:09:25Z D! [agenthealth] stats header (PutMetricData/034d8be2-9142-46cc-8b3e-3e46b163d61d): "lat":490,"load":2339,"code":200
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




