### PR TITLE
Add omit nil option to marshaler

### DIFF
--- a/translator/cmdutil/translatorutil.go
+++ b/translator/cmdutil/translatorutil.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/tocwconfig/toyamlconfig"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel"
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	translatorUtil "github.com/aws/amazon-cloudwatch-agent/translator/util"
 )
 
@@ -231,30 +230,7 @@ func TranslateJsonMapToYamlConfig(jsonConfigValue interface{}) (interface{}, err
 	if result, err = mapstructure.Marshal(cfg); err != nil {
 		return nil, err
 	}
-	RemoveTLSRedacted(result)
 	return result, nil
-}
-
-func RemoveTLSRedacted(stringMap map[string]interface{}) {
-	type Node struct {
-		isTLSParent bool
-		data        map[string]interface{}
-	}
-	root := Node{isTLSParent: false, data: stringMap}
-	queue := []Node{root}
-	// Using BFS search through string Map and find sub settings of TLS
-	// Then delete REDACTED settings under TLS
-	for len(queue) > 0 {
-		node := queue[0]
-		queue = queue[1:]
-		for key, child := range node.data {
-			if childMap, ok := child.(map[string]interface{}); ok {
-				queue = append(queue, Node{key == common.TlsKey, childMap})
-			} else if child == "[REDACTED]" && node.isTLSParent {
-				delete(node.data, key)
-			}
-		}
-	}
 }
 
 func ConfigToTomlFile(config interface{}, tomlConfigFilePath string) error {

--- a/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
@@ -25,11 +25,9 @@ processors:
             metrics:
                 - iops_in_progress
                 - diskio_iops_in_progress
-            regexp: null
         include:
             match_type: ""
             metrics: []
-            regexp: null
         initial_value: 0
         max_staleness: 0s
     ec2tagger:

--- a/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
@@ -25,11 +25,9 @@ processors:
             metrics:
                 - iops_in_progress
                 - diskio_iops_in_progress
-            regexp: null
         include:
             match_type: ""
             metrics: []
-            regexp: null
         initial_value: 0
         max_staleness: 0s
     ec2tagger:

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -334,7 +334,6 @@ processors:
                 cloud.provider:
                     enabled: true
         attributes: []
-        auth: null
         azure:
             resource_attributes:
                 azure.resourcegroup.name:
@@ -384,7 +383,6 @@ processors:
                     enabled: true
                 host.name:
                     enabled: true
-            token: '[REDACTED]'
             token_file: ""
         detectors:
             - eks
@@ -554,9 +552,7 @@ processors:
                     enabled: true
                 faas.version:
                     enabled: true
-        max_conns_per_host: null
         max_idle_conns: 100
-        max_idle_conns_per_host: null
         openshift:
             address: ""
             resource_attributes:
@@ -638,10 +634,8 @@ receivers:
     otlp/app_signals:
         protocols:
             grpc:
-                auth: null
                 endpoint: 0.0.0.0:4315
                 include_metadata: false
-                keepalive: null
                 max_concurrent_streams: 0
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
@@ -657,8 +651,6 @@ receivers:
                 transport: tcp
                 write_buffer_size: 0
             http:
-                auth: null
-                cors: null
                 endpoint: 0.0.0.0:4316
                 include_metadata: false
                 logs_url_path: /v1/logs

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -334,7 +334,6 @@ processors:
           cloud.provider:
             enabled: true
       attributes: []
-      auth: null
       azure:
         resource_attributes:
           azure.resourcegroup.name:
@@ -384,7 +383,6 @@ processors:
             enabled: true
           host.name:
             enabled: true
-        token: '[REDACTED]'
         token_file: ""
       detectors:
         - eks
@@ -554,9 +552,7 @@ processors:
             enabled: true
           faas.version:
             enabled: true
-      max_conns_per_host: null
       max_idle_conns: 100
-      max_idle_conns_per_host: null
       openshift:
         address: ""
         resource_attributes:
@@ -638,26 +634,20 @@ receivers:
     otlp/app_signals:
         protocols:
             grpc:
-                auth: null
                 endpoint: 0.0.0.0:4315
                 include_metadata: false
-                keepalive: null
                 max_concurrent_streams: 0
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
-                tls: null
                 transport: tcp
                 write_buffer_size: 0
             http:
-                auth: null
-                cors: null
                 endpoint: 0.0.0.0:4316
                 include_metadata: false
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
                 response_headers: {}
-                tls: null
                 traces_url_path: /v1/traces
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -150,7 +150,6 @@ processors:
             - name: ""
               platform: generic
         rules: []
-        limiter: null
     resourcedetection:
       aks:
         resource_attributes:
@@ -159,7 +158,6 @@ processors:
           cloud.provider:
             enabled: true
       attributes: []
-      auth: null
       azure:
         resource_attributes:
           azure.resourcegroup.name:
@@ -209,7 +207,6 @@ processors:
             enabled: true
           host.name:
             enabled: true
-        token: '[REDACTED]'
         token_file: ""
       detectors:
         - eks
@@ -379,9 +376,7 @@ processors:
             enabled: true
           faas.version:
             enabled: true
-      max_conns_per_host: null
       max_idle_conns: 100
-      max_idle_conns_per_host: null
       openshift:
         address: ""
         resource_attributes:
@@ -437,26 +432,20 @@ receivers:
     otlp/app_signals:
         protocols:
             grpc:
-                auth: null
                 endpoint: 0.0.0.0:4315
                 include_metadata: false
-                keepalive: null
                 max_concurrent_streams: 0
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
-                tls: null
                 transport: tcp
                 write_buffer_size: 0
             http:
-                auth: null
-                cors: null
                 endpoint: 0.0.0.0:4316
                 include_metadata: false
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
                 response_headers: {}
-                tls: null
                 traces_url_path: /v1/traces
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
@@ -31,7 +31,6 @@ exporters:
             enabled: true
             num_consumers: 1
             queue_size: 1000
-            storage: null
         shared_credentials_file: []
     awsemf/containerinsights:
         certificate_file_path: /etc/test/ca_bundle.pem
@@ -215,7 +214,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: tcp_input
     udplog/emf_logs:
         attributes: {}
@@ -234,7 +232,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: udp_input
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -48,7 +48,6 @@ exporters:
             enabled: true
             num_consumers: 1
             queue_size: 1000
-            storage: null
         shared_credentials_file: []
     awsxray:
         aws_log_groups: []
@@ -116,11 +115,9 @@ processors:
             metrics:
                 - iops_in_progress
                 - diskio_iops_in_progress
-            regexp: null
         include:
             match_type: ""
             metrics: []
-            regexp: null
         initial_value: 0
         max_staleness: 0s
     ec2tagger:
@@ -172,26 +169,20 @@ receivers:
     otlp/traces:
         protocols:
             grpc:
-                auth: null
                 endpoint: 0.0.0.0:1111
                 include_metadata: false
-                keepalive: null
                 max_concurrent_streams: 0
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
-                tls: null
                 transport: tcp
                 write_buffer_size: 0
             http:
-                auth: null
-                cors: null
                 endpoint: 0.0.0.0:2222
                 include_metadata: false
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
                 response_headers: {}
-                tls: null
                 traces_url_path: /v1/traces
     telegraf_cpu:
         collection_interval: 10s
@@ -255,7 +246,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: udp_input
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -51,7 +51,6 @@ exporters:
             enabled: true
             num_consumers: 1
             queue_size: 1000
-            storage: null
         shared_credentials_file: []
     awsxray:
         aws_log_groups: []
@@ -119,11 +118,9 @@ processors:
             metrics:
                 - iops_in_progress
                 - diskio_iops_in_progress
-            regexp: null
         include:
             match_type: ""
             metrics: []
-            regexp: null
         initial_value: 0
         max_staleness: 0s
     ec2tagger:
@@ -175,26 +172,20 @@ receivers:
     otlp/traces:
         protocols:
             grpc:
-                auth: null
                 endpoint: 0.0.0.0:1111
                 include_metadata: false
-                keepalive: null
                 max_concurrent_streams: 0
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
-                tls: null
                 transport: tcp
                 write_buffer_size: 0
             http:
-                auth: null
-                cors: null
                 endpoint: 0.0.0.0:2222
                 include_metadata: false
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
                 response_headers: {}
-                tls: null
                 traces_url_path: /v1/traces
     telegraf_cpu:
         collection_interval: 10s
@@ -258,7 +249,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: udp_input
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
@@ -48,7 +48,6 @@ exporters:
             enabled: true
             num_consumers: 1
             queue_size: 1000
-            storage: null
         shared_credentials_file: []
     awsxray:
         aws_log_groups: []
@@ -158,26 +157,20 @@ receivers:
     otlp/traces:
         protocols:
             grpc:
-                auth: null
                 endpoint: 0.0.0.0:1111
                 include_metadata: false
-                keepalive: null
                 max_concurrent_streams: 0
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
-                tls: null
                 transport: tcp
                 write_buffer_size: 0
             http:
-                auth: null
-                cors: null
                 endpoint: 0.0.0.0:2222
                 include_metadata: false
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
                 response_headers: {}
-                tls: null
                 traces_url_path: /v1/traces
     telegraf_nvidia_smi:
         collection_interval: 1m0s
@@ -239,7 +232,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: udp_input
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/config_with_env.yaml
+++ b/translator/tocwconfig/sampleConfig/config_with_env.yaml
@@ -31,7 +31,6 @@ exporters:
             enabled: true
             num_consumers: 1
             queue_size: 1000
-            storage: null
         shared_credentials_file: []
 extensions:
     agenthealth/logs:
@@ -63,7 +62,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: tcp_input
     udplog/emf_logs:
         attributes: {}
@@ -82,7 +80,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: udp_input
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
@@ -25,11 +25,9 @@ processors:
             metrics:
                 - iops_in_progress
                 - diskio_iops_in_progress
-            regexp: null
         include:
             match_type: ""
             metrics: []
-            regexp: null
         initial_value: 0
         max_staleness: 0s
     ec2tagger:

--- a/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
@@ -23,11 +23,9 @@ processors:
         exclude:
             match_type: ""
             metrics: []
-            regexp: null
         include:
             match_type: ""
             metrics: []
-            regexp: null
         initial_value: 0
         max_staleness: 0s
     ec2tagger:

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -31,7 +31,6 @@ exporters:
             enabled: true
             num_consumers: 1
             queue_size: 1000
-            storage: null
         shared_credentials_file:
             - /root/.aws/credentials
     awsemf/containerinsights:
@@ -483,7 +482,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: tcp_input
     udplog/emf_logs:
         attributes: {}
@@ -502,7 +500,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: udp_input
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
@@ -31,7 +31,6 @@ exporters:
       enabled: true
       num_consumers: 1
       queue_size: 1000
-      storage: null
     shared_credentials_file:
       - /root/.aws/credentials
   awsemf/containerinsights:
@@ -1291,7 +1290,6 @@ receivers:
       initial_interval: 0s
       max_elapsed_time: 0s
       max_interval: 0s
-    storage: null
     type: tcp_input
   udplog/emf_logs:
     attributes: {}
@@ -1310,7 +1308,6 @@ receivers:
       initial_interval: 0s
       max_elapsed_time: 0s
       max_interval: 0s
-    storage: null
     type: udp_input
 service:
   extensions:

--- a/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
+++ b/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
@@ -31,7 +31,6 @@ exporters:
             enabled: true
             num_consumers: 1
             queue_size: 1000
-            storage: null
         shared_credentials_file: []
     awsemf/containerinsights:
         certificate_file_path: ""
@@ -157,7 +156,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: tcp_input
     udplog/emf_logs:
         attributes: {}
@@ -176,7 +174,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: udp_input
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -31,7 +31,6 @@ exporters:
             enabled: true
             num_consumers: 1
             queue_size: 1000
-            storage: null
         shared_credentials_file: []
     awsemf/containerinsights:
         certificate_file_path: ""
@@ -480,7 +479,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: tcp_input
     udplog/emf_logs:
         attributes: {}
@@ -499,7 +497,6 @@ receivers:
             initial_interval: 0s
             max_elapsed_time: 0s
             max_interval: 0s
-        storage: null
         type: udp_input
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
@@ -25,11 +25,9 @@ processors:
             metrics:
                 - iops_in_progress
                 - diskio_iops_in_progress
-            regexp: null
         include:
             match_type: ""
             metrics: []
-            regexp: null
         initial_value: 0
         max_staleness: 0s
     ec2tagger:

--- a/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
@@ -27,11 +27,9 @@ processors:
             metrics:
                 - iops_in_progress
                 - diskio_iops_in_progress
-            regexp: null
         include:
             match_type: ""
             metrics: []
-            regexp: null
         initial_value: 0
         max_staleness: 0s
     ec2tagger:

--- a/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
@@ -58,26 +58,20 @@ receivers:
     otlp/traces:
         protocols:
             grpc:
-                auth: null
                 endpoint: 127.0.0.1:4317
                 include_metadata: false
-                keepalive: null
                 max_concurrent_streams: 0
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
-                tls: null
                 transport: tcp
                 write_buffer_size: 0
             http:
-                auth: null
-                cors: null
                 endpoint: 127.0.0.1:4318
                 include_metadata: false
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
                 response_headers: {}
-                tls: null
                 traces_url_path: /v1/traces
 service:
     extensions:

--- a/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
@@ -58,26 +58,20 @@ receivers:
     otlp/traces:
         protocols:
             grpc:
-                auth: null
                 endpoint: 127.0.0.1:4317
                 include_metadata: false
-                keepalive: null
                 max_concurrent_streams: 0
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
-                tls: null
                 transport: tcp
                 write_buffer_size: 0
             http:
-                auth: null
-                cors: null
                 endpoint: 127.0.0.1:4318
                 include_metadata: false
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
                 response_headers: {}
-                tls: null
                 traces_url_path: /v1/traces
 service:
     extensions:


### PR DESCRIPTION
# Description of the issue
Now that the encoder/marshaler is in the agent again, omitting the `configopaque.String` should be done at the encoder level.

# Description of changes
Adds a nil hook and `OmitAllNil` option, which when combined will omit the `configopaque.String`. Replaced `RemoveTLSRedacted`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




