### PR TITLE
Add back mapstructure encoder

### DIFF
--- a/internal/mapstructure/encoder.go
+++ b/internal/mapstructure/encoder.go
@@ -1,0 +1,223 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package mapstructure
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	tagNameMapStructure = "mapstructure"
+	optionSeparator     = ","
+	optionOmitEmpty     = "omitempty"
+	optionSquash        = "squash"
+	optionRemain        = "remain"
+	optionSkip          = "-"
+)
+
+var (
+	errNonStringEncodedKey = errors.New("non string-encoded key")
+)
+
+// tagInfo stores the mapstructure tag details.
+type tagInfo struct {
+	name      string
+	omitEmpty bool
+	squash    bool
+}
+
+// An Encoder takes structured data and converts it into an
+// interface following the mapstructure tags.
+type Encoder struct {
+	config *EncoderConfig
+}
+
+// EncoderConfig is the configuration used to create a new encoder.
+type EncoderConfig struct {
+	// EncodeHook, if set, is a way to provide custom encoding. It
+	// will be called before structs and primitive types.
+	EncodeHook mapstructure.DecodeHookFunc
+}
+
+// New returns a new encoder for the configuration.
+func New(cfg *EncoderConfig) *Encoder {
+	return &Encoder{config: cfg}
+}
+
+// Encode takes the input and uses reflection to encode it to
+// an interface based on the mapstructure spec.
+func (e *Encoder) Encode(input any) (any, error) {
+	return e.encode(reflect.ValueOf(input))
+}
+
+// encode processes the value based on the reflect.Kind.
+func (e *Encoder) encode(value reflect.Value) (any, error) {
+	if value.IsValid() {
+		switch value.Kind() {
+		case reflect.Interface, reflect.Ptr:
+			return e.encode(value.Elem())
+		case reflect.Map:
+			return e.encodeMap(value)
+		case reflect.Slice:
+			return e.encodeSlice(value)
+		case reflect.Struct:
+			return e.encodeStruct(value)
+		default:
+			return e.encodeHook(value)
+		}
+	}
+	return nil, nil
+}
+
+// encodeHook calls the EncodeHook in the EncoderConfig with the value passed in.
+// This is called before processing structs and for primitive data types.
+func (e *Encoder) encodeHook(value reflect.Value) (any, error) {
+	if e.config != nil && e.config.EncodeHook != nil {
+		out, err := mapstructure.DecodeHookExec(e.config.EncodeHook, value, value)
+		if err != nil {
+			return nil, fmt.Errorf("error running encode hook: %w", err)
+		}
+		return out, nil
+	}
+	return value.Interface(), nil
+}
+
+// encodeStruct encodes the struct by iterating over the fields, getting the
+// mapstructure tagInfo for each exported field, and encoding the value.
+func (e *Encoder) encodeStruct(value reflect.Value) (any, error) {
+	if value.Kind() != reflect.Struct {
+		return nil, &reflect.ValueError{
+			Method: "encodeStruct",
+			Kind:   value.Kind(),
+		}
+	}
+	out, err := e.encodeHook(value)
+	if err != nil {
+		return nil, err
+	}
+	value = reflect.ValueOf(out)
+	// if the output of encodeHook is no longer a struct,
+	// call encode against it.
+	if value.Kind() != reflect.Struct {
+		return e.encode(value)
+	}
+	result := make(map[string]any)
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Field(i)
+		if field.CanInterface() {
+			info := getTagInfo(value.Type().Field(i))
+			if (info.omitEmpty && field.IsZero()) || info.name == optionSkip {
+				continue
+			}
+			encoded, err := e.encode(field)
+			if err != nil {
+				return nil, fmt.Errorf("error encoding field %q: %w", info.name, err)
+			}
+			if info.squash {
+				if m, ok := encoded.(map[string]any); ok {
+					for k, v := range m {
+						result[k] = v
+					}
+				}
+			} else {
+				result[info.name] = encoded
+			}
+		}
+	}
+	return result, nil
+}
+
+// encodeSlice iterates over the slice and encodes each of the elements.
+func (e *Encoder) encodeSlice(value reflect.Value) (any, error) {
+	if value.Kind() != reflect.Slice {
+		return nil, &reflect.ValueError{
+			Method: "encodeSlice",
+			Kind:   value.Kind(),
+		}
+	}
+	result := make([]any, value.Len())
+	for i := 0; i < value.Len(); i++ {
+		var err error
+		if result[i], err = e.encode(value.Index(i)); err != nil {
+			return nil, fmt.Errorf("error encoding element in slice at index %d: %w", i, err)
+		}
+	}
+	return result, nil
+}
+
+// encodeMap encodes a map by encoding the key and value. Returns errNonStringEncodedKey
+// if the key is not encoded into a string.
+func (e *Encoder) encodeMap(value reflect.Value) (any, error) {
+	if value.Kind() != reflect.Map {
+		return nil, &reflect.ValueError{
+			Method: "encodeMap",
+			Kind:   value.Kind(),
+		}
+	}
+	result := make(map[string]any)
+	iterator := value.MapRange()
+	for iterator.Next() {
+		encoded, err := e.encode(iterator.Key())
+		if err != nil {
+			return nil, fmt.Errorf("error encoding key: %w", err)
+		}
+		key, ok := encoded.(string)
+		if !ok {
+			return nil, fmt.Errorf("%w key %q, kind: %v", errNonStringEncodedKey, iterator.Key().Interface(), iterator.Key().Kind())
+		}
+		if _, ok = result[key]; ok {
+			return nil, fmt.Errorf("duplicate key %q while encoding", key)
+		}
+		if result[key], err = e.encode(iterator.Value()); err != nil {
+			return nil, fmt.Errorf("error encoding map value for key %q: %w", key, err)
+		}
+	}
+	return result, nil
+}
+
+// getTagInfo looks up the mapstructure tag and uses that if available.
+// Uses the lowercase field if not found. Checks for omitempty and squash.
+func getTagInfo(field reflect.StructField) *tagInfo {
+	info := tagInfo{}
+	if tag, ok := field.Tag.Lookup(tagNameMapStructure); ok {
+		options := strings.Split(tag, optionSeparator)
+		info.name = options[0]
+		if len(options) > 1 {
+			for _, option := range options[1:] {
+				switch option {
+				case optionOmitEmpty:
+					info.omitEmpty = true
+				case optionSquash, optionRemain:
+					info.squash = true
+				}
+			}
+		}
+	} else {
+		info.name = strings.ToLower(field.Name)
+	}
+	return &info
+}
+
+// TextMarshalerHookFunc returns a DecodeHookFuncValue that checks
+// for the encoding.TextMarshaler interface and calls the MarshalText
+// function if found.
+func TextMarshalerHookFunc() mapstructure.DecodeHookFuncValue {
+	return func(from reflect.Value, _ reflect.Value) (any, error) {
+		marshaler, ok := from.Interface().(encoding.TextMarshaler)
+		if !ok {
+			return from.Interface(), nil
+		}
+		out, err := marshaler.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+		return string(out), nil
+	}
+}

