### PR TITLE
Add JMX Metrics

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -157,6 +157,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
@@ -221,6 +222,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{env.CWA_GITHUB_TEST_REPO_NAME}}
+          ref: ${{env.CWA_GITHUB_TEST_REPO_BRANCH}}
           path: test
 
       - name: Set up Go 1.x

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ package-prepare-rpm:
 	cp $(BASE_SPACE)/packaging/linux/amazon-cloudwatch-agent.conf $(BUILD_SPACE)/private/linux/amd64/rpm/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/linux/amazon-cloudwatch-agent.spec $(BUILD_SPACE)/private/linux/amd64/rpm/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/translator/config/schema.json $(BUILD_SPACE)/private/linux/amd64/rpm/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent-schema.json
+	cp $(BASE_SPACE)/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/linux/amd64/rpm/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
 
 	# arm64 rpm
 	mkdir -p $(BUILD_SPACE)/private/linux/arm64/rpm/amazon-cloudwatch-agent-pre-pkg
@@ -227,6 +228,7 @@ package-prepare-rpm:
 	cp $(BASE_SPACE)/packaging/linux/amazon-cloudwatch-agent.conf $(BUILD_SPACE)/private/linux/arm64/rpm/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/linux/amazon-cloudwatch-agent.spec $(BUILD_SPACE)/private/linux/arm64/rpm/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/translator/config/schema.json $(BUILD_SPACE)/private/linux/arm64/rpm/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent-schema.json
+	cp $(BASE_SPACE)/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/linux/arm64/rpm/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
 	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 
 package-prepare-deb:
@@ -241,6 +243,7 @@ package-prepare-deb:
 	cp $(BASE_SPACE)/cfg/commonconfig/common-config.toml $(BUILD_SPACE)/private/linux/amd64/deb/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/linux/amazon-cloudwatch-agent.conf $(BUILD_SPACE)/private/linux/amd64/deb/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/translator/config/schema.json $(BUILD_SPACE)/private/linux/amd64/deb/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent-schema.json
+	cp $(BASE_SPACE)/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/linux/amd64/deb/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
 
 	# arm64 deb
 	mkdir -p $(BUILD_SPACE)/private/linux/arm64/deb/amazon-cloudwatch-agent-pre-pkg
@@ -253,6 +256,7 @@ package-prepare-deb:
 	cp $(BASE_SPACE)/cfg/commonconfig/common-config.toml $(BUILD_SPACE)/private/linux/arm64/deb/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/linux/amazon-cloudwatch-agent.conf $(BUILD_SPACE)/private/linux/arm64/deb/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/translator/config/schema.json $(BUILD_SPACE)/private/linux/arm64/deb/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent-schema.json
+	cp $(BASE_SPACE)/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/linux/arm64/deb/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
 
 	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 	cp -rf $(BASE_SPACE)/packaging $(BUILD_SPACE)/
@@ -269,6 +273,7 @@ package-prepare-win-zip:
 	cp ${BASE_SPACE}/packaging/windows/amazon-cloudwatch-agent-ctl.ps1 $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg/
 	cp ${BASE_SPACE}/packaging/windows/install.ps1 $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg/
 	cp ${BASE_SPACE}/packaging/windows/uninstall.ps1 $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg/
+	cp $(BASE_SPACE)/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
 	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 
 package-prepare-darwin-tar:
@@ -282,6 +287,7 @@ package-prepare-darwin-tar:
 	cp $(BASE_SPACE)/translator/config/schema.json $(BUILD_SPACE)/private/darwin/amd64/tar/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent-schema.json
 	cp $(BASE_SPACE)/packaging/darwin/amazon-cloudwatch-agent-ctl $(BUILD_SPACE)/private/darwin/amd64/tar/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/darwin/com.amazon.cloudwatch.agent.plist $(BUILD_SPACE)/private/darwin/amd64/tar/amazon-cloudwatch-agent-pre-pkg/
+	cp $(BASE_SPACE)/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/darwin/amd64/tar/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
 
 	# arm64 darwin
 	mkdir -p $(BUILD_SPACE)/private/darwin/arm64/tar/amazon-cloudwatch-agent-pre-pkg
@@ -293,6 +299,7 @@ package-prepare-darwin-tar:
 	cp $(BASE_SPACE)/translator/config/schema.json $(BUILD_SPACE)/private/darwin/arm64/tar/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent-schema.json
 	cp $(BASE_SPACE)/packaging/darwin/amazon-cloudwatch-agent-ctl $(BUILD_SPACE)/private/darwin/arm64/tar/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/darwin/com.amazon.cloudwatch.agent.plist $(BUILD_SPACE)/private/darwin/arm64/tar/amazon-cloudwatch-agent-pre-pkg/
+	cp $(BASE_SPACE)/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/darwin/arm64/tar/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
 
 	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 

--- a/Tools/src/create_darwin.sh
+++ b/Tools/src/create_darwin.sh
@@ -43,6 +43,7 @@ cp ${PREPKGPATH}/config-translator ${BUILD_ROOT}${MACHINE_ROOT}bin/
 cp ${PREPKGPATH}/config-downloader ${BUILD_ROOT}${MACHINE_ROOT}bin/
 cp ${PREPKGPATH}/amazon-cloudwatch-agent-config-wizard ${BUILD_ROOT}${MACHINE_ROOT}bin/
 cp ${PREPKGPATH}/start-amazon-cloudwatch-agent ${BUILD_ROOT}${MACHINE_ROOT}bin/
