### PR TITLE
[App Signals] Update dependency metric rollups list

### DIFF
--- a/translator/tocwconfig/sampleConfig/appsignals_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_kubernetes_config.yaml
@@ -95,6 +95,8 @@ exporters:
                   - RemoteService
                   - Service
                 - - RemoteService
+                  - RemoteTarget
+                - - RemoteService
               label_matchers:
                 - label_names:
                     - aws.span.kind

--- a/translator/tocwconfig/sampleConfig/appsignals_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_kubernetes_config.yaml
@@ -94,6 +94,11 @@ exporters:
                   - RemoteOperation
                   - RemoteService
                   - Service
+                - - HostedIn.EKS.Cluster
+                  - HostedIn.K8s.Namespace
+                  - RemoteService
+                  - RemoteTarget
+                  - Service
                 - - RemoteService
                   - RemoteTarget
                 - - RemoteService

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -55,6 +55,8 @@ exporters:
                   - RemoteService
                   - Service
                 - - RemoteService
+                  - RemoteTarget
+                - - RemoteService
               label_matchers:
                 - label_names:
                     - aws.span.kind

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -54,6 +54,10 @@ exporters:
                   - RemoteOperation
                   - RemoteService
                   - Service
+                - - HostedIn.Environment
+                  - RemoteService
+                  - RemoteTarget
+                  - Service
                 - - RemoteService
                   - RemoteTarget
                 - - RemoteService

--- a/translator/translate/otel/exporter/awsemf/appsignals_config_eks.yaml
+++ b/translator/translate/otel/exporter/awsemf/appsignals_config_eks.yaml
@@ -25,6 +25,7 @@ metric_declarations:
       - [HostedIn.EKS.Cluster, HostedIn.K8s.Namespace, Service, RemoteService, RemoteOperation, K8s.RemoteNamespace]
       - [HostedIn.EKS.Cluster, HostedIn.K8s.Namespace, Service, RemoteService, RemoteOperation, RemoteTarget]
       - [HostedIn.EKS.Cluster, HostedIn.K8s.Namespace, Service, RemoteService, RemoteOperation]
+      - [HostedIn.EKS.Cluster, HostedIn.K8s.Namespace, Service, RemoteService, RemoteTarget]
       - [RemoteService, RemoteTarget]
       - [RemoteService]
     label_matchers:

--- a/translator/translate/otel/exporter/awsemf/appsignals_config_eks.yaml
+++ b/translator/translate/otel/exporter/awsemf/appsignals_config_eks.yaml
@@ -25,6 +25,7 @@ metric_declarations:
       - [HostedIn.EKS.Cluster, HostedIn.K8s.Namespace, Service, RemoteService, RemoteOperation, K8s.RemoteNamespace]
       - [HostedIn.EKS.Cluster, HostedIn.K8s.Namespace, Service, RemoteService, RemoteOperation, RemoteTarget]
       - [HostedIn.EKS.Cluster, HostedIn.K8s.Namespace, Service, RemoteService, RemoteOperation]
+      - [RemoteService, RemoteTarget]
       - [RemoteService]
     label_matchers:
       - label_names:

--- a/translator/translate/otel/exporter/awsemf/appsignals_config_generic.yaml
+++ b/translator/translate/otel/exporter/awsemf/appsignals_config_generic.yaml
@@ -20,6 +20,7 @@ metric_declarations:
       - [HostedIn.Environment, Service, RemoteService]
       - [HostedIn.Environment, Service, RemoteService, RemoteOperation, RemoteTarget]
       - [HostedIn.Environment, Service, RemoteService, RemoteOperation]
+      - [HostedIn.Environment, Service, RemoteService, RemoteTarget]
       - [RemoteService, RemoteTarget]
       - [RemoteService]
     label_matchers:

--- a/translator/translate/otel/exporter/awsemf/appsignals_config_generic.yaml
+++ b/translator/translate/otel/exporter/awsemf/appsignals_config_generic.yaml
@@ -20,6 +20,7 @@ metric_declarations:
       - [HostedIn.Environment, Service, RemoteService]
       - [HostedIn.Environment, Service, RemoteService, RemoteOperation, RemoteTarget]
       - [HostedIn.Environment, Service, RemoteService, RemoteOperation]
+      - [RemoteService, RemoteTarget]
       - [RemoteService]
     label_matchers:
       - label_names:


### PR DESCRIPTION
# Description of the issue
We want to expand the list of dependency rollup metrics for App Signals with the following dimensions: `[RemoteService, RemoteTarget]` and `[HostedIn.<Attributes>, Service, RemoteService, RemoteTarget]`

# Description of changes
Added the following metric rollups to the 2 AppSignal Configuration files.
- `[RemoteService, RemoteTarget]`
- `[HostedIn.<Attributes>, Service, RemoteService, RemoteTarget]`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Followed GH Workflow Environment setup guide in: https://github.com/aws-observability/aws-otel-java-instrumentation/tree/main/testing#how-to-test-e2e-resource-changes
Setup E2E GH Workflow tests for EKS+EC2 in personal local fork from: https://github.com/aws/amazon-cloudwatch-agent/pull/1002
>EKS: Test was performed by generating a new CW agent image, pushing the image into the ECR, then retrieving the image from the ECR and running E2E Test.
>EC2: Test was performed by generating a new cw-agent.rpm file and uploaded to personal S3 bucket, then installing it on the sample app and running the E2E test

In AWS CW Console, the following rollup metrics appeared:
```
HostedIn.EKS.Cluster, HostedIn.K8s.Namespace, RemoteService, RemoteTarget, Service
HostedIn.Environment, RemoteService, RemoteTarget, Service
RemoteService, RemoteTarget
``` 

EKS Test (IAD) - https://github.com/jj22ee/amazon-cloudwatch-agent/actions/runs/7574564798
EC2 Test (IAD) - https://github.com/jj22ee/amazon-cloudwatch-agent/actions/runs/7576444391

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




