### PR TITLE
Move usage flag configuration to agenthealth extension

### DIFF
--- a/cfg/aws/credentials.go
+++ b/cfg/aws/credentials.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 
-	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/provider"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
 )
 
 const (
@@ -116,7 +116,7 @@ func getSession(config *aws.Config) *session.Session {
 		if len(found) > 0 {
 			log.Printf("W! Unused shared config file(s) found: %v. If you would like to use them, "+
 				"please update your common-config.toml.", found)
-			provider.GetFlagsStats().SetFlag(provider.FlagSharedConfigFallback)
+			agent.UsageFlags().Set(agent.FlagSharedConfigFallback)
 		}
 	}
 	return ses

--- a/extension/agenthealth/handler/stats/agent/agent.go
+++ b/extension/agenthealth/handler/stats/agent/agent.go
@@ -111,4 +111,6 @@ func NewOperationsFilter(operations ...string) OperationsFilter {
 type StatsConfig struct {
 	// Operations are the allowed operation names to gather stats for.
 	Operations []string `mapstructure:"operations,omitempty"`
+	// UsageFlags are the usage flags to set on start up.
+	UsageFlags map[Flag]any `mapstructure:"usage_flags,omitempty"`
 }

--- a/extension/agenthealth/handler/stats/agent/flag.go
+++ b/extension/agenthealth/handler/stats/agent/flag.go
@@ -1,0 +1,188 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+var (
+	errUnsupportedFlag = errors.New("unsupported usage flag")
+)
+
+const (
+	FlagIMDSFallbackSuccess Flag = iota
+	FlagSharedConfigFallback
+	FlagAppSignal
+	FlagEnhancedContainerInsights
+	FlagRunningInContainer
+	FlagMode
+	FlagRegionType
+
+	flagIMDSFallbackSuccessStr       = "imds_fallback_success"
+	flagSharedConfigFallbackStr      = "shared_config_fallback"
+	flagAppSignalsStr                = "app_signals"
+	flagEnhancedContainerInsightsStr = "enhanced_container_insights"
+	flagRunningInContainerStr        = "running_in_container"
+	flagModeStr                      = "mode"
+	flagRegionTypeStr                = "region_type"
+)
+
+type Flag int
+
+var _ encoding.TextMarshaler = (*Flag)(nil)
+var _ encoding.TextUnmarshaler = (*Flag)(nil)
+
+func (f Flag) String() string {
+	switch f {
+	case FlagAppSignal:
+		return flagAppSignalsStr
+	case FlagEnhancedContainerInsights:
+		return flagEnhancedContainerInsightsStr
+	case FlagIMDSFallbackSuccess:
+		return flagIMDSFallbackSuccessStr
+	case FlagMode:
+		return flagModeStr
+	case FlagRegionType:
+		return flagRegionTypeStr
+	case FlagRunningInContainer:
+		return flagRunningInContainerStr
+	case FlagSharedConfigFallback:
+		return flagSharedConfigFallbackStr
+	}
+	return ""
+}
+
+func (f Flag) MarshalText() (text []byte, err error) {
+	s := f.String()
+	if s == "" {
+		return nil, fmt.Errorf("%w: %[2]T(%[2]d)", errUnsupportedFlag, f)
+	}
+	return []byte(s), nil
+}
+
+func (f *Flag) UnmarshalText(text []byte) error {
+	switch s := string(text); s {
+	case flagAppSignalsStr:
+		*f = FlagAppSignal
+	case flagEnhancedContainerInsightsStr:
+		*f = FlagEnhancedContainerInsights
+	case flagIMDSFallbackSuccessStr:
+		*f = FlagIMDSFallbackSuccess
+	case flagModeStr:
+		*f = FlagMode
+	case flagRegionTypeStr:
+		*f = FlagRegionType
+	case flagRunningInContainerStr:
+		*f = FlagRunningInContainer
+	case flagSharedConfigFallbackStr:
+		*f = FlagSharedConfigFallback
+	default:
+		return fmt.Errorf("%w: %s", errUnsupportedFlag, s)
+	}
+	return nil
+}
+
+var (
+	flagSingleton FlagSet
+	flagOnce      sync.Once
+)
+
+// FlagSet is a getter/setter for flag/value pairs. Once a flag key is set, its value is immutable.
+type FlagSet interface {
+	// IsSet returns if the flag is present in the backing map.
+	IsSet(flag Flag) bool
+	// GetString if the value stored with the flag is a string. If not, returns nil.
+	GetString(flag Flag) *string
+	// Set adds the Flag with an unused value.
+	Set(flag Flag)
+	// SetValue adds the Flag with a value.
+	SetValue(flag Flag, value any)
+	// SetValues adds each Flag/value pair.
+	SetValues(flags map[Flag]any)
+	// OnChange registers a callback that triggers on flag sets.
+	OnChange(callback func())
+}
+
+type flagSet struct {
+	m         sync.Map
+	mu        sync.RWMutex
+	callbacks []func()
+}
+
+var _ FlagSet = (*flagSet)(nil)
+
+func (p *flagSet) IsSet(flag Flag) bool {
+	_, ok := p.m.Load(flag)
+	return ok
+}
+
+func (p *flagSet) GetString(flag Flag) *string {
+	value, ok := p.m.Load(flag)
+	if !ok {
+		return nil
+	}
+	var str string
+	str, ok = value.(string)
+	if !ok || str == "" {
+		return nil
+	}
+	return aws.String(str)
+}
+
+func (p *flagSet) Set(flag Flag) {
+	p.SetValue(flag, 1)
+}
+
+func (p *flagSet) SetValue(flag Flag, value any) {
+	if p.setWithValue(flag, value) {
+		p.notify()
+	}
+}
+
+func (p *flagSet) SetValues(m map[Flag]any) {
+	var changed bool
+	for flag, value := range m {
+		if p.setWithValue(flag, value) {
+			changed = true
+		}
+	}
+	if changed {
+		p.notify()
+	}
+}
+
+func (p *flagSet) setWithValue(flag Flag, value any) bool {
+	if !p.IsSet(flag) {
+		p.m.Store(flag, value)
+		return true
+	}
+	return false
+}
+
+func (p *flagSet) OnChange(f func()) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.callbacks = append(p.callbacks, f)
+}
+
+func (p *flagSet) notify() {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, callback := range p.callbacks {
+		callback()
+	}
+}
+
+func UsageFlags() FlagSet {
+	flagOnce.Do(func() {
+		flagSingleton = &flagSet{}
+	})
+	return flagSingleton
+}

--- a/extension/agenthealth/handler/stats/agent/flag_test.go
+++ b/extension/agenthealth/handler/stats/agent/flag_test.go
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlagSet(t *testing.T) {
+	fs := &flagSet{}
+	var notifyCount int
+	fs.OnChange(func() {
+		notifyCount++
+	})
+	assert.False(t, fs.IsSet(FlagIMDSFallbackSuccess))
+	assert.Nil(t, fs.GetString(FlagIMDSFallbackSuccess))
+	fs.Set(FlagIMDSFallbackSuccess)
+	assert.True(t, fs.IsSet(FlagIMDSFallbackSuccess))
+	assert.Nil(t, fs.GetString(FlagIMDSFallbackSuccess))
+	assert.Equal(t, 1, notifyCount)
+	// already set, so ignored
+	fs.SetValue(FlagIMDSFallbackSuccess, "ignores this")
+	assert.Nil(t, fs.GetString(FlagIMDSFallbackSuccess))
+	assert.Equal(t, 1, notifyCount)
+	fs.SetValues(map[Flag]any{
+		FlagMode:       "test/mode",
+		FlagRegionType: "test/region-type",
+	})
+	assert.True(t, fs.IsSet(FlagMode))
+	assert.True(t, fs.IsSet(FlagRegionType))
+	got := fs.GetString(FlagMode)
+	assert.NotNil(t, got)
+	assert.Equal(t, "test/mode", *got)
+	got = fs.GetString(FlagRegionType)
+	assert.NotNil(t, got)
+	assert.Equal(t, "test/region-type", *got)
+	assert.Equal(t, 2, notifyCount)
+	fs.SetValues(map[Flag]any{
+		FlagRegionType: "other",
+	})
+	assert.NotNil(t, got)
+	assert.Equal(t, "test/region-type", *got)
+	assert.Equal(t, 2, notifyCount)
+	fs.SetValues(map[Flag]any{
+		FlagMode:               "other/mode",
+		FlagRunningInContainer: true,
+	})
+	got = fs.GetString(FlagMode)
+	assert.NotNil(t, got)
+	assert.Equal(t, "test/mode", *got)
+	assert.True(t, fs.IsSet(FlagRunningInContainer))
+	assert.Equal(t, 3, notifyCount)
+}
+
+func TestFlag(t *testing.T) {
+	testCases := []struct {
+		flag Flag
+		str  string
+	}{
+		{flag: FlagAppSignal, str: flagAppSignalsStr},
+		{flag: FlagEnhancedContainerInsights, str: flagEnhancedContainerInsightsStr},
+		{flag: FlagIMDSFallbackSuccess, str: flagIMDSFallbackSuccessStr},
+		{flag: FlagMode, str: flagModeStr},
+		{flag: FlagRegionType, str: flagRegionTypeStr},
+		{flag: FlagRunningInContainer, str: flagRunningInContainerStr},
+		{flag: FlagSharedConfigFallback, str: flagSharedConfigFallbackStr},
+	}
+	for _, testCase := range testCases {
+		flag := testCase.flag
+		got, err := flag.MarshalText()
+		assert.NoError(t, err)
+		assert.EqualValues(t, testCase.str, got)
+		assert.NoError(t, flag.UnmarshalText(got))
+		assert.Equal(t, flag, testCase.flag)
+	}
+}
+
+func TestInvalidFlag(t *testing.T) {
+	f := Flag(-1)
+	got, err := f.MarshalText()
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errUnsupportedFlag)
+	assert.Nil(t, got)
+	err = f.UnmarshalText([]byte("Flag(-1)"))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errUnsupportedFlag)
+}

