### PR TITLE
[AppSignals] Update components translators to set missing fields

### DIFF
--- a/internal/util/testutil/testutil.go
+++ b/internal/util/testutil/testutil.go
@@ -29,3 +29,12 @@ func GetConf(t *testing.T, path string) *confmap.Conf {
 	require.NoError(t, err)
 	return conf
 }
+
+func GetConfWithOverrides(t *testing.T, path string, overrides map[string]any) *confmap.Conf {
+	t.Helper()
+	conf, err := confmaptest.LoadConf(path)
+	require.NoError(t, err)
+	err = conf.Merge(confmap.NewFromStringMap(overrides))
+	require.NoError(t, err)
+	return conf
+}

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -6,9 +6,9 @@ exporters:
         dimension_rollup_option: NoDimensionRollup
         disable_metric_extraction: false
         eks_fargate_container_insights_enabled: false
-        endpoint: ""
+        endpoint: https://fake_endpoint
         enhanced_container_insights: false
-        imds_retries: 0
+        imds_retries: 1
         local_mode: false
         log_group_name: /aws/appsignals/eks
         log_retention: 0
@@ -120,7 +120,7 @@ exporters:
         parse_json_encoded_attr_values: []
         profile: ""
         proxy_address: ""
-        region: ""
+        region: us-east-1
         request_timeout_seconds: 30
         resource_arn: ""
         resource_to_telemetry_conversion:
@@ -296,7 +296,7 @@ extensions:
         endpoint: 0.0.0.0:2000
         local_mode: false
         proxy_address: ""
-        region: ""
+        region: us-east-1
         role_arn: ""
 processors:
     awsappsignals:

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -6,9 +6,9 @@ exporters:
         dimension_rollup_option: NoDimensionRollup
         disable_metric_extraction: false
         eks_fargate_container_insights_enabled: false
-        endpoint: ""
+        endpoint: https://fake_endpoint
         enhanced_container_insights: false
-        imds_retries: 0
+        imds_retries: 1
         local_mode: false
         log_group_name: /aws/appsignals/k8s
         log_retention: 0
@@ -120,7 +120,7 @@ exporters:
         parse_json_encoded_attr_values: []
         profile: ""
         proxy_address: ""
-        region: ""
+        region: us-east-1
         request_timeout_seconds: 30
         resource_arn: ""
         resource_to_telemetry_conversion:
@@ -296,7 +296,7 @@ extensions:
         endpoint: 0.0.0.0:2000
         local_mode: false
         proxy_address: ""
-        region: ""
+        region: us-east-1
         role_arn: ""
 processors:
     awsappsignals:

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -6,10 +6,10 @@ exporters:
         dimension_rollup_option: NoDimensionRollup
         disable_metric_extraction: false
         eks_fargate_container_insights_enabled: false
-        endpoint: ""
+        endpoint: https://fake_endpoint
         enhanced_container_insights: false
-        imds_retries: 0
-        local_mode: false
+        imds_retries: 1
+        local_mode: true
         log_group_name: /aws/appsignals/generic
         log_retention: 0
         log_stream_name: ""
@@ -77,16 +77,16 @@ exporters:
         num_workers: 8
         output_destination: cloudwatch
         parse_json_encoded_attr_values: []
-        profile: ""
+        profile: AmazonCloudWatchAgent
         proxy_address: ""
-        region: ""
+        region: us-east-1
         request_timeout_seconds: 30
         resource_arn: ""
         resource_to_telemetry_conversion:
             enabled: false
         retain_initial_value_of_delta_metric: false
         role_arn: ""
-        shared_credentials_file: []
+        shared_credentials_file: ["fake-path"]
         version: "1"
     awsxray/app_signals:
         aws_log_groups: []
@@ -101,7 +101,7 @@ exporters:
             - aws.remote.operation
             - aws.remote.target
             - HostedIn.Environment
-        local_mode: false
+        local_mode: true
         max_retries: 2
         middleware: agenthealth/traces
         no_verify_ssl: false
@@ -130,9 +130,9 @@ extensions:
     awsproxy/app_signals:
         aws_endpoint: ""
         endpoint: 0.0.0.0:2000
-        local_mode: false
+        local_mode: true
         proxy_address: ""
-        region: ""
+        region: us-east-1
         role_arn: ""
 processors:
     awsappsignals:

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -9,7 +9,7 @@ exporters:
         endpoint: https://fake_endpoint
         enhanced_container_insights: true
         imds_retries: 1
-        local_mode: false
+        local_mode: true
         log_group_name: /aws/containerinsights/{ClusterName}/performance
         log_retention: 0
         log_stream_name: '{NodeName}'

--- a/translator/translate/otel/exporter/awsemf/translator.go
+++ b/translator/translate/otel/exporter/awsemf/translator.go
@@ -78,22 +78,10 @@ func (t *translator) Translate(c *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*awsemfexporter.Config)
 	cfg.MiddlewareID = &agenthealth.LogsID
 
