### PR TITLE
Check the usage_data in the config.

### DIFF
--- a/translator/translate/otel/extension/agenthealth/translator.go
+++ b/translator/translate/otel/extension/agenthealth/translator.go
@@ -18,6 +18,8 @@ const (
 	OperationPutMetricData    = "PutMetricData"
 	OperationPutLogEvents     = "PutLogEvents"
 	OperationPutTraceSegments = "PutTraceSegments"
+
+	usageDataKey = "usage_data"
 )
 
 var (
@@ -49,9 +51,12 @@ func (t *translator) ID() component.ID {
 }
 
 // Translate creates an extension configuration.
-func (t *translator) Translate(*confmap.Conf) (component.Config, error) {
+func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*agenthealth.Config)
 	cfg.IsUsageDataEnabled = t.isUsageDataEnabled
+	if usageData, ok := common.GetBool(conf, common.ConfigKey(common.AgentKey, usageDataKey)); ok {
+		cfg.IsUsageDataEnabled = cfg.IsUsageDataEnabled && usageData
+	}
 	cfg.Stats = agent.StatsConfig{Operations: t.operations}
 	return cfg, nil
 }

--- a/translator/translate/otel/extension/agenthealth/translator_test.go
+++ b/translator/translate/otel/extension/agenthealth/translator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
@@ -14,14 +15,61 @@ import (
 
 func TestTranslate(t *testing.T) {
 	operations := []string{OperationPutLogEvents}
-	tt := NewTranslator("test", operations).(*translator)
-	assert.Equal(t, "agenthealth/test", tt.ID().String())
-	tt.isUsageDataEnabled = true
-	got, err := tt.Translate(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, &agenthealth.Config{IsUsageDataEnabled: true, Stats: agent.StatsConfig{Operations: operations}}, got)
-	tt.isUsageDataEnabled = false
-	got, err = tt.Translate(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, &agenthealth.Config{IsUsageDataEnabled: false, Stats: agent.StatsConfig{Operations: operations}}, got)
+	testCases := map[string]struct {
+		input          map[string]interface{}
+		isEnvUsageData bool
+		want           *agenthealth.Config
+	}{
+		"WithUsageData/NotInConfig": {
+			input:          map[string]interface{}{"agent": map[string]interface{}{}},
+			isEnvUsageData: true,
+			want: &agenthealth.Config{
+				IsUsageDataEnabled: true,
+				Stats: agent.StatsConfig{
+					Operations: operations,
+				},
+			},
+		},
+		"WithUsageData/FalseInConfig": {
+			input:          map[string]interface{}{"agent": map[string]interface{}{"usage_data": false}},
+			isEnvUsageData: true,
+			want: &agenthealth.Config{
+				IsUsageDataEnabled: false,
+				Stats: agent.StatsConfig{
+					Operations: operations,
+				},
+			},
+		},
+		"WithUsageData/FalseInEnv": {
+			input:          map[string]interface{}{"agent": map[string]interface{}{"usage_data": true}},
+			isEnvUsageData: false,
+			want: &agenthealth.Config{
+				IsUsageDataEnabled: false,
+				Stats: agent.StatsConfig{
+					Operations: operations,
+				},
+			},
+		},
+		"WithUsageData/BothTrue": {
+			input:          map[string]interface{}{"agent": map[string]interface{}{"usage_data": true}},
+			isEnvUsageData: true,
+			want: &agenthealth.Config{
+				IsUsageDataEnabled: true,
+				Stats: agent.StatsConfig{
+					Operations: operations,
+				},
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tt := NewTranslator("test", operations).(*translator)
+			assert.Equal(t, "agenthealth/test", tt.ID().String())
+			tt.isUsageDataEnabled = testCase.isEnvUsageData
+			conf := confmap.NewFromStringMap(testCase.input)
+			got, err := tt.Translate(conf)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
 }


### PR DESCRIPTION
# Description of the issue
The agenthealth translator was not respecting the `usage_data` field in the `agent` section of the config.

# Description of changes
Updated the translator to check the `usage_data` field. If either the field or the environment variable are false, then it will be false.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