--- a/extension/agenthealth/handler/stats/handler.go
+++ b/extension/agenthealth/handler/stats/handler.go
@@ -25,6 +25,7 @@ func NewHandlers(logger *zap.Logger, cfg agent.StatsConfig) ([]awsmiddleware.Req
 	filter := agent.NewOperationsFilter(cfg.Operations...)
 	clientStats := client.NewHandler(filter)
 	stats := newStatsHandler(logger, filter, []agent.StatsProvider{clientStats, provider.GetProcessStats(), provider.GetFlagsStats()})
+	agent.UsageFlags().SetValues(cfg.UsageFlags)
 	return []awsmiddleware.RequestHandler{stats, clientStats}, []awsmiddleware.ResponseHandler{clientStats}
 }
 

--- a/extension/agenthealth/handler/stats/provider/flag_test.go
+++ b/extension/agenthealth/handler/stats/provider/flag_test.go
@@ -10,28 +10,29 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
 )
 
 func TestFlagStats(t *testing.T) {
 	t.Setenv(envconfig.RunInContainer, envconfig.TrueValue)
-	provider := newFlagStats(time.Microsecond)
-	got := provider.getStats()
+	fs := newFlagStats(agent.UsageFlags(), time.Microsecond)
+	got := fs.getStats()
 	assert.Nil(t, got.ImdsFallbackSucceed)
 	assert.Nil(t, got.SharedConfigFallback)
 	assert.NotNil(t, got.RunningInContainer)
 	assert.Equal(t, 1, *got.RunningInContainer)
-	provider.SetFlag(FlagIMDSFallbackSucceed)
+	fs.flagSet.Set(agent.FlagIMDSFallbackSuccess)
 	assert.Nil(t, got.ImdsFallbackSucceed)
-	got = provider.getStats()
+	got = fs.getStats()
 	assert.NotNil(t, got.ImdsFallbackSucceed)
 	assert.Equal(t, 1, *got.ImdsFallbackSucceed)
 	assert.Nil(t, got.SharedConfigFallback)
-	provider.SetFlag(FlagSharedConfigFallback)
-	got = provider.getStats()
+	fs.flagSet.Set(agent.FlagSharedConfigFallback)
+	got = fs.getStats()
 	assert.NotNil(t, got.SharedConfigFallback)
 	assert.Equal(t, 1, *got.SharedConfigFallback)
-	provider.SetFlagWithValue(FlagMode, "test")
-	got = provider.getStats()
+	fs.flagSet.SetValue(agent.FlagMode, "test")
+	got = fs.getStats()
 	assert.NotNil(t, got.Mode)
 	assert.Equal(t, "test", *got.Mode)
 }

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
-	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/provider"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
 	"github.com/aws/amazon-cloudwatch-agent/internal/util/collections"
 	"github.com/aws/amazon-cloudwatch-agent/internal/version"
 	"github.com/aws/amazon-cloudwatch-agent/receiver/adapter"
