### PR TITLE
Add metrics cardinality control for Application Signals

### DIFF
--- a/plugins/processors/awsappsignals/common/types.go
+++ b/plugins/processors/awsappsignals/common/types.go
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package common
+
+const (
+	AttributeRemoteService       = "aws.remote.service"
+	AttributeHostedInEnvironment = "aws.hostedin.environment"
+)
+
+const (
+	MetricAttributeRemoteNamespace = "K8s.RemoteNamespace"
+	MetricAttributeLocalService    = "Service"
+	MetricAttributeLocalOperation  = "Operation"
+	MetricAttributeRemoteService   = "RemoteService"
+	MetricAttributeRemoteOperation = "RemoteOperation"
+	MetricAttributeRemoteTarget    = "RemoteTarget"
+)
+const (
+	HostedInAttributeClusterName  = "HostedIn.EKS.Cluster"
+	HostedInAttributeK8SNamespace = "HostedIn.K8s.Namespace"
+	HostedInAttributeEnvironment  = "HostedIn.Environment"
+)
+
+const (
+	AttributeTmpReserved = "aws.tmp.reserved"
+)

--- a/plugins/processors/awsappsignals/factory.go
+++ b/plugins/processors/awsappsignals/factory.go
@@ -58,7 +58,7 @@ func createTracesProcessor(
 		next,
 		ap.processTraces,
 		processorhelper.WithCapabilities(consumerCapabilities),
-		processorhelper.WithStart(ap.Start),
+		processorhelper.WithStart(ap.StartTraces),
 		processorhelper.WithShutdown(ap.Shutdown))
 }
 
@@ -80,7 +80,7 @@ func createMetricsProcessor(
 		nextMetricsConsumer,
 		ap.processMetrics,
 		processorhelper.WithCapabilities(consumerCapabilities),
-		processorhelper.WithStart(ap.Start),
+		processorhelper.WithStart(ap.StartMetrics),
 		processorhelper.WithShutdown(ap.Shutdown))
 }
 

--- a/plugins/processors/awsappsignals/internal/cardinalitycontrol/count_min_sketch.go
+++ b/plugins/processors/awsappsignals/internal/cardinalitycontrol/count_min_sketch.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package cardinalitycontrol
+
+import (
+	"hash/adler32"
+	"hash/crc32"
+	"hash/fnv"
+)
+
+type CountMinSketchHashFunc func(hashKey string) int64
+
+type CountMinSketchEntry interface {
+	HashKey() string
+	Frequency() int
+}
+
+type CountMinSketch struct {
+	depth     int
+	maxDepth  int
+	width     int
+	matrix    [][]int
+	hashFuncs []CountMinSketchHashFunc
+}
+
+func (cms *CountMinSketch) Insert(obj CountMinSketchEntry) {
+	for i := 0; i < cms.depth; i++ {
+		hashFunc := cms.hashFuncs[i]
+		hashValue := hashFunc(obj.HashKey())
+		pos := int(hashValue % int64(cms.width))
+
+		cms.matrix[i][pos] += obj.Frequency()
+	}
+}
+
+func NewCountMinSketch(depth, width int, hashFuncs ...CountMinSketchHashFunc) *CountMinSketch {
+	matrix := make([][]int, depth)
+	for i := range matrix {
+		matrix[i] = make([]int, width)
+	}
+	cms := &CountMinSketch{
+		depth:    0,
+		maxDepth: depth,
+		width:    width,
+		matrix:   matrix,
+	}
+	if hashFuncs != nil {
+		cms.RegisterHashFunc(hashFuncs...)
+	} else {
+		RegisterDefaultHashFuncs(cms)
+	}
+	return cms
+}
+
+func RegisterDefaultHashFuncs(cms *CountMinSketch) {
+	hashFunc1 := func(hashKey string) int64 {
+		h := fnv.New32a()
+		h.Write([]byte(hashKey))
+		return int64(h.Sum32())
+	}
+	hashFunc2 := func(hashKey string) int64 {
+		hash := crc32.ChecksumIEEE([]byte(hashKey))
+		return int64(hash)
+	}
+	hashFunc3 := func(hashKey string) int64 {
+		hash := adler32.Checksum([]byte(hashKey))
+		return int64(hash)
+	}
+	cms.RegisterHashFunc(hashFunc1, hashFunc2, hashFunc3)
+}
+
+func (cms *CountMinSketch) RegisterHashFunc(hashFuncs ...CountMinSketchHashFunc) {
+	if cms.hashFuncs == nil {
+		cms.hashFuncs = hashFuncs
+	} else {
+		cms.hashFuncs = append(cms.hashFuncs, hashFuncs...)
+	}
+	if cms.maxDepth < len(cms.hashFuncs) {
+		cms.depth = cms.maxDepth
+	} else {
+		cms.depth = len(cms.hashFuncs)
+	}
+}
+
+func (cms *CountMinSketch) Get(obj CountMinSketchEntry) int {
+	minCount := int(^uint(0) >> 1) // Initialize with the maximum possible integer value
+	for i := 0; i < cms.depth; i++ {
+		hashFunc := cms.hashFuncs[i]
+		hashValue := hashFunc(obj.HashKey())
+		pos := int(hashValue % int64(cms.width))
+
+		if cms.matrix[i][pos] < minCount {
+			minCount = cms.matrix[i][pos]
+		}
+	}
+	return minCount
+}

