### PR TITLE
Service Discovery Works With Only A Single Cluster Name And The Key W…

### DIFF
--- a/internal/ecsservicediscovery/README.md
+++ b/internal/ecsservicediscovery/README.md
@@ -72,7 +72,7 @@ Sample Configuration in TOML format:
       sd_cluster_region = "us-east-2"
       sd_frequency = "15s"
       sd_result_file = "/opt/aws/amazon-cloudwatch-agent/etc/ecs_sd_targets.yaml"
-      sd_target_clusters = "EC2-Justin-Testing; Fargate-Justin-Testing"
+      sd_target_cluster = "EC2-Justin-Testing"
       [inputs.prometheus.ecs_service_discovery.docker_label]
         sd_job_name_label = "ECS_PROMETHEUS_JOB_NAME"
         sd_metrics_path_label = "ECS_PROMETHEUS_METRICS_PATH"


### PR DESCRIPTION
…ord Is sd_target_cluster Not sd_target_clusters

# Description of the issue
Service discovery readme is wrong. The toml should be sd_target_cluster not sd_target_clusters

# Description of changes
Fix the readme me toml with correct key

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




