### PR TITLE
Add support for Elastic Fabric Adapter (EFA) metrics.

### DIFF
--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -659,7 +659,7 @@ func getEFAMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 				Dimensions: [][]string{
 					{"ClusterName"},
 					{"ClusterName", "NodeName", "InstanceId"},
-					{"ClusterName", "NodeName", "InstanceId", "EfaDevice"},
+					{"ClusterName", "NodeName", "InstanceId", "InstanceType", "EfaDevice"},
 				},
 				MetricNameSelectors: []string{
 					"node_efa_rx_bytes",

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -430,6 +430,7 @@ func TestTranslator(t *testing.T) {
 						},
 					},
 					{
+<<<<<<< HEAD
 						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "Namespace", "PodName", "ContainerName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName", "NeuronDevice", "NeuronCore"}},
 						MetricNameSelectors: []string{
 							"container_neuroncore_utilization",
@@ -511,6 +512,23 @@ func TestTranslator(t *testing.T) {
 							"node_neurondevice_hw_ecc_events_total_mem_ecc_uncorrected",
 							"node_neurondevice_hw_ecc_events_total_sram_ecc_corrected",
 							"node_neurondevice_hw_ecc_events_total_sram_ecc_uncorrected",
+=======
+						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "Namespace", "PodName", "ContainerName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName", "EfaDevice"}},
+						MetricNameSelectors: []string{
+							"container_efa_rx_bytes", "container_efa_tx_bytes", "container_efa_rx_dropped", "container_efa_rdma_read_bytes", "container_efa_rdma_write_bytes", "container_efa_rdma_write_recv_bytes",
+						},
+					},
+					{
+						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "Namespace"}, {"ClusterName", "Namespace", "Service"}, {"ClusterName", "Namespace", "PodName"}, {"ClusterName", "Namespace", "PodName", "FullPodName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "EfaDevice"}},
+						MetricNameSelectors: []string{
+							"pod_efa_rx_bytes", "pod_efa_tx_bytes", "pod_efa_rx_dropped", "pod_efa_rdma_read_bytes", "pod_efa_rdma_write_bytes", "pod_efa_rdma_write_recv_bytes",
+						},
+					},
+					{
+						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "NodeName", "InstanceId"}, {"ClusterName", "NodeName", "InstanceId", "InstanceType", "EfaDevice"}},
+						MetricNameSelectors: []string{
+							"node_efa_rx_bytes", "node_efa_tx_bytes", "node_efa_rx_dropped", "node_efa_rdma_read_bytes", "node_efa_rdma_write_bytes", "node_efa_rdma_write_recv_bytes",
+>>>>>>> b9a716f6 (add instancetype)
 						},
 					},
 				},


### PR DESCRIPTION
Add support for Elastic Fabric Adapter (EFA) metrics.

See OTel contrib PR: https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/186



Example EMF entry:

```
{
    "AutoScalingGroupName": "eks-my-efa-ng-2-e0c6b2df-63f4-2f31-f58f-d2486362107f",
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "ContainerName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName",
                    "ContainerName",
                    "FullPodName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName",
                    "ContainerName",
                    "EfaDevice",
                    "FullPodName",
                    "Namespace",
                    "PodName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "container_efa_rdma_read_bytes",
                    "Unit": "Bytes/Second"
                },
                {
                    "Name": "container_efa_rdma_write_bytes",
                    "Unit": "Bytes/Second"
                },
                {
                    "Name": "container_efa_rdma_write_recv_bytes",
                    "Unit": "Bytes/Second"
                },
                {
                    "Name": "container_efa_rx_bytes",
                    "Unit": "Bytes/Second"
                },
                {
                    "Name": "container_efa_rx_dropped",
                    "Unit": "Count/Second"
                },
                {
                    "Name": "container_efa_tx_bytes",
                    "Unit": "Count/Second"
                }
            ]
        }
    ],
    "ClusterName": "efa-eks-test",
    "ContainerName": "pingpong-container",
    "EfaDevice": "rdmap0s31",
    "FullPodName": "pingpong-replica-set-kcftp",
    "InstanceId": "i-0beb78c183159c06a",
    "InstanceType": "m5n.24xlarge",
    "Namespace": "pingpong",
    "NodeName": "ip-192-168-94-253.us-east-2.compute.internal",
    "PodName": "pingpong-replica-set",
    "Timestamp": "1710903582062",
    "Type": "ContainerEFA",
    "Version": "0",
    "kubernetes": {
        "container_name": "pingpong-container",
        "containerd": {
            "container_id": "8ff925029ed43a55f85a66187eed65aea9b1a726f571e9cc937c37aa9825d0e1"
        },
        "host": "ip-192-168-94-253.us-east-2.compute.internal",
        "labels": {
            "name": "pingpong-app"
        },
        "namespace_name": "pingpong",
        "pod_name": "pingpong-replica-set-kcftp",
        "pod_owners": [
            {
                "owner_kind": "ReplicaSet",
                "owner_name": "pingpong-replica-set"
            }
        ]
    },
    "container_efa_rdma_read_bytes": 0,
    "container_efa_rdma_write_bytes": 0,
    "container_efa_rdma_write_recv_bytes": 0,
    "container_efa_rx_bytes": 247213868,
    "container_efa_rx_dropped": 0,
    "container_efa_tx_bytes": 247215100
}
```