@@ -91,11 +91,11 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 				cfg := otelCfg.Exporters[exporter].(*awsemfexporter.Config)
 				if cfg.IsAppSignalsEnabled() {
 					ua.outputs.Add(flagAppSignals)
-					provider.GetFlagsStats().SetFlag(provider.FlagAppSignal)
+					agent.UsageFlags().Set(agent.FlagAppSignal)
 				}
 				if cfg.IsEnhancedContainerInsights() {
 					ua.outputs.Add(flagEnhancedContainerInsights)
-					provider.GetFlagsStats().SetFlag(provider.FlagEnhancedContainerInsights)
+					agent.UsageFlags().Set(agent.FlagEnhancedContainerInsights)
 				}
 			}
 		}

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -27,7 +27,6 @@ import (
 	"golang.org/x/exp/maps"
 
 	configaws "github.com/aws/amazon-cloudwatch-agent/cfg/aws"
-	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/provider"
 	"github.com/aws/amazon-cloudwatch-agent/handlers"
 	"github.com/aws/amazon-cloudwatch-agent/internal/publisher"
 	"github.com/aws/amazon-cloudwatch-agent/internal/retryer"
@@ -97,8 +96,6 @@ func (c *CloudWatch) Start(_ context.Context, host component.Host) error {
 		Filename:  c.config.SharedCredentialFilename,
 		Token:     c.config.Token,
 	}
-	provider.GetFlagsStats().SetFlagWithValue(provider.FlagRegionType, c.config.RegionType)
-	provider.GetFlagsStats().SetFlagWithValue(provider.FlagMode, c.config.Mode)
 	configProvider := credentialConfig.Credentials()
 	logger := models.NewLogger("outputs", "cloudwatch", "")
 	logThrottleRetryer := retryer.NewLogThrottleRetryer(logger)

--- a/plugins/outputs/cloudwatch/config.go
+++ b/plugins/outputs/cloudwatch/config.go
@@ -18,8 +18,6 @@ type Config struct {
 	AccessKey                string          `mapstructure:"access_key,omitempty"`
 	SecretKey                string          `mapstructure:"secret_key,omitempty"`
 	RoleARN                  string          `mapstructure:"role_arn,omitempty"`
-	RegionType               string          `mapstructure:"region_type,omitempty"`
-	Mode                     string          `mapstructure:"mode,omitempty"`
 	Profile                  string          `mapstructure:"profile,omitempty"`
 	SharedCredentialFilename string          `mapstructure:"shared_credential_file,omitempty"`
 	Token                    string          `mapstructure:"token,omitempty"`

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -23,7 +23,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
-	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/provider"
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/useragent"
 	"github.com/aws/amazon-cloudwatch-agent/handlers"
 	"github.com/aws/amazon-cloudwatch-agent/internal"
@@ -150,8 +149,8 @@ func (c *CloudWatchLogs) getDest(t Target) *cwDest {
 			Logger:   configaws.SDKLogger{},
 		},
 	)
-	provider.GetFlagsStats().SetFlagWithValue(provider.FlagRegionType, c.RegionType)
-	provider.GetFlagsStats().SetFlagWithValue(provider.FlagMode, c.Mode)
+	agent.UsageFlags().SetValue(agent.FlagRegionType, c.RegionType)
+	agent.UsageFlags().SetValue(agent.FlagMode, c.Mode)
 	if containerInsightsRegexp.MatchString(t.Group) {
 		useragent.Get().SetContainerInsightsFlag()
 	}

--- a/plugins/processors/ec2tagger/ec2metadataprovider.go
+++ b/plugins/processors/ec2tagger/ec2metadataprovider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 
 	configaws "github.com/aws/amazon-cloudwatch-agent/cfg/aws"
-	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/provider"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
 	"github.com/aws/amazon-cloudwatch-agent/internal/retryer"
 )
 
