### PR TITLE
Add reduce lastvalid timestamp warn logs frequency

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -5,6 +5,8 @@ package logger
 
 import (
 	"io"
+        "os"
+	"time"
 
 	"github.com/influxdata/wlog"
 	"go.uber.org/zap"
@@ -94,6 +96,28 @@ func ConvertToLetterLevel(l zapcore.Level) string {
 	return string(l.CapitalString()[0])
 }
 
+func SampledLogger() *zap.Logger {
+	stdout := zapcore.AddSync(os.Stdout)
+
+	level := zap.NewAtomicLevelAt(zap.InfoLevel)
+	productionCfg := newProductionEncoderConfig()
+	productionCfg.TimeKey = "timestamp"
+	productionCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	jsonEncoder := zapcore.NewJSONEncoder(productionCfg)
+
+	jsonOutCore := zapcore.NewCore(jsonEncoder, stdout, level)
+
+	// Create a logger that samples every Nth message after the first M messages every S seconds
+	// where N = sc.Thereafter, M = sc.Initial, S = sc.Tick.
+	samplingCore := zapcore.NewSamplerWithOptions(
+		jsonOutCore,
+		time.Hour, // interval
+		5,           // log first 3 entries
+		500,           // thereafter log zero entires within the interval
+	)
+	return zap.New(samplingCore)
+}
 func init() {
 	loggerLevel = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 }
+

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,10 +4,6 @@
 package logger
 
 import (
-	"io"
-        "os"
-	"time"
-
 	"github.com/influxdata/wlog"
 	"go.uber.org/zap"
 	"go.uber.org/zap/buffer"
@@ -96,28 +92,6 @@ func ConvertToLetterLevel(l zapcore.Level) string {
 	return string(l.CapitalString()[0])
 }
 
-func SampledLogger() *zap.Logger {
-	stdout := zapcore.AddSync(os.Stdout)
-
-	level := zap.NewAtomicLevelAt(zap.InfoLevel)
-	productionCfg := newProductionEncoderConfig()
-	productionCfg.TimeKey = "timestamp"
-	productionCfg.EncodeTime = zapcore.ISO8601TimeEncoder
-	jsonEncoder := zapcore.NewJSONEncoder(productionCfg)
-
-	jsonOutCore := zapcore.NewCore(jsonEncoder, stdout, level)
-
-	// Create a logger that samples every Nth message after the first M messages every S seconds
-	// where N = sc.Thereafter, M = sc.Initial, S = sc.Tick.
-	samplingCore := zapcore.NewSamplerWithOptions(
-		jsonOutCore,
-		time.Hour, // interval
-		5,           // log first 3 entries
-		500,           // thereafter log zero entires within the interval
-	)
-	return zap.New(samplingCore)
-}
 func init() {
 	loggerLevel = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 }
-

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,6 +4,8 @@
 package logger
 
 import (
+	"io"
+
 	"github.com/influxdata/wlog"
 	"go.uber.org/zap"
 	"go.uber.org/zap/buffer"

--- a/plugins/outputs/cloudwatchlogs/pusher.go
+++ b/plugins/outputs/cloudwatchlogs/pusher.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	reqSizeLimit     = 1024 * 1024
-	reqEventsLimit   = 10000
-	warnOldTimeStamp = 1 * 24 * time.Hour
-	logWarnInterval  = 1 * 5 * time.Minute
+	reqSizeLimit                = 1024 * 1024
+	reqEventsLimit              = 10000
+	warnOldTimeStamp            = 1 * 24 * time.Hour
+	warnOldTimeStampLogInterval = 1 * 5 * time.Minute
 )
 
 var (
@@ -427,12 +427,10 @@ func (p *pusher) convertEvent(e logs.LogEvent) *cloudwatchlogs.InputLogEvent {
 			t = p.lastValidTime
 			if !p.lastUpdateTime.IsZero() {
 				// Check when timestamp has an interval of 1 days.
-				if time.Since(p.lastUpdateTime) > warnOldTimeStamp {
+				if (time.Since(p.lastUpdateTime) > warnOldTimeStamp) && (time.Since(p.lastWarnMessage) > warnOldTimeStampLogInterval) {
 					{
-						if time.Since(p.lastWarnMessage) > logWarnInterval {
-							p.Log.Warnf("Unable to parse timestamp, using last valid timestamp found in the logs %v: which is at least older than 1 day for log group %v: ", p.lastValidTime, p.Group)
-							p.lastWarnMessage = time.Now()
-						}
+						p.Log.Warnf("Unable to parse timestamp, using last valid timestamp found in the logs %v: which is at least older than 1 day for log group %v: ", p.lastValidTime, p.Group)
+						p.lastWarnMessage = time.Now()
 					}
 				}
 			}


### PR DESCRIPTION
# Description of the issue
CloudWatch Agent  introduced a warning log when timestamp falls back to an older valid timestamp https://github.com/aws/amazon-cloudwatch-agent/pull/870 
This log isn't throttled and can produce excessive warning logs when timestamp isn't parsing

# Description of changes
Set the warning log message to print per set interval time

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manually tested confirmed warning log prints per set interval (default 5 minutes)
<img width="1606" alt="Screenshot 2024-01-30 at 4 51 56 PM" src="https://github.com/aws/amazon-cloudwatch-agent/assets/45324375/3f9f939a-87da-4069-86e3-dc6e72f69e11">

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




