### PR TITLE
Removes LogGroupClass parameter in CreateLogGroup request when customer config does not define parameter

### DIFF
--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -340,10 +340,7 @@ func (p *pusher) createLogGroupAndStream() error {
 
 	p.Log.Debugf("creating stream fail due to : %v", err)
 	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
-		_, err = p.Service.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
-			LogGroupName:  &p.Group,
-			LogGroupClass: &p.Class,
-		})
+		err = p.createLogGroup()
 
 		// attempt to create stream again if group created successfully.
 		if err == nil {
@@ -367,6 +364,21 @@ func (p *pusher) createLogGroupAndStream() error {
 		return nil // if the log group or log stream already exist, this is not worth returning an error for
 	}
 
+	return err
+}
+
+func (p *pusher) createLogGroup() error {
+	var err error
+	if p.Class != "" {
+		_, err = p.Service.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+			LogGroupName:  &p.Group,
+			LogGroupClass: &p.Class,
+		})
+	} else {
+		_, err = p.Service.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+			LogGroupName: &p.Group,
+		})
+	}
 	return err
 }
 

--- a/translator/defaultKeyCase.go
+++ b/translator/defaultKeyCase.go
@@ -93,9 +93,9 @@ func DefaultLogGroupClassCase(key string, defaultVal, input interface{}) (return
 		//CreateLogGroup API only accepts values STANDARD or INFREQUENT_ACCESS
 		returnVal = strings.ToUpper(classVal)
 	} else {
-		AddErrorMessages(
+		AddInfoMessages(
 			fmt.Sprintf("LogGroupClass key: %s", key),
-			fmt.Sprintf("%s value (%v) in is not a valid Log Group Class field. Defaulting to standard.", key, returnVal))
+			fmt.Sprintf("%s value (%v) in is not a valid Log Group Class field. Agent will not set the LogGroupClass parameter.", key, returnVal))
 		returnVal = ""
 	}
 	return

--- a/translator/defaultKeyCase.go
+++ b/translator/defaultKeyCase.go
@@ -6,8 +6,6 @@ package translator
 import (
 	"fmt"
 	"strings"
-
-	"github.com/aws/amazon-cloudwatch-agent/tool/util"
 )
 
 // DefaultCase check if current input overrides the default value for the given config entry key.
@@ -95,10 +93,10 @@ func DefaultLogGroupClassCase(key string, defaultVal, input interface{}) (return
 		//CreateLogGroup API only accepts values STANDARD or INFREQUENT_ACCESS
 		returnVal = strings.ToUpper(classVal)
 	} else {
-		returnVal = util.StandardLogGroupClass
 		AddErrorMessages(
 			fmt.Sprintf("LogGroupClass key: %s", key),
 			fmt.Sprintf("%s value (%v) in is not a valid Log Group Class field. Defaulting to standard.", key, returnVal))
+		returnVal = ""
 	}
 	return
 

--- a/translator/isValid.go
+++ b/translator/isValid.go
@@ -94,5 +94,5 @@ func IsValidRetentionDays(days int) bool {
 }
 
 func IsValidLogGroupClass(class string) bool {
-	return slices.Contains(ValidLogGroupClasses, class)
+	return slices.Contains(ValidLogGroupClasses, class) && class != ""
 }