@@ -52,7 +52,7 @@ func (c *metadataClient) InstanceID(ctx context.Context) (string, error) {
 		log.Printf("D! could not get instance id without imds v1 fallback enable thus enable fallback")
 		instanceInner, errorInner := c.metadataFallbackEnabled.GetMetadataWithContext(ctx, "instance-id")
 		if errorInner == nil {
-			provider.GetFlagsStats().SetFlag(provider.FlagIMDSFallbackSucceed)
+			agent.UsageFlags().Set(agent.FlagIMDSFallbackSuccess)
 		}
 		return instanceInner, errorInner
 	}
@@ -65,7 +65,7 @@ func (c *metadataClient) Hostname(ctx context.Context) (string, error) {
 		log.Printf("D! could not get hostname without imds v1 fallback enable thus enable fallback")
 		hostnameInner, errorInner := c.metadataFallbackEnabled.GetMetadataWithContext(ctx, "hostname")
 		if errorInner == nil {
-			provider.GetFlagsStats().SetFlag(provider.FlagIMDSFallbackSucceed)
+			agent.UsageFlags().Set(agent.FlagIMDSFallbackSuccess)
 		}
 		return hostnameInner, errorInner
 	}
@@ -78,7 +78,7 @@ func (c *metadataClient) Get(ctx context.Context) (ec2metadata.EC2InstanceIdenti
 		log.Printf("D! could not get instance document without imds v1 fallback enable thus enable fallback")
 		instanceDocumentInner, errorInner := c.metadataFallbackEnabled.GetInstanceIdentityDocumentWithContext(ctx)
 		if errorInner == nil {
-			provider.GetFlagsStats().SetFlag(provider.FlagIMDSFallbackSucceed)
+			agent.UsageFlags().Set(agent.FlagIMDSFallbackSuccess)
 		}
 		return instanceDocumentInner, errorInner
 	}