--- a/plugins/processors/awsappsignals/internal/cardinalitycontrol/count_min_sketch_test.go
+++ b/plugins/processors/awsappsignals/internal/cardinalitycontrol/count_min_sketch_test.go
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package cardinalitycontrol
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var metricNames = []string{"latency", "error", "fault"}
+
+func TestUpdateFrequency(t *testing.T) {
+	cms := NewCountMinSketch(3, 10)
+	for i := 0; i < 10; i++ {
+		md := MetricData{
+			hashKey:   "xxx",
+			name:      "latency",
+			service:   "app1",
+			frequency: 1,
+		}
+		cms.Insert(md)
+		val := cms.Get(md)
+		assert.Equal(t, 1+i, val)
+	}
+}
+
+var testCases = []int{50, 100, 200, 500, 1000, 2000}
+
+func TestWriteMultipleEntries(t *testing.T) {
+	cms := NewCountMinSketch(3, 5000)
+
+	maxCollisionRate := 0
+	for _, dataCount := range testCases {
+		metricDataArray := make([]*MetricData, dataCount)
+		for i := 0; i < dataCount; i++ {
+			labels := map[string]string{
+				"operation": "/api/customers/" + strconv.Itoa(rand.Int()),
+			}
+			for _, metricName := range metricNames {
+				freq := rand.Intn(5000)
+				md := MetricData{
+					hashKey:   sortAndConcatLabels(labels),
+					name:      metricName,
+					service:   "app",
+					frequency: freq,
+				}
+				cms.Insert(md)
+				if metricDataArray[i] == nil {
+					metricDataArray[i] = &md
+				} else {
+					metricDataArray[i].frequency = metricDataArray[i].frequency + freq
+				}
+
+			}
+		}
+
+		err := 0
+		for _, data := range metricDataArray {
+			val := cms.Get(data)
+			if data.frequency != val {
+				err += 1
+			}
+		}
+		collisionRate := err * 100 / len(metricDataArray)
+		if maxCollisionRate < collisionRate {
+			maxCollisionRate = collisionRate
+		}
+		t.Logf("When the item count is %d with even distribution, the collision rate is %d.\n", dataCount, collisionRate)
+	}
+
+	// revisit the count min sketch setting if the assertion fails.
+	assert.True(t, maxCollisionRate < 30)
+}
+
+func TestAdjustUnsupportedDepth(t *testing.T) {
+	cms := NewCountMinSketch(5, 10)
+	assert.Equal(t, 3, cms.depth)
+	for i := 0; i < 2; i++ {
+		cms.RegisterHashFunc(func(hashKey string) int64 {
+			return int64(0)
+		})
+	}
+	assert.Equal(t, 5, cms.depth)
+	for i := 0; i < 2; i++ {
+		cms.RegisterHashFunc(func(hashKey string) int64 {
+			return int64(0)
+		})
+	}
+	assert.Equal(t, 5, cms.depth)
+}

