### PR TITLE
[awsappsignalsprocessor] Bugfix: Append dropper rules to the mutators

### DIFF
--- a/plugins/processors/awsappsignals/processor.go
+++ b/plugins/processors/awsappsignals/processor.go
@@ -60,7 +60,7 @@ func (ap *awsappsignalsprocessor) Start(_ context.Context, _ component.Host) err
 	ap.allowlistMutators = []allowListMutator{keeper}
 
 	dropper := rules.NewDropper(ap.config.Rules)
-	ap.allowlistMutators = []allowListMutator{dropper}
+	ap.allowlistMutators = append(ap.allowlistMutators, dropper)
 
 	return nil
 }


### PR DESCRIPTION
# Description of the issue
The mutator list was being overridden in the start function of the awsappsignalsprocessor. This causes the keep rules to never take effect. This is a bugfix to have the dropper rules by appended, not overwriting the list.

# Description of changes
Use append instead of a direct assignment of the list

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manual testing by using the keeper rule on an EKS cluster.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