+cp ${PREPKGPATH}/opentelemetry-jmx-metrics.jar ${BUILD_ROOT}${MACHINE_ROOT}bin/
 cp ${PREPKGPATH}/common-config.toml ${BUILD_ROOT}${MACHINE_ROOT}etc/
 cp ${PREPKGPATH}/amazon-cloudwatch-agent-schema.json ${BUILD_ROOT}${MACHINE_ROOT}doc/
 cp ${PREPKGPATH}/com.amazon.cloudwatch.agent.plist ${BUILD_ROOT}/Library/LaunchDaemons/

--- a/Tools/src/create_deb.sh
+++ b/Tools/src/create_deb.sh
@@ -32,6 +32,7 @@ cp ${PREPKGPATH}/config-translator ${BUILD_ROOT}/opt/aws/amazon-cloudwatch-agent
 cp ${PREPKGPATH}/config-downloader ${BUILD_ROOT}/opt/aws/amazon-cloudwatch-agent/bin/
 cp ${PREPKGPATH}/amazon-cloudwatch-agent-config-wizard ${BUILD_ROOT}/opt/aws/amazon-cloudwatch-agent/bin/
 cp ${PREPKGPATH}/start-amazon-cloudwatch-agent ${BUILD_ROOT}/opt/aws/amazon-cloudwatch-agent/bin/
+cp ${PREPKGPATH}/opentelemetry-jmx-metrics.jar ${BUILD_ROOT}/opt/aws/amazon-cloudwatch-agent/bin/
 cp ${PREPKGPATH}/common-config.toml ${BUILD_ROOT}/opt/aws/amazon-cloudwatch-agent/etc/
 cp ${PREPKGPATH}/amazon-cloudwatch-agent.conf ${BUILD_ROOT}/etc/init/
 cp ${PREPKGPATH}/amazon-cloudwatch-agent-schema.json ${BUILD_ROOT}/opt/aws/amazon-cloudwatch-agent/doc/

--- a/Tools/src/create_rpm.sh
+++ b/Tools/src/create_rpm.sh
@@ -36,6 +36,7 @@ cp ${PREPKGPATH}/config-translator ${BUILD_ROOT}/SOURCES/opt/aws/amazon-cloudwat
 cp ${PREPKGPATH}/config-downloader ${BUILD_ROOT}/SOURCES/opt/aws/amazon-cloudwatch-agent/bin/
 cp ${PREPKGPATH}/amazon-cloudwatch-agent-config-wizard ${BUILD_ROOT}/SOURCES/opt/aws/amazon-cloudwatch-agent/bin/
 cp ${PREPKGPATH}/start-amazon-cloudwatch-agent ${BUILD_ROOT}/SOURCES/opt/aws/amazon-cloudwatch-agent/bin/
+cp ${PREPKGPATH}/opentelemetry-jmx-metrics.jar ${BUILD_ROOT}/SOURCES/opt/aws/amazon-cloudwatch-agent/bin/
 cp ${PREPKGPATH}/common-config.toml ${BUILD_ROOT}/SOURCES/opt/aws/amazon-cloudwatch-agent/etc/
 cp ${PREPKGPATH}/amazon-cloudwatch-agent.conf ${BUILD_ROOT}/SOURCES/etc/init/amazon-cloudwatch-agent.conf
 cp ${PREPKGPATH}/amazon-cloudwatch-agent-schema.json ${BUILD_ROOT}/SOURCES/opt/aws/amazon-cloudwatch-agent/doc/

--- a/Tools/src/create_win.sh
+++ b/Tools/src/create_win.sh
@@ -29,6 +29,7 @@ cp ${PREPKGPATH}/amazon-cloudwatch-agent-config-wizard.exe ${BUILD_ROOT}/amazon-
 cp ${PREPKGPATH}/start-amazon-cloudwatch-agent.exe ${BUILD_ROOT}/amazon-cloudwatch-agent/
 cp ${PREPKGPATH}/common-config.toml ${BUILD_ROOT}/amazon-cloudwatch-agent/
 cp ${PREPKGPATH}/amazon-cloudwatch-agent-schema.json ${BUILD_ROOT}/amazon-cloudwatch-agent/
+cp ${PREPKGPATH}/opentelemetry-jmx-metrics.jar ${BUILD_ROOT}/amazon-cloudwatch-agent/
 
 echo "Constructing the zip package"
 

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	github.com/jellydator/ttlcache/v3 v3.1.0
 	github.com/kardianos/service v1.2.1 // Keep this pinned to v1.2.1. v1.2.2 causes the agent to not register as a service on Windows
 	github.com/kr/pretty v0.3.1
+	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 // indirect
 	github.com/oklog/run v1.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.89.0
@@ -120,6 +121,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.89.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.89.0
 	github.com/pkg/errors v0.9.1
@@ -131,6 +133,8 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/collector/component v0.89.0
+	go.opentelemetry.io/collector/config/configauth v0.89.0 // indirect
+	go.opentelemetry.io/collector/config/configopaque v0.89.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.89.0
 	go.opentelemetry.io/collector/confmap v0.89.0
 	go.opentelemetry.io/collector/consumer v0.89.0
@@ -299,7 +303,6 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
-	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -370,12 +373,10 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.89.0 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.89.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.89.0 // indirect
 	go.opentelemetry.io/collector/connector v0.89.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,7 @@ collectd.org v0.4.0 h1:nWNldfMqg7EVWAevG8oyOVsS9r/UHRG3LZRf6MdQho0=
 collectd.org v0.4.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2 h1:sqfsYl5GIY/L570iT+l93ehxaWJs2/OwXtiWwew3oAg=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9fpw1KeYcjrnC1J8B+JKjsZyRQ=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
 github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XBn0=