--- a/translator/isValid.go
+++ b/translator/isValid.go
@@ -94,5 +94,5 @@ func IsValidRetentionDays(days int) bool {
 }
 
 func IsValidLogGroupClass(class string) bool {
-	return slices.Contains(ValidLogGroupClasses, class) && class != ""
+	return slices.Contains(ValidLogGroupClasses, class) || class == ""
 }

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
@@ -23,7 +23,7 @@ func TestFileConfig(t *testing.T) {
 	f := new(FileConfig)
 	var input interface{}
 	e := json.Unmarshal([]byte(`{"collect_list":[{"file_path":"path1",
-            "log_group_name":"group1","log_stream_name":"LOG_STREAM_NAME"}]}`), &input)
+            "log_group_name":"group1","log_stream_name":"LOG_STREAM_NAME", "log_group_class":"STANDARD"}]}`), &input)
 	if e != nil {
 		assert.Fail(t, e.Error())
 	}
@@ -56,7 +56,7 @@ func TestFileConfigOverride(t *testing.T) {
 		"log_group_name":    "group1",
 		"pipe":              false,
 		"retention_in_days": -1,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -85,7 +85,7 @@ func TestTimestampFormat(t *testing.T) {
 		"timestamp_regex":   "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2})",
 		"timezone":          "UTC",
 		"retention_in_days": -1,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -111,7 +111,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  []string{"15:04:05 06 Jan _2"},
 				"timestamp_regex":   "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2})",
-				"log_group_class":   util.StandardLogGroupClass,
+				"log_group_class":   "",
 			}},
 		},
 		{
@@ -130,7 +130,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  []string{"1 _2 15:04:05", "01 _2 15:04:05"},
 				"timestamp_regex":   "(\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
-				"log_group_class":   util.StandardLogGroupClass,
+				"log_group_class":   "",
 			}},
 		},
 		{
@@ -149,7 +149,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  []string{"_2 1 15:04:05", "_2 01 15:04:05"},
 				"timestamp_regex":   "(\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
-				"log_group_class":   util.StandardLogGroupClass,
+				"log_group_class":   "",
 			}},
 		},
 		{
@@ -168,7 +168,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  []string{"Jan _2 15:04:05"},
 				"timestamp_regex":   "(\\w{3} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
-				"log_group_class":   util.StandardLogGroupClass,
+				"log_group_class":   "",
 			}},
 		},
 		{
@@ -187,7 +187,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  []string{"Jan _2 15:04:05"},
 				"timestamp_regex":   "(\\w{3} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
-				"log_group_class":   util.StandardLogGroupClass,
+				"log_group_class":   "",
 			}},
 		},
 		{
@@ -206,7 +206,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  []string{"5 _2 1 15:04:05", "5 _2 01 15:04:05"},
 				"timestamp_regex":   "(\\d{1,2} \\s{0,1}\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
-				"log_group_class":   util.StandardLogGroupClass,
+				"log_group_class":   "",
 			}},
 		},
 		{
@@ -225,7 +225,7 @@ func TestTimestampFormatAll(t *testing.T) {
 				"retention_in_days": -1,
 				"timestamp_layout":  []string{"5 _2 01 15:04:05", "5 _2 1 15:04:05"},
 				"timestamp_regex":   "(\\d{1,2} \\s{0,1}\\d{1,2} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})",
-				"log_group_class":   util.StandardLogGroupClass,
+				"log_group_class":   "",
 			}},
 		},
 	}
@@ -268,7 +268,7 @@ func TestTimestampFormat_NonZeroPadding(t *testing.T) {
 	expectedRegex := "(\\d{1,2}:\\d{1,2}:\\d{1,2} \\d{2} \\s{0,1}\\d{1,2} \\s{0,1}\\d{1,2})"
 	expectVal := []interface{}{map[string]interface{}{
 		"file_path":         "path1",
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
@@ -314,7 +314,7 @@ func TestTimestampFormat_SpecialCharacters(t *testing.T) {
 	expectedRegex := "(\\^\\.\\*\\?\\|\\[\\(\\{\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2}\\}\\)\\]\\$)"
 	expectVal := []interface{}{map[string]interface{}{
 		"file_path":         "path1",
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
@@ -354,7 +354,7 @@ func TestTimestampFormat_Template(t *testing.T) {
 	expectedRegex := "(\\w{3} \\s{0,1}\\d{1,2} \\d{2}:\\d{2}:\\d{2})"
 	expectVal := []interface{}{map[string]interface{}{
 		"file_path":         "path1",
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
@@ -412,7 +412,7 @@ func TestMultiLineStartPattern(t *testing.T) {
 		"from_beginning":           true,
 		"pipe":                     false,
 		"retention_in_days":        -1,
-		"log_group_class":          util.StandardLogGroupClass,
+		"log_group_class":          "",
 		"timestamp_layout":         []string{"15:04:05 06 Jan _2"},
 		"timestamp_regex":          "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2})",
 		"timezone":                 "UTC",
@@ -443,7 +443,7 @@ func TestEncoding(t *testing.T) {
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 		"timestamp_layout":  []string{"15:04:05 06 Jan _2"},
 		"timestamp_regex":   "(\\d{2}:\\d{2}:\\d{2} \\d{2} \\w{3} \\s{0,1}\\d{1,2})",
 		"timezone":          "UTC",
@@ -472,7 +472,7 @@ func TestEncoding_Invalid(t *testing.T) {
 		"file_path":         "path1",
 		"from_beginning":    true,
 		"pipe":              false,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 		"retention_in_days": -1,
 	}}
 	assert.Equal(t, expectVal, val)
@@ -501,7 +501,7 @@ func TestAutoRemoval(t *testing.T) {
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 		"auto_removal":      true,
 	}}
 	assert.Equal(t, expectVal, val)
@@ -524,7 +524,7 @@ func TestAutoRemoval(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": -1,
 		"auto_removal":      false,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -544,7 +544,7 @@ func TestAutoRemoval(t *testing.T) {
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -617,7 +617,7 @@ func TestPublishMultiLogs_WithBlackList(t *testing.T) {
 		"from_beginning":     true,
 		"pipe":               false,
 		"retention_in_days":  -1,
-		"log_group_class":    util.StandardLogGroupClass,
+		"log_group_class":    "",
 		"blacklist":          "^agent.log",
 		"publish_multi_logs": true,
 		"timezone":           "UTC",
@@ -644,7 +644,7 @@ func TestPublishMultiLogs_WithBlackList(t *testing.T) {
 		"retention_in_days":  -1,
 		"publish_multi_logs": false,
 		"timezone":           "UTC",
-		"log_group_class":    util.StandardLogGroupClass,
+		"log_group_class":    "",
 	}}
 	assert.Equal(t, expectVal, val)
 
@@ -664,7 +664,7 @@ func TestPublishMultiLogs_WithBlackList(t *testing.T) {
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -688,7 +688,7 @@ func TestLogFilters(t *testing.T) {
 		"from_beginning":    true,
 		"pipe":              false,
 		"retention_in_days": -1,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 		"filters": []interface{}{
 			map[string]interface{}{
 				"type":       "include",
@@ -730,14 +730,14 @@ func TestRetentionDifferentLogGroups(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}, map[string]interface{}{
 		"file_path":         "path1",
 		"log_group_name":    "test1",
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -769,14 +769,14 @@ func TestDuplicateRetention(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}, map[string]interface{}{
 		"file_path":         "path1",
 		"log_group_name":    "test1",
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -809,14 +809,14 @@ func TestConflictingRetention(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}, map[string]interface{}{
 		"file_path":         "path1",
 		"log_group_name":    "test1",
 		"pipe":              false,
 		"retention_in_days": 5,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, "Under path : /logs/logs_collected/files/collect_list/ | Error : Different retention_in_days values can't be set for the same log group: test1", translator.ErrorMessages[len(translator.ErrorMessages)-1])
 	assert.Equal(t, expectVal, val)
@@ -849,14 +849,14 @@ func TestDifferentLogGroupClasses(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}, map[string]interface{}{
 		"file_path":         "path1",
 		"log_group_name":    "test1",
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 }
@@ -890,14 +890,14 @@ func TestDuplicateLogGroupClass(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}, map[string]interface{}{
 		"file_path":         "path1",
 		"log_group_name":    "test1",
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   util.StandardLogGroupClass,
+		"log_group_class":   "",
 	}}
 	assert.Equal(t, expectVal, val)
 }

--- a/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/collect_list_test.go
@@ -890,14 +890,14 @@ func TestDuplicateLogGroupClass(t *testing.T) {
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   "",
+		"log_group_class":   util.StandardLogGroupClass,
 	}, map[string]interface{}{
 		"file_path":         "path1",
 		"log_group_name":    "test1",
 		"pipe":              false,
 		"retention_in_days": 3,
 		"from_beginning":    true,
-		"log_group_class":   "",
+		"log_group_class":   util.StandardLogGroupClass,
 	}}
 	assert.Equal(t, expectVal, val)
 }

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass.go
@@ -1,26 +1,24 @@
-// // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// // SPDX-License-Identifier: MIT
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
 package collect_list
 
-//
-//import (
-//	"github.com/aws/amazon-cloudwatch-agent/tool/util"
-//	"github.com/aws/amazon-cloudwatch-agent/translator"
-//)
-//
-//const LogGroupClassSectionKey = "log_group_class"
-//
-//type LogGroupClass struct {
-//}
-//
-//func (f *LogGroupClass) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
-//	_, returnVal = translator.DefaultLogGroupClassCase(LogGroupClassSectionKey, util.StandardLogGroupClass, input)
-//	returnKey = LogGroupClassSectionKey
-//	return
-//}
-//
-//func init() {
-//	l := new(LogGroupClass)
-//	r := []Rule{l}
-//	RegisterRule(LogGroupClassSectionKey, r)
-//}
+import (
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+)
+
+const LogGroupClassSectionKey = "log_group_class"
+
+type LogGroupClass struct {
+}
+
+func (f *LogGroupClass) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+	_, returnVal = translator.DefaultLogGroupClassCase(LogGroupClassSectionKey, "", input)
+	returnKey = LogGroupClassSectionKey
+	return
+}
+
+func init() {
+	l := new(LogGroupClass)
+	r := []Rule{l}
+	RegisterRule(LogGroupClassSectionKey, r)
+}

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass.go
@@ -1,26 +1,26 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
-
+// // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// // SPDX-License-Identifier: MIT
 package collect_list
 
-import (
-	"github.com/aws/amazon-cloudwatch-agent/tool/util"
-	"github.com/aws/amazon-cloudwatch-agent/translator"
-)
-
-const LogGroupClassSectionKey = "log_group_class"
-
-type LogGroupClass struct {
-}
-
-func (f *LogGroupClass) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
-	_, returnVal = translator.DefaultLogGroupClassCase(LogGroupClassSectionKey, util.StandardLogGroupClass, input)
-	returnKey = LogGroupClassSectionKey
-	return
-}
-
-func init() {
-	l := new(LogGroupClass)
-	r := []Rule{l}
-	RegisterRule(LogGroupClassSectionKey, r)
-}
+//
+//import (
+//	"github.com/aws/amazon-cloudwatch-agent/tool/util"
+//	"github.com/aws/amazon-cloudwatch-agent/translator"
+//)
+//
+//const LogGroupClassSectionKey = "log_group_class"
+//
+//type LogGroupClass struct {
+//}
+//
+//func (f *LogGroupClass) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
+//	_, returnVal = translator.DefaultLogGroupClassCase(LogGroupClassSectionKey, util.StandardLogGroupClass, input)
+//	returnKey = LogGroupClassSectionKey
+//	return
+//}
+//
+//func init() {
+//	l := new(LogGroupClass)
+//	r := []Rule{l}
+//	RegisterRule(LogGroupClassSectionKey, r)
+//}

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass_test.go
@@ -57,3 +57,18 @@ func TestInvalidTypeLogGroupClass(t *testing.T) {
 		panic(e)
 	}
 }
+
+func TestEmptyLogGroupClass(t *testing.T) {
+	r := new(LogGroupClass)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{
+			"log_group_class": ""
+	}`), &input)
+	if e == nil {
+		actualReturnKey, actualReturnValue := r.ApplyRule(input)
+		assert.Equal(t, "log_group_class", actualReturnKey)
+		assert.Equal(t, "", actualReturnValue)
+	} else {
+		panic(e)
+	}
+}

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass_test.go
@@ -1,60 +1,60 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
-
+// // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// // SPDX-License-Identifier: MIT
 package collect_list
 
