### PR TITLE
Make unit conversion case-insensitive

### DIFF
--- a/internal/util/unit/prefix.go
+++ b/internal/util/unit/prefix.go
@@ -5,6 +5,11 @@ package unit
 
 import "fmt"
 
+type Prefix interface {
+	fmt.Stringer
+	Scale() float64
+}
+
 // MetricPrefix is a base 10 prefix used by the metric system.
 type MetricPrefix string
 
@@ -20,8 +25,10 @@ const (
 	MetricPrefixTera              = "T"
 )
 
-// Value returns the scale from the base unit or -1 if invalid.
-func (m MetricPrefix) Value() float64 {
+var MetricPrefixes = []MetricPrefix{MetricPrefixKilo, MetricPrefixMega, MetricPrefixGiga, MetricPrefixTera}
+
+// Scale returns the scale from the base unit or -1 if invalid.
+func (m MetricPrefix) Scale() float64 {
 	switch m {
 	case MetricPrefixKilo:
 		return kilo
@@ -33,6 +40,10 @@ func (m MetricPrefix) Value() float64 {
 		return tera
 	}
 	return -1
+}
+
+func (m MetricPrefix) String() string {
+	return string(m)
 }
 
 // BinaryPrefix is a base 2 prefix for data storage.
@@ -51,8 +62,10 @@ const (
 	BinaryPrefixTebi              = "Ti"
 )
 
-// Value returns the scale from the base unit or -1 if invalid.
-func (b BinaryPrefix) Value() float64 {
+var BinaryPrefixes = []BinaryPrefix{BinaryPrefixKibi, BinaryPrefixMebi, BinaryPrefixGibi, BinaryPrefixTebi}
+
+// Scale returns the scale from the base unit or -1 if invalid.
+func (b BinaryPrefix) Scale() float64 {
 	switch b {
 	case BinaryPrefixKibi:
 		return kibi
@@ -64,6 +77,10 @@ func (b BinaryPrefix) Value() float64 {
 		return tebi
 	}
 	return -1
+}
+
+func (b BinaryPrefix) String() string {
+	return string(b)
 }
 
 var binaryToMetricMapping = map[BinaryPrefix]MetricPrefix{
@@ -79,6 +96,6 @@ func ConvertToMetric(binaryPrefix BinaryPrefix) (MetricPrefix, float64, error) {
 	if !ok {
 		return "", -1, fmt.Errorf("no valid conversion for %v", binaryPrefix)
 	}
-	scale := binaryPrefix.Value() / metricPrefix.Value()
+	scale := binaryPrefix.Scale() / metricPrefix.Scale()
 	return metricPrefix, scale, nil
 }

--- a/internal/util/unit/prefix_test.go
+++ b/internal/util/unit/prefix_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMetricPrefix(t *testing.T) {
@@ -18,12 +17,16 @@ func TestMetricPrefix(t *testing.T) {
 	}{
 		{"Ki", -1},
 		{"k", 1e3},
+		{"M", 1e6},
 		{"G", 1e9},
+		{"T", 1e12},
 	}
 	for _, testCase := range testCases {
 		got := MetricPrefix(testCase.prefix)
-		assert.Equal(t, testCase.value, got.Value())
+		assert.Equal(t, testCase.value, got.Scale())
+		assert.Equal(t, testCase.prefix, got.String())
 	}
+	assert.Len(t, MetricPrefixes, 4)
 }
 
 func TestBinaryPrefix(t *testing.T) {
@@ -32,13 +35,17 @@ func TestBinaryPrefix(t *testing.T) {
 		value  float64
 	}{
 		{"k", -1},
-		{"Ki", 1024},
-		{"Gi", 1073741824},
+		{"Ki", math.Pow(2, 10)},
+		{"Mi", math.Pow(2, 20)},
+		{"Gi", math.Pow(2, 30)},
+		{"Ti", math.Pow(2, 40)},
 	}
 	for _, testCase := range testCases {
 		got := BinaryPrefix(testCase.prefix)
-		assert.Equal(t, testCase.value, got.Value())
+		assert.Equal(t, testCase.value, got.Scale())
+		assert.Equal(t, testCase.prefix, got.String())
 	}
+	assert.Len(t, BinaryPrefixes, 4)
 }
 
 func TestConvertBinaryToMetric(t *testing.T) {
@@ -50,15 +57,14 @@ func TestConvertBinaryToMetric(t *testing.T) {
 		prefix       BinaryPrefix
 		metricPrefix MetricPrefix
 		scale        float64
-		epsilon      float64
 	}{
-		{BinaryPrefixKibi, MetricPrefixKilo, 1.024, 0},
-		{BinaryPrefixGibi, MetricPrefixGiga, 1.073, 0.001},
+		{BinaryPrefixKibi, MetricPrefixKilo, 1.024},
+		{BinaryPrefixGibi, MetricPrefixGiga, 1.073741824},
 	}
 	for _, testCase := range testCases {
 		got, scale, err = ConvertToMetric(testCase.prefix)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, testCase.metricPrefix, got)
-		assert.GreaterOrEqual(t, testCase.epsilon, math.Abs(testCase.scale-scale))
+		assert.Equal(t, testCase.scale, scale)
 	}
 }


### PR DESCRIPTION
# Description of the issue
When converting OTEL units, the CloudWatch Agent is currently case sensitive. This results in warnings like
```
W! cloudwatch: metricname "<metric-name>" has non-convertible unit: "by"
```

"by" should be equivalent to "By"

# Description of changes
Make unit conversion case-insensitive by changing the way prefixes are determined.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