--- a/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:

--- a/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:

--- a/translator/tocwconfig/sampleConfig/advanced_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_windows.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -286,11 +286,17 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+              mode: EC2
+              region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
+            usage_flags:
+              mode: EC2
+              region_type: ACJ
     awsproxy/app_signals:
         aws_endpoint: ""
         endpoint: 0.0.0.0:2000

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -286,11 +286,17 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+              mode: EC2
+              region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
+            usage_flags:
+              mode: EC2
+              region_type: ACJ
     awsproxy/app_signals:
         aws_endpoint: ""
         endpoint: 0.0.0.0:2000

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -122,11 +122,17 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+              mode: OP
+              region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
+            usage_flags:
+              mode: OP
+              region_type: ACJ
     awsproxy/app_signals:
         aws_endpoint: ""
         endpoint: 0.0.0.0:2000

--- a/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
@@ -159,6 +159,9 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+              mode: EC2
+              region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/basic_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/basic_config_linux.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-east-1
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/basic_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/basic_config_windows.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/collectd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/collectd_config_linux.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors: {}
 receivers:
     telegraf_socket_listener:

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -6,10 +6,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 5000
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test
@@ -80,16 +78,25 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
     agenthealth/metrics:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/emf_logs:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -9,10 +9,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 5000
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test
@@ -83,16 +81,25 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
     agenthealth/metrics:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/emf_logs:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
@@ -6,10 +6,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 5000
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         role_arn: metrics_role_arn_value_test
@@ -80,16 +78,25 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
     agenthealth/metrics:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/emf_logs:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/config_with_env.yaml
+++ b/translator/tocwconfig/sampleConfig/config_with_env.yaml
@@ -39,6 +39,9 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/emf_logs:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-east-1
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:

--- a/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-east-1
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:

--- a/translator/tocwconfig/sampleConfig/drop_origin_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/drop_origin_linux.yaml
@@ -10,10 +10,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -22,6 +20,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -5,7 +5,7 @@ exporters:
         emf_only: true
         endpoint: https://fake_endpoint
         imds_retries: 2
-        local_mode: false
+        local_mode: true
         log_group_name: emf/logs/default
         log_retention: 0
         log_stream_name: host_name_from_env
@@ -43,7 +43,7 @@ exporters:
         endpoint: https://fake_endpoint
         enhanced_container_insights: true
         imds_retries: 2
