### PR TITLE
Add unit test to ensure log timestamp defaults to local timezone

### DIFF
--- a/plugins/inputs/logfile/fileconfig_test.go
+++ b/plugins/inputs/logfile/fileconfig_test.go
@@ -233,6 +233,17 @@ func TestTimestampParserWithFracSeconds(t *testing.T) {
 		fmt.Sprintf("The timestampFromLogLine value %v is not the same as expected %v.", timestamp, expectedTimestamp))
 }
 
+func TestNonAllowlistedTimezone(t *testing.T) {
+	fileConfig := &FileConfig{
+		Timezone: "EST",
+	}
+
+	err := fileConfig.init()
+	assert.NoError(t, err)
+
+	assert.Equal(t, time.Local, fileConfig.TimezoneLoc, "The timezone location should be in local timezone.")
+}
+
 func TestMultiLineStartPattern(t *testing.T) {
 	multiLineStartPattern := "---"
 	fileConfig := &FileConfig{


### PR DESCRIPTION
# Description of the issue
We experienced timezone issues with other products and want to ensure CloudWatch Agent is also in a good state. After code audit, we are missing edge case unit test where the timezone is set to a valid value from the host timezone options but not allowlisted in the agent.

# Description of changes
Add unit test to check for timezone that is not allowlisted by the agent(We only use timezone when it's specified to UTC, if not, default to local)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit test

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