@@ -103,6 +104,7 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go
 github.com/Mellanox/rdmamap v0.0.0-20191106181932-7c3c4763a6ee h1:atI/FFjXh6hIVlPE1Jup9m8N4B9q/OSbMUe2EBahs+w=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/Microsoft/hcsshim v0.11.1 h1:hJ3s7GbWlGK4YVV92sO88BQSyF4ZLVy7/awqOlPxFbA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -291,6 +293,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
+github.com/containerd/containerd v1.7.7 h1:QOC2K4A42RQpcrZyptP6z9EJZnlHfHJUfZrAAHe15q4=
+github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/ttrpc v1.2.2 h1:9vqZr0pxwOF5koz6N0N3kJ0zDHokrcPxIR/ZR2YFtOs=
 github.com/containerd/ttrpc v1.2.2/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf1G5tYZak=
 github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY7aY=
@@ -302,6 +306,7 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/couchbase/go-couchbase v0.1.1 h1:ClFXELcKj/ojyoTYbsY34QUrrYCBi/1G749sXSCkdhk=
 github.com/couchbase/gomemcached v0.1.3 h1:HIc5qMYNbuhB7zNaiEtj61DCYkquAwrQlf64q7JzdEY=
 github.com/couchbase/goutils v0.1.0 h1:0WLlKJilu7IBm98T8nS9+J36lBFVLRUSIUtyD/uWpAE=
+github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
@@ -773,6 +778,7 @@ github.com/linode/linodego v1.23.0 h1:s0ReCZtuN9Z1IoUN9w1RLeYO1dMZUGPwOQ/IBFsBHt
 github.com/linode/linodego v1.23.0/go.mod h1:0U7wj/UQOqBNbKv1FYTXiBUXueR8DY4HvIotwE0ENgg=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
+github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
@@ -838,9 +844,11 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/ipvs v1.0.1 h1:aoZ7fhLTXgDbzVrAnvV+XbKOU8kOET7B3+xULDF/1o0=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
+github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -942,6 +950,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstrans
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.89.0/go.mod h1:dMuzeobFNwvW7TgxHVVF1UH2HMK4jcU1JxzGdv+WZVk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.89.0 h1:aX/JOO9uRSuu1QXOw6pgKoofobxkFqz0nkevwctbkFU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.89.0/go.mod h1:AUxeyAuaT9fxbjMmCzZkbEJsxmdKo1Fe7BhWwfbzRq8=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.89.0 h1:1f+u8yq0DopZbAF2HiTLfEkcxrnQM0wOsCLDafn8Z58=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.89.0/go.mod h1:zMJ7CAiq2nh7Yv+qyHh2mL/nWHq24kbgfoPbQipb8lk=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.89.0 h1:D6kSn1hw5DMfQVspWSYmofWks1RP0wci9VJbLTckwdQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.89.0/go.mod h1:vAA4Q3EW70/LRvMM3oXJznZ7Q/2bU9c9SdOW7TyLqR4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.89.0 h1:tjKz5xlnwYgR9xSb3eDSawcNyImUtl/MGnAYcizfUSw=
@@ -1120,6 +1130,7 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/testcontainers/testcontainers-go v0.26.0 h1:uqcYdoOHBy1ca7gKODfBd9uTHVK3a7UL848z09MVZ0c=
 github.com/tidwall/gjson v1.10.2 h1:APbLGOM0rrEkd8WBw9C24nllro4ajFuJu0Sc9hRz8Bo=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/packaging/linux/amazon-cloudwatch-agent.spec
+++ b/packaging/linux/amazon-cloudwatch-agent.spec
@@ -54,6 +54,7 @@ ln -f -s /opt/aws/amazon-cloudwatch-agent/var ${RPM_BUILD_ROOT}/var/run/amazon/a
 /opt/aws/amazon-cloudwatch-agent/bin/config-downloader
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-config-wizard
 /opt/aws/amazon-cloudwatch-agent/bin/start-amazon-cloudwatch-agent
+/opt/aws/amazon-cloudwatch-agent/bin/opentelemetry-jmx-metrics.jar
 /opt/aws/amazon-cloudwatch-agent/doc/amazon-cloudwatch-agent-schema.json
 %config(noreplace) /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml
 /opt/aws/amazon-cloudwatch-agent/LICENSE

--- a/service/defaultcomponents/components.go
+++ b/service/defaultcomponents/components.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver"
 	"go.opentelemetry.io/collector/exporter"
