### PR TITLE
[Logfile] Clean up state folder on init

### DIFF
--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -107,8 +107,9 @@ func (t *LogFile) Start(acc telegraf.Accumulator) error {
 		return fmt.Errorf("failed to create state file directory %s: %v", t.FileStateFolder, err)
 	}
 
-	// Clean state file regularly
+	// Clean state file on init and regularly
 	go func() {
+		t.cleanupStateFolder()
 		ticker := time.NewTicker(1 * time.Hour)
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
# Description of the issue
Currently, customers using the logs plugin have a state folder tracking log files on the host that are being watched. This folder gets cleaned up periodically every hour. If the agent dies or crashes before the 1 hour, the agent could end up creating more state files causing excessive inodes to fill up on the host.

# Description of changes
We can clean up the state folder on initialization of the logfile plugin, as well as periodically.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
pass unit tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