--- a/plugins/processors/awsappsignals/internal/cardinalitycontrol/metrics_limiter.go
+++ b/plugins/processors/awsappsignals/internal/cardinalitycontrol/metrics_limiter.go
@@ -1,0 +1,415 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package cardinalitycontrol
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/common"
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/config"
+)
+
+const (
+	UnprocessedMetricValue = "AggregatedHighCardinalityMetrics"
+)
+
+const (
+	defaultCMSDepth = 3
+	defaultCMSWidth = 5000
+)
+
+var awsDeclaredMetricAttributes = []string{
+	common.HostedInAttributeClusterName,
+	common.HostedInAttributeK8SNamespace,
+	common.HostedInAttributeEnvironment,
+	common.MetricAttributeLocalService,
+	common.MetricAttributeLocalOperation,
+	common.MetricAttributeRemoteService,
+	common.MetricAttributeRemoteOperation,
+	common.MetricAttributeRemoteTarget,
+	common.MetricAttributeRemoteNamespace,
+}
+
+type Limiter interface {
+	Admit(name string, attributes, resourceAttributes pcommon.Map) (bool, error)
+}
+
+type MetricsLimiter struct {
+	DropThreshold     int
+	LogDroppedMetrics bool
+	RotationInterval  time.Duration
+
+	logger   *zap.Logger
+	ctx      context.Context
+	mapLock  sync.RWMutex
+	services map[string]*service
+}
+
+func NewMetricsLimiter(config *config.LimiterConfig, logger *zap.Logger) Limiter {
+	logger.Info("creating metrics limiter with config", zap.Any("config", config))
+
+	ctx := config.ParentContext
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+
+	limiter := &MetricsLimiter{
+		DropThreshold:     config.Threshold,
+		LogDroppedMetrics: config.LogDroppedMetrics,
+		RotationInterval:  config.RotationInterval,
+
+		logger:   logger,
+		ctx:      ctx,
+		services: map[string]*service{},
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				limiter.removeStaleServices()
+				time.Sleep(config.GarbageCollectionInterval)
+			}
+		}
+	}()
+
+	logger.Info("metrics limiter created.")
+
+	return limiter
+}
+
+func (m *MetricsLimiter) Admit(metricName string, attributes, resourceAttributes pcommon.Map) (bool, error) {
+	labels, serviceName, found := m.filterAWSDeclaredAttributes(attributes, resourceAttributes)
+	if !found {
+		return true, nil
+	}
+	admitted := true
+
+	m.mapLock.RLock()
+	svc := m.services[serviceName]
+	m.mapLock.RUnlock()
+	if svc == nil {
+		m.mapLock.Lock()
+		svc = m.services[serviceName]
+		if svc == nil {
+			svc = newService(serviceName, m.DropThreshold, m.RotationInterval, m.ctx, m.logger)
+			m.services[serviceName] = svc
+		}
+		m.mapLock.Unlock()
+	}
+
+	metricData := newMetricData(serviceName, metricName, labels)
+
+	reserved, _ := attributes.Get(common.AttributeTmpReserved)
+	if reserved.Bool() {
+		attributes.Remove(common.AttributeTmpReserved)
+		return true, nil
+	}
+
+	if !svc.admitMetricData(metricData) {
+		svc.rollupMetricData(attributes)
+
+		svc.totalRollup++
+		admitted = false
+
+		if m.LogDroppedMetrics {
+			m.logger.Debug(fmt.Sprintf("[%s] drop metric data", svc.name), zap.Any("labels", labels))
+		}
+	}
+
+	svc.totalMetricSent++
+
+	svc.rwLock.RLock()
+	defer svc.rwLock.RUnlock()
+
+	svc.totalCount++
+	svc.InsertMetricDataToPrimary(metricData)
+	svc.InsertMetricDataToSecondary(metricData)
+	return admitted, nil
+}
+
+func (m *MetricsLimiter) filterAWSDeclaredAttributes(attributes, resourceAttributes pcommon.Map) (map[string]string, string, bool) {
+	svcNameAttr, exists := attributes.Get(common.MetricAttributeLocalService)
+	if !exists {
+		return nil, "", false
+	}
+	labels := map[string]string{}
+	svcName := svcNameAttr.AsString()
+	for _, attrKey := range awsDeclaredMetricAttributes {
+		if attr, ok := attributes.Get(attrKey); ok {
+			labels[attrKey] = attr.AsString()
+		}
+	}
+	return labels, svcName, true
+}
+
+func (m *MetricsLimiter) removeStaleServices() {
+	var svcToRemove []string
+	for name, svc := range m.services {
+		if svc.rotations > 3 {
+			if svc.countSnapshot[0] == svc.countSnapshot[1] && svc.countSnapshot[1] == svc.countSnapshot[2] {
+				svc.cancelFunc()
+				svcToRemove = append(svcToRemove, name)
+			}
+		}
+	}
+
+	m.mapLock.Lock()
+	defer m.mapLock.Unlock()
+
+	for _, name := range svcToRemove {
+		m.logger.Info("remove stale service " + name + ".")
+		delete(m.services, name)
+	}
+}
+
+type service struct {
+	logger     *zap.Logger
+	name       string
+	cancelFunc context.CancelFunc
+
+	rwLock        sync.RWMutex
+	primaryCMS    *CountMinSketch
+	primaryTopK   *topKMetrics
+	secondaryCMS  *CountMinSketch
+	secondaryTopK *topKMetrics
+
+	totalCount    int
+	rotations     int
+	countSnapshot []int
+
+	totalRollup     int
+	totalMetricSent int
+}
+
+func (s *service) InsertMetricDataToPrimary(md *MetricData) {
+	s.primaryCMS.Insert(md)
+	updatedFrequency := s.primaryCMS.Get(md)
+	updatedMd := copyMetricDataWithUpdatedFrequency(md, updatedFrequency)
+	s.primaryTopK.Push(md, updatedMd)
+}
+
+func (s *service) InsertMetricDataToSecondary(md *MetricData) {
+	if s.secondaryCMS != nil {
+		s.secondaryCMS.Insert(md)
+		updatedFrequency := s.secondaryCMS.Get(md)
+		updatedMd := copyMetricDataWithUpdatedFrequency(md, updatedFrequency)
+		s.secondaryTopK.Push(md, updatedMd)
+	}
+}
+
+// MetricData represents a key-value pair.
+type MetricData struct {
+	hashKey   string
+	name      string
+	service   string
+	frequency int
+}
+
+func (m MetricData) HashKey() string {
+	return m.hashKey
+}
+
+func (m MetricData) Frequency() int {
+	return m.frequency
+}
+
+func newMetricData(serviceName, metricName string, labels map[string]string) *MetricData {
+	hashID := sortAndConcatLabels(labels)
+	return &MetricData{
+		hashKey:   hashID,
+		name:      metricName,
+		service:   serviceName,
+		frequency: 1,
+	}
+}
+
+func copyMetricDataWithUpdatedFrequency(md *MetricData, frequency int) *MetricData {
+	return &MetricData{
+		hashKey:   md.hashKey,
+		name:      md.name,
+		service:   md.service,
+		frequency: frequency,
+	}
+}
+
+func sortAndConcatLabels(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var concatenatedLabels string
+	for _, key := range keys {
+		concatenatedLabels += labels[key]
+	}
+	keys = nil
+	return concatenatedLabels
+}
+
+// topKMetrics represents the priority queue with a map for key lookup and a size limit.
+type topKMetrics struct {
+	metricMap map[string]*MetricData
+	minMetric *MetricData
+	sizeLimit int
+}
+
+// newTopKMetrics creates a new topKMetrics with a specified size limit.
+func newTopKMetrics(sizeLimit int) *topKMetrics {
+	return &topKMetrics{
+		metricMap: make(map[string]*MetricData),
+		minMetric: nil,
+		sizeLimit: sizeLimit,
+	}
+}
+
+// Push adds a key-value pair to the priority queue. If the value already exists, it updates the frequency.
+func (t *topKMetrics) Push(oldMetric, newMetric *MetricData) {
+	hashValue := oldMetric.hashKey
+	if t.minMetric == nil {
+		t.minMetric = oldMetric
+	}
+
+	_, found := t.metricMap[hashValue]
+	if found {
+		// Update the frequency.
+		t.metricMap[hashValue].frequency = newMetric.frequency
+		// Check if this oldMetric is the new minimum, find the new minMetric after the updates
+		if t.minMetric.hashKey == hashValue {
+			// Find the new minMetrics after update the frequency
+			t.minMetric = t.findMinMetric()
+		}
+		return
+	}
+
+	// If exceeded size limit, delete the smallest
+	if len(t.metricMap) >= t.sizeLimit {
+		if newMetric.frequency > t.minMetric.frequency {
+			delete(t.metricMap, t.minMetric.hashKey)
+			t.metricMap[hashValue] = newMetric
+			t.minMetric = t.findMinMetric()
+		}
+	} else {
+		// Check if this newMetric is the new minimum.
+		if newMetric.frequency < t.minMetric.frequency {
+			t.minMetric = newMetric
+		}
+		t.metricMap[hashValue] = newMetric
+	}
+}
+
+// findMinMetric removes and returns the key-value pair with the minimum value.
+func (t *topKMetrics) findMinMetric() *MetricData {
+	// Find the new minimum metric and smallest frequency.
+	var newMinMetric *MetricData
+	smallestFrequency := int(^uint(0) >> 1) // Initialize with the maximum possible integer value
+
+	for _, metric := range t.metricMap {
+		if metric.frequency < smallestFrequency {
+			smallestFrequency = metric.frequency
+			newMinMetric = metric
+		}
+	}
+	return newMinMetric
+}
+
+func (s *service) admitMetricData(metric *MetricData) bool {
+	_, found := s.primaryTopK.metricMap[metric.hashKey]
+	if len(s.primaryTopK.metricMap) < s.primaryTopK.sizeLimit || found {
+		return true
+	}
+	return false
+}
+
+func (s *service) rollupMetricData(attributes pcommon.Map) {
+	for _, indexAttr := range awsDeclaredMetricAttributes {
+		if strings.HasPrefix(indexAttr, "HostedIn.") || (indexAttr == common.MetricAttributeLocalService) {
+			continue
+		}
+		if indexAttr == common.MetricAttributeLocalOperation || indexAttr == common.MetricAttributeRemoteService {
+			attributes.PutStr(indexAttr, UnprocessedMetricValue)
+		} else {
+			attributes.PutStr(indexAttr, "-")
+		}
+	}
+}
+
+// As a starting point, you can use rules of thumb, such as setting the depth to be around 4-6 times the logarithm of the expected number of distinct items and the width based on your memory constraints. However, these are rough guidelines, and the optimal size will depend on your unique application and requirements.
+func newService(name string, limit int, rotationInterval time.Duration, parentCtx context.Context, logger *zap.Logger) *service {
+	depth := defaultCMSDepth
+	width := defaultCMSWidth
+
+	ctx, cancel := context.WithCancel(parentCtx)
+	svc := &service{
+		logger:        logger,
+		name:          name,
+		cancelFunc:    cancel,
+		primaryCMS:    NewCountMinSketch(depth, width),
+		primaryTopK:   newTopKMetrics(limit),
+		countSnapshot: make([]int, 3),
+	}
+
+	// Create a ticker to create a new countMinSketch every 1 hour
+	rotationTicker := time.NewTicker(rotationInterval)
+	//defer rotationTicker.Stop()
+
+	// Create a goroutine to handle rotationTicker.C
+	go func() {
+		for {
+			select {
+			case <-rotationTicker.C:
+				svc.logger.Info(fmt.Sprintf("[%s] rotating visit records, current rotation %d", name, svc.rotations))
+				if err := rotateVisitRecords(svc); err != nil {
+					svc.logger.Error(fmt.Sprintf("[%s] failed to rotate visit records.", name), zap.Error(err))
+				}
+			case <-ctx.Done():
+				return
+			default:
+				// Continue running the main program
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}()
+
+	svc.logger.Info(fmt.Sprintf("[%s] service entry is created.\n", name))
+	return svc
+}
+
+func rotateVisitRecords(svc *service) error {
+	svc.rwLock.Lock()
+	defer svc.rwLock.Unlock()
+
+	cmsDepth := svc.primaryCMS.depth
+	cmsWidth := svc.primaryCMS.width
+	topKLimit := svc.primaryTopK.sizeLimit
+
+	nextPrimaryCMS := svc.secondaryCMS
+	nextPrimaryTopK := svc.secondaryTopK
+
+	svc.secondaryCMS = NewCountMinSketch(cmsDepth, cmsWidth)
+	svc.secondaryTopK = newTopKMetrics(topKLimit)
+
+	if nextPrimaryCMS != nil && nextPrimaryTopK != nil {
+		svc.primaryCMS = nextPrimaryCMS
+		svc.primaryTopK = nextPrimaryTopK
+	} else {
+		svc.logger.Info(fmt.Sprintf("[%s] secondary visit records are nil.", svc.name))
+	}
+
+	svc.countSnapshot[svc.rotations%3] = svc.totalCount
+	svc.rotations++
+
+	return nil
+}

--- a/plugins/processors/awsappsignals/internal/cardinalitycontrol/metrics_limiter_test.go
+++ b/plugins/processors/awsappsignals/internal/cardinalitycontrol/metrics_limiter_test.go
@@ -1,0 +1,269 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package cardinalitycontrol
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/common"
+	awsappsignalsconfig "github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/config"
+)
+
+var emptyResourceAttributes = pcommon.NewMap()
+var logger, _ = zap.NewDevelopment()
+
+func TestAdmitAndRollup(t *testing.T) {
+	config := &awsappsignalsconfig.LimiterConfig{
+		Threshold:         2,
+		Disabled:          false,
+		LogDroppedMetrics: false,
+		RotationInterval:  awsappsignalsconfig.DefaultRotationInterval,
+	}
+	config.Validate()
+
+	limiter := NewMetricsLimiter(config, logger)
+
+	admittedAttributes := map[string]pcommon.Map{}
+	for i := 0; i < 10; i++ {
+		attr := newLowCardinalityAttributes(100)
+		if ok, _ := limiter.Admit("latency", attr, emptyResourceAttributes); ok {
+			uniqKey, _ := attr.Get("RemoteOperation")
+			admittedAttributes[uniqKey.AsString()] = attr
+		} else {
+			for _, indexedAttrKey := range awsDeclaredMetricAttributes {
+				if strings.HasPrefix(indexedAttrKey, "HostedIn.") || indexedAttrKey == "Service" {
+					continue
+				}
+				attrValue, _ := attr.Get(indexedAttrKey)
+				if indexedAttrKey == common.MetricAttributeLocalOperation || indexedAttrKey == common.MetricAttributeRemoteService {
+					assert.Equal(t, UnprocessedMetricValue, attrValue.AsString())
+				} else {
+					assert.Equal(t, "-", attrValue.AsString())
+				}
+			}
+		}
+	}
+	assert.Equal(t, 2, len(admittedAttributes), fmt.Sprintf("admitted attributes are %v", admittedAttributes))
+}
+
+func TestAdmitByTopK(t *testing.T) {
+	config := awsappsignalsconfig.LimiterConfig{
+		Threshold:         100,
+		Disabled:          false,
+		LogDroppedMetrics: false,
+		RotationInterval:  awsappsignalsconfig.DefaultRotationInterval,
+	}
+	config.Validate()
+
+	limiter := NewMetricsLimiter(&config, logger)
+
+	// fulfill topk with high cardinality attributes
+	for i := 0; i < 110; i++ {
+		attr := newHighCardinalityAttributes()
+		limiter.Admit("latency", attr, emptyResourceAttributes)
+	}
+
+	// sending low cardinality attributes
+	for i := 0; i < 100; i++ {
+		attr := newFixedAttributes(i % 20)
+		limiter.Admit("latency", attr, emptyResourceAttributes)
+	}
+
+	for i := 0; i < 20; i++ {
+		attr := newFixedAttributes(i)
+		ok, _ := limiter.Admit("latency", attr, emptyResourceAttributes)
+		assert.True(t, ok)
+	}
+}
+
+func TestAdmitLowCardinalityAttributes(t *testing.T) {
+	config := awsappsignalsconfig.LimiterConfig{
+		Threshold:         10,
+		Disabled:          false,
+		LogDroppedMetrics: false,
+		RotationInterval:  awsappsignalsconfig.DefaultRotationInterval,
+	}
+	config.Validate()
+
+	limiter := NewMetricsLimiter(&config, logger)
+
+	rejectCount := 0
+	for i := 0; i < 100; i++ {
+		if ok, _ := limiter.Admit("latency", newLowCardinalityAttributes(10), emptyResourceAttributes); !ok {
+			rejectCount += 1
+		}
+	}
+	assert.Equal(t, 0, rejectCount)
+}
+
+func TestAdmitReservedMetrics(t *testing.T) {
+	config := awsappsignalsconfig.LimiterConfig{
+		Threshold:         10,
+		Disabled:          false,
+		LogDroppedMetrics: false,
+		RotationInterval:  awsappsignalsconfig.DefaultRotationInterval,
+	}
+	config.Validate()
+
+	limiter := NewMetricsLimiter(&config, logger)
+
+	// fulfill topk with high cardinality attributes
+	for i := 0; i < 20; i++ {
+		attr := newHighCardinalityAttributes()
+		limiter.Admit("latency", attr, emptyResourceAttributes)
+	}
+
+	for i := 0; i < 20; i++ {
+		attr := newHighCardinalityAttributes()
+		// simulate attributes touched by customization rules
+		attr.PutBool(common.AttributeTmpReserved, true)
+
+		ok, _ := limiter.Admit("latency", attr, emptyResourceAttributes)
+		assert.True(t, ok)
+		_, exists := attr.Get(common.AttributeTmpReserved)
+		assert.False(t, exists)
+	}
+}
+
+func TestClearStaleService(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	config := awsappsignalsconfig.LimiterConfig{
+		Threshold:         10,
+		Disabled:          false,
+		LogDroppedMetrics: false,
+
+		ParentContext:             ctx,
+		RotationInterval:          time.Second,
+		GarbageCollectionInterval: time.Second,
+	}
+	limiter := NewMetricsLimiter(&config, logger)
+
+	for i := 0; i < 10; i++ {
+		appName := "app" + strconv.Itoa(i)
+		attr := pcommon.NewMap()
+		attr.PutStr("Service", appName)
+		limiter.Admit(appName, attr, emptyResourceAttributes)
+	}
+
+	time.Sleep(10 * time.Second)
+	cancel()
+
+	metricsLimiter := limiter.(*MetricsLimiter)
+	assert.Equal(t, 0, len(metricsLimiter.services))
+}
+
+func TestInheritanceAfterRotation(t *testing.T) {
+	config := awsappsignalsconfig.LimiterConfig{
+		Threshold:         10,
+		Disabled:          false,
+		LogDroppedMetrics: true,
+		RotationInterval:  5 * time.Second,
+	}
+	config.Validate()
+
+	limiter := NewMetricsLimiter(&config, logger)
+
+	// fulfill primary with 0-10
+	for i := 0; i < 10; i++ {
+		attr := newFixedAttributes(i)
+		ok, _ := limiter.Admit("latency", attr, emptyResourceAttributes)
+		assert.True(t, ok)
+	}
+
+	// wait for rotation
+	time.Sleep(6 * time.Second)
+	// validate 0-10 are admitted
+	for i := 0; i < 10; i++ {
+		attr := newFixedAttributes(i)
+		ok, _ := limiter.Admit("latency", attr, emptyResourceAttributes)
+		assert.True(t, ok)
+	}
+
+	// validate 10-20 are rejected
+	// promote 10-20 to top k
+	for j := 0; j < 2; j++ {
+		for i := 10; i < 20; i++ {
+			attr := newFixedAttributes(i)
+			ok, _ := limiter.Admit("latency", attr, emptyResourceAttributes)
+			assert.False(t, ok)
+		}
+	}
+
+	// wait for rotation
+	time.Sleep(6 * time.Second)
+
+	// validate 1--20 are admitted
+	for i := 10; i < 20; i++ {
+		attr := newFixedAttributes(i)
+		ok, _ := limiter.Admit("latency", attr, emptyResourceAttributes)
+		assert.True(t, ok)
+	}
+}
+
+func TestRotationInterval(t *testing.T) {
+	svc := newService("test", 1, 5*time.Second, context.Background(), logger)
+	// wait for secondary to be created
+	time.Sleep(7 * time.Second)
+	for i := 0; i < 5; i++ {
+		svc.secondaryCMS.matrix[0][0] = 1
+
+		// wait for rotation
+		time.Sleep(5 * time.Second)
+
+		// verify secondary is promoted to primary
+		assert.Equal(t, 0, svc.secondaryCMS.matrix[0][0])
+		assert.Equal(t, 1, svc.primaryCMS.matrix[0][0])
+	}
+}
+
+func newRandomIP() string {
+	rand.NewSource(time.Now().UnixNano())
+
+	ipPart1 := rand.Intn(256)
+	ipPart2 := rand.Intn(256)
+	ipPart3 := rand.Intn(256)
+	ipPart4 := rand.Intn(256)
+
+	return fmt.Sprintf("%d.%d.%d.%d", ipPart1, ipPart2, ipPart3, ipPart4)
+}
+
+func newFixedAttributes(val int) pcommon.Map {
+	methodName := "/test" + strconv.Itoa(val)
+	attr := pcommon.NewMap()
+	attr.PutStr("Service", "app")
+	attr.PutStr("Operation", "/api/gateway"+methodName)
+	attr.PutStr("RemoteService", "upstream1")
+	attr.PutStr("RemoteOperation", methodName)
+	return attr
+}
+
+func newLowCardinalityAttributes(admitRange int) pcommon.Map {
+	methodName := "/test" + strconv.Itoa(rand.Intn(admitRange))
+	attr := pcommon.NewMap()
+	attr.PutStr("Service", "app")
+	attr.PutStr("Operation", "/api/gateway"+methodName)
+	attr.PutStr("RemoteService", "upstream1")
+	attr.PutStr("RemoteOperation", methodName)
+	return attr
+}
+
+func newHighCardinalityAttributes() pcommon.Map {
+	attr := pcommon.NewMap()
+	attr.PutStr("Service", "app")
+	attr.PutStr("Operation", "/api/gateway/test")
+	attr.PutStr("RemoteService", newRandomIP())
+	attr.PutStr("RemoteOperation", "/test/"+strconv.Itoa(rand.Int()))
+	return attr
+}

--- a/plugins/processors/awsappsignals/processor.go
+++ b/plugins/processors/awsappsignals/processor.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 
 	appsignalsconfig "github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/config"
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/internal/cardinalitycontrol"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/internal/normalizer"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/internal/resolver"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/rules"
@@ -21,6 +22,7 @@ import (
 const (
 	failedToProcessAttribute               = "failed to process attributes"
 	failedToProcessAttributeWithCustomRule = "failed to process attributes with custom rule, will drop the metric"
+	failedToProcessAttributeWithLimiter    = "failed to process attributes with limiter, keep the data"
 )
 
 // this is used to Process some attributes (like IP addresses) to a generic form to reduce high cardinality
@@ -43,24 +45,46 @@ type awsappsignalsprocessor struct {
 	allowlistMutators []allowListMutator
 	metricMutators    []attributesMutator
 	traceMutators     []attributesMutator
+	limiter           cardinalitycontrol.Limiter
 	stoppers          []stopper
 }
 
-func (ap *awsappsignalsprocessor) Start(_ context.Context, _ component.Host) error {
+func (ap *awsappsignalsprocessor) StartMetrics(ctx context.Context, _ component.Host) error {
 	attributesResolver := resolver.NewAttributesResolver(ap.config.Resolvers, ap.logger)
 	ap.stoppers = []stopper{attributesResolver}
-	ap.metricMutators = []attributesMutator{attributesResolver}
-
 	attributesNormalizer := normalizer.NewAttributesNormalizer(ap.logger)
 	ap.metricMutators = []attributesMutator{attributesResolver, attributesNormalizer}
 
-	ap.replaceActions = rules.NewReplacer(ap.config.Rules)
-	ap.traceMutators = []attributesMutator{attributesResolver, attributesNormalizer, ap.replaceActions}
+	limiterConfig := ap.config.Limiter
+	if limiterConfig == nil {
+		limiterConfig = appsignalsconfig.NewDefaultLimiterConfig()
+	}
+	if limiterConfig.ParentContext == nil {
+		limiterConfig.ParentContext = ctx
+	}
 
-	keeper := rules.NewKeeper(ap.config.Rules)
+	if !limiterConfig.Disabled {
+		ap.limiter = cardinalitycontrol.NewMetricsLimiter(limiterConfig, ap.logger)
+	} else {
+		ap.logger.Info("metrics limiter is disabled.")
+	}
+
+	ap.replaceActions = rules.NewReplacer(ap.config.Rules, !limiterConfig.Disabled)
+
+	keeper := rules.NewKeeper(ap.config.Rules, !limiterConfig.Disabled)
 	dropper := rules.NewDropper(ap.config.Rules)
 	ap.allowlistMutators = []allowListMutator{keeper, dropper}
 
+	return nil
+}
+
+func (ap *awsappsignalsprocessor) StartTraces(_ context.Context, _ component.Host) error {
+	attributesResolver := resolver.NewAttributesResolver(ap.config.Resolvers, ap.logger)
+	attributesNormalizer := normalizer.NewAttributesNormalizer(ap.logger)
+	customReplacer := rules.NewReplacer(ap.config.Rules, false)
+
+	ap.stoppers = append(ap.stoppers, attributesResolver)
+	ap.traceMutators = append(ap.traceMutators, attributesResolver, attributesNormalizer, customReplacer)
 	return nil
 }
 
@@ -74,7 +98,7 @@ func (ap *awsappsignalsprocessor) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func (ap *awsappsignalsprocessor) processTraces(ctx context.Context, td ptrace.Traces) (ptrace.Traces, error) {
+func (ap *awsappsignalsprocessor) processTraces(_ context.Context, td ptrace.Traces) (ptrace.Traces, error) {
 	rss := td.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
 		rs := rss.At(i)
@@ -117,7 +141,7 @@ func (ap *awsappsignalsprocessor) processMetrics(ctx context.Context, md pmetric
 
 // Attributes are provided for each log and trace, but not at the metric level
 // Need to process attributes for every data point within a metric.
-func (ap *awsappsignalsprocessor) processMetricAttributes(ctx context.Context, m pmetric.Metric, resourceAttribes pcommon.Map) {
+func (ap *awsappsignalsprocessor) processMetricAttributes(_ context.Context, m pmetric.Metric, resourceAttribes pcommon.Map) {
 
 	// This is a lot of repeated code, but since there is no single parent superclass
 	// between metric data types, we can't use polymorphism.
@@ -150,6 +174,13 @@ func (ap *awsappsignalsprocessor) processMetricAttributes(ctx context.Context, m
 				ap.logger.Debug(failedToProcessAttribute, zap.Error(err))
 			}
 		}
+		if ap.limiter != nil {
+			for i := 0; i < dps.Len(); i++ {
+				if _, err := ap.limiter.Admit(m.Name(), dps.At(i).Attributes(), resourceAttribes); err != nil {
+					ap.logger.Debug(failedToProcessAttributeWithLimiter, zap.Error(err))
+				}
+			}
+		}
 	case pmetric.MetricTypeSum:
 		dps := m.Sum().DataPoints()
 		for i := 0; i < dps.Len(); i++ {
@@ -176,6 +207,13 @@ func (ap *awsappsignalsprocessor) processMetricAttributes(ctx context.Context, m
 			err := ap.replaceActions.Process(dps.At(i).Attributes(), resourceAttribes, false)
 			if err != nil {
 				ap.logger.Debug(failedToProcessAttribute, zap.Error(err))
+			}
+		}
+		if ap.limiter != nil {
+			for i := 0; i < dps.Len(); i++ {
+				if _, err := ap.limiter.Admit(m.Name(), dps.At(i).Attributes(), resourceAttribes); err != nil {
+					ap.logger.Debug(failedToProcessAttributeWithLimiter, zap.Error(err))
+				}
 			}
 		}
 	case pmetric.MetricTypeHistogram:
@@ -206,6 +244,13 @@ func (ap *awsappsignalsprocessor) processMetricAttributes(ctx context.Context, m
 				ap.logger.Debug(failedToProcessAttribute, zap.Error(err))
 			}
 		}
+		if ap.limiter != nil {
+			for i := 0; i < dps.Len(); i++ {
+				if _, err := ap.limiter.Admit(m.Name(), dps.At(i).Attributes(), resourceAttribes); err != nil {
+					ap.logger.Debug(failedToProcessAttributeWithLimiter, zap.Error(err))
+				}
+			}
+		}
 	case pmetric.MetricTypeExponentialHistogram:
 		dps := m.ExponentialHistogram().DataPoints()
 		for i := 0; i < dps.Len(); i++ {
@@ -234,6 +279,13 @@ func (ap *awsappsignalsprocessor) processMetricAttributes(ctx context.Context, m
 				ap.logger.Debug(failedToProcessAttribute, zap.Error(err))
 			}
 		}
+		if ap.limiter != nil {
+			for i := 0; i < dps.Len(); i++ {
+				if _, err := ap.limiter.Admit(m.Name(), dps.At(i).Attributes(), resourceAttribes); err != nil {
+					ap.logger.Debug(failedToProcessAttributeWithLimiter, zap.Error(err))
+				}
+			}
+		}
 	case pmetric.MetricTypeSummary:
 		dps := m.Summary().DataPoints()
 		for i := 0; i < dps.Len(); i++ {
@@ -260,6 +312,13 @@ func (ap *awsappsignalsprocessor) processMetricAttributes(ctx context.Context, m
 			err := ap.replaceActions.Process(dps.At(i).Attributes(), resourceAttribes, false)
 			if err != nil {
 				ap.logger.Debug(failedToProcessAttribute, zap.Error(err))
+			}
+		}
+		if ap.limiter != nil {
+			for i := 0; i < dps.Len(); i++ {
+				if _, err := ap.limiter.Admit(m.Name(), dps.At(i).Attributes(), resourceAttribes); err != nil {
+					ap.logger.Debug(failedToProcessAttributeWithLimiter, zap.Error(err))
+				}
 			}
 		}
 	default:

--- a/plugins/processors/awsappsignals/processor_test.go
+++ b/plugins/processors/awsappsignals/processor_test.go
@@ -67,7 +67,7 @@ func TestProcessMetrics(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ap.Start(ctx, nil)
+	ap.StartMetrics(ctx, nil)
 
 	keepMetrics := generateMetrics(map[string]string{
 		"dim_action": "reserved",
@@ -111,7 +111,7 @@ func TestProcessTraces(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ap.Start(ctx, nil)
+	ap.StartTraces(ctx, nil)
 
 	traces := ptrace.NewTraces()
 	span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()

--- a/plugins/processors/awsappsignals/rules/keeper.go
+++ b/plugins/processors/awsappsignals/rules/keeper.go
@@ -3,15 +3,21 @@
 
 package rules
 
-import "go.opentelemetry.io/collector/pdata/pcommon"
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/common"
+)
 
 type KeepActions struct {
-	Actions []ActionItem
+	Actions                 []ActionItem
+	markDataPointAsReserved bool
 }
 
-func NewKeeper(rules []Rule) *KeepActions {
+func NewKeeper(rules []Rule, markDataPointAsReserved bool) *KeepActions {
 	return &KeepActions{
-		Actions: generateActionDetails(rules, AllowListActionKeep),
+		Actions:                 generateActionDetails(rules, AllowListActionKeep),
+		markDataPointAsReserved: markDataPointAsReserved,
 	}
 }
 
@@ -22,6 +28,9 @@ func (k *KeepActions) ShouldBeDropped(attributes pcommon.Map) (bool, error) {
 	}
 	for _, element := range k.Actions {
 		isMatched := matchesSelectors(attributes, element.SelectorMatchers, false)
+		if k.markDataPointAsReserved {
+			attributes.PutBool(common.AttributeTmpReserved, true)
+		}
 		if isMatched {
 			// keep the datapoint as one of the keep rules is matched
 			return false, nil

--- a/plugins/processors/awsappsignals/rules/keeper_test.go
+++ b/plugins/processors/awsappsignals/rules/keeper_test.go
@@ -69,7 +69,7 @@ func TestKeeperProcessor(t *testing.T) {
 		},
 	}
 
-	testKeeper := NewKeeper(config)
+	testKeeper := NewKeeper(config, false)
 	assert.Equal(t, 1, len(testKeeper.Actions))
 
 	isTrace := false
@@ -102,7 +102,7 @@ func TestKeeperProcessor(t *testing.T) {
 }
 
 func TestKeeperProcessorWithNilConfig(t *testing.T) {
-	testKeeper := NewKeeper(nil)
+	testKeeper := NewKeeper(nil, false)
 	isTrace := false
 
 	testCases := []TestCaseForKeeper{
@@ -141,7 +141,7 @@ func TestKeeperProcessorWithEmptyConfig(t *testing.T) {
 
 	config := []Rule{}
 
-	testKeeper := NewKeeper(config)
+	testKeeper := NewKeeper(config, false)
 	isTrace := false
 
 	testCases := []TestCaseForKeeper{

--- a/plugins/processors/awsappsignals/rules/replacer.go
+++ b/plugins/processors/awsappsignals/rules/replacer.go
@@ -5,15 +5,19 @@ package rules
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/common"
 )
 
 type ReplaceActions struct {
-	Actions []ActionItem
+	Actions                 []ActionItem
+	markDataPointAsReserved bool
 }
 
-func NewReplacer(rules []Rule) *ReplaceActions {
+func NewReplacer(rules []Rule, markDataPointAsReserved bool) *ReplaceActions {
 	return &ReplaceActions{
-		generateActionDetails(rules, AllowListActionReplace),
+		Actions:                 generateActionDetails(rules, AllowListActionReplace),
+		markDataPointAsReserved: markDataPointAsReserved,
 	}
 }
 
@@ -49,6 +53,10 @@ func (r *ReplaceActions) Process(attributes, _ pcommon.Map, isTrace bool) error 
 
 	for key, value := range finalRules {
 		attributes.PutStr(key, value)
+	}
+
+	if len(finalRules) > 0 && r.markDataPointAsReserved {
+		attributes.PutBool(common.AttributeTmpReserved, true)
 	}
 	return nil
 }

--- a/plugins/processors/awsappsignals/rules/replacer_test.go
+++ b/plugins/processors/awsappsignals/rules/replacer_test.go
@@ -71,7 +71,7 @@ func TestReplacerProcess(t *testing.T) {
 		},
 	}
 
-	testReplacer := NewReplacer(config)
+	testReplacer := NewReplacer(config, false)
 	assert.Equal(t, 1, len(testReplacer.Actions))
 
 	testCases := []TestCaseForReplacer{
@@ -170,7 +170,7 @@ func TestReplacerProcessWithPriority(t *testing.T) {
 		},
 	}
 
-	testReplacer := NewReplacer(config)
+	testReplacer := NewReplacer(config, false)
 	testMapPlaceHolder := pcommon.NewMap()
 
 	testCases := []TestCaseForReplacer{
@@ -218,7 +218,7 @@ func TestReplacerProcessWithPriority(t *testing.T) {
 
 func TestReplacerProcessWithNilConfig(t *testing.T) {
 
-	testReplacer := NewReplacer(nil)
+	testReplacer := NewReplacer(nil, false)
 	testMapPlaceHolder := pcommon.NewMap()
 
 	testCases := []TestCaseForReplacer{
@@ -252,7 +252,7 @@ func TestReplacerProcessWithEmptyConfig(t *testing.T) {
 
 	config := []Rule{}
 
-	testReplacer := NewReplacer(config)
+	testReplacer := NewReplacer(config, false)
 	testMapPlaceHolder := pcommon.NewMap()
 
 	testCases := []TestCaseForReplacer{

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.json
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.json
@@ -5,7 +5,11 @@
   "logs": {
     "metrics_collected": {
       "app_signals": {
-        "hosted_in": "TestCluster"
+        "hosted_in": "TestCluster",
+        "limiter": {
+          "log_dropped_metrics": true,
+          "rotation_interval": "10m"
+        }
       },
       "kubernetes": {
         "cluster_name": "TestCluster",

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -304,6 +304,11 @@ processors:
           - platform: eks
             name: TestCluster
         rules: []
+        limiter:
+          disabled: true
+          drop_threshold: 500
+          log_dropped_metrics: true
+          rotation_interval: 10m0s
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         metadata_keys: []

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.json
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.json
@@ -5,7 +5,11 @@
   "logs": {
     "metrics_collected": {
       "app_signals": {
-        "hosted_in": "TestCluster"
+        "hosted_in": "TestCluster",
+        "limiter": {
+          "log_dropped_metrics": true,
+          "rotation_interval": "10m"
+        }
       },
       "kubernetes": {
         "cluster_name": "TestCluster",

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -304,6 +304,11 @@ processors:
           - platform: k8s
             name: TestCluster
         rules: []
+        limiter:
+          disabled: true
+          drop_threshold: 500
+          log_dropped_metrics: true
+          rotation_interval: 10m0s
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         metadata_keys: []

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -143,6 +143,7 @@ processors:
             - name: ""
               platform: generic
         rules: []
+        limiter: null
     resourcedetection:
         aks:
             resource_attributes:

--- a/translator/translate/otel/processor/awsappsignals/testdata/invalidRulesConfig.json
+++ b/translator/translate/otel/processor/awsappsignals/testdata/invalidRulesConfig.json
@@ -3,6 +3,11 @@
     "metrics_collected": {
       "app_signals": {
         "hosted_in": "test",
+        "limiter": {
+          "drop_threshold": 20,
+          "log_dropped_metrics": true,
+          "rotation_interval": "10m"
+        },
         "rules": [
           {
             "selectors": [

--- a/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfig.json
+++ b/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfig.json
@@ -3,6 +3,11 @@
     "metrics_collected": {
       "app_signals": {
         "hosted_in": "test",
+        "limiter": {
+          "drop_threshold": 20,
+          "log_dropped_metrics": true,
+          "rotation_interval": "10m"
+        },
         "rules": [
           {
             "selectors": [

--- a/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfigEKS.yaml
+++ b/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfigEKS.yaml
@@ -1,6 +1,11 @@
 resolvers:
   - platform: eks
     name: test
+limiter:
+  disabled: true
+  drop_threshold: 20
+  log_dropped_metrics: true
+  rotation_interval: 10m
 rules:
   - selectors:
     - dimension: Operation

--- a/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfigGeneric.yaml
+++ b/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfigGeneric.yaml
@@ -1,6 +1,11 @@
 resolvers:
   - platform: generic
     name: test
+limiter:
+  disabled: true
+  drop_threshold: 20
+  log_dropped_metrics: true
+  rotation_interval: 10m
 rules:
   - selectors:
       - dimension: Operation


### PR DESCRIPTION

This PR is an updated version from https://github.com/aws/amazon-cloudwatch-agent/pull/1000, Since @bjrara is not available atm so I create this new PR with a few changes below. 
1. Removed Metrics labels referenece in `MetricData` structure
2. Disabled Metric Limiter by default until AppSignals console team completed the related changes for supporting E2E CX.
# Description of the issue
Due to the nature of metrics generated from auto-instrumentation, high cardinality metrics may occur if attributes which are intended to have low cardinality, are assigned values with high cardinality.

# Description of changes
A new component `metric_limiter` is introduced into `awsappsignalsprocessor` to enhance cardinality control. Customers can set `drop_threshold` to indicate the anticipated number of low cardinality metrics for each `service`. The local metrics limiter will prioritize exporting the most crucial metrics (e.g. most frequently used, manually retained) up to that threshold. Metrics identified as high cardinality will be rolled up, and only the number of observations will be reported.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. Unit tests.
3. E2E tests.
4. Performance tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
5. Run `make lint`




