### PR TITLE
Do not update RemoteService dimension on the to be aggregated dependency metrics

### DIFF
--- a/plugins/processors/awsappsignals/internal/cardinalitycontrol/metrics_limiter.go
+++ b/plugins/processors/awsappsignals/internal/cardinalitycontrol/metrics_limiter.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	UnprocessedServiceOperationValue = "AllOtherOperations"
-	UnprocessedRemoteServiceValue    = "AllOtherDependencies"
+	UnprocessedServiceOperationValue       = "AllOtherOperations"
+	UnprocessedRemoteServiceOperationValue = "AllOtherRemoteOperations"
 )
 
 const (
@@ -338,13 +338,13 @@ func (s *service) admitMetricData(metric *MetricData) bool {
 
 func (s *service) rollupMetricData(attributes pcommon.Map) {
 	for _, indexAttr := range awsDeclaredMetricAttributes {
-		if strings.HasPrefix(indexAttr, "HostedIn.") || (indexAttr == common.MetricAttributeLocalService) {
+		if strings.HasPrefix(indexAttr, "HostedIn.") || (indexAttr == common.MetricAttributeLocalService) || (indexAttr == common.MetricAttributeRemoteService) {
 			continue
 		}
 		if indexAttr == common.MetricAttributeLocalOperation {
 			attributes.PutStr(indexAttr, UnprocessedServiceOperationValue)
-		} else if indexAttr == common.MetricAttributeRemoteService {
-			attributes.PutStr(indexAttr, UnprocessedRemoteServiceValue)
+		} else if indexAttr == common.MetricAttributeRemoteOperation {
+			attributes.PutStr(indexAttr, UnprocessedRemoteServiceOperationValue)
 		} else {
 			attributes.PutStr(indexAttr, "-")
 		}

--- a/plugins/processors/awsappsignals/internal/cardinalitycontrol/metrics_limiter_test.go
+++ b/plugins/processors/awsappsignals/internal/cardinalitycontrol/metrics_limiter_test.go
@@ -42,14 +42,14 @@ func TestAdmitAndRollup(t *testing.T) {
 			admittedAttributes[uniqKey.AsString()] = attr
 		} else {
 			for _, indexedAttrKey := range awsDeclaredMetricAttributes {
-				if strings.HasPrefix(indexedAttrKey, "HostedIn.") || indexedAttrKey == "Service" {
+				if strings.HasPrefix(indexedAttrKey, "HostedIn.") || indexedAttrKey == "Service" || indexedAttrKey == "RemoteService" {
 					continue
 				}
 				attrValue, _ := attr.Get(indexedAttrKey)
 				if indexedAttrKey == common.MetricAttributeLocalOperation {
 					assert.Equal(t, UnprocessedServiceOperationValue, attrValue.AsString())
-				} else if indexedAttrKey == common.MetricAttributeRemoteService {
-					assert.Equal(t, UnprocessedRemoteServiceValue, attrValue.AsString())
+				} else if indexedAttrKey == common.MetricAttributeRemoteOperation {
+					assert.Equal(t, UnprocessedRemoteServiceOperationValue, attrValue.AsString())
 				} else {
 					assert.Equal(t, "-", attrValue.AsString())
 				}


### PR DESCRIPTION
# Description of changes
Most of  high cardinality metrics case in AppSignals. the high cardinality values will come from Local and Remote Operation dimensions. and we do want to keep some of the key dimensions if it will not be in the high cardinality situation. So in this changes, we will keep the original dimension value of RemoteService that was previously overrode by MetricLimiter, but change RemoteOperation dimension value to `AllOtherRemoteOperations`

The new MetricLimiter overall aggregation rule, we don't aggregate the dimension of `LocalService`, `RemoteService` and `HostedIn_*` dimensions . We will replace `LocalOperation` to `AllOtherOperations` and `RemoteOperation` dimension into `AllOtherRemoteOperations` . The rest of other dimension values  into "-"

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
unit test

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




