### PR TITLE
add application log group info for AppSignals

### DIFF
--- a/plugins/processors/awsappsignals/internal/resolver/kubernetes.go
+++ b/plugins/processors/awsappsignals/internal/resolver/kubernetes.go
@@ -685,6 +685,12 @@ func (h *kubernetesHostedInAttributeResolver) Process(attributes, resourceAttrib
 		attributes.PutStr(attr.HostedInClusterNameK8s, h.clusterName)
 	}
 
+	//The application log group in Container Insights is a fixed pattern:
+	// "/aws/containerinsights/{Cluster_Name}/application"
+	// See https://github.com/aws/amazon-cloudwatch-agent-operator/blob/fe144bb02d7b1930715aa3ea32e57a5ff13406aa/helm/templates/fluent-bit-configmap.yaml#L82
+	logGroupName := "/aws/containerinsights/" + h.clusterName + "/application"
+	resourceAttributes.PutStr(semconv.AttributeAWSLogGroupNames, logGroupName)
+
 	return nil
 }
 

--- a/plugins/processors/awsappsignals/internal/resolver/kubernetes_test.go
+++ b/plugins/processors/awsappsignals/internal/resolver/kubernetes_test.go
@@ -13,6 +13,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	semconv "go.opentelemetry.io/collector/semconv/v1.17.0"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -838,6 +839,7 @@ func TestHostedInEksResolver(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "test-namespace-3", getStrAttr(attributes, attr.HostedInK8SNamespace, t))
 	assert.Equal(t, "test-cluster", getStrAttr(attributes, attr.HostedInClusterNameEKS, t))
+	assert.Equal(t, "/aws/containerinsights/test-cluster/application", getStrAttr(resourceAttributes, semconv.AttributeAWSLogGroupNames, t))
 }
 
 func TestExtractIPPort(t *testing.T) {


### PR DESCRIPTION
# Description of changes
* set resource attribute `aws.log.group.names` to be the application log group name for Container Insights use case so that later we can correlate application logs with traces

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
`make test`

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