-        local_mode: false
+        local_mode: true
         log_group_name: /aws/containerinsights/{ClusterName}/performance
         log_retention: 0
         log_stream_name: '{NodeName}'
@@ -414,6 +414,9 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+              mode: OP
+              region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000
@@ -453,7 +456,7 @@ receivers:
         imds_retries: 2
         leader_lock_name: cwagent-clusterleader
         leader_lock_using_config_map_only: true
-        local_mode: false
+        local_mode: true
         max_retries: 0
         no_verify_ssl: false
         num_workers: 0

--- a/translator/tocwconfig/sampleConfig/ignore_append_dimensions.yaml
+++ b/translator/tocwconfig/sampleConfig/ignore_append_dimensions.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-east-1
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     ec2tagger:
         ec2_instance_tag_keys: []

--- a/translator/tocwconfig/sampleConfig/invalid_input_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/invalid_input_linux.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-east-1
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -380,6 +380,9 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+              mode: OP
+              region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
+++ b/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
@@ -101,6 +101,9 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -412,6 +412,9 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+              mode: EC2
+              region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/prometheus_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_config_linux.yaml
@@ -77,6 +77,9 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+              mode: EC2
+              region_type: ACJ
 processors:
     batch/prometheus:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/prometheus_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_config_windows.yaml
@@ -59,6 +59,9 @@ extensions:
         stats:
             operations:
                 - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/prometheus:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:

--- a/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
@@ -5,11 +5,9 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         profile: AmazonCloudWatchAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         shared_credential_file: fake-path
@@ -19,6 +17,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     cumulativetodelta/hostDeltaMetrics:
         exclude:

--- a/translator/tocwconfig/sampleConfig/standard_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_windows.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/standard_config_windows_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_windows_with_common_config.yaml
@@ -5,11 +5,9 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         profile: AmazonCloudWatchAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
         shared_credential_file: fake-path
@@ -19,6 +17,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/statsd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/statsd_config_linux.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors: {}
 receivers:
     telegraf_statsd:

--- a/translator/tocwconfig/sampleConfig/statsd_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/statsd_config_windows.yaml
@@ -5,10 +5,8 @@ exporters:
         max_datums_per_call: 1000
         max_values_per_datum: 150
         middleware: agenthealth/metrics
-        mode: EC2
         namespace: CWAgent
         region: us-west-2
-        region_type: ACJ
         resource_to_telemetry_conversion:
             enabled: true
 extensions:
@@ -17,6 +15,9 @@ extensions:
         stats:
             operations:
                 - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors: {}
 receivers:
     telegraf_statsd:

