### PR TITLE
awsappsignals processor: check for case insensitivity in metric names

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,7 @@ env:
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_BRANCH: "lisaguo-test-appsignals"
 
 on:
   push:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,7 @@ env:
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "lisaguo-test-appsignals"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
 
 on:
   push:

--- a/plugins/processors/awsappsignals/processor.go
+++ b/plugins/processors/awsappsignals/processor.go
@@ -138,6 +138,10 @@ func (ap *awsappsignalsprocessor) processMetrics(ctx context.Context, md pmetric
 			metrics := ils.Metrics()
 			for k := 0; k < metrics.Len(); k++ {
 				m := metrics.At(k)
+				// Check if metric name is lowercase
+				if normalizedName, exists := metricNameCase[m.Name()]; exists {
+					m.SetName(normalizedName)
+				}
 				ap.processMetricAttributes(ctx, m, resourceAttributes)
 			}
 		}
@@ -148,11 +152,6 @@ func (ap *awsappsignalsprocessor) processMetrics(ctx context.Context, md pmetric
 // Attributes are provided for each log and trace, but not at the metric level
 // Need to process attributes for every data point within a metric.
 func (ap *awsappsignalsprocessor) processMetricAttributes(_ context.Context, m pmetric.Metric, resourceAttribes pcommon.Map) {
-	// Check if metric name is lowercase
-	if normalizedName, exists := metricNameCase[m.Name()]; exists {
-		m.SetName(normalizedName)
-	}
-
 	// This is a lot of repeated code, but since there is no single parent superclass
 	// between metric data types, we can't use polymorphism.
 	switch m.Type() {

--- a/plugins/processors/awsappsignals/processor.go
+++ b/plugins/processors/awsappsignals/processor.go
@@ -136,7 +136,7 @@ func (ap *awsappsignalsprocessor) processMetrics(ctx context.Context, md pmetric
 			metrics := ils.Metrics()
 			for k := 0; k < metrics.Len(); k++ {
 				m := metrics.At(k)
-				m.SetName(metricCaser.String(m.Name())) // Ensure metric name is uppercase
+				m.SetName(metricCaser.String(m.Name())) // Ensure metric name is in sentence case
 				ap.processMetricAttributes(ctx, m, resourceAttributes)
 			}
 		}

--- a/plugins/processors/awsappsignals/processor.go
+++ b/plugins/processors/awsappsignals/processor.go
@@ -26,8 +26,8 @@ const (
 )
 
 var metricNameCase = map[string]string{
-	"error": "Error",
-	"fault": "Fault",
+	"error":   "Error",
+	"fault":   "Fault",
 	"latency": "Latency",
 }
 

--- a/plugins/processors/awsappsignals/processor.go
+++ b/plugins/processors/awsappsignals/processor.go
@@ -25,6 +25,12 @@ const (
 	failedToProcessAttributeWithLimiter    = "failed to process attributes with limiter, keep the data"
 )
 
+var metricNameCase = map[string]string{
+	"error": "Error",
+	"fault": "Fault",
+	"latency": "Latency",
+}
+
 // this is used to Process some attributes (like IP addresses) to a generic form to reduce high cardinality
 type attributesMutator interface {
 	Process(attributes, resourceAttributes pcommon.Map, isTrace bool) error
@@ -142,6 +148,10 @@ func (ap *awsappsignalsprocessor) processMetrics(ctx context.Context, md pmetric
 // Attributes are provided for each log and trace, but not at the metric level
 // Need to process attributes for every data point within a metric.
 func (ap *awsappsignalsprocessor) processMetricAttributes(_ context.Context, m pmetric.Metric, resourceAttribes pcommon.Map) {
+	// Check if metric name is lowercase
+	if normalizedName, exists := metricNameCase[m.Name()]; exists {
+		m.SetName(normalizedName)
+	}
 
 	// This is a lot of repeated code, but since there is no single parent superclass
 	// between metric data types, we can't use polymorphism.

--- a/plugins/processors/awsappsignals/processor.go
+++ b/plugins/processors/awsappsignals/processor.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	appsignalsconfig "github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/config"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsappsignals/internal/cardinalitycontrol"
@@ -25,11 +27,7 @@ const (
 	failedToProcessAttributeWithLimiter    = "failed to process attributes with limiter, keep the data"
 )
 
-var metricNameCase = map[string]string{
-	"error":   "Error",
-	"fault":   "Fault",
-	"latency": "Latency",
-}
+var metricCaser = cases.Title(language.English)
 
 // this is used to Process some attributes (like IP addresses) to a generic form to reduce high cardinality
 type attributesMutator interface {
@@ -138,10 +136,7 @@ func (ap *awsappsignalsprocessor) processMetrics(ctx context.Context, md pmetric
 			metrics := ils.Metrics()
 			for k := 0; k < metrics.Len(); k++ {
 				m := metrics.At(k)
-				// Check if metric name is lowercase
-				if normalizedName, exists := metricNameCase[m.Name()]; exists {
-					m.SetName(normalizedName)
-				}
+				m.SetName(metricCaser.String(m.Name())) // Ensure metric name is uppercase
 				ap.processMetricAttributes(ctx, m, resourceAttributes)
 			}
 		}


### PR DESCRIPTION
# Description of the issue
The adot/otel language instrumentation sdks sometimes sends metric names in lowercase over otlp. This PR maps the application signals metrics from lowercase to uppercase (ex: error -> Error)

# Description of changes
Add a map for lowercase metrics to the uppercase ones for emission

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Passed 
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/7975715500/job/21774963354

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




