### PR TITLE
Add extra logging to ctl script to aid in debugging failures.

### DIFF
--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -5,6 +5,7 @@
 
 set -e
 set -u
+set -x
 
 readonly AGENTDIR="/opt/aws/amazon-cloudwatch-agent"
 readonly CMDDIR="${AGENTDIR}/bin"


### PR DESCRIPTION
# Description of the issue
See ticket V1154110212, customer is having intermittent failures with the ctl script returning non-zero exit code even though it otherwise appears to succeed.

# Description of changes
Add extra logging to the ctl script to help find out exactly where it's failing for this customer.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Built locally and ran `sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s`.  See output:

```
[ec2-user@ip-10-0-10-241 ~]$ sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s
+ readonly AGENTDIR=/opt/aws/amazon-cloudwatch-agent
+ AGENTDIR=/opt/aws/amazon-cloudwatch-agent
+ readonly CMDDIR=/opt/aws/amazon-cloudwatch-agent/bin
+ CMDDIR=/opt/aws/amazon-cloudwatch-agent/bin
+ readonly CONFDIR=/opt/aws/amazon-cloudwatch-agent/etc
+ CONFDIR=/opt/aws/amazon-cloudwatch-agent/etc
+ readonly CWA_RESTART_FILE=/opt/aws/amazon-cloudwatch-agent/etc/restart
+ CWA_RESTART_FILE=/opt/aws/amazon-cloudwatch-agent/etc/restart
+ readonly VERSION_FILE=/opt/aws/amazon-cloudwatch-agent/bin/CWAGENT_VERSION
+ VERSION_FILE=/opt/aws/amazon-cloudwatch-agent/bin/CWAGENT_VERSION
+ readonly TOML=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
+ TOML=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
+ readonly OTEL_YAML=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.yaml
+ OTEL_YAML=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.yaml
+ readonly JSON=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+ JSON=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+ readonly JSON_DIR=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d
+ JSON_DIR=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d
+ readonly CV_LOG_FILE=/opt/aws/amazon-cloudwatch-agent/logs/configuration-validation.log
+ CV_LOG_FILE=/opt/aws/amazon-cloudwatch-agent/logs/configuration-validation.log
+ readonly COMMON_CONIG=/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml
+ COMMON_CONIG=/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml
+ readonly ENV_CONFIG=/opt/aws/amazon-cloudwatch-agent/etc/env-config.json
+ ENV_CONFIG=/opt/aws/amazon-cloudwatch-agent/etc/env-config.json
+ readonly CWA_NAME=amazon-cloudwatch-agent
+ CWA_NAME=amazon-cloudwatch-agent
+ readonly ALL_CONFIG=all
+ ALL_CONFIG=all
+ SYSTEMD=false
+ UsageString='


        usage:  amazon-cloudwatch-agent-ctl -a
                stop|start|status|fetch-config|append-config|remove-config|set-log-level
                [-m ec2|onPremise|onPrem|auto]
                [-c default|all|ssm:<parameter-store-name>|file:<file-path>]
                [-s]
                [-l INFO|DEBUG|WARN|ERROR|OFF]

        e.g.
        1. apply a SSM parameter store config on EC2 instance and restart the agent afterwards:
            amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:AmazonCloudWatch-Config.json -s
        2. append a local json config file on onPremise host and restart the agent afterwards:
            amazon-cloudwatch-agent-ctl -a append-config -m onPremise -c file:/tmp/config.json -s
        3. query agent status:
            amazon-cloudwatch-agent-ctl -a status

        -a: action
            stop:                                   stop the agent process.
            start:                                  start the agent process.
            status:                                 get the status of the agent process.
            fetch-config:                           apply config for agent, followed by -c. Target config can be based on location (ssm parameter store name, file name), or '\''default'\''.
            append-config:                          append json config with the existing json configs if any, followed by -c. Target config can be based on the location (ssm parameter store name, file name), or '\''default'\''.
            remove-config:                          remove config for agent, followed by -c. Target config can be based on the location (ssm parameter store name, file name), or '\''all'\''.
            set-log-level:                          sets the log level, followed by -l to provide the level in all caps.

        -m: mode
            ec2:                                    indicate this is on ec2 host.
            onPremise, onPrem:                      indicate this is on onPremise host.
            auto:                                   use ec2 metadata to determine the environment, may not be accurate if ec2 metadata is not available for some reason on EC2.

        -c: amazon-cloudwatch-agent configuration
            default:                                default configuration for quick trial.
            ssm:<parameter-store-name>:             ssm parameter store name.
            file:<file-path>:                       file path on the host.
            all:                                    all existing configs. Only apply to remove-config action.

        -s: optionally restart after configuring the agent configuration
            this parameter is used for '\''fetch-config'\'', '\''append-config'\'', '\''remove-config'\'' action only.

        -l: log level to set the agent to INFO, DEBUG, WARN, ERROR, or OFF
            this parameter is used for '\''set-log-level'\'' only.

'
+ main -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s
+ action=
+ cwa_config_location=
+ restart=false
+ mode=ec2
++ /sbin/init --version
++ grep -c upstart
+ '[' 0 = 1 ']'
++ systemctl
++ grep -c -E '\-\.mount\s'
+ '[' 1 = 1 ']'
+ SYSTEMD=true
+ OPTIND=1
+ getopts :hsa:c:m:l: opt
+ case "${opt}" in
+ action=fetch-config
+ getopts :hsa:c:m:l: opt
+ case "${opt}" in
+ mode=ec2
+ getopts :hsa:c:m:l: opt
+ case "${opt}" in
+ cwa_config_location=file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
+ getopts :hsa:c:m:l: opt
+ case "${opt}" in
+ restart=true
+ getopts :hsa:c:m:l: opt
+ shift 7
+ case "${mode}" in
+ case "${action}" in
+ config_all file:/opt/aws/amazon-cloudwatch-agent/bin/config.json true ec2 default
+ cwa_config_location=file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
+ restart=true
+ mode=ec2
+ multi_config=default
+ '[' -z file:/opt/aws/amazon-cloudwatch-agent/bin/config.json ']'
+ mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+ '[' -n file:/opt/aws/amazon-cloudwatch-agent/bin/config.json ']'
+ echo '****** processing amazon-cloudwatch-agent ******'
****** processing amazon-cloudwatch-agent ******
+ cwa_config file:/opt/aws/amazon-cloudwatch-agent/bin/config.json true ec2 default
+ cwa_config_location=file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
+ restart=true
+ param_mode=ec2
+ multi_config=default
+ '[' file:/opt/aws/amazon-cloudwatch-agent/bin/config.json = all ']'
+ '[' file:/opt/aws/amazon-cloudwatch-agent/bin/config.json = all ']'
++ /opt/aws/amazon-cloudwatch-agent/bin/config-downloader --output-dir /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d --download-source file:/opt/aws/amazon-cloudwatch-agent/bin/config.json --mode ec2 --config /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml --multi-config default
2024/01/03 16:44:20 I! imds retry client will retry 1 times
+ runDownloaderCommand='I! Trying to detect region from ec2
D! [EC2] Found active network interface
Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp'
+ echo 'I!' Trying to detect region from ec2 'D!' '[EC2]' Found active network interface Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp
I! Trying to detect region from ec2 D! [EC2] Found active network interface Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp
++ ls /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d
+ '[' '!' file_config.json.tmp ']'
+ echo 'Start configuration validation...'
Start configuration validation...
++ /opt/aws/amazon-cloudwatch-agent/bin/config-translator --input /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json --input-dir /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d --output /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml --mode ec2 --config /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml --multi-config default
2024/01/03 16:44:20 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp ...
2024/01/03 16:44:20 I! Valid Json input schema.
2024/01/03 16:44:20 I! imds retry client will retry 1 times
2024/01/03 16:44:20 D! pipeline hostDeltaMetrics has no receivers
2024/01/03 16:44:20 Configuration validation first phase succeeded
+ runTranslatorCommand='I! Detecting run_as_user...
I! Trying to detect region from ec2
D! [EC2] Found active network interface'
+ echo 'I! Detecting run_as_user...
I! Trying to detect region from ec2
D! [EC2] Found active network interface'
I! Detecting run_as_user...
I! Trying to detect region from ec2
D! [EC2] Found active network interface
+ runAgentSchemaTestCommand='/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -schematest -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml'
+ echo '/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -schematest -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml'
/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -schematest -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
+ /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -schematest -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
+ echo 'Configuration validation second phase succeeded'
Configuration validation second phase succeeded
+ echo 'Configuration validation succeeded'
Configuration validation succeeded
+ chmod ug+rw /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
+ '[' -f /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.yaml ']'
+ chmod ug+rw /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.yaml
+ '[' default = default ']'
+ rm -f /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+ for file in "${JSON_DIR}"/*
++ basename /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp .tmp
+ base=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json
+ '[' /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp = /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json ']'
+ mv -f /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json.tmp /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_config.json
+ '[' true = true ']'
+ agent_stop_and_disable amazon-cloudwatch-agent
+ agent_name=amazon-cloudwatch-agent
+ agent_stop amazon-cloudwatch-agent
+ agent_name=amazon-cloudwatch-agent
++ runstatus amazon-cloudwatch-agent
++ agent_name=amazon-cloudwatch-agent
++ running=false
++ '[' true = true ']'
++ set +e
++ systemctl is-active amazon-cloudwatch-agent.service
++ set -e
++ '[' false = true ']'
++ echo stopped
+ '[' stopped = stopped ']'
+ echo 'amazon-cloudwatch-agent has already been stopped'
amazon-cloudwatch-agent has already been stopped
+ return 0
+ agent_start amazon-cloudwatch-agent ec2
+ agent_name=amazon-cloudwatch-agent
+ mode=ec2
++ runstatus amazon-cloudwatch-agent
++ agent_name=amazon-cloudwatch-agent
++ running=false
++ '[' true = true ']'
++ set +e
++ systemctl is-active amazon-cloudwatch-agent.service
++ set -e
++ '[' false = true ']'
++ echo stopped
+ '[' stopped = running ']'
+ '[' amazon-cloudwatch-agent = amazon-cloudwatch-agent ']'
+ '[' '!' -f /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml ']'
+ '[' true = true ']'
+ systemctl daemon-reload
+ systemctl enable amazon-cloudwatch-agent.service
Created symlink /etc/systemd/system/multi-user.target.wants/amazon-cloudwatch-agent.service → /etc/systemd/system/amazon-cloudwatch-agent.service.
+ systemctl restart amazon-cloudwatch-agent.service
```