-import (
-	"encoding/json"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/aws/amazon-cloudwatch-agent/tool/util"
-)
-
-func TestApplyLogGroupClassRule(t *testing.T) {
-	r := new(LogGroupClass)
-	var input interface{}
-	e := json.Unmarshal([]byte(`{
-			"log_group_class": "Infrequent_access"
-	}`), &input)
-	if e == nil {
-		actualReturnKey, actualReturnVal := r.ApplyRule(input)
-		assert.Equal(t, "log_group_class", actualReturnKey)
-		assert.Equal(t, util.InfrequentAccessLogGroupClass, actualReturnVal)
-	} else {
-		panic(e)
-	}
-}
-
-// Since retention can only be set to specific numbers (1,3,5,7...),
-// test to make sure other numbers are invalid (and set to -1)
-func TestInvalidLogGroupClass(t *testing.T) {
-	r := new(LogGroupClass)
-	var input interface{}
-	e := json.Unmarshal([]byte(`{
-			"log_group_class": "invalidValue"
-	}`), &input)
-	if e == nil {
-		actualReturnKey, actualReturnValue := r.ApplyRule(input)
-		assert.Equal(t, "log_group_class", actualReturnKey)
-		assert.Equal(t, util.StandardLogGroupClass, actualReturnValue)
-	} else {
-		panic(e)
-	}
-}
-
-func TestInvalidTypeLogGroupClass(t *testing.T) {
-	r := new(LogGroupClass)
-	var input interface{}
-	e := json.Unmarshal([]byte(`{
-			"log_group_class": 5
-	}`), &input)
-	if e == nil {
-		actualReturnKey, actualReturnValue := r.ApplyRule(input)
-		assert.Equal(t, "log_group_class", actualReturnKey)
-		assert.Equal(t, util.StandardLogGroupClass, actualReturnValue)
-	} else {
-		panic(e)
-	}
-}
+//
+//import (
+//	"encoding/json"
+//	"testing"
+//
+//	"github.com/stretchr/testify/assert"
+//
+//	"github.com/aws/amazon-cloudwatch-agent/tool/util"
+//)
+//
+//func TestApplyLogGroupClassRule(t *testing.T) {
+//	r := new(LogGroupClass)
+//	var input interface{}
+//	e := json.Unmarshal([]byte(`{
+//			"log_group_class": "Infrequent_access"
+//	}`), &input)
+//	if e == nil {
+//		actualReturnKey, actualReturnVal := r.ApplyRule(input)
+//		assert.Equal(t, "log_group_class", actualReturnKey)
+//		assert.Equal(t, util.InfrequentAccessLogGroupClass, actualReturnVal)
+//	} else {
+//		panic(e)
+//	}
+//}
+//
+//// Since retention can only be set to specific numbers (1,3,5,7...),
+//// test to make sure other numbers are invalid (and set to -1)
+//func TestInvalidLogGroupClass(t *testing.T) {
+//	r := new(LogGroupClass)
+//	var input interface{}
+//	e := json.Unmarshal([]byte(`{
+//			"log_group_class": "invalidValue"
+//	}`), &input)
+//	if e == nil {
+//		actualReturnKey, actualReturnValue := r.ApplyRule(input)
+//		assert.Equal(t, "log_group_class", actualReturnKey)
+//		assert.Equal(t, util.StandardLogGroupClass, actualReturnValue)
+//	} else {
+//		panic(e)
+//	}
+//}
+//
+//func TestInvalidTypeLogGroupClass(t *testing.T) {
+//	r := new(LogGroupClass)
+//	var input interface{}
+//	e := json.Unmarshal([]byte(`{
+//			"log_group_class": 5
+//	}`), &input)
+//	if e == nil {
+//		actualReturnKey, actualReturnValue := r.ApplyRule(input)
+//		assert.Equal(t, "log_group_class", actualReturnKey)
+//		assert.Equal(t, util.StandardLogGroupClass, actualReturnValue)
+//	} else {
+//		panic(e)
+//	}
+//}

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass_test.go
@@ -1,5 +1,5 @@
-// // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// // SPDX-License-Identifier: MIT
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
 package collect_list
 
 import (

--- a/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass_test.go
+++ b/translator/translate/logs/logs_collected/files/collect_list/ruleLogGroupClass_test.go
@@ -2,59 +2,58 @@
 // // SPDX-License-Identifier: MIT
 package collect_list
 
-//
-//import (
-//	"encoding/json"
-//	"testing"
-//
-//	"github.com/stretchr/testify/assert"
-//
-//	"github.com/aws/amazon-cloudwatch-agent/tool/util"
-//)
-//
-//func TestApplyLogGroupClassRule(t *testing.T) {
-//	r := new(LogGroupClass)
-//	var input interface{}
-//	e := json.Unmarshal([]byte(`{
-//			"log_group_class": "Infrequent_access"
-//	}`), &input)
-//	if e == nil {
-//		actualReturnKey, actualReturnVal := r.ApplyRule(input)
-//		assert.Equal(t, "log_group_class", actualReturnKey)
-//		assert.Equal(t, util.InfrequentAccessLogGroupClass, actualReturnVal)
-//	} else {
-//		panic(e)
-//	}
-//}
-//
-//// Since retention can only be set to specific numbers (1,3,5,7...),
-//// test to make sure other numbers are invalid (and set to -1)
-//func TestInvalidLogGroupClass(t *testing.T) {
-//	r := new(LogGroupClass)
-//	var input interface{}
-//	e := json.Unmarshal([]byte(`{
-//			"log_group_class": "invalidValue"
-//	}`), &input)
-//	if e == nil {
-//		actualReturnKey, actualReturnValue := r.ApplyRule(input)
-//		assert.Equal(t, "log_group_class", actualReturnKey)
-//		assert.Equal(t, util.StandardLogGroupClass, actualReturnValue)
-//	} else {
-//		panic(e)
-//	}
-//}
-//
-//func TestInvalidTypeLogGroupClass(t *testing.T) {
-//	r := new(LogGroupClass)
-//	var input interface{}
-//	e := json.Unmarshal([]byte(`{
-//			"log_group_class": 5
-//	}`), &input)
-//	if e == nil {
-//		actualReturnKey, actualReturnValue := r.ApplyRule(input)
-//		assert.Equal(t, "log_group_class", actualReturnKey)
-//		assert.Equal(t, util.StandardLogGroupClass, actualReturnValue)
-//	} else {
-//		panic(e)
-//	}
-//}
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/amazon-cloudwatch-agent/tool/util"
+)
+
+func TestApplyLogGroupClassRule(t *testing.T) {
+	r := new(LogGroupClass)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{
+			"log_group_class": "Infrequent_access"
+	}`), &input)
+	if e == nil {
+		actualReturnKey, actualReturnVal := r.ApplyRule(input)
+		assert.Equal(t, "log_group_class", actualReturnKey)
+		assert.Equal(t, util.InfrequentAccessLogGroupClass, actualReturnVal)
+	} else {
+		panic(e)
+	}
+}
+
+// Since retention can only be set to specific numbers (1,3,5,7...),
+// test to make sure other numbers are invalid (and set to -1)
+func TestInvalidLogGroupClass(t *testing.T) {
+	r := new(LogGroupClass)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{
+			"log_group_class": "invalidValue"
+	}`), &input)
+	if e == nil {
+		actualReturnKey, actualReturnValue := r.ApplyRule(input)
+		assert.Equal(t, "log_group_class", actualReturnKey)
+		assert.Equal(t, "", actualReturnValue)
+	} else {
+		panic(e)
+	}
+}
+
+func TestInvalidTypeLogGroupClass(t *testing.T) {
+	r := new(LogGroupClass)
+	var input interface{}
+	e := json.Unmarshal([]byte(`{
+			"log_group_class": 5
+	}`), &input)
+	if e == nil {
+		actualReturnKey, actualReturnValue := r.ApplyRule(input)
+		assert.Equal(t, "log_group_class", actualReturnKey)
+		assert.Equal(t, "", actualReturnValue)
+	} else {
+		panic(e)
+	}
+}