@@ -38,6 +39,7 @@ func Factories() (otelcol.Factories, error) {
 	if factories.Receivers, err = receiver.MakeFactoryMap(
 		awscontainerinsightreceiver.NewFactory(),
 		awsxrayreceiver.NewFactory(),
+		jmxreceiver.NewFactory(),
 		otlpreceiver.NewFactory(),
 		tcplogreceiver.NewFactory(),
 		udplogreceiver.NewFactory(),

--- a/service/defaultcomponents/components_test.go
+++ b/service/defaultcomponents/components_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	receiversCount  = 5
+	receiversCount  = 6
 	processorCount  = 7
 	exportersCount  = 5
 	extensionsCount = 2
@@ -24,6 +24,7 @@ func TestComponents(t *testing.T) {
 	assert.NotNil(t, receivers["awscontainerinsightreceiver"])
 	assert.NotNil(t, receivers["awsxray"])
 	assert.NotNil(t, receivers["otlp"])
+	assert.NotNil(t, receivers["jmx"])
 	assert.NotNil(t, receivers["tcplog"])
 	assert.NotNil(t, receivers["udplog"])
 

--- a/translator/cmdutil/translatorutil.go
+++ b/translator/cmdutil/translatorutil.go
@@ -23,6 +23,8 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/tocwconfig/toyamlconfig"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/jmx"
 	translatorUtil "github.com/aws/amazon-cloudwatch-agent/translator/util"
 )
 
@@ -224,9 +226,65 @@ func TranslateJsonMapToYamlConfig(jsonConfigValue interface{}) (interface{}, err
 	if err = conf.Marshal(cfg); err != nil {
 		return nil, err
 	}
-	return conf.ToStringMap(), nil
+	strMap := conf.ToStringMap()
+	ConvertOtelNullToEmpty(strMap)
+	RemoveTLSRedacted(strMap)
+	return strMap, nil
 }
-
+func RemoveTLSRedacted(stringMap map[string]interface{}) {
+	type Node struct {
+		isTLSParent bool
+		isJMXParent bool
+		parentKey   string
+		data        map[string]interface{}
+	}
+	root := Node{isTLSParent: false, parentKey: "", data: stringMap}
+	queue := []Node{root}
+	// Using BFS search through string Map and find sub settings of TLS
+	// Then delete REDACTED settings under TLS
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		for key, child := range node.data {
+			if childMap, ok := child.(map[string]interface{}); ok {
+				queue = append(queue, Node{key == common.TLSKey, strings.Contains(key, common.JmxKey), key, childMap})
+			} else if jmx.GetRedactedMap(node.parentKey, key) != "" {
+				node.data[key] = jmx.GetRedactedMap(node.parentKey, key)
+			} else if child == "[REDACTED]" && (node.isTLSParent || node.isJMXParent) {
+				delete(node.data, key)
+			}
+		}
+	}
+}
+func ConvertOtelNullToEmpty(stringMap map[string]interface{}) {
+	receivers, ok := stringMap["receivers"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	for key, value := range receivers {
+		if !strings.Contains(key, "otlp/metrics") {
+			continue
+		}
+		otlp, ok := value.(map[string]interface{})
+		if !ok {
+			return
+		}
+		protocols, ok := otlp["protocols"].(map[string]interface{})
+		if !ok {
+			return
+		}
+		//Remove either HTTP or GRPC depending on if one of them is used and other isn't
+		http, ok := protocols["http"]
+		if http == nil {
+			delete(protocols, "http")
+		}
+		grpc, ok := protocols["grpc"]
+		if grpc == nil {
+			delete(protocols, "grpc")
+		}
+	}
+	return
+}
 func ConfigToTomlFile(config interface{}, tomlConfigFilePath string) error {
 	res := totomlconfig.ToTomlConfig(config)
 	return os.WriteFile(tomlConfigFilePath, []byte(res), fileMode)

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -134,6 +134,9 @@
             },
             "nvidia_smi": {
               "$ref": "#/definitions/metricsDefinition/definitions/nvidiaGpuDefinitions"
+            },
+            "jmx": {
+              "$ref": "#/definitions/metricsDefinition/definitions/jmxDefinitions"
             }
           },
           "minProperties": 1,
@@ -293,6 +296,21 @@
             },
             {
               "$ref": "#/definitions/metricsDefinition/definitions/basicResourcesDefinition"
+            }
+          ]
+        },
+        "jmxDefinitions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 255,
+              "items": {
+                "$ref": "#/definitions/jmxObjectDefinition"
+              }
+            },
+            {
+              "$ref": "#/definitions/jmxObjectDefinition"
             }
           ]
         },
