### PR TITLE
Add sdk metadata to metric attributes for EMF export

### DIFF
--- a/plugins/processors/awsappsignals/internal/attributes/attributes.go
+++ b/plugins/processors/awsappsignals/internal/attributes/attributes.go
@@ -36,4 +36,7 @@ const (
 	HostedInK8SNamespace   = "HostedIn.K8s.Namespace"
 	HostedInEC2Environment = "HostedIn.EC2.Environment"
 	HostedInEnvironment    = "HostedIn.Environment"
+
+	// sdk attributes
+	MetricAttributeSDKMetadata = "SDK"
 )


### PR DESCRIPTION
# Description of the issue
We want to extract SDK metadata and export them into EMF logs to identify SDK vendor, version, language and instrumentation mode.

# Description of changes
Add `SDK` as a new attribute in App Signals metrics.

Output samples:
```
// auto-instrumented sample app using ADOT
SDK: opentelemetry,1.32.0-aws-SNAPSHOT,java,Auto
```

```
// if sdk info is missing
SDK: -,-,java,Manual
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