--- a/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
+++ b/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
@@ -24,7 +24,8 @@ func TestApplyRule(t *testing.T) {
           "INFORMATION",
           "CRITICAL"
         ],
-        "log_group_name": "System"
+        "log_group_name": "System",
+		"log_group_class": "STANDARD"
       },
       {
         "event_name": "Application",
@@ -58,7 +59,7 @@ func TestApplyRule(t *testing.T) {
 			"log_group_name":    "Application",
 			"batch_read_size":   BatchReadSizeValue,
 			"retention_in_days": 1,
-			"log_group_class":   util.StandardLogGroupClass,
+			"log_group_class":   "",
 		},
 	}
 

--- a/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
+++ b/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
@@ -86,7 +86,8 @@ func TestDuplicateRetention(t *testing.T) {
           "CRITICAL"
         ],
         "log_group_name": "System",
-		"retention_in_days": 3
+		"retention_in_days": 3,
+		"log_group_class": "INFREQUENT_ACCESS"
       },
       {
         "event_name": "Application",
@@ -97,7 +98,8 @@ func TestDuplicateRetention(t *testing.T) {
         ],
         "event_format": "xml",
         "log_group_name": "System",
-		"retention_in_days": 3
+		"retention_in_days": 3,
+		"log_group_class": "INFREQUENT_ACCESS"
       },
       {
         "event_name": "Application",
@@ -108,7 +110,8 @@ func TestDuplicateRetention(t *testing.T) {
         ],
         "event_format": "xml",
         "log_group_name": "System",
-		"retention_in_days": 3
+		"retention_in_days": 3,
+		"log_group_class": "INFREQUENT_ACCESS"
       }
     ]
 }
