### PR TITLE
Change payload size measurement method for client stats

### DIFF
--- a/extension/agenthealth/handler/stats/client/client.go
+++ b/extension/agenthealth/handler/stats/client/client.go
@@ -75,20 +75,18 @@ func (csh *clientStatsHandler) HandleRequest(ctx context.Context, r *http.Reques
 	}
 	requestID := csh.getRequestID(ctx)
 	recorder := &requestRecorder{start: time.Now()}
-	if r.ContentLength != 0 {
+	if r.ContentLength > 0 {
 		recorder.payloadBytes = r.ContentLength
 	} else if r.Body != nil {
 		rsc, ok := r.Body.(aws.ReaderSeekerCloser)
 		if !ok {
 			rsc = aws.ReadSeekCloser(r.Body)
 		}
-		length, _ := aws.SeekerLen(rsc)
-		if length == -1 {
-			if body, err := r.GetBody(); err == nil {
-				length, _ = io.Copy(io.Discard, body)
-			}
+		if length, _ := aws.SeekerLen(rsc); length > 0 {
+			recorder.payloadBytes = length
+		} else if body, err := r.GetBody(); err == nil {
+			recorder.payloadBytes, _ = io.Copy(io.Discard, body)
 		}
-		recorder.payloadBytes = length
 	}
 	csh.requestCache.Set(requestID, recorder, ttlcache.DefaultTTL)
 }


### PR DESCRIPTION
# Description of the issue
With the introduction of the agenthealth extension, the latency metric increased from ~30-40ms to ~80-90ms. This appears to in part be due to the payload size calculation.

# Description of changes
Instead of using `request.GetBody`, which creates a copy of the existing request body, and `io.Copy`, try to use the `request.ContentLength` if it's available. If not, try to follow the [AWS SDK content length calculation method](https://github.com/aws/aws-sdk-go/blob/main/aws/corehandlers/handlers.go#L39). If all of that fails, then fall back on the `io.Copy`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests. Built and ran the agent. Latency is now ~30-40ms
```
2023-10-27T21:48:08Z D! stats header (PutMetricData/cc6d1bcc-bb44-454f-8623-531a36f4a4d7): "lat":31,"load":6193,"code":200
2023-10-27T21:48:16Z D! stats header (PutLogEvents/1be16b1a-33e7-4413-a1eb-d6fc582c3ba2): "lat":41,"load":729,"code":200
2023-10-27T21:48:32Z D! stats header (PutLogEvents/7072d8a2-de65-491e-8bb4-de38367cb4dd): "lat":30,"load":804,"code":200
2023-10-27T21:48:47Z D! stats header (PutLogEvents/093dda4f-19f9-44d1-a449-bbfb0b5cf32c): "lat":29,"load":585,"code":200
2023-10-27T21:49:02Z D! stats header (PutLogEvents/93f81452-47ac-4e51-9930-9a1e1f062d06): "cpu":0.3,"mem":80752640,"fd":12,"th":6,"lat":33,"load":638,"code":200
2023-10-27T21:49:08Z D! stats header (PutMetricData/b7543287-6c67-4f6e-acac-fa44bfdbf1ac): "lat":32,"load":4242,"code":200
2023-10-27T21:49:17Z D! stats header (PutLogEvents/703efb07-f595-4578-b27a-3da2915b606d): "lat":39,"load":598,"code":200
2023-10-27T21:49:32Z D! stats header (PutLogEvents/4ecfc1fa-d95a-4575-997f-387063f18b9d): "lat":28,"load":693,"code":200
```
as opposed to the ~80-90ms it was before.
```
2023-10-27T20:35:12Z D! [agenthealth] stats header (PutLogEvents/037163f8-cba9-4521-8c9e-d0072721b970): "lat":97,"load":710,"code":200
2023-10-27T20:35:27Z D! [agenthealth] stats header (PutLogEvents/ff914e0b-d620-48b5-8621-48e1017a5c68): "lat":90,"load":659,"code":200
2023-10-27T20:35:57Z D! [agenthealth] stats header (PutLogEvents/4eb35ce0-8859-4c02-b754-916594d9885c): "lat":81,"load":561,"code":200
2023-10-27T20:36:12Z D! [agenthealth] stats header (PutMetricData/596ad1df-531c-428c-8674-e42ff40f3d91): "lat":79,"load":4248,"code":200
2023-10-27T20:36:13Z D! [agenthealth] stats header (PutLogEvents/f0c1babf-cf05-460c-b711-e11ec68f63b5): "lat":91,"load":712,"code":200
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




