### PR TITLE
[AppSignals] Explicitly set the GCCollectionInterval for MetricsLimiter

### DIFF
--- a/plugins/processors/awsappsignals/config/config.go
+++ b/plugins/processors/awsappsignals/config/config.go
@@ -22,7 +22,7 @@ type LimiterConfig struct {
 	Disabled                  bool            `mapstructure:"disabled"`
 	LogDroppedMetrics         bool            `mapstructure:"log_dropped_metrics"`
 	RotationInterval          time.Duration   `mapstructure:"rotation_interval"`
-	GarbageCollectionInterval time.Duration   `mapstructure:"-"`
+	GarbageCollectionInterval time.Duration   `mapstructure:"garbage_collection_interval"`
 	ParentContext             context.Context `mapstructure:"-"`
 }
 

--- a/plugins/processors/awsappsignals/config/config.go
+++ b/plugins/processors/awsappsignals/config/config.go
@@ -34,10 +34,11 @@ const (
 
 func NewDefaultLimiterConfig() *LimiterConfig {
 	return &LimiterConfig{
-		Threshold:         DefaultThreshold,
-		Disabled:          false,
-		LogDroppedMetrics: false,
-		RotationInterval:  DefaultRotationInterval,
+		Threshold:                 DefaultThreshold,
+		Disabled:                  false,
+		LogDroppedMetrics:         false,
+		RotationInterval:          DefaultRotationInterval,
+		GarbageCollectionInterval: DefaultGCInterval,
 	}
 }
 

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -319,6 +319,7 @@ processors:
           drop_threshold: 500
           log_dropped_metrics: true
           rotation_interval: 10m0s
+          garbage_collection_interval: 10m0s
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         metadata_keys: []

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -319,6 +319,7 @@ processors:
           drop_threshold: 500
           log_dropped_metrics: true
           rotation_interval: 10m0s
+          garbage_collection_interval: 10m0s
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         metadata_keys: []

--- a/translator/translate/otel/processor/awsappsignals/testdata/invalidRulesConfig.json
+++ b/translator/translate/otel/processor/awsappsignals/testdata/invalidRulesConfig.json
@@ -6,7 +6,8 @@
         "limiter": {
           "drop_threshold": 20,
           "log_dropped_metrics": true,
-          "rotation_interval": "10m"
+          "rotation_interval": "10m",
+          "garbage_collection_interval": "10m"
         },
         "rules": [
           {

--- a/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfig.json
+++ b/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfig.json
@@ -6,7 +6,8 @@
         "limiter": {
           "drop_threshold": 20,
           "log_dropped_metrics": true,
-          "rotation_interval": "10m"
+          "rotation_interval": "10m",
+          "garbage_collection_interval": "10m"
         },
         "rules": [
           {

--- a/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfigEKS.yaml
+++ b/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfigEKS.yaml
@@ -6,6 +6,7 @@ limiter:
   drop_threshold: 20
   log_dropped_metrics: true
   rotation_interval: 10m
+  garbage_collection_interval: 10m
 rules:
   - selectors:
     - dimension: Operation

--- a/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfigGeneric.yaml
+++ b/translator/translate/otel/processor/awsappsignals/testdata/validRulesConfigGeneric.yaml
@@ -6,6 +6,7 @@ limiter:
   drop_threshold: 20
   log_dropped_metrics: true
   rotation_interval: 10m
+  garbage_collection_interval: 10m
 rules:
   - selectors:
       - dimension: Operation

--- a/translator/translate/otel/processor/awsappsignals/translator.go
+++ b/translator/translate/otel/processor/awsappsignals/translator.go
@@ -125,6 +125,17 @@ func (t *translator) translateMetricLimiterConfig(conf *confmap.Conf, configKey 
 			limiterConfig.LogDroppedMetrics = val
 		}
 	}
+	if rawVal, exists := configJson["garbage_collection_interval"]; exists {
+		if val, ok := rawVal.(string); !ok {
+			return nil, errors.New("type conversion error: garbage_collection_interval is not a string")
+		} else {
+			if interval, err := time.ParseDuration(val); err != nil {
+				return nil, errors.New("type conversion error: garbage_collection_interval is not a time string")
+			} else {
+				limiterConfig.GarbageCollectionInterval = interval
+			}
+		}
+	}
 	if rawVal, exists := configJson["rotation_interval"]; exists {
 		if val, ok := rawVal.(string); !ok {
 			return nil, errors.New("type conversion error: rotation_interval is not a string")


### PR DESCRIPTION
# Description of the issue
When not explicitly set, the current validate logic doesnt seem to get invoked before the start of the component, so it doesnt respect the default GC collection interval causing an infinite loop leading to CPU maxing out.

# Description of changes
Explicitly set the GC collection interval when initializing the config.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manually tested on an EKS cluster that CPU spike goes away.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




