### PR TITLE
implement eksdetector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -224,6 +224,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.11.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.2 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,7 @@ github.com/euank/go-kmsg-parser v2.0.0+incompatible h1:cHD53+PLQuuQyLZeriD1V/esu
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=

--- a/translator/translate/otel/common/eksdetector.go
+++ b/translator/translate/otel/common/eksdetector.go
@@ -63,7 +63,7 @@ func IsEKS() (bool, error) {
 	// Make HTTP GET request
 	awsAuth, err := eksDetector.getConfigMap(authConfigNamespace, authConfigConfigMap)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 
 	return awsAuth != nil, nil

--- a/translator/translate/otel/common/eksdetector.go
+++ b/translator/translate/otel/common/eksdetector.go
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type Detector interface {
+	getConfigMap(namespace string, name string) (map[string]string, error)
+}
+
+type EksDetector struct {
+	Clientset kubernetes.Interface
+}
+
+const (
+	authConfigNamespace = "kube-system"
+	authConfigConfigMap = "aws-auth"
+)
+
+var _ Detector = (*EksDetector)(nil)
+
+var (
+	detectorSingleton Detector
+	once              sync.Once
+)
+
+var (
+	getInClusterConfig  = func() (*rest.Config, error) { return rest.InClusterConfig() }
+	getKubernetesClient = func(confs *rest.Config) (kubernetes.Interface, error) { return kubernetes.NewForConfig(confs) }
+	// NewDetector creates a new singleton detector for EKS
+	NewDetector = func() (Detector, error) {
+		var errors error
+		once.Do(func() {
+			if clientset, err := getClient(); err != nil {
+				errors = err
+			} else {
+				detectorSingleton = &EksDetector{Clientset: clientset}
+			}
+		})
+
+		return detectorSingleton, errors
+	}
+)
+
+// IsEKS checks if the agent is running on EKS. This is done by using the kubernetes API to determine if the aws-auth
+// configmap exists in the kube-system namespace
+func IsEKS(eksDetector Detector) bool {
+
+	// Make HTTP GET request
+	awsAuth, err := eksDetector.getConfigMap(authConfigNamespace, authConfigConfigMap)
+	if err != nil {
+		return false
+	}
+
+	return awsAuth != nil
+}
+
+// getConfigMap retrieves the configmap with the provided name in the provided namespace
+func (d *EksDetector) getConfigMap(namespace string, name string) (map[string]string, error) {
+	configMap, err := d.Clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve ConfigMap %s/%s: %w", namespace, name, err)
+	}
+
+	return configMap.Data, nil
+}
+
+func getClient() (kubernetes.Interface, error) {
+	//Get cluster config
+	confs, err := getInClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config: %w", err)
+	}
+
+	// Create Clientset using generated configuration
+	clientset, err := getKubernetesClient(confs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Clientset for Kubernetes client")
+	}
+
+	return clientset, err
+}

--- a/translator/translate/otel/common/eksdetector.go
+++ b/translator/translate/otel/common/eksdetector.go
@@ -53,15 +53,20 @@ var (
 
 // IsEKS checks if the agent is running on EKS. This is done by using the kubernetes API to determine if the aws-auth
 // configmap exists in the kube-system namespace
-func IsEKS(eksDetector Detector) bool {
+func IsEKS() (bool, error) {
+	// Create eks detector
+	eksDetector, err := NewDetector()
+	if err != nil {
+		return false, err
+	}
 
 	// Make HTTP GET request
 	awsAuth, err := eksDetector.getConfigMap(authConfigNamespace, authConfigConfigMap)
 	if err != nil {
-		return false
+		return false, err
 	}
 
-	return awsAuth != nil
+	return awsAuth != nil, nil
 }
 
 // getConfigMap retrieves the configmap with the provided name in the provided namespace

--- a/translator/translate/otel/common/eksdetector_test.go
+++ b/translator/translate/otel/common/eksdetector_test.go
@@ -74,7 +74,6 @@ func TestNotEKS(t *testing.T) {
 	testDetector.On("getConfigMap", authConfigNamespace, authConfigConfigMap).Return(map[string]string{}, fmt.Errorf("error"))
 	isEks, err = IsEKS()
 	assert.False(t, isEks)
-	assert.Error(t, err)
 }
 
 func Test_getConfigMap(t *testing.T) {

--- a/translator/translate/otel/common/eksdetector_test.go
+++ b/translator/translate/otel/common/eksdetector_test.go
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+type MockDetector struct {
+	mock.Mock
+}
+
+func (detector *MockDetector) getConfigMap(namespace string, name string) (map[string]string, error) {
+	args := detector.Called(namespace, name)
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+func TestNewDetector(t *testing.T) {
+	getInClusterConfig = func() (*rest.Config, error) {
+		return &rest.Config{}, nil
+	}
+
+	testDetector1, err := NewDetector()
+	assert.NoError(t, err)
+	assert.NotNil(t, testDetector1)
+
+	// Test singleton
+	testDetector2, err := NewDetector()
+	assert.NoError(t, err)
+	assert.True(t, testDetector1 == testDetector2)
+}
+
+// Tests EKS resource detector running in EKS environment
+func TestEKS(t *testing.T) {
+	testDetector := new(MockDetector)
+
+	testDetector.On("getConfigMap", authConfigNamespace, authConfigConfigMap).Return(map[string]string{conventions.AttributeK8SClusterName: "my-cluster"}, nil)
+	isEks := IsEKS(testDetector)
+	assert.True(t, isEks)
+}
+
+// Tests EKS resource detector not running in EKS environment by verifying resource is not running on k8s
+func TestNotEKS(t *testing.T) {
+	testDetector := new(MockDetector)
+
+	testDetector.On("getConfigMap", authConfigNamespace, authConfigConfigMap).Return(map[string]string{}, fmt.Errorf("error"))
+	isEks := IsEKS(testDetector)
+	assert.False(t, isEks)
+}
+
+func Test_getConfigMap(t *testing.T) {
+	// No matching configmap
+	client := fake.NewSimpleClientset()
+	testDetector := &EksDetector{Clientset: client}
+	res, err := testDetector.getConfigMap("test", "test")
+	assert.Error(t, err)
+	assert.Nil(t, res)
+
+	// matching configmap
+	cm := &v1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: authConfigNamespace, Name: authConfigConfigMap},
+		Data:       make(map[string]string),
+	}
+
+	client = fake.NewSimpleClientset(cm)
+	testDetector = &EksDetector{Clientset: client}
+
+	res, err = testDetector.getConfigMap(authConfigNamespace, authConfigConfigMap)
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+}
+
+func Test_getClientError(t *testing.T) {
+	//InClusterConfig error
+	getInClusterConfig = func() (*rest.Config, error) {
+		return nil, fmt.Errorf("test error")
+	}
+
+	_, err := getClient()
+	assert.Error(t, err)
+
+	//Getting Kubernetes client error
+	getInClusterConfig = func() (*rest.Config, error) {
+		return &rest.Config{}, nil
+	}
+	getKubernetesClient = func(confs *rest.Config) (kubernetes.Interface, error) {
+		return nil, fmt.Errorf("test error")
+	}
+
+	_, err = getClient()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
# Description of the issue
Currently, the CWA is unable to distinguish between EKS and native Kubernetes. 

# Description of changes
This change implements an EKS detector which can determine if the agent is on an EKS cluster or native K8s. It does this by checking for the aws-auth configmap in the kube-system namespace, which is only present if it's an EKS cluster.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit  tests.
Not being used anywhere currently. Pending confirmation of k8s configurations

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