--- a/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
@@ -29,6 +29,9 @@ extensions:
         stats:
             operations:
                 - PutTraceSegments
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/xray:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
@@ -29,6 +29,9 @@ extensions:
         stats:
             operations:
                 - PutTraceSegments
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/xray:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -59,6 +59,7 @@ type testCase struct {
 func TestBaseContainerInsightsConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(true)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	t.Setenv(config.HOST_NAME, "host_name_from_env")
 	t.Setenv(config.HOST_IP, "127.0.0.1")
 	t.Setenv(envconfig.AWS_CA_BUNDLE, "/etc/test/ca_bundle.pem")
@@ -83,6 +84,7 @@ func TestGenericAppSignalsConfig(t *testing.T) {
 func TestAppSignalsAndKubernetesConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(true)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	t.Setenv(config.HOST_NAME, "host_name_from_env")
 	t.Setenv(config.HOST_IP, "127.0.0.1")
 	t.Setenv(common.KubernetesEnvVar, "use_appsignals_eks_config")
@@ -106,6 +108,7 @@ func TestEmfAndKubernetesConfig(t *testing.T) {
 	resetContext(t)
 	readCommonConfig(t, "./sampleConfig/commonConfig/withCredentials.toml")
 	context.CurrentContext().SetRunInContainer(true)
+	context.CurrentContext().SetMode(config.ModeOnPrem)
 	t.Setenv(config.HOST_NAME, "host_name_from_env")
 	t.Setenv(config.HOST_IP, "127.0.0.1")
 	expectedEnvVars := map[string]string{}
@@ -126,6 +129,7 @@ func TestKubernetesModeOnPremiseConfig(t *testing.T) {
 func TestLogsAndKubernetesConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(true)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	t.Setenv(config.HOST_NAME, "host_name_from_env")
 	t.Setenv(config.HOST_IP, "127.0.0.1")
 	// for otel components and not our adapter components like
@@ -188,6 +192,7 @@ func TestCollectDConfig(t *testing.T) {
 func TestPrometheusConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(true)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	t.Setenv(config.HOST_NAME, "host_name_from_env")
 	temp := t.TempDir()
 	prometheusConfigFileName := filepath.Join(temp, "prometheus.yaml")
@@ -409,6 +414,7 @@ func TestTraceConfig(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			resetContext(t)
+			context.CurrentContext().SetMode(config.ModeEC2)
 			readCommonConfig(t, "./sampleConfig/commonConfig/withCredentials.toml")
 			checkTranslation(t, testCase.filename, testCase.targetPlatform, testCase.expectedEnvVars, testCase.appendString)
 		})
@@ -417,6 +423,7 @@ func TestTraceConfig(t *testing.T) {
 
 func TestConfigWithEnvironmentVariables(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "config_with_env", "linux", expectedEnvVars, "")
 }
@@ -472,6 +479,8 @@ func TestDeltaNetConfigLinux(t *testing.T) {
 
 func TestECSNodeMetricConfig(t *testing.T) {
 	resetContext(t)
+	context.CurrentContext().SetRunInContainer(true)
+	context.CurrentContext().SetMode(config.ModeEC2)
 	t.Setenv("RUN_IN_CONTAINER", "True")
 	t.Setenv("HOST_NAME", "fake-host-name")
 	t.Setenv("HOST_IP", "127.0.0.1")

--- a/translator/translate/otel/exporter/awscloudwatch/translator.go
+++ b/translator/translate/otel/exporter/awscloudwatch/translator.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/metric"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatch"
-	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/metrics/rollup_dimensions"
@@ -59,8 +58,6 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	_ = credentials.Unmarshal(cfg)
 	cfg.RoleARN = getRoleARN(conf)
 	cfg.Region = agent.Global_Config.Region
-	cfg.RegionType = agent.Global_Config.RegionType
-	cfg.Mode = context.CurrentContext().ShortMode()
 	if namespace, ok := common.GetString(conf, common.ConfigKey(common.MetricsKey, namespaceKey)); ok {
 		cfg.Namespace = namespace
 	}

--- a/translator/translate/otel/exporter/otel_aws_cloudwatch_logs/translator.go
+++ b/translator/translate/otel/exporter/otel_aws_cloudwatch_logs/translator.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 	"github.com/aws/amazon-cloudwatch-agent/internal/retryer"
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
@@ -56,8 +58,6 @@ func (t *translator) Translate(c *confmap.Conf) (component.Config, error) {
 	// Add more else if when otel supports log reading
 	if t.name == common.PipelineNameEmfLogs && t.isEmf(c) {
 		defaultConfig = defaultAwsCloudwatchLogsDefault
-	} else {
-		return cfg, nil
 	}
 
 	if defaultConfig != "" {
@@ -93,6 +93,9 @@ func (t *translator) Translate(c *confmap.Conf) (component.Config, error) {
 	}
 	if credentialsFileKey, ok := agent.Global_Config.Credentials[agent.CredentialsFile_Key]; ok {
 		cfg.AWSSessionSettings.SharedCredentialsFile = []string{fmt.Sprintf("%v", credentialsFileKey)}
+	}
+	if context.CurrentContext().Mode() == config.ModeOnPrem || context.CurrentContext().Mode() == config.ModeOnPremise {
+		cfg.AWSSessionSettings.LocalMode = true
 	}
 	return cfg, nil
 }

--- a/translator/translate/otel/extension/agenthealth/translator.go
+++ b/translator/translate/otel/extension/agenthealth/translator.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
+	translateagent "github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
@@ -57,6 +59,12 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	if usageData, ok := common.GetBool(conf, common.ConfigKey(common.AgentKey, usageDataKey)); ok {
 		cfg.IsUsageDataEnabled = cfg.IsUsageDataEnabled && usageData
 	}
-	cfg.Stats = agent.StatsConfig{Operations: t.operations}
+	cfg.Stats = agent.StatsConfig{
+		Operations: t.operations,
+		UsageFlags: map[agent.Flag]any{
+			agent.FlagMode:       context.CurrentContext().ShortMode(),
+			agent.FlagRegionType: translateagent.Global_Config.RegionType,
+		},
+	}
 	return cfg, nil
 }

--- a/translator/translate/otel/extension/agenthealth/translator_test.go
+++ b/translator/translate/otel/extension/agenthealth/translator_test.go
@@ -11,10 +11,19 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
+	translateagent "github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 )
 
 func TestTranslate(t *testing.T) {
+	context.CurrentContext().SetMode(config.ModeEC2)
+	translateagent.Global_Config.RegionType = config.RegionTypeNotFound
 	operations := []string{OperationPutLogEvents}
+	usageFlags := map[agent.Flag]any{
+		agent.FlagMode:       config.ShortModeEC2,
+		agent.FlagRegionType: config.RegionTypeNotFound,
+	}
 	testCases := map[string]struct {
 		input          map[string]interface{}
 		isEnvUsageData bool
@@ -27,6 +36,7 @@ func TestTranslate(t *testing.T) {
 				IsUsageDataEnabled: true,
 				Stats: agent.StatsConfig{
 					Operations: operations,
+					UsageFlags: usageFlags,
 				},
 			},
 		},
@@ -37,6 +47,7 @@ func TestTranslate(t *testing.T) {
 				IsUsageDataEnabled: false,
 				Stats: agent.StatsConfig{
 					Operations: operations,
+					UsageFlags: usageFlags,
 				},
 			},
 		},
@@ -47,6 +58,7 @@ func TestTranslate(t *testing.T) {
 				IsUsageDataEnabled: false,
 				Stats: agent.StatsConfig{
 					Operations: operations,
+					UsageFlags: usageFlags,
 				},
 			},
 		},
@@ -57,6 +69,7 @@ func TestTranslate(t *testing.T) {
 				IsUsageDataEnabled: true,
 				Stats: agent.StatsConfig{
 					Operations: operations,
+					UsageFlags: usageFlags,
 				},
 			},
 		},

--- a/translator/util/ec2util/ec2util.go
+++ b/translator/util/ec2util/ec2util.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	configaws "github.com/aws/amazon-cloudwatch-agent/cfg/aws"
-	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/provider"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
 	"github.com/aws/amazon-cloudwatch-agent/internal/retryer"
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
@@ -116,7 +116,7 @@ func (e *ec2Util) deriveEC2MetadataFromIMDS() error {
 		hostnameInner, errInner := mdEnableFallback.GetMetadata("hostname")
 		if errInner == nil {
 			e.Hostname = hostnameInner
-			provider.GetFlagsStats().SetFlag(provider.FlagIMDSFallbackSucceed)
+			agent.UsageFlags().Set(agent.FlagIMDSFallbackSuccess)
 		} else {
 			fmt.Println("E! [EC2] Fetch hostname from EC2 metadata fail:", errInner)
 		}
@@ -136,7 +136,7 @@ func (e *ec2Util) deriveEC2MetadataFromIMDS() error {
 			e.AccountID = instanceIdentityDocumentInner.AccountID
 			e.PrivateIP = instanceIdentityDocumentInner.PrivateIP
 			e.InstanceID = instanceIdentityDocumentInner.InstanceID
-			provider.GetFlagsStats().SetFlag(provider.FlagIMDSFallbackSucceed)
+			agent.UsageFlags().Set(agent.FlagIMDSFallbackSuccess)
 		} else {
 			fmt.Println("E! [EC2] Fetch identity document from EC2 metadata fail:", errInner)
 		}


### PR DESCRIPTION
# Description of the issue
Currently, the `mode`/`region_type` flags are only getting configured on the `cloudwatch` and `cloudwatchlogs` output plugins. If neither of those are configured, then those two flags will not get set.

# Description of changes
- Moves the configured flags to the `agenthealth` extension instead.
- Separates out the flag set from the stats provider.
- Fixes the local mode for the `awscloudwatchlogs` exporter.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Fixed the unit tests (particularly the sample config tests).

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




