### PR TITLE
Use local dockerignore instead of tmp directories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,10 @@ WIN_BUILD = GOOS=windows GOARCH=amd64 go build -trimpath -buildmode=${CWAGENT_BU
 DARWIN_BUILD_AMD64 = CGO_ENABLED=1 GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/darwin_amd64
 DARWIN_BUILD_ARM64 = CGO_ENABLED=1 GO111MODULE=on GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="${LDFLAGS}" -o $(BUILD_SPACE)/bin/darwin_arm64
 
-IMAGE = amazon/cloudwatch-agent:$(VERSION)
+IMAGE_REGISTRY = amazon
+IMAGE_REPO = cloudwatch-agent
+IMAGE_TAG = $(VERSION)
+IMAGE = $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(IMAGE_TAG)
 DOCKER_BUILD_FROM_SOURCE = docker build -t $(IMAGE) -f ./amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
 
 CW_AGENT_IMPORT_PATH=github.com/aws/amazon-cloudwatch-agent
@@ -111,31 +114,17 @@ build-for-docker-arm64:
 	$(LINUX_ARM64_BUILD)/start-amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/start-amazon-cloudwatch-agent
 	$(LINUX_ARM64_BUILD)/config-translator github.com/aws/amazon-cloudwatch-agent/cmd/config-translator
 
-# this is because we docker ignore our build dir
-# even if there is no dir rm -rf will not fail but if there already is a dir mkdir will
-# for local registery you may only load a single platform
-build-for-docker-fast: build-for-docker-amd64 build-for-docker-arm64
-	rm -rf tmp
-	mkdir -p tmp/amd64
-	mkdir -p tmp/arm64
-	cp build/bin/linux_amd64/* tmp/amd64
-	cp build/bin/linux_arm64/* tmp/arm64
-	docker buildx build --platform linux/amd64,linux/arm64 . -f amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localbin/Dockerfile -t amazon-cloudwatch-agent
-	rm -rf tmp
+docker-build: build-for-docker-amd64 build-for-docker-arm64
+	docker buildx build --platform linux/amd64,linux/arm64 . -f amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localbin/Dockerfile -t $(IMAGE)
 
-build-for-docker-fast-amd64: build-for-docker-amd64
-	rm -rf tmp
-	mkdir -p tmp/amd64
-	cp build/bin/linux_amd64/* tmp/amd64
-	docker buildx build --platform linux/amd64 . -f amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localbin/Dockerfile -t amazon-cloudwatch-agent --load
-	rm -rf tmp
+docker-build-amd64: build-for-docker-amd64
+	docker buildx build --platform linux/amd64 . -f amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localbin/Dockerfile -t $(IMAGE) --load
 
-build-for-docker-fast-arm64: build-for-docker-arm64
-	rm -rf tmp
-	mkdir -p tmp/arm64
-	cp build/bin/linux_arm64/* tmp/arm64
-	docker buildx build --platform linux/arm64 . -f amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localbin/Dockerfile -t amazon-cloudwatch-agent --load
-	rm -rf tmp
+docker-build-arm64: build-for-docker-arm64
+	docker buildx build --platform linux/arm64 . -f amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localbin/Dockerfile -t $(IMAGE) --load
+
+docker-push:
+	docker push $(IMAGE)
 
 install-goimports:
 	GOBIN=$(TOOLS_BIN_DIR) go install golang.org/x/tools/cmd/goimports

--- a/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localbin/Dockerfile
+++ b/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/localbin/Dockerfile
@@ -1,14 +1,23 @@
+# Build the binary
+ARG CERT_IMAGE=ubuntu:latest
+
 # Install cert and binaries
-FROM ubuntu:latest
+FROM $CERT_IMAGE as cert
 
 # Need to repeat the ARG after each FROM
 ARG TARGETARCH
-
 RUN mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
 RUN mkdir -p /opt/aws/amazon-cloudwatch-agent/var
-RUN mkdir -p /opt/aws/amazon-cloudwatch-agent/bin
-COPY tmp/${TARGETARCH} /opt/aws/amazon-cloudwatch-agent/bin
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update &&  \
+    apt-get install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+COPY build/bin/linux_${TARGETARCH}/ /opt/aws/amazon-cloudwatch-agent/bin
+
+FROM scratch
+
+COPY --from=cert /tmp /tmp
+COPY --from=cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=cert /opt/aws/amazon-cloudwatch-agent /opt/aws/amazon-cloudwatch-agent
 
 ENV RUN_IN_CONTAINER="True"
 ENTRYPOINT ["/opt/aws/amazon-cloudwatch-agent/bin/start-amazon-cloudwatch-agent"]


### PR DESCRIPTION
# Description of the issue
Docker supports multiple .dockerignore files (https://docs.docker.com/build/building/context/#filename-and-location). This allows us to copy in the built binaries directly instead of copying them around.

# Description of changes
Replaces the `localbin` Dockerfile so it follows the pattern in the `source`. Uses a scratch base image. Renamed Makefile targets to separate `build-for-docker`, which builds the binaries, from `docker-build`, which builds the image. Separates the image name into parts to make it easier to replace for dev builds.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Built and pushed the image.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




