### PR TITLE
Rename JMX resource_attributes.

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: 
       - main*
+      - feature*
     types: 
       - opened
       - synchronize

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1140,14 +1140,8 @@
             }
           }
         },
-        "resource_attributes": {
-          "type": "object",
-          "description": "List of resource attributes that will be applied to any metrics emitted from the metrics gatherer.",
-          "properties": {
-            "items": {
-              "type": "string"
-            }
-          }
+        "append_dimensions": {
+          "$ref": "#/definitions/generalAppendDimensionsDefinition"
         }
       },
       "additionalProperties": false

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.json
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.json
@@ -34,7 +34,7 @@
           "truststore_type": "PKCS12",
           "remote_profile": "SASL/PLAIN",
           "realm": "test_realm",
-          "resource_attributes": {
+          "append_dimensions": {
             "service.name": "jmx_app"
           }
         },
@@ -57,7 +57,7 @@
           "truststore_type": "PKCS12",
           "remote_profile": "SASL/PLAIN",
           "realm": "test_realm",
-          "resource_attributes": {
+          "append_dimensions": {
             "service.name": "jmx_app"
           }
         }

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -48,6 +48,7 @@ const (
 	ContainerInsightsMetricGranularity = "metric_granularity" // replaced with enhanced_container_insights
 	EnhancedContainerInsights          = "enhanced_container_insights"
 	PreferFullPodName                  = "prefer_full_pod_name"
+	AppendDimensionsKey                = "append_dimensions"
 	Console                            = "console"
 	DiskIOKey                          = "diskio"
 	NetKey                             = "net"

--- a/translator/translate/otel/pipeline/host/translator.go
+++ b/translator/translate/otel/pipeline/host/translator.go
@@ -60,7 +60,7 @@ func (t translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators,
 		translators.Processors.Set(cumulativetodeltaprocessor.NewTranslatorWithName(t.name))
 	}
 
-	if conf.IsSet(common.ConfigKey(common.MetricsKey, "append_dimensions")) {
+	if conf.IsSet(common.ConfigKey(common.MetricsKey, common.AppendDimensionsKey)) {
 		log.Printf("D! ec2tagger processor required because append_dimensions is set")
 		translators.Processors.Set(ec2taggerprocessor.NewTranslator())
 	}

--- a/translator/translate/otel/processor/ec2taggerprocessor/translator.go
+++ b/translator/translate/otel/processor/ec2taggerprocessor/translator.go
@@ -16,11 +16,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
-const (
-	AppendDimensionsKey = "append_dimensions"
-)
-
-var ec2taggerKey = common.ConfigKey(common.MetricsKey, AppendDimensionsKey)
+var ec2taggerKey = common.ConfigKey(common.MetricsKey, common.AppendDimensionsKey)
 
 type translator struct {
 	name    string
@@ -52,7 +48,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	credentials := confmap.NewFromStringMap(agent.Global_Config.Credentials)
 	_ = credentials.Unmarshal(cfg)
 	for k, v := range ec2tagger.SupportedAppendDimensions {
-		value, ok := common.GetString(conf, common.ConfigKey(common.MetricsKey, AppendDimensionsKey, k))
+		value, ok := common.GetString(conf, common.ConfigKey(common.MetricsKey, common.AppendDimensionsKey, k))
 		if ok && v == value {
 			if k == "AutoScalingGroupName" {
 				cfg.EC2InstanceTagKeys = append(cfg.EC2InstanceTagKeys, k)

--- a/translator/translate/otel/receiver/jmx/testdata/config.json
+++ b/translator/translate/otel/receiver/jmx/testdata/config.json
@@ -21,7 +21,7 @@
         "truststore_type": "PKCS12",
         "remote_profile": "SASL/PLAIN",
         "realm": "test_realm",
-        "resource_attributes": {
+        "append_dimensions": {
           "service.name": "jmx_app"
         }
       }

--- a/translator/translate/otel/receiver/jmx/translator.go
+++ b/translator/translate/otel/receiver/jmx/translator.go
@@ -22,19 +22,18 @@ import (
 )
 
 const (
-	jarPathKey            = "jar_path"
-	targetSystemKey       = "target_system"
-	usernameKey           = "username"
-	keystorePathKey       = "keystore_path"
-	keystoreTypeKey       = "keystore_type"
-	truststorePathKey     = "truststore_path"
-	truststoreTypeKey     = "truststore_type"
-	remoteProfileKey      = "remote_profile"
-	realmKey              = "realm"
-	resourceAttributesKey = "resource_attributes"
-	passwordFileKey       = "password_file"
-	otlpTimeoutKey        = "timeout"
-	otlpHeadersKey        = "headers"
+	jarPathKey        = "jar_path"
+	targetSystemKey   = "target_system"
+	usernameKey       = "username"
+	keystorePathKey   = "keystore_path"
+	keystoreTypeKey   = "keystore_type"
+	truststorePathKey = "truststore_path"
+	truststoreTypeKey = "truststore_type"
+	remoteProfileKey  = "remote_profile"
+	realmKey          = "realm"
+	passwordFileKey   = "password_file"
+	otlpTimeoutKey    = "timeout"
+	otlpHeadersKey    = "headers"
 
 	defaultOTLPEndpoint = "127.0.0.1:3000"
 	defaultTargetSystem = "activemq,cassandra,hbase,hadoop,jetty,jvm,kafka,kafka-consumer,kafka-producer,solr,tomcat,wildfly"
@@ -162,10 +161,10 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		cfg.Realm = realm
 	}
 
-	if resourceAttributes, ok := jmxKeyMap[resourceAttributesKey].(map[string]any); ok {
-		c := confmap.NewFromStringMap(resourceAttributes)
+	if appendDimensions, ok := jmxKeyMap[common.AppendDimensionsKey].(map[string]any); ok {
+		c := confmap.NewFromStringMap(appendDimensions)
 		if err = c.Unmarshal(&cfg.ResourceAttributes); err != nil {
-			return nil, fmt.Errorf("unable to unmarshal %s::%s: %w", configKey, resourceAttributesKey, err)
+			return nil, fmt.Errorf("unable to unmarshal %s::%s: %w", configKey, common.AppendDimensionsKey, err)
 		}
 	}
 


### PR DESCRIPTION
# Description of the issue
For all the other plugins/receivers, the field that allows customers to add custom dimensions is called `append_dimensions`.

# Description of changes
Renames `resource_attributes` to `append_dimensions` for consistency.

Add feature branch to PR workflow to validate unit tests.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