@@ -122,7 +125,7 @@ func TestDuplicateRetention(t *testing.T) {
 			"log_group_name":    "System",
 			"batch_read_size":   BatchReadSizeValue,
 			"retention_in_days": 3,
-			"log_group_class":   util.StandardLogGroupClass,
+			"log_group_class":   util.InfrequentAccessLogGroupClass,
 		},
 		map[string]interface{}{
 			"event_name":        "Application",
@@ -131,7 +134,7 @@ func TestDuplicateRetention(t *testing.T) {
 			"log_group_name":    "System",
 			"batch_read_size":   BatchReadSizeValue,
 			"retention_in_days": 3,
-			"log_group_class":   util.StandardLogGroupClass,
+			"log_group_class":   util.InfrequentAccessLogGroupClass,
 		},
 		map[string]interface{}{
 			"event_name":        "Application",
@@ -140,7 +143,7 @@ func TestDuplicateRetention(t *testing.T) {
 			"log_group_name":    "System",
 			"batch_read_size":   BatchReadSizeValue,
 			"retention_in_days": 3,
-			"log_group_class":   util.StandardLogGroupClass,
+			"log_group_class":   util.InfrequentAccessLogGroupClass,
 		},
 	}
 

--- a/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
+++ b/translator/translate/logs/logs_collected/windows_events/collect_list/collectlist_test.go
@@ -196,7 +196,7 @@ func TestConflictingRetention(t *testing.T) {
 			"log_group_name":    "System",
 			"batch_read_size":   BatchReadSizeValue,
 			"retention_in_days": 3,
-			"log_group_class":   util.StandardLogGroupClass,
+			"log_group_class":   "",
 		},
 		map[string]interface{}{
 			"event_name":        "Application",
@@ -205,7 +205,7 @@ func TestConflictingRetention(t *testing.T) {
 			"log_group_name":    "System",
 			"batch_read_size":   BatchReadSizeValue,
 			"retention_in_days": 1,
-			"log_group_class":   util.StandardLogGroupClass,
+			"log_group_class":   "",
 		},
 	}
 

--- a/translator/translate/logs/logs_collected/windows_events/collect_list/ruleLogGroupClass.go
+++ b/translator/translate/logs/logs_collected/windows_events/collect_list/ruleLogGroupClass.go
@@ -4,7 +4,6 @@
 package collectlist
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent/tool/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator"
 )
 
