### PR TITLE
Fix empty measurement field causing agent crash

### DIFF
--- a/translator/translate/otel/receiver/adapter/translators.go
+++ b/translator/translate/otel/receiver/adapter/translators.go
@@ -152,6 +152,9 @@ func fromInputs(conf *confmap.Conf, validInputs map[string]bool, baseKey string)
 			if skipInputSet.Contains(inputName) {
 				// logs agent is separate from otel agent
 				continue
+			} else if measurement := common.GetArray[any](conf, common.ConfigKey(cfgKey, common.MeasurementKey)); measurement != nil && len(measurement) == 0 {
+				log.Printf("W! Agent will not emit any metrics for %s due to empty measurement field ", inputName)
+				continue
 			} else if multipleInputSet.Contains(inputName) {
 				translators.Merge(fromMultipleInput(conf, inputName, ""))
 			} else {


### PR DESCRIPTION
# Description of the issue
CloudWatch agent team released major version v1.3x which migrates to OpenTelemetry. Old agent with major version 1.2x silently passes when measurement field is empty because the plugins with empty measurement field will be removed during translation, therefore not emitting anything for that metric.

New version will fail the agent during startup because the OTEL translators will still include the plugins with empty measurement field in the YAML config but the component will not be recognized.

# Description of changes
To achieve backward compatibility and avoid breaking existing customers config that may be using the empty measurement field, we will allow empty measurement but print out a warning message to remind the customers.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests passed. Also manually tested on EC2 instance using the following config
```
{
    "agent": {
        "debug": true,
        "aws_sdk_log_level": "LogDebugWithHTTPBody"
    },
    "metrics": {
        "append_dimensions": {
            "InstanceId": "${aws:InstanceId}",
            "InstanceType": "${aws:InstanceType}"
        },
        "metrics_collected": {
            "cpu": {
                "measurement": ["cpu_usage_idle", "cpu_usage_iowait", "cpu_usage_user", "cpu_usage_system"],
                "metrics_collection_interval": 1,
                "resources": ["*"],
                "totalcpu": true
            },
            "diskio": {
                "measurement": [],
                "metrics_collection_interval": 60,
                "resources": ["*"],
                "append_dimensions": {}
            }
        }
    }
}
```
![Screenshot 2023-11-03 at 2 01 17 PM](https://github.com/aws/amazon-cloudwatch-agent/assets/61301537/bc078a3d-f9b5-4431-9705-681b5382869f)

The agent was able to start and the CloudWatch console only receives the CPU metrics. 
**Note**: The gap between the metric was when I uninstalled the agent for another test build

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