--- a/internal/mapstructure/encoder_test.go
+++ b/internal/mapstructure/encoder_test.go
@@ -1,0 +1,302 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package mapstructure
+
+import (
+	"encoding"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/require"
+)
+
+type TestComplexStruct struct {
+	Skipped   TestEmptyStruct             `mapstructure:",squash"`
+	Nested    TestSimpleStruct            `mapstructure:",squash"`
+	Slice     []TestSimpleStruct          `mapstructure:"slice,omitempty"`
+	Pointer   *TestSimpleStruct           `mapstructure:"ptr"`
+	Map       map[string]TestSimpleStruct `mapstructure:"map,omitempty"`
+	Remain    map[string]any              `mapstructure:",remain"`
+	Interface encoding.TextMarshaler
+}
+
+type TestSimpleStruct struct {
+	Value   string `mapstructure:"value"`
+	skipped string
+	err     error
+}
+
+type TestEmptyStruct struct {
+	Value string `mapstructure:"-"`
+}
+
+type TestID string
+
+func (tID TestID) MarshalText() (text []byte, err error) {
+	out := string(tID)
+	if out == "error" {
+		return nil, errors.New("parsing error")
+	}
+	if !strings.HasSuffix(out, "_") {
+		out += "_"
+	}
+	return []byte(out), nil
+}
+
+func TestEncode(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: TextMarshalerHookFunc(),
+	})
+	testCases := map[string]struct {
+		input any
+		want  any
+	}{
+		"WithString": {
+			input: "test",
+			want:  "test",
+		},
+		"WithTextMarshaler": {
+			input: TestID("type"),
+			want:  "type_",
+		},
+		"WithSlice": {
+			input: []TestID{
+				TestID("nop"),
+				TestID("type_"),
+			},
+			want: []any{"nop_", "type_"},
+		},
+		"WithSimpleStruct": {
+			input: TestSimpleStruct{Value: "test", skipped: "skipped"},
+			want: map[string]any{
+				"value": "test",
+			},
+		},
+		"WithComplexStruct": {
+			input: &TestComplexStruct{
+				Skipped: TestEmptyStruct{
+					Value: "omitted",
+				},
+				Nested: TestSimpleStruct{
+					Value: "nested",
+				},
+				Slice: []TestSimpleStruct{
+					{Value: "slice"},
+				},
+				Map: map[string]TestSimpleStruct{
+					"Key": {Value: "map"},
+				},
+				Pointer: &TestSimpleStruct{
+					Value: "pointer",
+				},
+				Remain: map[string]any{
+					"remain1": 23,
+					"remain2": "value",
+				},
+				Interface: TestID("value"),
+			},
+			want: map[string]any{
+				"value": "nested",
+				"slice": []any{map[string]any{"value": "slice"}},
+				"map": map[string]any{
+					"Key": map[string]any{"value": "map"},
+				},
+				"ptr":       map[string]any{"value": "pointer"},
+				"interface": "value_",
+				"remain1":   23,
+				"remain2":   "value",
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := enc.Encode(testCase.input)
+			require.NoError(t, err)
+			require.Equal(t, testCase.want, got)
+		})
+	}
+	// without the TextMarshalerHookFunc
+	enc.config.EncodeHook = nil
+	testCase := TestID("test")
+	got, err := enc.Encode(testCase)
+	require.NoError(t, err)
+	require.Equal(t, testCase, got)
+}
+
+func TestGetTagInfo(t *testing.T) {
+	testCases := map[string]struct {
+		field      reflect.StructField
+		wantName   string
+		wantOmit   bool
+		wantSquash bool
+	}{
+		"WithoutTags": {
+			field: reflect.StructField{
+				Name: "Test",
+			},
+			wantName: "test",
+		},
+		"WithoutMapStructureTag": {
+			field: reflect.StructField{
+				Tag:  `yaml:"hello,inline"`,
+				Name: "YAML",
+			},
+			wantName: "yaml",
+		},
+		"WithRename": {
+			field: reflect.StructField{
+				Tag:  `mapstructure:"hello"`,
+				Name: "Test",
+			},
+			wantName: "hello",
+		},
+		"WithOmitEmpty": {
+			field: reflect.StructField{
+				Tag:  `mapstructure:"hello,omitempty"`,
+				Name: "Test",
+			},
+			wantName: "hello",
+			wantOmit: true,
+		},
+		"WithSquash": {
+			field: reflect.StructField{
+				Tag:  `mapstructure:",squash"`,
+				Name: "Test",
+			},
+			wantSquash: true,
+		},
+		"WithRemain": {
+			field: reflect.StructField{
+				Tag:  `mapstructure:",remain"`,
+				Name: "Test",
+			},
+			wantSquash: true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := getTagInfo(testCase.field)
+			require.Equal(t, testCase.wantName, got.name)
+			require.Equal(t, testCase.wantOmit, got.omitEmpty)
+			require.Equal(t, testCase.wantSquash, got.squash)
+		})
+	}
+}
+
+func TestEncodeValueError(t *testing.T) {
+	enc := New(nil)
+	testValue := reflect.ValueOf("")
+	testCases := []struct {
+		encodeFn func(value reflect.Value) (any, error)
+		wantErr  error
+	}{
+		{encodeFn: enc.encodeMap, wantErr: &reflect.ValueError{Method: "encodeMap", Kind: reflect.String}},
+		{encodeFn: enc.encodeStruct, wantErr: &reflect.ValueError{Method: "encodeStruct", Kind: reflect.String}},
+		{encodeFn: enc.encodeSlice, wantErr: &reflect.ValueError{Method: "encodeSlice", Kind: reflect.String}},
+	}
+	for _, testCase := range testCases {
+		got, err := testCase.encodeFn(testValue)
+		require.Error(t, err)
+		require.Equal(t, testCase.wantErr, err)
+		require.Nil(t, got)
+	}
+}
+
+func TestEncodeNonStringEncodedKey(t *testing.T) {
+	enc := New(nil)
+	testCase := []struct {
+		Test map[string]any
+	}{
+		{
+			Test: map[string]any{
+				"test": map[TestEmptyStruct]TestSimpleStruct{
+					{Value: "key"}: {Value: "value"},
+				},
+			},
+		},
+	}
+	got, err := enc.Encode(testCase)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errNonStringEncodedKey))
+	require.Nil(t, got)
+}
+
+func TestDuplicateKey(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: TextMarshalerHookFunc(),
+	})
+	testCase := map[TestID]string{
+		"test":  "value",
+		"test_": "other value",
+	}
+	got, err := enc.Encode(testCase)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestTextMarshalerError(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: TextMarshalerHookFunc(),
+	})
+	testCase := map[TestID]string{
+		"error": "value",
+	}
+	got, err := enc.Encode(testCase)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestEncodeStruct(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: testHookFunc(),
+	})
+	testCase := TestSimpleStruct{
+		Value:   "original",
+		skipped: "final",
+	}
+	got, err := enc.Encode(testCase)
+	require.NoError(t, err)
+	require.Equal(t, "final", got)
+}
+
+func TestEncodeStructError(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: testHookFunc(),
+	})
+	wantErr := errors.New("test")
+	testCase := map[TestSimpleStruct]string{
+		{err: wantErr}: "value",
+	}
+	got, err := enc.Encode(testCase)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, wantErr))
+	require.Nil(t, got)
+}
+
+func TestEncodeNil(t *testing.T) {
+	enc := New(nil)
+	got, err := enc.Encode(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func testHookFunc() mapstructure.DecodeHookFuncValue {
+	return func(from reflect.Value, _ reflect.Value) (any, error) {
+		if from.Kind() != reflect.Struct {
+			return from.Interface(), nil
+		}
+
+		got, ok := from.Interface().(TestSimpleStruct)
+		if !ok {
+			return from.Interface(), nil
+		}
+		if got.err != nil {
+			return nil, got.err
+		}
+		return got.skipped, nil
+	}
+}

--- a/internal/mapstructure/marshaler.go
+++ b/internal/mapstructure/marshaler.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package mapstructure
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func Marshal(rawVal any) (map[string]any, error) {
+	enc := New(encoderConfig(rawVal))
+	data, err := enc.Encode(rawVal)
+	if err != nil {
+		return nil, err
+	}
+	out, ok := data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid config encoding")
+	}
+	return out, nil
+}
+
+// encoderConfig returns a default encoder.EncoderConfig that includes an EncodeHook that handles both
+// TextMarshaller and confmap.Marshaler interfaces.
+func encoderConfig(rawVal any) *EncoderConfig {
+	return &EncoderConfig{
+		EncodeHook: mapstructure.ComposeDecodeHookFunc(
+			TextMarshalerHookFunc(),
+			marshalerHookFunc(rawVal),
+		),
+	}
+}
+
+// marshalerHookFunc returns a DecodeHookFuncValue that checks structs that aren't
+// the original to see if they implement the Marshaler interface.
+func marshalerHookFunc(orig any) mapstructure.DecodeHookFuncValue {
+	origType := reflect.TypeOf(orig)
+	return func(from reflect.Value, _ reflect.Value) (any, error) {
+		if from.Kind() != reflect.Struct {
+			return from.Interface(), nil
+		}
+
+		// ignore original to avoid infinite loop.
+		if from.Type() == origType && reflect.DeepEqual(from.Interface(), orig) {
+			return from.Interface(), nil
+		}
+		marshaler, ok := from.Interface().(confmap.Marshaler)
+		if !ok {
+			return from.Interface(), nil
+		}
+		conf := confmap.New()
+		if err := marshaler.Marshal(conf); err != nil {
+			return nil, err
+		}
+		return conf.ToStringMap(), nil
+	}
+}

--- a/internal/mapstructure/marshaler_test.go
+++ b/internal/mapstructure/marshaler_test.go
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package mapstructure
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+type TestConfig struct {
+	Boolean   *bool              `mapstructure:"boolean"`
+	Struct    *Struct            `mapstructure:"struct"`
+	MapStruct map[string]*Struct `mapstructure:"map_struct"`
+}
+
+func (t TestConfig) Marshal(conf *confmap.Conf) error {
+	if t.Boolean != nil && !*t.Boolean {
+		return errors.New("unable to marshal")
+	}
+	if err := conf.Marshal(t); err != nil {
+		return err
+	}
+	return conf.Merge(confmap.NewFromStringMap(map[string]any{
+		"additional": "field",
+	}))
+}
+
+type Struct struct {
+	Name string
+}
+
+type TestIDConfig struct {
+	Boolean bool              `mapstructure:"bool"`
+	Map     map[TestID]string `mapstructure:"map"`
+}
+
+func TestMarshal(t *testing.T) {
+	cfg := &TestIDConfig{
+		Boolean: true,
+		Map: map[TestID]string{
+			"string": "this is a string",
+		},
+	}
+	got, err := Marshal(cfg)
+	assert.NoError(t, err)
+	conf := confmap.NewFromStringMap(got)
+	assert.Equal(t, true, conf.Get("bool"))
+	assert.Equal(t, map[string]any{"string_": "this is a string"}, conf.Get("map"))
+}
+
+func TestMarshalDuplicateID(t *testing.T) {
+	cfg := &TestIDConfig{
+		Boolean: true,
+		Map: map[TestID]string{
+			"string":  "this is a string",
+			"string_": "this is another string",
+		},
+	}
+	_, err := Marshal(cfg)
+	assert.Error(t, err)
+}
+
+func TestMarshalError(t *testing.T) {
+	_, err := Marshal(nil)
+	assert.Error(t, err)
+}
+
+func TestMarshaler(t *testing.T) {
+	cfg := &TestConfig{
+		Struct: &Struct{
+			Name: "StructName",
+		},
+	}
+	got, err := Marshal(cfg)
+	assert.NoError(t, err)
+	conf := confmap.NewFromStringMap(got)
+	assert.Equal(t, "field", conf.Get("additional"))
+
+	type NestedMarshaler struct {
+		TestConfig *TestConfig
+	}
+	nmCfg := &NestedMarshaler{
+		TestConfig: cfg,
+	}
+	got, err = Marshal(nmCfg)
+	assert.NoError(t, err)
+	conf = confmap.NewFromStringMap(got)
+	sub, err := conf.Sub("testconfig")
+	assert.NoError(t, err)
+	assert.True(t, sub.IsSet("additional"))
+	assert.Equal(t, "field", sub.Get("additional"))
+	varBool := false
+	nmCfg.TestConfig.Boolean = &varBool
+	assert.Error(t, conf.Marshal(nmCfg))
+}

--- a/translator/cmdutil/translatorutil.go
+++ b/translator/cmdutil/translatorutil.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
-	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/aws/amazon-cloudwatch-agent/internal/mapstructure"
 	"github.com/aws/amazon-cloudwatch-agent/translator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
@@ -227,13 +227,12 @@ func TranslateJsonMapToYamlConfig(jsonConfigValue interface{}) (interface{}, err
 	if err != nil {
 		return nil, err
 	}
-	conf := confmap.New()
-	if err = conf.Marshal(cfg); err != nil {
+	var result map[string]any
+	if result, err = mapstructure.Marshal(cfg); err != nil {
 		return nil, err
 	}
-	strMap := conf.ToStringMap()
-	RemoveTLSRedacted(strMap)
-	return strMap, nil
+	RemoveTLSRedacted(result)
+	return result, nil
 }
 
 func RemoveTLSRedacted(stringMap map[string]interface{}) {


### PR DESCRIPTION
# Description of the issue
The encoder was added to the OTEL collector core a while back, but getting fixes and further changes has been slow. This has resulted in numerous workarounds like https://github.com/aws/amazon-cloudwatch-agent/blob/487bfcf661fa16067184644fd49685b3aa99d5a8/translator/cmdutil/translatorutil.go#L239

and even forking a component (https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/99) for the sole purpose of fixing marshaling issues.

# Description of changes
Moves the mapstructure encoder (https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/internal/mapstructure) back into the agent.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Adds existing unit tests back.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