@@ -14,7 +13,7 @@ type LogGroupClass struct {
 }
 
 func (f *LogGroupClass) ApplyRule(input interface{}) (returnKey string, returnVal interface{}) {
-	_, returnVal = translator.DefaultLogGroupClassCase(LogGroupClassSectionKey, util.StandardLogGroupClass, input)
+	_, returnVal = translator.DefaultLogGroupClassCase(LogGroupClassSectionKey, "", input)
 	returnKey = LogGroupClassSectionKey
 	return
 }


### PR DESCRIPTION
# Description of the issue
In regions where the LogGroupClass parameter is not yet deployed, customers are unable to create LogGroups, even with valid configurations.

# Description of changes
When a customer defines a config without a `log_group_class`, the agent will no longer send a CreateLogGroup request with a `STANDARD` log group class. Instead, the CreateLogGroup request will be made without the `LogGroupClass` parameter, which the CWL Service also accepts as a `STANDARD` Log Group Class 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
On us-gov-west-1, I deployed the following config
```
{
  "agent": {
    "run_as_user": "root",
    "debug": true
  },
  "logs": {
    "logs_collected": {
      "files": {
        "collect_list": [
          {
            "file_path": "/var/gazpacho-standard.log",
            "log_group_name": "{instance_id}-standard",
            "log_stream_name": "{instance_id}",
            "timezone": "UTC"
          }
        ]
      }
    }
  }
}
```
Previously, it would fail with the error, `2023-12-07T16:49:03Z D! [outputs.cloudwatchlogs] creating group fail due to : InvalidParameterException: Only Standard log class is supported.`

Now it succeeds in log group creation
![image](https://github.com/aws/amazon-cloudwatch-agent/assets/19413347/4d4fb58a-ff35-4ab8-a0f7-836d313c58f7)

Setting the `log_group_class` parameter will continue to fail in these regions until this CW Logs feature is available in these regions.


I also verified that the fix continues to work in commercial regions
![image](https://github.com/aws/amazon-cloudwatch-agent/assets/19413347/9c81830d-3776-454d-ab6e-22fa563c9e1c)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




