### PR TITLE
fix(logfile): use Warnf instead of warn

### DIFF
--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -143,7 +143,7 @@ func (t *LogFile) Stop() {
 // Try to find if there is any new file needs to be added for monitoring.
 func (t *LogFile) FindLogSrc() []logs.LogSrc {
 	if !t.started {
-		t.Log.Warn("not started with file state folder %s", t.FileStateFolder)
+		t.Log.Warnf("not started with file state folder %s", t.FileStateFolder)
 		return nil
 	}
 


### PR DESCRIPTION
# Description of the issue
Encountered an error "stating not started with file state folder %s/.../logs/state" in a logstream.

# Description of changes
_How does this change address the problem?_

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
None, I just made sure the command is listed in telegraf documentation. 
https://pkg.go.dev/github.com/influxdata/telegraf#Logger