@@ -1041,6 +1059,99 @@
         "bind_address": {
           "description": "TCP endpoint for proxy server",
           "$ref": "#/definitions/endpointOverrideDefinition"
+        }
+      },
+      "additionalProperties": false
+    },
+    "jmxObjectDefinition": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "description": "The endpoint to listen for JMX",
+          "$ref": "#/definitions/endpointOverrideDefinition"
+        },
+        "jar_path": {
+          "description": "The path to the JMX metric gatherer jar file",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "target_system": {
+          "description": "built-in target system (or systems) metric gatherer script to run",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "metrics_collection_interval": {
+          "$ref": "#/definitions/timeIntervalDefinition"
+        },
+        "username": {
+          "description": "The username to use for JMX authentication",
+          "type": "string"
+        },
+        "password": {
+          "description": "The password to use for JMX authentication",
+          "type": "string"
+        },
+        "keystore_path": {
+          "description": "The keystore path is required if SSL is enabled on the target JVM",
+          "type": "string"
+        },
+        "keystore_password": {
+          "description": "The keystore file password if required by SSL",
+          "type": "string"
+        },
+        "keystore_type": {
+          "description": "The keystore type if required by SSL",
+          "type": "string"
+        },
+        "truststore_path": {
+          "description": "The truststore path is required if SSL is enabled on the target JVM",
+          "type": "string"
+        },
+        "truststore_password": {
+          "description": "The truststore file password if required by SSL",
+          "type": "string"
+        },
+        "truststore_type": {
+          "description": "The truststore type if required by SSL",
+          "type": "string"
+        },
+        "remote_profile": {
+          "description": "Supported JMX remote profiles in combination with SASL profiles",
+          "type": "string"
+        },
+        "realm": {
+          "description": "The realm, as required by remote profile SASL/DIGEST-MD5.",
+          "type": "string"
+        },
+        "otlp": {
+          "type": "object",
+          "properties": {
+            "endpoint": {
+              "$ref": "#/definitions/endpointOverrideDefinition"
+            },
+            "timeout": {
+              "description": "The otlp exporter request timeout",
+              "type": "string"
+            },
+            "headers": {
+              "description": "The otlp exporter request header",
+              "type": "object",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "resource_attributes": {
+          "type": "object",
+          "description": "List of resource attributes that will be applied to any metrics emitted from the metrics gatherer.",
+          "properties": {
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -558,13 +558,10 @@ processors:
                     enabled: true
             tls:
                 ca_file: ""
-                ca_pem: '[REDACTED]'
                 cert_file: ""
-                cert_pem: '[REDACTED]'
                 insecure: false
                 insecure_skip_verify: false
                 key_file: ""
-                key_pem: '[REDACTED]'
                 max_version: ""
                 min_version: ""
                 reload_interval: 0s

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -387,13 +387,10 @@ processors:
                     enabled: true
             tls:
                 ca_file: ""
-                ca_pem: '[REDACTED]'
                 cert_file: ""
-                cert_pem: '[REDACTED]'
                 insecure: false
                 insecure_skip_verify: false
                 key_file: ""
-                key_pem: '[REDACTED]'
                 max_version: ""
                 min_version: ""
                 reload_interval: 0s

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -149,13 +149,10 @@ receivers:
             role_arn: trace_role_arn_value_test
             tls:
                 ca_file: ""
-                ca_pem: '[REDACTED]'
                 cert_file: ""
-                cert_pem: '[REDACTED]'
                 insecure: true
                 insecure_skip_verify: false
                 key_file: ""
-                key_pem: '[REDACTED]'
                 max_version: ""
                 min_version: ""
                 reload_interval: 0s

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.json
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.json
@@ -14,6 +14,59 @@
   },
   "metrics": {
     "metrics_collected": {
+      "jmx": [
+        {
+          "jar_path": "../../opentelemetry-jmx-metrics.jar",
+          "endpoint": "my_jmx_host:12345",
+          "target_system": "jvm",
+          "metrics_collection_interval": 60,
+          "otlp": {
+            "endpoint": "mycollectorotlpreceiver:4317",
+            "timeout": "60s",
+            "headers": {
+              "header_test": "test"
+            }
+          },
+          "username": "cwagent",
+          "password": "testpassword",
+          "keystore_path": "/keystore",
+          "keystore_password": "keystore_password",
+          "keystore_type": "PKCS",
+          "truststore_path": "/truststore",
+          "truststore_password": "truststore_password",
+          "truststore_type": "PKCS12",
+          "remote_profile": "SASL/PLAIN",
+          "realm": "test_realm",
+          "resource_attributes": {
+            "service.name": "jmx_app"
+          }
+        },
+        {
+          "jar_path": "../../opentelemetry-jmx-metrics.jar",
+          "endpoint": "my_jmx_host:12345",
+          "target_system": "jvm",
+          "metrics_collection_interval": 60,
+          "otlp": {
+            "endpoint": "mycollectorotlpreceiver:4317",
+            "timeout": "60s",
+            "headers": {
+              "header_test": "test"
+            }
+          },
+          "username": "cwagent",
+          "password": "testpassword",
+          "keystore_path": "/keystore",
+          "keystore_type": "PKCS",
+          "truststore_path": "/truststore",
+          "truststore_password": "truststore_password",
+          "truststore_type": "PKCS12",
+          "remote_profile": "SASL/PLAIN",
+          "realm": "test_realm",
+          "resource_attributes": {
+            "service.name": "jmx_app"
+          }
+        }
+      ],
       "collectd": {
         "service_address": "udp://127.0.0.1:25826",
         "name_prefix": "collectd_",
@@ -28,7 +81,10 @@
         "resources": [
           "*"
         ],
-        "drop_original_metrics": ["cpu_usage_idle", "time_active"],
+        "drop_original_metrics": [
+          "cpu_usage_idle",
+          "time_active"
+        ],
         "measurement": [
           {
             "name": "cpu_usage_idle",

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -152,18 +152,62 @@ receivers:
             role_arn: trace_role_arn_value_test
             tls:
                 ca_file: ""
-                ca_pem: '[REDACTED]'
                 cert_file: ""
-                cert_pem: '[REDACTED]'
                 insecure: true
                 insecure_skip_verify: false
                 key_file: ""
-                key_pem: '[REDACTED]'
                 max_version: ""
                 min_version: ""
                 reload_interval: 0s
                 server_name_override: ""
         transport: udp
+    jmx/metrics/0:
+        jar_path: ../../opentelemetry-jmx-metrics.jar
+        endpoint: my_jmx_host:12345
+        target_system: jvm
+        collection_interval: 1m0s
+        otlp:
+            endpoint: mycollectorotlpreceiver:4317
+            timeout: 1m0s
+            headers:
+                header_test: test
+        username: cwagent
+        keystore_path: /keystore
+        keystore_type: PKCS
+        truststore_path: /truststore
+        truststore_type: PKCS12
+        remote_profile: SASL/PLAIN
+        realm: test_realm
+        resource_attributes:
+            service.name: jmx_app
+        log_level: ""
+        additional_jars: [ ]
+        keystore_password: keystore_password
+        password: testpassword
+        truststore_password: truststore_password
+    jmx/metrics/1:
+        jar_path: ../../opentelemetry-jmx-metrics.jar
+        endpoint: my_jmx_host:12345
+        target_system: jvm
+        collection_interval: 1m0s
+        otlp:
+            endpoint: mycollectorotlpreceiver:4317
+            timeout: 1m0s
+            headers:
+                header_test: test
+        username: cwagent
+        keystore_path: /keystore
+        keystore_type: PKCS
+        truststore_path: /truststore
+        truststore_type: PKCS12
+        remote_profile: SASL/PLAIN
+        realm: test_realm
+        resource_attributes:
+            service.name: jmx_app
+        log_level: ""
+        additional_jars: [ ]
+        password: testpassword
+        truststore_password: truststore_password
     otlp:
         protocols:
             grpc:
@@ -281,6 +325,8 @@ service:
                 - telegraf_netstat
                 - telegraf_cpu
                 - telegraf_statsd
+                - jmx/metrics/0
+                - jmx/metrics/1
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
@@ -135,13 +135,10 @@ receivers:
             role_arn: trace_role_arn_value_test
             tls:
                 ca_file: ""
-                ca_pem: "[REDACTED]"
                 cert_file: ""
-                cert_pem: "[REDACTED]"
                 insecure: true
                 insecure_skip_verify: false
                 key_file: ""
-                key_pem: "[REDACTED]"
                 max_version: ""
                 min_version: ""
                 reload_interval: 0s

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -31,6 +31,9 @@ const (
 	DisableMetricExtraction            = "disable_metric_extraction"
 	XrayKey                            = "xray"
 	OtlpKey                            = "otlp"
+	JmxKey                             = "jmx"
+	TLSKey                             = "tls"
+	Endpoint                           = "endpoint"
 	EndpointOverrideKey                = "endpoint_override"
 	RegionOverrideKey                  = "region_override"
 	ProxyOverrideKey                   = "proxy_override"
@@ -56,6 +59,7 @@ const (
 	Region                             = "region"
 	LogGroupName                       = "log_group_name"
 	LogStreamName                      = "log_stream_name"
+	Reacted                            = "[REDACTED]"
 )
 
 const (

--- a/translator/translate/otel/pipeline/host/translators.go
+++ b/translator/translate/otel/pipeline/host/translators.go
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package host
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/aws/amazon-cloudwatch-agent/receiver/adapter"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline"
+	adaptertranslator "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/adapter"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/jmx"
+)
+
+func NewTranslators(conf *confmap.Conf, os string) (pipeline.TranslatorMap, error) {
+	adapterReceivers, err := adaptertranslator.FindReceiversInConfig(conf, os)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find receivers in config: %w", err)
+	}
+
+	translators := common.NewTranslatorMap[*common.ComponentTranslators]()
+	// split out delta receiver types
+	deltaReceivers := common.NewTranslatorMap[component.Config]()
+	hostReceivers := common.NewTranslatorMap[component.Config]()
+	adapterReceivers.Range(func(translator common.Translator[component.Config]) {
+		if translator.ID().Type() == adapter.Type(common.DiskIOKey) || translator.ID().Type() == adapter.Type(common.NetKey) {
+			deltaReceivers.Set(translator)
+		} else {
+			hostReceivers.Set(translator)
+		}
+	})
+
+	switch v := conf.Get(common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.JmxKey)).(type) {
+	case []interface{}:
+		for index := range v {
+			hostReceivers.Set(jmx.NewTranslator(
+				jmx.WithDataType(component.DataTypeMetrics),
+				jmx.WithIndex(index),
+			))
+		}
+	case map[string]interface{}:
+		hostReceivers.Set(jmx.NewTranslator(jmx.WithDataType(component.DataTypeMetrics)))
+	}
+
+	hasHostPipeline := hostReceivers.Len() != 0
+	hasDeltaPipeline := deltaReceivers.Len() != 0
+
+	if hasHostPipeline {
+		translators.Set(NewTranslator(common.PipelineNameHost, hostReceivers))
+	}
+	if hasDeltaPipeline {
+		translators.Set(NewTranslator(common.PipelineNameHostDeltaMetrics, deltaReceivers))
+	}
+
+	return translators, nil
+}

--- a/translator/translate/otel/pipeline/translator.go
+++ b/translator/translate/otel/pipeline/translator.go
@@ -17,7 +17,9 @@ var (
 	ErrNoPipelines = errors.New("no valid pipelines")
 )
 
-type Translator common.Translator[*common.ComponentTranslators]
+type Translator = common.Translator[*common.ComponentTranslators]
+
+type TranslatorMap = common.TranslatorMap[*common.ComponentTranslators]
 
 type Translation struct {
 	// Pipelines is a map of component IDs to service pipelines.

--- a/translator/translate/otel/receiver/adapter/translators.go
+++ b/translator/translate/otel/receiver/adapter/translators.go
@@ -66,6 +66,13 @@ var (
 	defaultCollectionIntervalMap = map[string]time.Duration{
 		statsd.SectionKey: 10 * time.Second,
 	}
+
+	// otelReceivers is used for receivers that need to be in the same pipeline that
+	// exports to Cloudwatch while not having to follow the adapter rules
+	otelReceivers = collections.NewSet[string](
+		common.JmxKey,
+		common.OtlpKey,
+	)
 )
 
 // FindReceiversInConfig looks in the metrics and logs sections to determine which

--- a/translator/translate/otel/receiver/jmx/testdata/config.json
+++ b/translator/translate/otel/receiver/jmx/testdata/config.json
@@ -1,0 +1,32 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "jmx": {
+        "jar_path": "/jmxtest/opentelemetry-java-contrib-jmx-metrics.jar",
+        "endpoint": "my_jmx_host:12345",
+        "target_system": "jvm",
+        "metrics_collection_interval": 60,
+        "otlp": {
+          "endpoint": "mycollectorotlpreceiver:4317",
+          "timeout": "60s",
+          "headers": {
+            "header_test": "test"
+          }
+        },
+        "username": "cwagent",
+        "password": "testpassword",
+        "keystore_path": "/keystore",
+        "keystore_password": "keystore_password",
+        "keystore_type": "PKCS",
+        "truststore_path": "/truststore",
+        "truststore_password": "truststore_password",
+        "truststore_type": "PKCS12",
+        "remote_profile": "SASL/PLAIN",
+        "realm": "test_realm",
+        "resource_attributes": {
+          "service.name": "jmx_app"
+        }
+      }
+    }
+  }
+}

--- a/translator/translate/otel/receiver/jmx/testdata/config.yaml
+++ b/translator/translate/otel/receiver/jmx/testdata/config.yaml
@@ -1,0 +1,21 @@
+jar_path: /jmxtest/opentelemetry-java-contrib-jmx-metrics.jar
+endpoint: my_jmx_host:12345
+target_system: jvm
+collection_interval: 60s
+otlp:
+  endpoint: mycollectorotlpreceiver:4317
+  timeout: 60s
+  headers:
+    header_test: test
+username: cwagent
+password: testpassword
+keystore_path: /keystore
+keystore_password: keystore_password
+keystore_type: PKCS
+truststore_path: /truststore
+truststore_password: truststore_password
+truststore_type: PKCS12
+remote_profile: SASL/PLAIN
+realm: test_realm
+resource_attributes: 
+  service.name: jmx_app

--- a/translator/translate/otel/receiver/jmx/translator.go
+++ b/translator/translate/otel/receiver/jmx/translator.go
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package jmx
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+const (
+	jarPath             = "jar_path"
+	targetSystem        = "target_system"
+	username            = "username"
+	password            = "password"
+	keystorePath        = "keystore_path"
+	keystorePassword    = "keystore_password"
+	keystoreType        = "keystore_type"
+	truststorePath      = "truststore_path"
+	truststorePassword  = "truststore_password"
+	truststoreType      = "truststore_type"
+	remoteProfile       = "remote_profile"
+	realm               = "realm"
+	resourceAttributes  = "resource_attributes"
+	timeout             = "timeout"
+	headers             = "headers"
+	defaultOTLPEndpoint = "127.0.0.1:3000"
+	defaultJMXJarPath   = "/opt/aws/amazon-cloudwatch-agent/bin/opentelemetry-jmx-metrics.jar"
+	defaultTargetSystem = "activemq,cassandra,hbase,hadoop,jetty,jvm,kafka,kafka-consumer,kafka-producer,solr,tomcat,wildfly"
+)
+
+var (
+	configKeys = map[component.DataType]string{
+		component.DataTypeMetrics: common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.JmxKey),
+	}
+	redactedMap = make(map[string]string)
+)
+
+type translator struct {
+	name     string
+	dataType component.DataType
+	factory  receiver.Factory
+	index    int
+}
+
+type Option interface {
+	apply(t *translator)
+}
+
+type optionFunc func(t *translator)
+
+func (o optionFunc) apply(t *translator) {
+	o(t)
+}
+
+// WithDataType determines where the translator should look to find
+// the configuration.
+func WithDataType(dataType component.DataType) Option {
+	return optionFunc(func(t *translator) {
+		t.dataType = dataType
+	})
+}
+
+func WithIndex(index int) Option {
+	return optionFunc(func(t *translator) {
+		t.index = index
+	})
+}
+
+var _ common.Translator[component.Config] = (*translator)(nil)
+
+func NewTranslator(opts ...Option) common.Translator[component.Config] {
+	return NewTranslatorWithName("", opts...)
+}
+
+func NewTranslatorWithName(name string, opts ...Option) common.Translator[component.Config] {
+	t := &translator{name: name, index: -1, factory: jmxreceiver.NewFactory()}
+	for _, opt := range opts {
+		opt.apply(t)
+	}
+	if name == "" && t.dataType != "" {
+		t.name = string(t.dataType)
+		if t.index != -1 {
+			t.name += "/" + strconv.Itoa(t.index)
+		}
+	}
+	return t
+}
+
+func (t *translator) ID() component.ID {
+	return component.NewIDWithName(t.factory.Type(), t.name)
+}
+
+func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
+	configKey, ok := configKeys[t.dataType]
+	if !ok {
+		return nil, fmt.Errorf("no config key defined for data type: %s", t.dataType)
+	}
+	if conf == nil || !conf.IsSet(configKey) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: configKey}
+	}
+	cfg := t.factory.CreateDefaultConfig().(*jmxreceiver.Config)
+
+	var jmxKeyMap map[string]interface{}
+	if jmxSlice := common.GetArray[any](conf, configKey); t.index != -1 && len(jmxSlice) > t.index {
+		jmxKeyMap = jmxSlice[t.index].(map[string]interface{})
+	} else if _, ok := conf.Get(configKey).(map[string]interface{}); !ok {
+		jmxKeyMap = make(map[string]interface{})
+	} else {
+		jmxKeyMap = conf.Get(configKey).(map[string]interface{})
+	}
+
+	cfg.JARPath = defaultJMXJarPath
+	if jarPath, ok := jmxKeyMap[jarPath].(string); ok {
+		cfg.JARPath = jarPath
+	}
+
+	if endpoint, ok := jmxKeyMap[common.Endpoint].(string); ok {
+		cfg.Endpoint = endpoint
+	}
+
+	cfg.TargetSystem = defaultTargetSystem
+	if targetSystem, ok := jmxKeyMap[targetSystem].(string); ok {
+		cfg.TargetSystem = targetSystem
+	}
+
+	// Prioritize metric collection internal in JMX section, then agent section
+	// Setting default to 10 seconds which is used by OTEL as well
+	intervalKeyChain := []string{
+		common.ConfigKey(common.AgentKey, common.MetricsCollectionIntervalKey),
+	}
+	cfg.CollectionInterval = common.GetOrDefaultDuration(conf, intervalKeyChain, 10*time.Second)
+	collectionInterval, err := common.ParseDuration(jmxKeyMap[common.MetricsCollectionIntervalKey])
+	if err == nil {
+		cfg.CollectionInterval = collectionInterval
+	}
+
+	if username, ok := jmxKeyMap[username].(string); ok {
+		cfg.Username = username
+	}
+
+	if pass, ok := jmxKeyMap[password].(string); ok {
+		t.addRedactedMap(password, pass)
+		cfg.Password = configopaque.String(pass)
+	}
+
+	if keystorePath, ok := jmxKeyMap[keystorePath].(string); ok {
+		cfg.KeystorePath = keystorePath
+	}
+
+	if keystorePass, ok := jmxKeyMap[keystorePassword].(string); ok {
+		t.addRedactedMap(keystorePassword, keystorePass)
+		cfg.KeystorePassword = configopaque.String(keystorePass)
+	}
+
+	if keystoreType, ok := jmxKeyMap[keystoreType].(string); ok {
+		cfg.KeystoreType = keystoreType
+	}
+
+	if truststorePath, ok := jmxKeyMap[truststorePath].(string); ok {
+		cfg.TruststorePath = truststorePath
+	}
+
+	if truststorePass, ok := jmxKeyMap[truststorePassword].(string); ok {
+		t.addRedactedMap(truststorePassword, truststorePass)
+		cfg.TruststorePassword = configopaque.String(truststorePass)
+	}
+
+	if truststoreType, ok := jmxKeyMap[truststoreType].(string); ok {
+		cfg.TruststoreType = truststoreType
+	}
+
+	if remoteProfile, ok := jmxKeyMap[remoteProfile].(string); ok {
+		cfg.RemoteProfile = remoteProfile
+	}
+
+	if realm, ok := jmxKeyMap[realm].(string); ok {
+		cfg.Realm = realm
+	}
+
+	if resourceAttributes, ok := jmxKeyMap[resourceAttributes].(map[string]interface{}); ok {
+		cfg.ResourceAttributes = convertToStringMap(resourceAttributes)
+	}
+
+	// set OTLP settings
+	cfg.OTLPExporterConfig.Endpoint = defaultOTLPEndpoint
+	if otlpMap, ok := jmxKeyMap[common.OtlpKey].(map[string]interface{}); ok {
+		if endpoint, ok := otlpMap[common.Endpoint].(string); ok {
+			cfg.OTLPExporterConfig.Endpoint = endpoint
+		}
+		timeout, err := common.ParseDuration(otlpMap[timeout])
+		if err == nil {
+			cfg.OTLPExporterConfig.Timeout = timeout
+		}
+		if headers, ok := otlpMap[headers].(map[string]interface{}); ok {
+			cfg.OTLPExporterConfig.Headers = convertToStringMap(headers)
+		}
+	}
+
+	return cfg, nil
+}
+
+func convertToStringMap(input map[string]interface{}) map[string]string {
+	convertedMap := make(map[string]string)
+	for key, value := range input {
+		strKey := fmt.Sprintf("%v", key)
+		strValue := fmt.Sprintf("%v", value)
+		convertedMap[strKey] = strValue
+	}
+	return convertedMap
+}
+
+func (t *translator) addRedactedMap(postfix string, value string) {
+	redactedMap[fmt.Sprintf("%v", t.factory.Type())+"/"+t.name+"/"+postfix] = value
+}
+
+func GetRedactedMap(prefix string, key string) string {
+	return redactedMap[prefix+"/"+key]
+}

--- a/translator/translate/otel/receiver/jmx/translator_test.go
+++ b/translator/translate/otel/receiver/jmx/translator_test.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package jmx
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/util/testutil"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+func TestTranslator(t *testing.T) {
+	tt := NewTranslator(WithDataType(component.DataTypeMetrics))
+	assert.EqualValues(t, "jmx/metrics", tt.ID().String())
+	testCases := map[string]struct {
+		input   map[string]interface{}
+		want    *confmap.Conf
+		wantErr error
+	}{
+		"WithMissingKey": {
+			input: map[string]interface{}{"logs": map[string]interface{}{}},
+			wantErr: &common.MissingKeyError{
+				ID:      tt.ID(),
+				JsonKey: common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.JmxKey),
+			},
+		},
+		"WithDefault": {
+			input: map[string]interface{}{"metrics": map[string]interface{}{"metrics_collected": map[string]interface{}{"jmx": nil}}},
+			want: confmap.NewFromStringMap(map[string]interface{}{
+				"jar_path":            defaultJMXJarPath,
+				"target_system":       defaultTargetSystem,
+				"collection_interval": "10s",
+				"otlp": map[string]interface{}{
+					"endpoint": "127.0.0.1:3000",
+					"timeout":  "5s",
+				},
+			}),
+		},
+		"WithCompleteConfig": {
+			input: testutil.GetJson(t, filepath.Join("testdata", "config.json")),
+			want:  testutil.GetConf(t, filepath.Join("testdata", "config.yaml")),
+		},
+	}
+	factory := jmxreceiver.NewFactory()
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Log(name)
+			conf := confmap.NewFromStringMap(testCase.input)
+			got, err := tt.Translate(conf)
+			assert.Equal(t, testCase.wantErr, err)
+			if err == nil {
+				require.NotNil(t, got)
+				gotCfg, ok := got.(*jmxreceiver.Config)
+				require.True(t, ok)
+				wantCfg := factory.CreateDefaultConfig()
+				require.NoError(t, component.UnmarshalConfig(testCase.want, wantCfg))
+				assert.Equal(t, wantCfg, gotCfg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add Auth Information To JMX

Add Default JMX Targets`

Add opentelemetry-jmx-metrics.jar To Deb, Darwin Zip, Windows, Zip

# Description of the issue
CloudWatch agent does not support jmx

# Description of changes
Add support for jmx

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent-test/pull/385

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