-	if common.IsAppSignalsKubernetes() && t.name == common.AppSignals {
-		isEks := common.IsEKS()
-		if isEks.Value {
-			return common.GetYamlFileToYamlConfig(cfg, appSignalsConfigEks)
-		}
-		return common.GetYamlFileToYamlConfig(cfg, appSignalsConfigK8s)
-	} else if t.name == common.AppSignals {
-		ctx := context.CurrentContext()
-		if ctx.Mode() == config.ModeEC2 {
-			return common.GetYamlFileToYamlConfig(cfg, appSignalsConfigEC2)
-		}
-		return common.GetYamlFileToYamlConfig(cfg, appSignalsConfigGeneric)
-	}
-
 	var defaultConfig string
-	if isEcs(c) {
+	if t.isAppSignals(c) {
+		defaultConfig = getAppSignalsConfig()
+	} else if isEcs(c) {
 		defaultConfig = defaultEcsConfig
 	} else if isKubernetes(c) {
 		defaultConfig = defaultKubernetesConfig
@@ -128,8 +116,15 @@ func (t *translator) Translate(c *confmap.Conf) (component.Config, error) {
 	if credentialsFileKey, ok := agent.Global_Config.Credentials[agent.CredentialsFile_Key]; ok {
 		cfg.AWSSessionSettings.SharedCredentialsFile = []string{fmt.Sprintf("%v", credentialsFileKey)}
 	}
+	if context.CurrentContext().Mode() == config.ModeOnPrem || context.CurrentContext().Mode() == config.ModeOnPremise {
+		cfg.AWSSessionSettings.LocalMode = true
+	}
 
-	if isEcs(c) {
+	if t.isAppSignals(c) {
+		if err := setAppSignalsFields(c, cfg); err != nil {
+			return nil, err
+		}
+	} else if isEcs(c) {
 		if err := setEcsFields(c, cfg); err != nil {
 			return nil, err
 		}
@@ -145,6 +140,25 @@ func (t *translator) Translate(c *confmap.Conf) (component.Config, error) {
 	return cfg, nil
 }
 
+func getAppSignalsConfig() string {
+	if common.IsAppSignalsKubernetes() {
+		isEks := common.IsEKS()
+		if isEks.Value {
+			return appSignalsConfigEks
+		}
+		return appSignalsConfigK8s
+	}
+	ctx := context.CurrentContext()
+	if ctx.Mode() == config.ModeEC2 {
+		return appSignalsConfigEC2
+	}
+	return appSignalsConfigGeneric
+}
+
+func (t *translator) isAppSignals(conf *confmap.Conf) bool {
+	return t.name == common.AppSignals && (conf.IsSet(common.AppSignalsMetrics) || conf.IsSet(common.AppSignalsTraces))
+}
+
 func isEcs(conf *confmap.Conf) bool {
 	return conf.IsSet(ecsBasePathKey)
 }
@@ -155,6 +169,10 @@ func isKubernetes(conf *confmap.Conf) bool {
 
 func isPrometheus(conf *confmap.Conf) bool {
 	return conf.IsSet(prometheusBasePathKey)
+}
+
+func setAppSignalsFields(_ *confmap.Conf, _ *awsemfexporter.Config) error {
+	return nil
 }
 
 func setEcsFields(conf *confmap.Conf, cfg *awsemfexporter.Config) error {

--- a/translator/translate/otel/exporter/awsxray/translator.go
+++ b/translator/translate/otel/exporter/awsxray/translator.go
@@ -111,6 +111,9 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		cfg.AWSSessionSettings.Endpoint = endpointOverride
 	}
 	cfg.AWSSessionSettings.IMDSRetries = retryer.GetDefaultRetryNumber()
+	if context.CurrentContext().Mode() == config.ModeOnPrem || context.CurrentContext().Mode() == config.ModeOnPremise {
+		cfg.AWSSessionSettings.LocalMode = true
+	}
 	if localMode, ok := common.GetBool(conf, common.ConfigKey(common.TracesKey, common.LocalModeKey)); ok {
 		cfg.AWSSessionSettings.LocalMode = localMode
 	}

--- a/translator/translate/otel/extension/awsproxy/translator.go
+++ b/translator/translate/otel/extension/awsproxy/translator.go
@@ -9,6 +9,9 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension"
 
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
@@ -33,5 +36,10 @@ func (t *translator) ID() component.ID {
 
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*awsproxy.Config)
+	if context.CurrentContext().Mode() == config.ModeOnPrem || context.CurrentContext().Mode() == config.ModeOnPremise {
+		cfg.ProxyConfig.LocalMode = true
+	}
+	cfg.ProxyConfig.Region = agent.Global_Config.Region
+	cfg.ProxyConfig.RoleARN = agent.Global_Config.Role_arn
 	return cfg, nil
 }


### PR DESCRIPTION
# Description of the issue
We are currently not setting all the required fields for our components during translation that are required to work on envs when IMDS isnt available.

# Description of changes
* Consistently set fields on our components.
* Remove deviation in awsemfexporter translator for APM to make it consistent with remaining plugins.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Unit tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




