### PR TITLE
Remove confighttp fork dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,9 +38,6 @@ replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20240314211421-34bd73a6cac8
 )
 
-// Omit fields in HTTPClientSettings. Pending fix for https://github.com/open-telemetry/opentelemetry-collector/issues/8627
-replace go.opentelemetry.io/collector/config/confighttp => github.com/amazon-contributing/opentelemetry-collector-contrib/config/confighttp v0.0.0-20240314211421-34bd73a6cac8
-
 // Temporary fix, pending PR https://github.com/shirou/gopsutil/pull/957
 replace github.com/shirou/gopsutil/v3 => github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20231109213610-a8c21c54a2be // indirect
 
@@ -111,6 +108,7 @@ require (
 	github.com/jellydator/ttlcache/v3 v3.1.0
 	github.com/kardianos/service v1.2.1 // Keep this pinned to v1.2.1. v1.2.2 causes the agent to not register as a service on Windows
 	github.com/kr/pretty v0.3.1
+	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/oklog/run v1.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.89.0
@@ -135,6 +133,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/collector/component v0.89.0
+	go.opentelemetry.io/collector/config/configopaque v0.89.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.89.0
 	go.opentelemetry.io/collector/config/configtls v0.89.0
 	go.opentelemetry.io/collector/confmap v0.89.0
@@ -306,7 +305,6 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
-	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -382,7 +380,6 @@ require (
 	go.opentelemetry.io/collector/config/configgrpc v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.89.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v0.89.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.89.0 // indirect
 	go.opentelemetry.io/collector/connector v0.89.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.89.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.1483 h1:J8HaD+Zpfi1gcel3HCKpoHHEsrcuRrZlSnx7R9SCf5I=
-github.com/amazon-contributing/opentelemetry-collector-contrib/config/confighttp v0.0.0-20240314211421-34bd73a6cac8 h1:KhAQN7OLhE6jOnVvt11kpjxHJZcnWlWYyOCGXqpaXJY=
-github.com/amazon-contributing/opentelemetry-collector-contrib/config/confighttp v0.0.0-20240314211421-34bd73a6cac8/go.mod h1:3sU3HgF5wc32CVljnzGo4Fn/9+T0N1Z6tCJyKdW2MvM=
 github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.0.0-20240314211421-34bd73a6cac8 h1:Ojr9LNjrlDWyuSDguL4V/O5oLzFc8HBUsuqFCRpN4b4=
 github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.0.0-20240314211421-34bd73a6cac8/go.mod h1:9L23Mib5WjvuWRMmLyZrH+OJyeDz0fEZ9e2ummzZlgU=
 github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awsemfexporter v0.0.0-20240314211421-34bd73a6cac8 h1:sPJEbFUsPR1+eNqELsjqZEf28lV3KsRV3GyRUnxwoGM=
@@ -1207,6 +1205,8 @@ go.opentelemetry.io/collector/config/configcompression v0.89.0 h1:Z4LG045HwoNqXa
 go.opentelemetry.io/collector/config/configcompression v0.89.0/go.mod h1:LaavoxZsro5lL7qh1g9DMifG0qixWPEecW18Qr8bpag=
 go.opentelemetry.io/collector/config/configgrpc v0.89.0 h1:Lnv/4EbImss5JuVE2nffk00pCGfk4tRyV8Gm3Gl7yuM=
 go.opentelemetry.io/collector/config/configgrpc v0.89.0/go.mod h1:2GuAxpU34a1X19kCZ8Kw3FUsxOIiFcWHiYorRCyhnCc=
+go.opentelemetry.io/collector/config/confighttp v0.89.0 h1:RatLdeZkCu3uLtCjbS8g5Aec2JB3/CSpB6O7P081Bhg=
+go.opentelemetry.io/collector/config/confighttp v0.89.0/go.mod h1:R5BIbvqlxSDQGpCRWd2HBZIWijfSIWRpLeSpZjkKkag=
 go.opentelemetry.io/collector/config/confignet v0.89.0 h1:Ekh+XhXelnnJ9as8IWhdUOfjnDPhz12XMJQ8sWNAbGw=
 go.opentelemetry.io/collector/config/confignet v0.89.0/go.mod h1:cpO8JYWGONaViOygKVw+Hd2UoBcn2cUiyi0WWeFTwJY=
 go.opentelemetry.io/collector/config/configopaque v0.89.0 h1:Ad6yGcGBHs+J9SNjkedY68JsLZ1vBn4kKzdqKuTCRsE=

--- a/internal/mapstructure/encoder.go
+++ b/internal/mapstructure/encoder.go
@@ -24,6 +24,7 @@ const (
 
 var (
 	errNonStringEncodedKey = errors.New("non string-encoded key")
+	errUnsupportedKind     = errors.New("unsupported kind")
 )
 
 // tagInfo stores the mapstructure tag details.
@@ -44,8 +45,10 @@ type EncoderConfig struct {
 	// EncodeHook, if set, is a way to provide custom encoding. It
 	// will be called before structs and primitive types.
 	EncodeHook mapstructure.DecodeHookFunc
-	// OmitAllNil, if set, is a way to omit all nil fields even if omitempty isn't present.
-	OmitAllNil bool
+	// NilEmptyMap, if set, is a way to nil out empty maps.
+	NilEmptyMap bool
+	// OmitNilFields, if set, is a way to omit all nil struct fields even if omitempty isn't present.
+	OmitNilFields bool
 }
 
 // New returns a new encoder for the configuration.
@@ -63,11 +66,11 @@ func (e *Encoder) Encode(input any) (any, error) {
 func (e *Encoder) encode(value reflect.Value) (any, error) {
 	if value.IsValid() {
 		switch value.Kind() {
-		case reflect.Interface, reflect.Ptr:
+		case reflect.Interface, reflect.Pointer:
 			return e.encode(value.Elem())
 		case reflect.Map:
 			return e.encodeMap(value)
-		case reflect.Slice:
+		case reflect.Slice, reflect.Array:
 			return e.encodeSlice(value)
 		case reflect.Struct:
 			return e.encodeStruct(value)
@@ -120,9 +123,12 @@ func (e *Encoder) encodeStruct(value reflect.Value) (any, error) {
 			}
 			encoded, err := e.encode(field)
 			if err != nil {
+				if errors.Is(err, errUnsupportedKind) {
+					continue
+				}
 				return nil, fmt.Errorf("error encoding field %q: %w", info.name, err)
 			}
-			if e.config.OmitAllNil && encoded == nil {
+			if e.config.OmitNilFields && encoded == nil {
 				continue
 			}
 			if info.squash {
@@ -141,7 +147,7 @@ func (e *Encoder) encodeStruct(value reflect.Value) (any, error) {
 
 // encodeSlice iterates over the slice and encodes each of the elements.
 func (e *Encoder) encodeSlice(value reflect.Value) (any, error) {
-	if value.Kind() != reflect.Slice {
+	if value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
 		return nil, &reflect.ValueError{
 			Method: "encodeSlice",
 			Kind:   value.Kind(),
@@ -183,6 +189,9 @@ func (e *Encoder) encodeMap(value reflect.Value) (any, error) {
 		if result[key], err = e.encode(iterator.Value()); err != nil {
 			return nil, fmt.Errorf("error encoding map value for key %q: %w", key, err)
 		}
+	}
+	if e.config.NilEmptyMap && len(result) == 0 {
+		return nil, nil
 	}
 	return result, nil
 }
@@ -233,14 +242,39 @@ func TextMarshalerHookFunc() mapstructure.DecodeHookFuncValue {
 // NilHookFunc returns a DecodeHookFuncValue that checks if the value matches the type and nils it out. Allows specific
 // types to be omitted.
 func NilHookFunc[T any]() mapstructure.DecodeHookFuncValue {
+	return nilHookFunc[T](false)
+}
+
+// NilZeroValueHookFunc returns a DecodeHookFuncValue that only nils the field if it's a zero value.
+func NilZeroValueHookFunc[T any]() mapstructure.DecodeHookFuncValue {
+	return nilHookFunc[T](true)
+}
+
+func nilHookFunc[T any](onlyIfZero bool) mapstructure.DecodeHookFuncValue {
 	return func(from reflect.Value, _ reflect.Value) (any, error) {
 		if !from.IsValid() {
 			return nil, nil
 		}
 		_, ok := from.Interface().(T)
-		if !ok {
+		if ok && (!onlyIfZero || from.IsZero()) {
+			return nil, nil
+		}
+		return from.Interface(), nil
+	}
+}
+
+// UnsupportedKindHookFunc returns a DecodeHookFuncValue that checks that the kind isn't one unsupported by the YAML
+// encoder.
+func UnsupportedKindHookFunc() mapstructure.DecodeHookFuncValue {
+	return func(from reflect.Value, _ reflect.Value) (any, error) {
+		if !from.IsValid() {
+			return nil, nil
+		}
+		switch from.Kind() {
+		case reflect.Chan, reflect.Func:
+			return nil, fmt.Errorf("%w: %s", errUnsupportedKind, from.Kind())
+		default:
 			return from.Interface(), nil
 		}
-		return nil, nil
 	}
 }

--- a/internal/mapstructure/encoder_test.go
+++ b/internal/mapstructure/encoder_test.go
@@ -11,18 +11,20 @@ import (
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/config/configopaque"
+	"github.com/stretchr/testify/assert"
 )
 
 type TestComplexStruct struct {
 	Skipped   TestEmptyStruct             `mapstructure:",squash"`
 	Nested    TestSimpleStruct            `mapstructure:",squash"`
-	Slice     []TestSimpleStruct          `mapstructure:"slice,omitempty"`
+	Slice     []TestSimpleStruct          `mapstructure:"slice"`
+	Array     [2]string                   `mapstructure:"array,omitempty"`
 	Pointer   *TestSimpleStruct           `mapstructure:"ptr"`
-	Map       map[string]TestSimpleStruct `mapstructure:"map,omitempty"`
+	Map       map[string]TestSimpleStruct `mapstructure:"map"`
 	Remain    map[string]any              `mapstructure:",remain"`
 	Interface encoding.TextMarshaler
+	Function  func() string
+	Channel   chan string
 }
 
 type TestSimpleStruct struct {
@@ -50,7 +52,10 @@ func (tID TestID) MarshalText() (text []byte, err error) {
 
 func TestEncode(t *testing.T) {
 	enc := New(&EncoderConfig{
-		EncodeHook: TextMarshalerHookFunc(),
+		EncodeHook: mapstructure.ComposeDecodeHookFunc(
+			TextMarshalerHookFunc(),
+			UnsupportedKindHookFunc(),
+		),
 	})
 	testCases := map[string]struct {
 		input any
@@ -88,6 +93,7 @@ func TestEncode(t *testing.T) {
 				Slice: []TestSimpleStruct{
 					{Value: "slice"},
 				},
+				Array: [2]string{"one", "two"},
 				Map: map[string]TestSimpleStruct{
 					"Key": {Value: "map"},
 				},
@@ -99,10 +105,15 @@ func TestEncode(t *testing.T) {
 					"remain2": "value",
 				},
 				Interface: TestID("value"),
+				Function: func() string {
+					return "ignore"
+				},
+				Channel: make(chan string),
 			},
 			want: map[string]any{
 				"value": "nested",
 				"slice": []any{map[string]any{"value": "slice"}},
+				"array": []any{"one", "two"},
 				"map": map[string]any{
 					"Key": map[string]any{"value": "map"},
 				},
@@ -116,16 +127,23 @@ func TestEncode(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, err := enc.Encode(testCase.input)
-			require.NoError(t, err)
-			require.Equal(t, testCase.want, got)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
 		})
 	}
 	// without the TextMarshalerHookFunc
 	enc.config.EncodeHook = nil
 	testCase := TestID("test")
 	got, err := enc.Encode(testCase)
-	require.NoError(t, err)
-	require.Equal(t, testCase, got)
+	assert.NoError(t, err)
+	assert.Equal(t, testCase, got)
+}
+
+func TestEncodeNil(t *testing.T) {
+	enc := New(nil)
+	got, err := enc.Encode(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, got)
 }
 
 func TestGetTagInfo(t *testing.T) {
@@ -181,9 +199,9 @@ func TestGetTagInfo(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got := getTagInfo(testCase.field)
-			require.Equal(t, testCase.wantName, got.name)
-			require.Equal(t, testCase.wantOmit, got.omitEmpty)
-			require.Equal(t, testCase.wantSquash, got.squash)
+			assert.Equal(t, testCase.wantName, got.name)
+			assert.Equal(t, testCase.wantOmit, got.omitEmpty)
+			assert.Equal(t, testCase.wantSquash, got.squash)
 		})
 	}
 }
@@ -201,9 +219,9 @@ func TestEncodeValueError(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		got, err := testCase.encodeFn(testValue)
-		require.Error(t, err)
-		require.Equal(t, testCase.wantErr, err)
-		require.Nil(t, got)
+		assert.Error(t, err)
+		assert.Equal(t, testCase.wantErr, err)
+		assert.Nil(t, got)
 	}
 }
 
@@ -221,9 +239,9 @@ func TestEncodeNonStringEncodedKey(t *testing.T) {
 		},
 	}
 	got, err := enc.Encode(testCase)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, errNonStringEncodedKey))
-	require.Nil(t, got)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, errNonStringEncodedKey))
+	assert.Nil(t, got)
 }
 
 func TestDuplicateKey(t *testing.T) {
@@ -235,8 +253,8 @@ func TestDuplicateKey(t *testing.T) {
 		"test_": "other value",
 	}
 	got, err := enc.Encode(testCase)
-	require.Error(t, err)
-	require.Nil(t, got)
+	assert.Error(t, err)
+	assert.Nil(t, got)
 }
 
 func TestTextMarshalerError(t *testing.T) {
@@ -247,32 +265,8 @@ func TestTextMarshalerError(t *testing.T) {
 		"error": "value",
 	}
 	got, err := enc.Encode(testCase)
-	require.Error(t, err)
-	require.Nil(t, got)
-}
-
-func TestNilConfigOpaqueString(t *testing.T) {
-	cfg := &EncoderConfig{
-		EncodeHook: mapstructure.ComposeDecodeHookFunc(
-			NilHookFunc[configopaque.String](),
-			TextMarshalerHookFunc(),
-		),
-	}
-	enc := New(cfg)
-	testCase := struct {
-		Confidential configopaque.String
-	}{
-		Confidential: configopaque.String("skip"),
-	}
-	got, err := enc.Encode(testCase)
-	require.NoError(t, err)
-	require.Equal(t, map[string]any{
-		"confidential": nil,
-	}, got)
-	cfg.OmitAllNil = true
-	got, err = enc.Encode(testCase)
-	require.NoError(t, err)
-	require.Equal(t, map[string]any{}, got)
+	assert.Error(t, err)
+	assert.Nil(t, got)
 }
 
 func TestEncodeStruct(t *testing.T) {
@@ -284,8 +278,8 @@ func TestEncodeStruct(t *testing.T) {
 		skipped: "final",
 	}
 	got, err := enc.Encode(testCase)
-	require.NoError(t, err)
-	require.Equal(t, "final", got)
+	assert.NoError(t, err)
+	assert.Equal(t, "final", got)
 }
 
 func TestEncodeStructError(t *testing.T) {
@@ -297,16 +291,9 @@ func TestEncodeStructError(t *testing.T) {
 		{err: wantErr}: "value",
 	}
 	got, err := enc.Encode(testCase)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, wantErr))
-	require.Nil(t, got)
-}
-
-func TestEncodeNil(t *testing.T) {
-	enc := New(nil)
-	got, err := enc.Encode(nil)
-	require.NoError(t, err)
-	require.Nil(t, got)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, wantErr))
+	assert.Nil(t, got)
 }
 
 func testHookFunc() mapstructure.DecodeHookFuncValue {
@@ -324,4 +311,92 @@ func testHookFunc() mapstructure.DecodeHookFuncValue {
 		}
 		return got.skipped, nil
 	}
+}
+
+func TestNilHook(t *testing.T) {
+	cfg := &EncoderConfig{
+		EncodeHook: mapstructure.ComposeDecodeHookFunc(
+			NilHookFunc[TestSimpleStruct](),
+			TextMarshalerHookFunc(),
+		),
+	}
+	enc := New(cfg)
+	testCase := struct {
+		Skip TestSimpleStruct
+	}{
+		Skip: TestSimpleStruct{Value: "skip"},
+	}
+	got, err := enc.Encode(testCase)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"skip": nil,
+	}, got)
+	cfg.OmitNilFields = true
+	got, err = enc.Encode(testCase)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{}, got)
+}
+
+func TestNilZeroValueHook(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: NilZeroValueHookFunc[TestSimpleStruct](),
+	})
+	testCase := struct {
+		NonZero TestSimpleStruct
+		Zero    TestSimpleStruct
+	}{
+		NonZero: TestSimpleStruct{
+			Value: "test",
+		},
+		Zero: TestSimpleStruct{},
+	}
+	got, err := enc.Encode(testCase)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"nonzero": map[string]any{
+			"value": "test",
+		},
+		"zero": nil,
+	}, got)
+}
+
+func TestUnsupportedKindHook(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: UnsupportedKindHookFunc(),
+	})
+	testCases := map[reflect.Kind]any{
+		reflect.Func: func() string {
+			return "unsupported"
+		},
+		reflect.Chan: make(chan string),
+	}
+	for kind, input := range testCases {
+		t.Run(kind.String(), func(t *testing.T) {
+			got, err := enc.Encode(input)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, errUnsupportedKind)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+type TestFunction func() string
+
+func (tf TestFunction) MarshalText() (text []byte, err error) {
+	return []byte(tf()), nil
+}
+
+func TestUnsupportedKindWithMarshaler(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: mapstructure.ComposeDecodeHookFunc(
+			TextMarshalerHookFunc(),
+			UnsupportedKindHookFunc(),
+		),
+	})
+	testCase := TestFunction(func() string {
+		return "marshal"
+	})
+	got, err := enc.Encode(testCase)
+	assert.NoError(t, err)
+	assert.Equal(t, "marshal", got)
 }

--- a/internal/mapstructure/marshaler.go
+++ b/internal/mapstructure/marshaler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -31,10 +32,13 @@ func encoderConfig(rawVal any) *EncoderConfig {
 	return &EncoderConfig{
 		EncodeHook: mapstructure.ComposeDecodeHookFunc(
 			NilHookFunc[configopaque.String](),
+			NilZeroValueHookFunc[configtls.TLSClientSetting](),
 			TextMarshalerHookFunc(),
 			MarshalerHookFunc(rawVal),
+			UnsupportedKindHookFunc(),
 		),
-		OmitAllNil: true,
+		NilEmptyMap:   true,
+		OmitNilFields: true,
 	}
 }
 

--- a/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -34,9 +33,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - InstanceType
             - ImageId
             - InstanceId
-            - InstanceType
         imds_retries: 1
         refresh_interval_seconds: 0s
 receivers:
@@ -74,11 +73,11 @@ service:
             processors:
                 - ec2tagger
             receivers:
+                - telegraf_mem
                 - telegraf_netstat
                 - telegraf_swap
                 - telegraf_cpu
                 - telegraf_disk
-                - telegraf_mem
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -94,7 +93,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -107,7 +105,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -82,13 +81,13 @@ service:
             processors:
                 - ec2tagger
             receivers:
+                - telegraf_disk
                 - telegraf_mem
                 - telegraf_netstat
                 - telegraf_swap
                 - telegraf_ethtool
                 - telegraf_nvidia_smi
                 - telegraf_cpu
-                - telegraf_disk
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -104,7 +103,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -117,7 +115,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/advanced_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_windows.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -74,13 +73,13 @@ service:
             processors:
                 - ec2tagger
             receivers:
+                - telegraf_win_perf_counters/3762679655
                 - telegraf_win_perf_counters/2073218482
                 - telegraf_win_perf_counters/2039663244
                 - telegraf_win_perf_counters/4283769065
                 - telegraf_win_perf_counters/1492679118
                 - telegraf_win_perf_counters/3610923661
                 - telegraf_win_perf_counters/3446270237
-                - telegraf_win_perf_counters/3762679655
     telemetry:
         logs:
             development: false
@@ -88,7 +87,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
@@ -101,7 +99,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awsemf/app_signals:
         certificate_file_path: ""
@@ -287,16 +286,16 @@ extensions:
             operations:
                 - PutLogEvents
             usage_flags:
-              mode: EKS
-              region_type: ACJ
+                mode: EKS
+                region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
             usage_flags:
-              mode: EKS
-              region_type: ACJ
+                mode: EKS
+                region_type: ACJ
     awsproxy/app_signals:
         aws_endpoint: ""
         certificate_file_path: ""
@@ -310,16 +309,16 @@ extensions:
         shared_credentials_file: []
 processors:
     awsappsignals:
-        resolvers:
-          - platform: eks
-            name: TestCluster
-        rules: []
         limiter:
-          disabled: false
-          drop_threshold: 500
-          log_dropped_metrics: true
-          rotation_interval: 10m0s
-          garbage_collection_interval: 10m0s
+            disabled: false
+            drop_threshold: 500
+            garbage_collection_interval: 10m0s
+            log_dropped_metrics: true
+            rotation_interval: 10m0s
+        resolvers:
+            - name: TestCluster
+              platform: eks
+        rules: []
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         metadata_keys: []
@@ -360,7 +359,6 @@ processors:
         consul:
             address: ""
             datacenter: ""
-            meta: {}
             namespace: ""
             resource_attributes:
                 azure.resourcegroup.name:
@@ -503,7 +501,6 @@ processors:
                     enabled: true
                 k8s.cluster.name:
                     enabled: true
-        headers: {}
         heroku:
             resource_attributes:
                 cloud.provider:
@@ -564,16 +561,6 @@ processors:
                     enabled: true
                 k8s.cluster.name:
                     enabled: true
-            tls:
-                ca_file: ""
-                cert_file: ""
-                insecure: false
-                insecure_skip_verify: false
-                key_file: ""
-                max_version: ""
-                min_version: ""
-                reload_interval: 0s
-                server_name_override: ""
             token: ""
         override: true
         read_buffer_size: 0
@@ -606,6 +593,7 @@ processors:
         write_buffer_size: 0
 receivers:
     awscontainerinsightreceiver:
+        accelerated_compute_metrics: false
         add_container_name_metric_label: false
         add_full_pod_name_metric_label: false
         add_service_as_attribute: true
@@ -630,7 +618,6 @@ receivers:
         resource_arn: ""
         role_arn: ""
         shared_credentials_file: []
-        accelerated_compute_metrics: false
     otlp/app_signals:
         protocols:
             grpc:
@@ -640,14 +627,14 @@ receivers:
                 max_recv_msg_size_mib: 0
                 read_buffer_size: 524288
                 tls:
-                  cert_file: path/to/cert.crt
-                  key_file: path/to/key.key
-                  ca_file: ""
-                  client_ca_file: ""
-                  client_ca_file_reload: false
-                  max_version: ""
-                  min_version: ""
-                  reload_interval: 0s
+                    ca_file: ""
+                    cert_file: path/to/cert.crt
+                    client_ca_file: ""
+                    client_ca_file_reload: false
+                    key_file: path/to/key.key
+                    max_version: ""
+                    min_version: ""
+                    reload_interval: 0s
                 transport: tcp
                 write_buffer_size: 0
             http:
@@ -656,16 +643,15 @@ receivers:
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
-                response_headers: {}
                 tls:
-                  cert_file: path/to/cert.crt
-                  key_file: path/to/key.key
-                  client_ca_file: ""
-                  client_ca_file_reload: false
-                  ca_file: ""
-                  max_version: ""
-                  min_version: ""
-                  reload_interval: 0s
+                    ca_file: ""
+                    cert_file: path/to/cert.crt
+                    client_ca_file: ""
+                    client_ca_file_reload: false
+                    key_file: path/to/key.key
+                    max_version: ""
+                    min_version: ""
+                    reload_interval: 0s
                 traces_url_path: /v1/traces
 service:
     extensions:
@@ -703,7 +689,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -715,7 +700,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awsemf/app_signals:
         certificate_file_path: ""
@@ -287,16 +286,16 @@ extensions:
             operations:
                 - PutLogEvents
             usage_flags:
-              mode: K8E
-              region_type: ACJ
+                mode: K8E
+                region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
             usage_flags:
-              mode: K8E
-              region_type: ACJ
+                mode: K8E
+                region_type: ACJ
     awsproxy/app_signals:
         aws_endpoint: ""
         certificate_file_path: ""
@@ -310,16 +309,16 @@ extensions:
         shared_credentials_file: []
 processors:
     awsappsignals:
-        resolvers:
-          - platform: k8s
-            name: TestCluster
-        rules: []
         limiter:
-          disabled: false
-          drop_threshold: 500
-          log_dropped_metrics: true
-          rotation_interval: 10m0s
-          garbage_collection_interval: 10m0s
+            disabled: false
+            drop_threshold: 500
+            garbage_collection_interval: 10m0s
+            log_dropped_metrics: true
+            rotation_interval: 10m0s
+        resolvers:
+            - name: TestCluster
+              platform: k8s
+        rules: []
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         metadata_keys: []
@@ -327,285 +326,274 @@ processors:
         send_batch_size: 8192
         timeout: 5s
     resourcedetection:
-      aks:
-        resource_attributes:
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-      attributes: []
-      azure:
-        resource_attributes:
-          azure.resourcegroup.name:
-            enabled: true
-          azure.vm.name:
-            enabled: true
-          azure.vm.scaleset.name:
-            enabled: true
-          azure.vm.size:
-            enabled: true
-          cloud.account.id:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          host.id:
-            enabled: true
-          host.name:
-            enabled: true
-      compression: ""
-      consul:
-        address: ""
-        datacenter: ""
-        meta: {}
-        namespace: ""
-        resource_attributes:
-          azure.resourcegroup.name:
-            enabled: true
-          azure.vm.name:
-            enabled: true
-          azure.vm.scaleset.name:
-            enabled: true
-          azure.vm.size:
-            enabled: true
-          cloud.account.id:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          host.id:
-            enabled: true
-          host.name:
-            enabled: true
-        token_file: ""
-      detectors:
-        - eks
-        - env
-        - ec2
-      disable_keep_alives: false
-      docker:
-        resource_attributes:
-          host.name:
-            enabled: true
-          os.type:
-            enabled: true
-      ec2:
-        resource_attributes:
-          cloud.account.id:
-            enabled: true
-          cloud.availability_zone:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          host.id:
-            enabled: true
-          host.image.id:
-            enabled: true
-          host.name:
-            enabled: true
-          host.type:
-            enabled: true
-        tags:
-          - ^kubernetes.io/cluster/.*$
-          - ^aws:autoscaling:groupName
-      ecs:
-        resource_attributes:
-          aws.ecs.cluster.arn:
-            enabled: true
-          aws.ecs.launchtype:
-            enabled: true
-          aws.ecs.task.arn:
-            enabled: true
-          aws.ecs.task.family:
-            enabled: true
-          aws.ecs.task.revision:
-            enabled: true
-          aws.log.group.arns:
-            enabled: true
-          aws.log.group.names:
-            enabled: true
-          aws.log.stream.arns:
-            enabled: true
-          aws.log.stream.names:
-            enabled: true
-          cloud.account.id:
-            enabled: true
-          cloud.availability_zone:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-      eks:
-        resource_attributes:
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-      elasticbeanstalk:
-        resource_attributes:
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          deployment.environment:
-            enabled: true
-          service.instance.id:
-            enabled: true
-          service.version:
-            enabled: true
-      endpoint: ""
-      gcp:
-        resource_attributes:
-          cloud.account.id:
-            enabled: true
-          cloud.availability_zone:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          faas.id:
-            enabled: true
-          faas.instance:
-            enabled: true
-          faas.name:
-            enabled: true
-          faas.version:
-            enabled: true
-          gcp.cloud_run.job.execution:
-            enabled: true
-          gcp.cloud_run.job.task_index:
-            enabled: true
-          gcp.gce.instance.hostname:
-            enabled: false
-          gcp.gce.instance.name:
-            enabled: false
-          host.id:
-            enabled: true
-          host.name:
-            enabled: true
-          host.type:
-            enabled: true
-          k8s.cluster.name:
-            enabled: true
-      headers: {}
-      heroku:
-        resource_attributes:
-          cloud.provider:
-            enabled: true
-          heroku.app.id:
-            enabled: true
-          heroku.dyno.id:
-            enabled: true
-          heroku.release.commit:
-            enabled: true
-          heroku.release.creation_timestamp:
-            enabled: true
-          service.instance.id:
-            enabled: true
-          service.name:
-            enabled: true
-          service.version:
-            enabled: true
-      idle_conn_timeout: 1m30s
-      k8snode:
-        auth_type: serviceAccount
-        context: ""
-        node_from_env_var: ""
-        resource_attributes:
-          k8s.node.name:
-            enabled: true
-          k8s.node.uid:
-            enabled: true
-      lambda:
-        resource_attributes:
-          aws.log.group.names:
-            enabled: true
-          aws.log.stream.names:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          faas.instance:
-            enabled: true
-          faas.max_memory:
-            enabled: true
-          faas.name:
-            enabled: true
-          faas.version:
-            enabled: true
-      max_idle_conns: 100
-      openshift:
-        address: ""
-        resource_attributes:
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          k8s.cluster.name:
-            enabled: true
-        tls:
-          ca_file: ""
-          cert_file: ""
-          insecure: false
-          insecure_skip_verify: false
-          key_file: ""
-          max_version: ""
-          min_version: ""
-          reload_interval: 0s
-          server_name_override: ""
-        token: ""
-      override: true
-      read_buffer_size: 0
-      system:
-        hostname_sources: []
-        resource_attributes:
-          host.arch:
-            enabled: false
-          host.cpu.cache.l2.size:
-            enabled: false
-          host.cpu.family:
-            enabled: false
-          host.cpu.model.id:
-            enabled: false
-          host.cpu.model.name:
-            enabled: false
-          host.cpu.stepping:
-            enabled: false
-          host.cpu.vendor.id:
-            enabled: false
-          host.id:
-            enabled: false
-          host.name:
-            enabled: true
-          os.description:
-            enabled: false
-          os.type:
-            enabled: true
-      timeout: 2s
-      write_buffer_size: 0
+        aks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+        attributes: []
+        azure:
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+        compression: ""
+        consul:
+            address: ""
+            datacenter: ""
+            namespace: ""
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            token_file: ""
+        detectors:
+            - eks
+            - env
+            - ec2
+        disable_keep_alives: false
+        docker:
+            resource_attributes:
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+        ec2:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+            tags:
+                - ^kubernetes.io/cluster/.*$
+                - ^aws:autoscaling:groupName
+        ecs:
+            resource_attributes:
+                aws.ecs.cluster.arn:
+                    enabled: true
+                aws.ecs.launchtype:
+                    enabled: true
+                aws.ecs.task.arn:
+                    enabled: true
+                aws.ecs.task.family:
+                    enabled: true
+                aws.ecs.task.revision:
+                    enabled: true
+                aws.log.group.arns:
+                    enabled: true
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.arns:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+        eks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+        elasticbeanstalk:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                deployment.environment:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.version:
+                    enabled: true
+        endpoint: ""
+        gcp:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.id:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+                gcp.cloud_run.job.execution:
+                    enabled: true
+                gcp.cloud_run.job.task_index:
+                    enabled: true
+                gcp.gce.instance.hostname:
+                    enabled: false
+                gcp.gce.instance.name:
+                    enabled: false
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+        heroku:
+            resource_attributes:
+                cloud.provider:
+                    enabled: true
+                heroku.app.id:
+                    enabled: true
+                heroku.dyno.id:
+                    enabled: true
+                heroku.release.commit:
+                    enabled: true
+                heroku.release.creation_timestamp:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.name:
+                    enabled: true
+                service.version:
+                    enabled: true
+        idle_conn_timeout: 1m30s
+        k8snode:
+            auth_type: serviceAccount
+            context: ""
+            node_from_env_var: ""
+            resource_attributes:
+                k8s.node.name:
+                    enabled: true
+                k8s.node.uid:
+                    enabled: true
+        lambda:
+            resource_attributes:
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.max_memory:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+        max_idle_conns: 100
+        openshift:
+            address: ""
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+            token: ""
+        override: true
+        read_buffer_size: 0
+        system:
+            hostname_sources: []
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.cpu.cache.l2.size:
+                    enabled: false
+                host.cpu.family:
+                    enabled: false
+                host.cpu.model.id:
+                    enabled: false
+                host.cpu.model.name:
+                    enabled: false
+                host.cpu.stepping:
+                    enabled: false
+                host.cpu.vendor.id:
+                    enabled: false
+                host.id:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: false
+                os.type:
+                    enabled: true
+        timeout: 2s
+        write_buffer_size: 0
 receivers:
     awscontainerinsightreceiver:
+        accelerated_compute_metrics: false
         add_container_name_metric_label: false
         add_full_pod_name_metric_label: false
         add_service_as_attribute: true
@@ -630,7 +618,6 @@ receivers:
         resource_arn: ""
         role_arn: ""
         shared_credentials_file: []
-        accelerated_compute_metrics: false
     otlp/app_signals:
         protocols:
             grpc:
@@ -647,7 +634,6 @@ receivers:
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
-                response_headers: {}
                 traces_url_path: /v1/traces
 service:
     extensions:
@@ -685,7 +671,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -697,7 +682,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awsemf/app_signals:
         certificate_file_path: ""
@@ -86,7 +85,8 @@ exporters:
             enabled: false
         retain_initial_value_of_delta_metric: false
         role_arn: ""
-        shared_credentials_file: ["fake-path"]
+        shared_credentials_file:
+            - fake-path
         version: "1"
     awsxray/app_signals:
         aws_log_groups: []
@@ -106,13 +106,14 @@ exporters:
         middleware: agenthealth/traces
         no_verify_ssl: false
         num_workers: 8
-        profile: "AmazonCloudWatchAgent"
+        profile: AmazonCloudWatchAgent
         proxy_address: ""
         region: us-east-1
         request_timeout_seconds: 30
         resource_arn: ""
         role_arn: ""
-        shared_credentials_file: ["fake-path"]
+        shared_credentials_file:
+            - fake-path
         telemetry:
             enabled: true
             include_metadata: true
@@ -123,27 +124,28 @@ extensions:
             operations:
                 - PutLogEvents
             usage_flags:
-              mode: OP
-              region_type: ACJ
+                mode: OP
+                region_type: ACJ
     agenthealth/traces:
         is_usage_data_enabled: true
         stats:
             operations:
                 - PutTraceSegments
             usage_flags:
-              mode: OP
-              region_type: ACJ
+                mode: OP
+                region_type: ACJ
     awsproxy/app_signals:
-        aws_endpoint: "https://fake_endpoint"
+        aws_endpoint: https://fake_endpoint
         certificate_file_path: ""
         endpoint: 0.0.0.0:2000
         imds_retries: 1
         local_mode: true
-        profile: "AmazonCloudWatchAgent"
+        profile: AmazonCloudWatchAgent
         proxy_address: ""
         region: us-east-1
         role_arn: ""
-        shared_credentials_file: ["fake-path"]
+        shared_credentials_file:
+            - fake-path
 processors:
     awsappsignals:
         resolvers:
@@ -151,283 +153,271 @@ processors:
               platform: generic
         rules: []
     resourcedetection:
-      aks:
-        resource_attributes:
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-      attributes: []
-      azure:
-        resource_attributes:
-          azure.resourcegroup.name:
-            enabled: true
-          azure.vm.name:
-            enabled: true
-          azure.vm.scaleset.name:
-            enabled: true
-          azure.vm.size:
-            enabled: true
-          cloud.account.id:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          host.id:
-            enabled: true
-          host.name:
-            enabled: true
-      compression: ""
-      consul:
-        address: ""
-        datacenter: ""
-        meta: {}
-        namespace: ""
-        resource_attributes:
-          azure.resourcegroup.name:
-            enabled: true
-          azure.vm.name:
-            enabled: true
-          azure.vm.scaleset.name:
-            enabled: true
-          azure.vm.size:
-            enabled: true
-          cloud.account.id:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          host.id:
-            enabled: true
-          host.name:
-            enabled: true
-        token_file: ""
-      detectors:
-        - eks
-        - env
-        - ec2
-      disable_keep_alives: false
-      docker:
-        resource_attributes:
-          host.name:
-            enabled: true
-          os.type:
-            enabled: true
-      ec2:
-        resource_attributes:
-          cloud.account.id:
-            enabled: true
-          cloud.availability_zone:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          host.id:
-            enabled: true
-          host.image.id:
-            enabled: true
-          host.name:
-            enabled: true
-          host.type:
-            enabled: true
-        tags:
-          - ^kubernetes.io/cluster/.*$
-          - ^aws:autoscaling:groupName
-      ecs:
-        resource_attributes:
-          aws.ecs.cluster.arn:
-            enabled: true
-          aws.ecs.launchtype:
-            enabled: true
-          aws.ecs.task.arn:
-            enabled: true
-          aws.ecs.task.family:
-            enabled: true
-          aws.ecs.task.revision:
-            enabled: true
-          aws.log.group.arns:
-            enabled: true
-          aws.log.group.names:
-            enabled: true
-          aws.log.stream.arns:
-            enabled: true
-          aws.log.stream.names:
-            enabled: true
-          cloud.account.id:
-            enabled: true
-          cloud.availability_zone:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-      eks:
-        resource_attributes:
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-      elasticbeanstalk:
-        resource_attributes:
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          deployment.environment:
-            enabled: true
-          service.instance.id:
-            enabled: true
-          service.version:
-            enabled: true
-      endpoint: ""
-      gcp:
-        resource_attributes:
-          cloud.account.id:
-            enabled: true
-          cloud.availability_zone:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          faas.id:
-            enabled: true
-          faas.instance:
-            enabled: true
-          faas.name:
-            enabled: true
-          faas.version:
-            enabled: true
-          gcp.cloud_run.job.execution:
-            enabled: true
-          gcp.cloud_run.job.task_index:
-            enabled: true
-          gcp.gce.instance.hostname:
-            enabled: false
-          gcp.gce.instance.name:
-            enabled: false
-          host.id:
-            enabled: true
-          host.name:
-            enabled: true
-          host.type:
-            enabled: true
-          k8s.cluster.name:
-            enabled: true
-      headers: {}
-      heroku:
-        resource_attributes:
-          cloud.provider:
-            enabled: true
-          heroku.app.id:
-            enabled: true
-          heroku.dyno.id:
-            enabled: true
-          heroku.release.commit:
-            enabled: true
-          heroku.release.creation_timestamp:
-            enabled: true
-          service.instance.id:
-            enabled: true
-          service.name:
-            enabled: true
-          service.version:
-            enabled: true
-      idle_conn_timeout: 1m30s
-      k8snode:
-        auth_type: serviceAccount
-        context: ""
-        node_from_env_var: ""
-        resource_attributes:
-          k8s.node.name:
-            enabled: true
-          k8s.node.uid:
-            enabled: true
-      lambda:
-        resource_attributes:
-          aws.log.group.names:
-            enabled: true
-          aws.log.stream.names:
-            enabled: true
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          faas.instance:
-            enabled: true
-          faas.max_memory:
-            enabled: true
-          faas.name:
-            enabled: true
-          faas.version:
-            enabled: true
-      max_idle_conns: 100
-      openshift:
-        address: ""
-        resource_attributes:
-          cloud.platform:
-            enabled: true
-          cloud.provider:
-            enabled: true
-          cloud.region:
-            enabled: true
-          k8s.cluster.name:
-            enabled: true
-        tls:
-          ca_file: ""
-          cert_file: ""
-          insecure: false
-          insecure_skip_verify: false
-          key_file: ""
-          max_version: ""
-          min_version: ""
-          reload_interval: 0s
-          server_name_override: ""
-        token: ""
-      override: true
-      read_buffer_size: 0
-      system:
-        hostname_sources: []
-        resource_attributes:
-          host.arch:
-            enabled: false
-          host.cpu.cache.l2.size:
-            enabled: false
-          host.cpu.family:
-            enabled: false
-          host.cpu.model.id:
-            enabled: false
-          host.cpu.model.name:
-            enabled: false
-          host.cpu.stepping:
-            enabled: false
-          host.cpu.vendor.id:
-            enabled: false
-          host.id:
-            enabled: false
-          host.name:
-            enabled: true
-          os.description:
-            enabled: false
-          os.type:
-            enabled: true
-      timeout: 2s
-      write_buffer_size: 0
+        aks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+        attributes: []
+        azure:
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+        compression: ""
+        consul:
+            address: ""
+            datacenter: ""
+            namespace: ""
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            token_file: ""
+        detectors:
+            - eks
+            - env
+            - ec2
+        disable_keep_alives: false
+        docker:
+            resource_attributes:
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+        ec2:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+            tags:
+                - ^kubernetes.io/cluster/.*$
+                - ^aws:autoscaling:groupName
+        ecs:
+            resource_attributes:
+                aws.ecs.cluster.arn:
+                    enabled: true
+                aws.ecs.launchtype:
+                    enabled: true
+                aws.ecs.task.arn:
+                    enabled: true
+                aws.ecs.task.family:
+                    enabled: true
+                aws.ecs.task.revision:
+                    enabled: true
+                aws.log.group.arns:
+                    enabled: true
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.arns:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+        eks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+        elasticbeanstalk:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                deployment.environment:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.version:
+                    enabled: true
+        endpoint: ""
+        gcp:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.id:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+                gcp.cloud_run.job.execution:
+                    enabled: true
+                gcp.cloud_run.job.task_index:
+                    enabled: true
+                gcp.gce.instance.hostname:
+                    enabled: false
+                gcp.gce.instance.name:
+                    enabled: false
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+        heroku:
+            resource_attributes:
+                cloud.provider:
+                    enabled: true
+                heroku.app.id:
+                    enabled: true
+                heroku.dyno.id:
+                    enabled: true
+                heroku.release.commit:
+                    enabled: true
+                heroku.release.creation_timestamp:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.name:
+                    enabled: true
+                service.version:
+                    enabled: true
+        idle_conn_timeout: 1m30s
+        k8snode:
+            auth_type: serviceAccount
+            context: ""
+            node_from_env_var: ""
+            resource_attributes:
+                k8s.node.name:
+                    enabled: true
+                k8s.node.uid:
+                    enabled: true
+        lambda:
+            resource_attributes:
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.max_memory:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+        max_idle_conns: 100
+        openshift:
+            address: ""
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+            token: ""
+        override: true
+        read_buffer_size: 0
+        system:
+            hostname_sources: []
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.cpu.cache.l2.size:
+                    enabled: false
+                host.cpu.family:
+                    enabled: false
+                host.cpu.model.id:
+                    enabled: false
+                host.cpu.model.name:
+                    enabled: false
+                host.cpu.stepping:
+                    enabled: false
+                host.cpu.vendor.id:
+                    enabled: false
+                host.id:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: false
+                os.type:
+                    enabled: true
+        timeout: 2s
+        write_buffer_size: 0
 receivers:
     otlp/app_signals:
         protocols:
@@ -445,7 +435,6 @@ receivers:
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
-                response_headers: {}
                 traces_url_path: /v1/traces
 service:
     extensions:
@@ -476,9 +465,9 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
-            output_paths: ["/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"]
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
             sampling:
                 enabled: true
                 initial: 2
@@ -488,7 +477,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatchlogs/emf_logs:
         certificate_file_path: /etc/test/ca_bundle.pem
@@ -159,8 +158,8 @@ extensions:
             operations:
                 - PutLogEvents
             usage_flags:
-              mode: EC2
-              region_type: ACJ
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000
@@ -176,6 +175,7 @@ processors:
         timeout: 5s
 receivers:
     awscontainerinsightreceiver:
+        accelerated_compute_metrics: false
         add_container_name_metric_label: false
         add_full_pod_name_metric_label: false
         add_service_as_attribute: true
@@ -200,15 +200,12 @@ receivers:
         resource_arn: ""
         role_arn: ""
         shared_credentials_file: []
-        accelerated_compute_metrics: false
     tcplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: tcp_input
         listen_address: 0.0.0.0:25888
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -216,7 +213,6 @@ receivers:
             max_interval: 0s
         type: tcp_input
     udplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: udp_input
         listen_address: 0.0.0.0:25888
@@ -226,7 +222,6 @@ receivers:
             omit_pattern: false
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -259,7 +254,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -271,7 +265,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/basic_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/basic_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -56,7 +55,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -69,7 +67,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/basic_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/basic_config_windows.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -58,7 +57,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
@@ -71,7 +69,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/collectd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/collectd_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -18,7 +17,6 @@ extensions:
             usage_flags:
                 mode: EC2
                 region_type: ACJ
-processors: {}
 receivers:
     telegraf_socket_listener:
         collection_interval: 1m0s
@@ -41,7 +39,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -54,7 +51,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         endpoint_override: https://monitoring-fips.us-west-2.amazonaws.com
@@ -135,11 +134,11 @@ processors:
         metric_statements:
             - context: metric
               statements:
-                - set(unit, "unit") where name == "disk_free"
-                - set(name, "DISK_FREE") where name == "disk_free"
                 - set(unit, "unit") where name == "cpu_usage_idle"
                 - set(name, "CPU_USAGE_IDLE") where name == "cpu_usage_idle"
                 - set(unit, "unit") where name == "cpu_usage_nice"
+                - set(unit, "unit") where name == "disk_free"
+                - set(name, "DISK_FREE") where name == "disk_free"
         trace_statements: []
 receivers:
     awsxray:
@@ -182,7 +181,6 @@ receivers:
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
-                response_headers: {}
                 traces_url_path: /v1/traces
     telegraf_cpu:
         collection_interval: 10s
@@ -230,7 +228,6 @@ receivers:
         initial_delay: 1s
         timeout: 0s
     udplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: udp_input
         listen_address: 127.0.0.1:25888
@@ -240,7 +237,6 @@ receivers:
             omit_pattern: false
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -267,15 +263,15 @@ service:
                 - ec2tagger
                 - transform
             receivers:
-                - telegraf_mem
-                - telegraf_cpu
-                - telegraf_processes
-                - telegraf_swap
-                - telegraf_statsd
-                - telegraf_disk
-                - telegraf_procstat/1917393364
                 - telegraf_socket_listener
+                - telegraf_statsd
+                - telegraf_processes
+                - telegraf_disk
+                - telegraf_swap
+                - telegraf_mem
                 - telegraf_netstat
+                - telegraf_cpu
+                - telegraf_procstat/1917393364
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -301,7 +297,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: debug
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -314,7 +309,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         drop_original_metrics:
@@ -185,7 +184,6 @@ receivers:
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
-                response_headers: {}
                 traces_url_path: /v1/traces
     telegraf_cpu:
         collection_interval: 10s
@@ -233,7 +231,6 @@ receivers:
         initial_delay: 1s
         timeout: 0s
     udplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: udp_input
         listen_address: 127.0.0.1:25888
@@ -243,7 +240,6 @@ receivers:
             omit_pattern: false
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -270,15 +266,15 @@ service:
                 - ec2tagger
                 - transform
             receivers:
-                - telegraf_mem
-                - telegraf_socket_listener
-                - telegraf_processes
                 - telegraf_procstat/1917393364
-                - telegraf_disk
+                - telegraf_statsd
+                - telegraf_socket_listener
                 - telegraf_swap
                 - telegraf_netstat
                 - telegraf_cpu
-                - telegraf_statsd
+                - telegraf_mem
+                - telegraf_processes
+                - telegraf_disk
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -304,7 +300,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: error
             output_paths:
                 - /tmp/fake/log/hotdog.log
@@ -317,7 +312,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         endpoint_override: https://monitoring-fips.us-west-2.amazonaws.com
@@ -170,7 +169,6 @@ receivers:
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
-                response_headers: {}
                 traces_url_path: /v1/traces
     telegraf_nvidia_smi:
         collection_interval: 1m0s
@@ -216,7 +214,6 @@ receivers:
         initial_delay: "1s"
         timeout: 0s
     udplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: udp_input
         listen_address: 127.0.0.1:25888
@@ -226,7 +223,6 @@ receivers:
             omit_pattern: false
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -277,7 +273,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: debug
             output_paths:
                 - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
@@ -290,7 +285,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/config_with_env.yaml
+++ b/translator/tocwconfig/sampleConfig/config_with_env.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatchlogs/emf_logs:
         certificate_file_path: ""
@@ -50,13 +49,11 @@ processors:
         timeout: 5s
 receivers:
     tcplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: tcp_input
         listen_address: 0.0.0.0:25888
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -64,7 +61,6 @@ receivers:
             max_interval: 0s
         type: tcp_input
     udplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: udp_input
         listen_address: 0.0.0.0:25888
@@ -74,7 +70,6 @@ receivers:
             omit_pattern: false
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -100,7 +95,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -113,7 +107,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -34,9 +33,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
-            - InstanceType
             - ImageId
             - InstanceId
+            - InstanceType
         imds_retries: 1
         refresh_interval_seconds: 0s
     transform:
@@ -77,7 +76,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -90,7 +88,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -32,9 +31,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
-            - ImageId
             - InstanceId
             - InstanceType
+            - ImageId
         imds_retries: 1
         refresh_interval_seconds: 0s
 receivers:
@@ -61,7 +60,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -74,7 +72,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/drop_origin_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/drop_origin_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         drop_original_metrics:
@@ -28,9 +27,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
-            - ImageId
             - InstanceId
             - InstanceType
+            - ImageId
         imds_retries: 1
         refresh_interval_seconds: 0s
     transform:
@@ -67,9 +66,9 @@ service:
                 - ec2tagger
                 - transform
             receivers:
-                - telegraf_nvidia_smi
                 - telegraf_cpu
                 - telegraf_disk
+                - telegraf_nvidia_smi
     telemetry:
         logs:
             development: false
@@ -77,7 +76,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -90,7 +88,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatchlogs/emf_logs:
         certificate_file_path: ""
@@ -414,8 +413,8 @@ extensions:
             operations:
                 - PutLogEvents
             usage_flags:
-              mode: OP
-              region_type: ACJ
+                mode: OP
+                region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000
@@ -435,7 +434,6 @@ processors:
               aggregation_type: ""
               experimental_match_labels:
                 code: ^5.*
-              group_resource_labels: {}
               include: apiserver_request_total
               match_type: regexp
               new_name: apiserver_request_total_5xx
@@ -443,6 +441,7 @@ processors:
               submatch_case: ""
 receivers:
     awscontainerinsightreceiver:
+        accelerated_compute_metrics: false
         add_container_name_metric_label: true
         add_full_pod_name_metric_label: true
         add_service_as_attribute: true
@@ -468,15 +467,12 @@ receivers:
         role_arn: ""
         shared_credentials_file:
             - /root/.aws/credentials
-        accelerated_compute_metrics: false
     tcplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: tcp_input
         listen_address: 0.0.0.0:25888
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -484,7 +480,6 @@ receivers:
             max_interval: 0s
         type: tcp_input
     udplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: udp_input
         listen_address: 0.0.0.0:25888
@@ -494,7 +489,6 @@ receivers:
             omit_pattern: false
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -528,7 +522,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -540,7 +533,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
@@ -1,1355 +1,1285 @@
-connectors: {}
 exporters:
-  awscloudwatchlogs/emf_logs:
-    certificate_file_path: ""
-    emf_only: true
-    endpoint: https://fake_endpoint
-    imds_retries: 2
-    local_mode: true
-    log_group_name: emf/logs/default
-    log_retention: 0
-    log_stream_name: host_name_from_env
-    max_retries: 2
-    middleware: agenthealth/logs
-    no_verify_ssl: false
-    num_workers: 8
-    profile: default
-    proxy_address: ""
-    raw_log: true
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_elapsed_time: 5m0s
-      max_interval: 30s
-      multiplier: 1.5
-      randomization_factor: 0.5
-    role_arn: ""
-    sending_queue:
-      enabled: true
-      num_consumers: 1
-      queue_size: 1000
-    shared_credentials_file:
-      - /root/.aws/credentials
-  awsemf/containerinsights:
-    certificate_file_path: ""
-    detailed_metrics: false
-    dimension_rollup_option: NoDimensionRollup
-    disable_metric_extraction: true
-    eks_fargate_container_insights_enabled: false
-    endpoint: https://fake_endpoint
-    enhanced_container_insights: true
-    imds_retries: 2
-    local_mode: true
-    log_group_name: /aws/containerinsights/{ClusterName}/performance
-    log_retention: 0
-    log_stream_name: '{NodeName}'
-    max_retries: 2
-    metric_declarations:
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - ContainerName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - ContainerName
-            - Namespace
-            - PodName
-        label_matchers: []
-        metric_name_selectors:
-          - container_cpu_utilization
-          - container_cpu_utilization_over_container_limit
-          - container_cpu_limit
-          - container_cpu_request
-          - container_memory_utilization
-          - container_memory_utilization_over_container_limit
-          - container_memory_failures_total
-          - container_memory_limit
-          - container_memory_request
-          - container_filesystem_usage
-          - container_filesystem_available
-          - container_filesystem_utilization
-      - dimensions:
-          - - ClusterName
-            - Namespace
-            - PodName
-          - - ClusterName
-          - - ClusterName
-            - Namespace
-            - Service
-          - - ClusterName
-            - Namespace
-          - - ClusterName
-            - FullPodName
-            - Namespace
-            - PodName
-        label_matchers: []
-        metric_name_selectors:
-          - pod_cpu_utilization
-          - pod_memory_utilization
-          - pod_network_rx_bytes
-          - pod_network_tx_bytes
-          - pod_cpu_utilization_over_pod_limit
-          - pod_memory_utilization_over_pod_limit
-      - dimensions:
-          - - ClusterName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - Namespace
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - pod_interface_network_rx_dropped
-          - pod_interface_network_tx_dropped
-      - dimensions:
-          - - ClusterName
-            - Namespace
-            - PodName
-          - - ClusterName
-          - - ClusterName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - Namespace
-            - Service
-        label_matchers: []
-        metric_name_selectors:
-          - pod_cpu_reserved_capacity
-          - pod_memory_reserved_capacity
-          - pod_number_of_container_restarts
-          - pod_number_of_containers
-          - pod_number_of_running_containers
-          - pod_status_ready
-          - pod_status_scheduled
-          - pod_status_running
-          - pod_status_pending
-          - pod_status_failed
-          - pod_status_unknown
-          - pod_status_succeeded
-          - pod_memory_request
-          - pod_memory_limit
-          - pod_cpu_limit
-          - pod_cpu_request
-          - pod_container_status_running
-          - pod_container_status_terminated
-          - pod_container_status_waiting
-          - pod_container_status_waiting_reason_crash_loop_back_off
-          - pod_container_status_waiting_reason_image_pull_error
-          - pod_container_status_waiting_reason_start_error
-          - pod_container_status_waiting_reason_create_container_error
-          - pod_container_status_waiting_reason_create_container_config_error
-          - pod_container_status_terminated_reason_oom_killed
-      - dimensions:
-          - - ClusterName
-            - InstanceId
-            - NodeName
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - node_cpu_utilization
-          - node_memory_utilization
-          - node_network_total_bytes
-          - node_cpu_reserved_capacity
-          - node_memory_reserved_capacity
-          - node_number_of_running_pods
-          - node_number_of_running_containers
-          - node_cpu_usage_total
-          - node_cpu_limit
-          - node_memory_working_set
-          - node_memory_limit
-          - node_status_condition_ready
-          - node_status_condition_disk_pressure
-          - node_status_condition_memory_pressure
-          - node_status_condition_pid_pressure
-          - node_status_condition_network_unavailable
-          - node_status_condition_unknown
-          - node_status_capacity_pods
-          - node_status_allocatable_pods
-      - dimensions:
-          - - ClusterName
-            - InstanceId
-            - NodeName
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - node_interface_network_rx_dropped
-          - node_interface_network_tx_dropped
-          - node_diskio_io_service_bytes_total
-          - node_diskio_io_serviced_total
-      - dimensions:
-          - - ClusterName
-            - InstanceId
-            - NodeName
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - node_filesystem_utilization
-          - node_filesystem_inodes
-          - node_filesystem_inodes_free
-      - dimensions:
-          - - ClusterName
-            - Namespace
-            - Service
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - service_number_of_running_pods
-      - dimensions:
-          - - ClusterName
-            - Namespace
-            - PodName
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - replicas_desired
-          - replicas_ready
-          - status_replicas_available
-          - status_replicas_unavailable
-      - dimensions:
-          - - ClusterName
-            - Namespace
-            - PodName
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - daemonset_status_number_available
-          - daemonset_status_number_unavailable
-      - dimensions:
-          - - ClusterName
-            - Namespace
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - namespace_number_of_running_pods
-      - dimensions:
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - cluster_node_count
-          - cluster_failed_node_count
-          - cluster_number_of_running_pods
-      - dimensions:
-          - - ClusterName
-            - endpoint
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_storage_size_bytes
-          - apiserver_storage_db_total_size_in_bytes
-          - etcd_db_total_size_in_bytes
-      - dimensions:
-          - - ClusterName
-            - resource
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_storage_list_duration_seconds
-          - apiserver_longrunning_requests
-          - apiserver_storage_objects
-      - dimensions:
-          - - ClusterName
-            - verb
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_request_duration_seconds
-          - rest_client_request_duration_seconds
-      - dimensions:
-          - - ClusterName
-            - code
-            - verb
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_request_total
-          - apiserver_request_total_5xx
-      - dimensions:
-          - - ClusterName
-            - operation
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_admission_controller_admission_duration_seconds
-          - apiserver_admission_step_admission_duration_seconds
-          - etcd_request_duration_seconds
-      - dimensions:
-          - - ClusterName
-            - code
-            - method
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - rest_client_requests_total
-      - dimensions:
-          - - ClusterName
-            - request_kind
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_current_inflight_requests
-          - apiserver_current_inqueue_requests
-      - dimensions:
-          - - ClusterName
-            - name
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_admission_webhook_admission_duration_seconds
-      - dimensions:
-          - - ClusterName
-            - group
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_requested_deprecated_apis
-      - dimensions:
-          - - ClusterName
-            - reason
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_flowcontrol_rejected_requests_total
-      - dimensions:
-          - - ClusterName
-            - priority_level
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - apiserver_flowcontrol_request_concurrency_limit
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - ContainerName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - ContainerName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - ContainerName
-            - FullPodName
-            - GpuDevice
-            - Namespace
-            - PodName
-        label_matchers: []
-        metric_name_selectors:
-          - container_gpu_utilization
-          - container_gpu_memory_utilization
-          - container_gpu_memory_total
-          - container_gpu_memory_used
-          - container_gpu_power_draw
-          - container_gpu_temperature
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - Namespace
-          - - ClusterName
-            - Namespace
-            - Service
-          - - ClusterName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - FullPodName
-            - GpuDevice
-            - Namespace
-            - PodName
-        label_matchers: []
-        metric_name_selectors:
-          - pod_gpu_utilization
-          - pod_gpu_memory_utilization
-          - pod_gpu_memory_total
-          - pod_gpu_memory_used
-          - pod_gpu_power_draw
-          - pod_gpu_temperature
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - InstanceId
-            - NodeName
-          - - ClusterName
-            - GpuDevice
-            - InstanceId
-            - InstanceType
-            - NodeName
-        label_matchers: []
-        metric_name_selectors:
-          - node_gpu_utilization
-          - node_gpu_memory_utilization
-          - node_gpu_memory_total
-          - node_gpu_memory_used
-          - node_gpu_power_draw
-          - node_gpu_temperature
-      - dimensions:
-          - - ClusterName
-            - InstanceId
-            - NodeName
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - node_gpu_total
-          - node_gpu_request
-          - node_gpu_limit
-      - dimensions:
-          - - ClusterName
-        label_matchers: []
-        metric_name_selectors:
-          - cluster_gpu_request
-          - cluster_gpu_total
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - ContainerName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - ContainerName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - ContainerName
-            - FullPodName
-            - Namespace
-            - NeuronCore
-            - NeuronDevice
-            - PodName
-        label_matchers: []
-        metric_name_selectors:
-          - container_neuroncore_utilization
-          - container_neuroncore_memory_usage_total
-          - container_neuroncore_memory_usage_constants
-          - container_neuroncore_memory_usage_model_code
-          - container_neuroncore_memory_usage_model_shared_scratchpad
-          - container_neuroncore_memory_usage_runtime_memory
-          - container_neuroncore_memory_usage_tensors
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - ContainerName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - ContainerName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - ContainerName
-            - FullPodName
-            - Namespace
-            - NeuronDevice
-            - PodName
-        label_matchers: []
-        metric_name_selectors:
-          - container_neurondevice_hw_ecc_events_total_mem_ecc_corrected
-          - container_neurondevice_hw_ecc_events_total_mem_ecc_uncorrected
-          - container_neurondevice_hw_ecc_events_total_sram_ecc_corrected
-          - container_neurondevice_hw_ecc_events_total_sram_ecc_uncorrected
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - Namespace
-          - - ClusterName
-            - Namespace
-            - Service
-          - - ClusterName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - FullPodName
-            - Namespace
-            - NeuronCore
-            - NeuronDevice
-            - PodName
-        label_matchers: []
-        metric_name_selectors:
-          - pod_neuroncore_utilization
-          - pod_neuroncore_memory_usage_total
-          - pod_neuroncore_memory_usage_constants
-          - pod_neuroncore_memory_usage_model_code
-          - pod_neuroncore_memory_usage_model_shared_scratchpad
-          - pod_neuroncore_memory_usage_runtime_memory
-          - pod_neuroncore_memory_usage_tensors
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - Namespace
-          - - ClusterName
-            - Namespace
-            - Service
-          - - ClusterName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - FullPodName
-            - Namespace
-            - PodName
-          - - ClusterName
-            - FullPodName
-            - Namespace
-            - NeuronDevice
-            - PodName
-        label_matchers: []
-        metric_name_selectors:
-          - pod_neurondevice_hw_ecc_events_total_mem_ecc_corrected
-          - pod_neurondevice_hw_ecc_events_total_mem_ecc_uncorrected
-          - pod_neurondevice_hw_ecc_events_total_sram_ecc_corrected
-          - pod_neurondevice_hw_ecc_events_total_sram_ecc_uncorrected
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - InstanceId
-            - NodeName
-          - - ClusterName
-            - InstanceId
-            - InstanceType
-            - NeuronCore
-            - NeuronDevice
-            - NodeName
-        label_matchers: []
-        metric_name_selectors:
-          - node_neuroncore_utilization
-          - node_neuroncore_memory_usage_total
-          - node_neuroncore_memory_usage_constants
-          - node_neuroncore_memory_usage_model_code
-          - node_neuroncore_memory_usage_model_shared_scratchpad
-          - node_neuroncore_memory_usage_runtime_memory
-          - node_neuroncore_memory_usage_tensors
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - InstanceId
-            - NodeName
-        label_matchers: []
-        metric_name_selectors:
-          - node_neuron_execution_errors_total
-          - node_neuron_execution_errors_generic
-          - node_neuron_execution_errors_numerical
-          - node_neuron_execution_errors_transient
-          - node_neuron_execution_errors_model
-          - node_neuron_execution_errors_runtime
-          - node_neuron_execution_errors_hardware
-          - node_neuron_execution_status_total
-          - node_neuron_execution_status_completed
-          - node_neuron_execution_status_timed_out
-          - node_neuron_execution_status_completed_with_err
-          - node_neuron_execution_status_completed_with_num_err
-          - node_neuron_execution_status_incorrect_input
-          - node_neuron_execution_status_failed_to_queue
-          - node_neurondevice_runtime_memory_used_bytes
-          - node_neuron_execution_latency
-      - dimensions:
-          - - ClusterName
-          - - ClusterName
-            - InstanceId
-            - NodeName
-          - - ClusterName
-            - InstanceId
-            - NeuronDevice
-            - NodeName
-        label_matchers: []
-        metric_name_selectors:
-          - node_neurondevice_hw_ecc_events_total_mem_ecc_corrected
-          - node_neurondevice_hw_ecc_events_total_mem_ecc_uncorrected
-          - node_neurondevice_hw_ecc_events_total_sram_ecc_corrected
-          - node_neurondevice_hw_ecc_events_total_sram_ecc_uncorrected
-    metric_descriptors:
-      - metric_name: apiserver_admission_controller_admission_duration_seconds
-        overwrite: true
-        unit: Seconds
-      - metric_name: apiserver_admission_step_admission_duration_seconds
-        overwrite: true
-        unit: Seconds
-      - metric_name: apiserver_admission_webhook_admission_duration_seconds
-        overwrite: true
-        unit: Seconds
-      - metric_name: apiserver_current_inflight_requests
-        overwrite: true
-        unit: Count
-      - metric_name: apiserver_current_inqueue_requests
-        overwrite: true
-        unit: Count
-      - metric_name: apiserver_flowcontrol_rejected_requests_total
-        overwrite: true
-        unit: Count
-      - metric_name: apiserver_flowcontrol_request_concurrency_limit
-        overwrite: true
-        unit: Count
-      - metric_name: apiserver_longrunning_requests
-        overwrite: true
-        unit: Count
-      - metric_name: apiserver_request_duration_seconds
-        overwrite: true
-        unit: Seconds
-      - metric_name: apiserver_request_total
-        overwrite: true
-        unit: Count
-      - metric_name: apiserver_request_total_5xx
-        overwrite: true
-        unit: Count
-      - metric_name: apiserver_requested_deprecated_apis
-        overwrite: true
-        unit: Count
-      - metric_name: apiserver_storage_objects
-        overwrite: true
-        unit: Count
-      - metric_name: etcd_request_duration_seconds
-        overwrite: true
-        unit: Seconds
-      - metric_name: apiserver_storage_list_duration_seconds
-        overwrite: true
-        unit: Seconds
-      - metric_name: apiserver_storage_db_total_size_in_bytes
-        overwrite: true
-        unit: Bytes
-      - metric_name: apiserver_storage_size_bytes
-        overwrite: true
-        unit: Bytes
-      - metric_name: etcd_db_total_size_in_bytes
-        overwrite: true
-        unit: Bytes
-      - metric_name: rest_client_request_duration_seconds
-        overwrite: true
-        unit: Seconds
-      - metric_name: rest_client_requests_total
-        overwrite: true
-        unit: Count
-    middleware: agenthealth/logs
-    namespace: ContainerInsights
-    no_verify_ssl: false
-    num_workers: 8
-    output_destination: cloudwatch
-    parse_json_encoded_attr_values:
-      - Sources
-      - kubernetes
-    profile: default
-    proxy_address: ""
-    region: us-east-1
-    request_timeout_seconds: 30
-    resource_arn: ""
-    resource_to_telemetry_conversion:
-      enabled: true
-    retain_initial_value_of_delta_metric: false
-    role_arn: ""
-    shared_credentials_file:
-      - /root/.aws/credentials
-    version: "0"
+    awscloudwatchlogs/emf_logs:
+        certificate_file_path: ""
+        emf_only: true
+        endpoint: https://fake_endpoint
+        imds_retries: 2
+        local_mode: true
+        log_group_name: emf/logs/default
+        log_retention: 0
+        log_stream_name: host_name_from_env
+        max_retries: 2
+        middleware: agenthealth/logs
+        no_verify_ssl: false
+        num_workers: 8
+        profile: default
+        proxy_address: ""
+        raw_log: true
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        role_arn: ""
+        sending_queue:
+            enabled: true
+            num_consumers: 1
+            queue_size: 1000
+        shared_credentials_file:
+            - /root/.aws/credentials
+    awsemf/containerinsights:
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: true
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: true
+        imds_retries: 2
+        local_mode: true
+        log_group_name: /aws/containerinsights/{ClusterName}/performance
+        log_retention: 0
+        log_stream_name: '{NodeName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - container_cpu_utilization
+                - container_cpu_utilization_over_container_limit
+                - container_cpu_limit
+                - container_cpu_request
+                - container_memory_utilization
+                - container_memory_utilization_over_container_limit
+                - container_memory_failures_total
+                - container_memory_limit
+                - container_memory_request
+                - container_filesystem_usage
+                - container_filesystem_available
+                - container_filesystem_utilization
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_utilization
+                - pod_memory_utilization
+                - pod_network_rx_bytes
+                - pod_network_tx_bytes
+                - pod_cpu_utilization_over_pod_limit
+                - pod_memory_utilization_over_pod_limit
+            - dimensions:
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_interface_network_rx_dropped
+                - pod_interface_network_tx_dropped
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - Namespace
+                  - Service
+              label_matchers: []
+              metric_name_selectors:
+                - pod_cpu_reserved_capacity
+                - pod_memory_reserved_capacity
+                - pod_number_of_container_restarts
+                - pod_number_of_containers
+                - pod_number_of_running_containers
+                - pod_status_ready
+                - pod_status_scheduled
+                - pod_status_running
+                - pod_status_pending
+                - pod_status_failed
+                - pod_status_unknown
+                - pod_status_succeeded
+                - pod_memory_request
+                - pod_memory_limit
+                - pod_cpu_limit
+                - pod_cpu_request
+                - pod_container_status_running
+                - pod_container_status_terminated
+                - pod_container_status_waiting
+                - pod_container_status_waiting_reason_crash_loop_back_off
+                - pod_container_status_waiting_reason_image_pull_error
+                - pod_container_status_waiting_reason_start_error
+                - pod_container_status_waiting_reason_create_container_error
+                - pod_container_status_waiting_reason_create_container_config_error
+                - pod_container_status_terminated_reason_oom_killed
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_cpu_utilization
+                - node_memory_utilization
+                - node_network_total_bytes
+                - node_cpu_reserved_capacity
+                - node_memory_reserved_capacity
+                - node_number_of_running_pods
+                - node_number_of_running_containers
+                - node_cpu_usage_total
+                - node_cpu_limit
+                - node_memory_working_set
+                - node_memory_limit
+                - node_status_condition_ready
+                - node_status_condition_disk_pressure
+                - node_status_condition_memory_pressure
+                - node_status_condition_pid_pressure
+                - node_status_condition_network_unavailable
+                - node_status_condition_unknown
+                - node_status_capacity_pods
+                - node_status_allocatable_pods
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_interface_network_rx_dropped
+                - node_interface_network_tx_dropped
+                - node_diskio_io_service_bytes_total
+                - node_diskio_io_serviced_total
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_filesystem_utilization
+                - node_filesystem_inodes
+                - node_filesystem_inodes_free
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - service_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - replicas_desired
+                - replicas_ready
+                - status_replicas_available
+                - status_replicas_unavailable
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - daemonset_status_number_available
+                - daemonset_status_number_unavailable
+            - dimensions:
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - namespace_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - cluster_node_count
+                - cluster_failed_node_count
+                - cluster_number_of_running_pods
+            - dimensions:
+                - - ClusterName
+                  - endpoint
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_storage_size_bytes
+                - apiserver_storage_db_total_size_in_bytes
+                - etcd_db_total_size_in_bytes
+            - dimensions:
+                - - ClusterName
+                  - resource
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_storage_list_duration_seconds
+                - apiserver_longrunning_requests
+                - apiserver_storage_objects
+            - dimensions:
+                - - ClusterName
+                  - verb
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_request_duration_seconds
+                - rest_client_request_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - code
+                  - verb
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_request_total
+                - apiserver_request_total_5xx
+            - dimensions:
+                - - ClusterName
+                  - operation
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_admission_controller_admission_duration_seconds
+                - apiserver_admission_step_admission_duration_seconds
+                - etcd_request_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - code
+                  - method
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - rest_client_requests_total
+            - dimensions:
+                - - ClusterName
+                  - request_kind
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_current_inflight_requests
+                - apiserver_current_inqueue_requests
+            - dimensions:
+                - - ClusterName
+                  - name
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_admission_webhook_admission_duration_seconds
+            - dimensions:
+                - - ClusterName
+                  - group
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_requested_deprecated_apis
+            - dimensions:
+                - - ClusterName
+                  - reason
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_flowcontrol_rejected_requests_total
+            - dimensions:
+                - - ClusterName
+                  - priority_level
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - apiserver_flowcontrol_request_concurrency_limit
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - ContainerName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - GpuDevice
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - container_gpu_utilization
+                - container_gpu_memory_utilization
+                - container_gpu_memory_total
+                - container_gpu_memory_used
+                - container_gpu_power_draw
+                - container_gpu_temperature
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - FullPodName
+                  - GpuDevice
+                  - Namespace
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_gpu_utilization
+                - pod_gpu_memory_utilization
+                - pod_gpu_memory_total
+                - pod_gpu_memory_used
+                - pod_gpu_power_draw
+                - pod_gpu_temperature
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+                  - GpuDevice
+                  - InstanceId
+                  - InstanceType
+                  - NodeName
+              label_matchers: []
+              metric_name_selectors:
+                - node_gpu_utilization
+                - node_gpu_memory_utilization
+                - node_gpu_memory_total
+                - node_gpu_memory_used
+                - node_gpu_power_draw
+                - node_gpu_temperature
+            - dimensions:
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - node_gpu_total
+                - node_gpu_request
+                - node_gpu_limit
+            - dimensions:
+                - - ClusterName
+              label_matchers: []
+              metric_name_selectors:
+                - cluster_gpu_request
+                - cluster_gpu_total
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - ContainerName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - NeuronCore
+                  - NeuronDevice
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - container_neuroncore_utilization
+                - container_neuroncore_memory_usage_total
+                - container_neuroncore_memory_usage_constants
+                - container_neuroncore_memory_usage_model_code
+                - container_neuroncore_memory_usage_model_shared_scratchpad
+                - container_neuroncore_memory_usage_runtime_memory
+                - container_neuroncore_memory_usage_tensors
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - ContainerName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - ContainerName
+                  - FullPodName
+                  - Namespace
+                  - NeuronDevice
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - container_neurondevice_hw_ecc_events_total_mem_ecc_corrected
+                - container_neurondevice_hw_ecc_events_total_mem_ecc_uncorrected
+                - container_neurondevice_hw_ecc_events_total_sram_ecc_corrected
+                - container_neurondevice_hw_ecc_events_total_sram_ecc_uncorrected
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - NeuronCore
+                  - NeuronDevice
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_neuroncore_utilization
+                - pod_neuroncore_memory_usage_total
+                - pod_neuroncore_memory_usage_constants
+                - pod_neuroncore_memory_usage_model_code
+                - pod_neuroncore_memory_usage_model_shared_scratchpad
+                - pod_neuroncore_memory_usage_runtime_memory
+                - pod_neuroncore_memory_usage_tensors
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - Namespace
+                - - ClusterName
+                  - Namespace
+                  - Service
+                - - ClusterName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - PodName
+                - - ClusterName
+                  - FullPodName
+                  - Namespace
+                  - NeuronDevice
+                  - PodName
+              label_matchers: []
+              metric_name_selectors:
+                - pod_neurondevice_hw_ecc_events_total_mem_ecc_corrected
+                - pod_neurondevice_hw_ecc_events_total_mem_ecc_uncorrected
+                - pod_neurondevice_hw_ecc_events_total_sram_ecc_corrected
+                - pod_neurondevice_hw_ecc_events_total_sram_ecc_uncorrected
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+                  - InstanceId
+                  - InstanceType
+                  - NeuronCore
+                  - NeuronDevice
+                  - NodeName
+              label_matchers: []
+              metric_name_selectors:
+                - node_neuroncore_utilization
+                - node_neuroncore_memory_usage_total
+                - node_neuroncore_memory_usage_constants
+                - node_neuroncore_memory_usage_model_code
+                - node_neuroncore_memory_usage_model_shared_scratchpad
+                - node_neuroncore_memory_usage_runtime_memory
+                - node_neuroncore_memory_usage_tensors
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+              label_matchers: []
+              metric_name_selectors:
+                - node_neuron_execution_errors_total
+                - node_neuron_execution_errors_generic
+                - node_neuron_execution_errors_numerical
+                - node_neuron_execution_errors_transient
+                - node_neuron_execution_errors_model
+                - node_neuron_execution_errors_runtime
+                - node_neuron_execution_errors_hardware
+                - node_neuron_execution_status_total
+                - node_neuron_execution_status_completed
+                - node_neuron_execution_status_timed_out
+                - node_neuron_execution_status_completed_with_err
+                - node_neuron_execution_status_completed_with_num_err
+                - node_neuron_execution_status_incorrect_input
+                - node_neuron_execution_status_failed_to_queue
+                - node_neurondevice_runtime_memory_used_bytes
+                - node_neuron_execution_latency
+            - dimensions:
+                - - ClusterName
+                - - ClusterName
+                  - InstanceId
+                  - NodeName
+                - - ClusterName
+                  - InstanceId
+                  - NeuronDevice
+                  - NodeName
+              label_matchers: []
+              metric_name_selectors:
+                - node_neurondevice_hw_ecc_events_total_mem_ecc_corrected
+                - node_neurondevice_hw_ecc_events_total_mem_ecc_uncorrected
+                - node_neurondevice_hw_ecc_events_total_sram_ecc_corrected
+                - node_neurondevice_hw_ecc_events_total_sram_ecc_uncorrected
+        metric_descriptors:
+            - metric_name: apiserver_admission_controller_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_admission_step_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_admission_webhook_admission_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_current_inflight_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_current_inqueue_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_flowcontrol_rejected_requests_total
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_flowcontrol_request_concurrency_limit
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_longrunning_requests
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_request_total
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_request_total_5xx
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_requested_deprecated_apis
+              overwrite: true
+              unit: Count
+            - metric_name: apiserver_storage_objects
+              overwrite: true
+              unit: Count
+            - metric_name: etcd_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_storage_list_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: apiserver_storage_db_total_size_in_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: apiserver_storage_size_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: etcd_db_total_size_in_bytes
+              overwrite: true
+              unit: Bytes
+            - metric_name: rest_client_request_duration_seconds
+              overwrite: true
+              unit: Seconds
+            - metric_name: rest_client_requests_total
+              overwrite: true
+              unit: Count
+        middleware: agenthealth/logs
+        namespace: ContainerInsights
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        parse_json_encoded_attr_values:
+            - Sources
+            - kubernetes
+        profile: default
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file:
+            - /root/.aws/credentials
+        version: "0"
 extensions:
-  agenthealth/logs:
-    is_usage_data_enabled: true
-    stats:
-      operations:
-        - PutLogEvents
-      usage_flags:
-        mode: OP
-        region_type: ACJ
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
+            usage_flags:
+                mode: OP
+                region_type: ACJ
 processors:
-  batch/containerinsights:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
-  batch/emf_logs:
-    metadata_cardinality_limit: 1000
-    metadata_keys: []
-    send_batch_max_size: 0
-    send_batch_size: 8192
-    timeout: 5s
-  gpuattributes/containerinsights: {}
-  metricstransform/containerinsights:
-    transforms:
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels:
-          code: ^5.*
-        group_resource_labels: {}
-        include: apiserver_request_total
-        match_type: regexp
-        new_name: apiserver_request_total_5xx
-        operations: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_USED_PERCENT
-        match_type: ""
-        new_name: container_gpu_memory_utilization
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: ContainerGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 100
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_USED_PERCENT
-        match_type: ""
-        new_name: pod_gpu_memory_utilization
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: PodGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 100
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_USED_PERCENT
-        match_type: ""
-        new_name: node_gpu_memory_utilization
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: NodeGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 100
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_USED
-        match_type: ""
-        new_name: container_gpu_memory_used
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: ContainerGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 1.048576e+06
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_USED
-        match_type: ""
-        new_name: pod_gpu_memory_used
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: PodGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 1.048576e+06
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_USED
-        match_type: ""
-        new_name: node_gpu_memory_used
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: NodeGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 1.048576e+06
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_TOTAL
-        match_type: ""
-        new_name: container_gpu_memory_total
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: ContainerGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 1.048576e+06
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_TOTAL
-        match_type: ""
-        new_name: pod_gpu_memory_total
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: PodGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 1.048576e+06
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_FB_TOTAL
-        match_type: ""
-        new_name: node_gpu_memory_total
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: NodeGPU
-            value_actions: []
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 1.048576e+06
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_GPU_TEMP
-        match_type: ""
-        new_name: container_gpu_temperature
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: ContainerGPU
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_GPU_TEMP
-        match_type: ""
-        new_name: pod_gpu_temperature
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: PodGPU
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_GPU_TEMP
-        match_type: ""
-        new_name: node_gpu_temperature
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: NodeGPU
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_POWER_USAGE
-        match_type: ""
-        new_name: container_gpu_power_draw
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: ContainerGPU
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_POWER_USAGE
-        match_type: ""
-        new_name: pod_gpu_power_draw
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: PodGPU
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_POWER_USAGE
-        match_type: ""
-        new_name: node_gpu_power_draw
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: NodeGPU
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_GPU_UTIL
-        match_type: ""
-        new_name: container_gpu_utilization
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: ContainerGPU
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_GPU_UTIL
-        match_type: ""
-        new_name: pod_gpu_utilization
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: PodGPU
-            value_actions: []
-        submatch_case: ""
-      - action: insert
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: DCGM_FI_DEV_GPU_UTIL
-        match_type: ""
-        new_name: node_gpu_utilization
-        operations:
-          - action: add_label
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 0
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: Type
-            new_value: NodeGPU
-            value_actions: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: neuroncore_memory_usage_constants
-        match_type: ""
-        new_name: neuroncore_memory_usage_constants
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: neuroncore_memory_usage_model_code
-        match_type: ""
-        new_name: neuroncore_memory_usage_model_code
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: neuroncore_memory_usage_model_shared_scratchpad
-        match_type: ""
-        new_name: neuroncore_memory_usage_model_shared_scratchpad
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: neuroncore_memory_usage_runtime_memory
-        match_type: ""
-        new_name: neuroncore_memory_usage_runtime_memory
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: neuroncore_memory_usage_tensors
-        match_type: ""
-        new_name: neuroncore_memory_usage_tensors
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: neuron_hardware
-        match_type: ""
-        new_name: neuron_hardware
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: execution_status_total
-        match_type: ""
-        new_name: neuron_execution_status
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: neuron_runtime_memory_used_bytes
-        match_type: ""
-        new_name: neurondevice_runtime_memory_used_bytes
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: instance_info
-        match_type: ""
-        new_name: instance_info
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: hardware_ecc_events_total
-        match_type: ""
-        new_name: neurondevice_hw_ecc_events_total
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: execution_latency_seconds
-        match_type: ""
-        new_name: neuron_execution_latency
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: execution_errors_total
-        match_type: ""
-        new_name: neuron_execution_errors
-        operations: []
-        submatch_case: ""
-      - action: update
-        aggregation_type: ""
-        experimental_match_labels: {}
-        group_resource_labels: {}
-        include: neuroncore_utilization_ratio
-        match_type: ""
-        new_name: neuroncore_utilization
-        operations:
-          - action: experimental_scale_value
-            aggregated_values: []
-            aggregation_type: ""
-            experimental_scale: 100
-            label: ""
-            label_set: []
-            label_value: ""
-            new_label: ""
-            new_value: ""
-            value_actions: []
-        submatch_case: ""
+    batch/containerinsights:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    batch/emf_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys: []
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    gpuattributes/containerinsights: {}
+    metricstransform/containerinsights:
+        transforms:
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                code: ^5.*
+              include: apiserver_request_total
+              match_type: regexp
+              new_name: apiserver_request_total_5xx
+              operations: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_POWER_USAGE
+              match_type: ""
+              new_name: container_gpu_power_draw
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: ContainerGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_POWER_USAGE
+              match_type: ""
+              new_name: pod_gpu_power_draw
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: PodGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_POWER_USAGE
+              match_type: ""
+              new_name: node_gpu_power_draw
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: NodeGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_GPU_UTIL
+              match_type: ""
+              new_name: container_gpu_utilization
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: ContainerGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_GPU_UTIL
+              match_type: ""
+              new_name: pod_gpu_utilization
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: PodGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_GPU_UTIL
+              match_type: ""
+              new_name: node_gpu_utilization
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: NodeGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_USED_PERCENT
+              match_type: ""
+              new_name: container_gpu_memory_utilization
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: ContainerGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 100
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_USED_PERCENT
+              match_type: ""
+              new_name: pod_gpu_memory_utilization
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: PodGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 100
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_USED_PERCENT
+              match_type: ""
+              new_name: node_gpu_memory_utilization
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: NodeGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 100
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_USED
+              match_type: ""
+              new_name: container_gpu_memory_used
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: ContainerGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 1.048576e+06
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_USED
+              match_type: ""
+              new_name: pod_gpu_memory_used
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: PodGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 1.048576e+06
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_USED
+              match_type: ""
+              new_name: node_gpu_memory_used
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: NodeGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 1.048576e+06
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_TOTAL
+              match_type: ""
+              new_name: container_gpu_memory_total
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: ContainerGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 1.048576e+06
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_TOTAL
+              match_type: ""
+              new_name: pod_gpu_memory_total
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: PodGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 1.048576e+06
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_FB_TOTAL
+              match_type: ""
+              new_name: node_gpu_memory_total
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: NodeGPU
+                  value_actions: []
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 1.048576e+06
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_GPU_TEMP
+              match_type: ""
+              new_name: container_gpu_temperature
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: ContainerGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_GPU_TEMP
+              match_type: ""
+              new_name: pod_gpu_temperature
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: PodGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: DCGM_FI_DEV_GPU_TEMP
+              match_type: ""
+              new_name: node_gpu_temperature
+              operations:
+                - action: add_label
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: Type
+                  new_value: NodeGPU
+                  value_actions: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: neuroncore_memory_usage_tensors
+              match_type: ""
+              new_name: neuroncore_memory_usage_tensors
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: neuroncore_utilization_ratio
+              match_type: ""
+              new_name: neuroncore_utilization
+              operations:
+                - action: experimental_scale_value
+                  aggregated_values: []
+                  aggregation_type: ""
+                  experimental_scale: 100
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                  value_actions: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: instance_info
+              match_type: ""
+              new_name: instance_info
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: hardware_ecc_events_total
+              match_type: ""
+              new_name: neurondevice_hw_ecc_events_total
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: neuron_runtime_memory_used_bytes
+              match_type: ""
+              new_name: neurondevice_runtime_memory_used_bytes
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: neuroncore_memory_usage_constants
+              match_type: ""
+              new_name: neuroncore_memory_usage_constants
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: neuroncore_memory_usage_model_shared_scratchpad
+              match_type: ""
+              new_name: neuroncore_memory_usage_model_shared_scratchpad
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: neuroncore_memory_usage_runtime_memory
+              match_type: ""
+              new_name: neuroncore_memory_usage_runtime_memory
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: execution_latency_seconds
+              match_type: ""
+              new_name: neuron_execution_latency
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: execution_errors_total
+              match_type: ""
+              new_name: neuron_execution_errors
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: execution_status_total
+              match_type: ""
+              new_name: neuron_execution_status
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: neuroncore_memory_usage_model_code
+              match_type: ""
+              new_name: neuroncore_memory_usage_model_code
+              operations: []
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: neuron_hardware
+              match_type: ""
+              new_name: neuron_hardware
+              operations: []
+              submatch_case: ""
 receivers:
-  awscontainerinsightreceiver:
-    accelerated_compute_metrics: true
-    add_container_name_metric_label: true
-    add_full_pod_name_metric_label: true
-    add_service_as_attribute: true
-    certificate_file_path: ""
-    cluster_name: TestCluster
-    collection_interval: 30s
-    container_orchestrator: eks
-    enable_control_plane_metrics: true
-    endpoint: ""
-    imds_retries: 2
-    leader_lock_name: cwagent-clusterleader
-    leader_lock_using_config_map_only: true
-    local_mode: true
-    max_retries: 0
-    no_verify_ssl: false
-    num_workers: 0
-    prefer_full_pod_name: true
-    profile: default
-    proxy_address: ""
-    region: us-east-1
-    request_timeout_seconds: 0
-    resource_arn: ""
-    role_arn: ""
-    shared_credentials_file:
-      - /root/.aws/credentials
-  tcplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: tcp_input
-    listen_address: 0.0.0.0:25888
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    type: tcp_input
-  udplog/emf_logs:
-    attributes: {}
-    encoding: utf-8
-    id: udp_input
-    listen_address: 0.0.0.0:25888
-    multiline:
-      line_end_pattern: .^
-      line_start_pattern: ""
-      omit_pattern: false
-    operators: []
-    output: []
-    resource: {}
-    retry_on_failure:
-      enabled: false
-      initial_interval: 0s
-      max_elapsed_time: 0s
-      max_interval: 0s
-    type: udp_input
+    awscontainerinsightreceiver:
+        accelerated_compute_metrics: true
+        add_container_name_metric_label: true
+        add_full_pod_name_metric_label: true
+        add_service_as_attribute: true
+        certificate_file_path: ""
+        cluster_name: TestCluster
+        collection_interval: 30s
+        container_orchestrator: eks
+        enable_control_plane_metrics: true
+        endpoint: ""
+        imds_retries: 2
+        leader_lock_name: cwagent-clusterleader
+        leader_lock_using_config_map_only: true
+        local_mode: true
+        max_retries: 0
+        no_verify_ssl: false
+        num_workers: 0
+        prefer_full_pod_name: true
+        profile: default
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 0
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file:
+            - /root/.aws/credentials
+    tcplog/emf_logs:
+        encoding: utf-8
+        id: tcp_input
+        listen_address: 0.0.0.0:25888
+        operators: []
+        output: []
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        type: tcp_input
+    udplog/emf_logs:
+        encoding: utf-8
+        id: udp_input
+        listen_address: 0.0.0.0:25888
+        multiline:
+            line_end_pattern: .^
+            line_start_pattern: ""
+            omit_pattern: false
+        operators: []
+        output: []
+        retry_on_failure:
+            enabled: false
+            initial_interval: 0s
+            max_elapsed_time: 0s
+            max_interval: 0s
+        type: udp_input
 service:
-  extensions:
-    - agenthealth/logs
-  pipelines:
-    logs/emf_logs:
-      exporters:
-        - awscloudwatchlogs/emf_logs
-      processors:
-        - batch/emf_logs
-      receivers:
-        - tcplog/emf_logs
-        - udplog/emf_logs
-    metrics/containerinsights:
-      exporters:
-        - awsemf/containerinsights
-      processors:
-        - metricstransform/containerinsights
-        - gpuattributes/containerinsights
-        - batch/containerinsights
-      receivers:
-        - awscontainerinsightreceiver
-  telemetry:
-    logs:
-      development: false
-      disable_caller: false
-      disable_stacktrace: false
-      encoding: console
-      error_output_paths: []
-      initial_fields: {}
-      level: info
-      output_paths: []
-      sampling:
-        enabled: true
-        initial: 2
-        thereafter: 500
-        tick: 10s
-    metrics:
-      address: ""
-      level: None
-      readers: []
-    resource: {}
-    traces:
-      processors: []
-      propagators: []
+    extensions:
+        - agenthealth/logs
+    pipelines:
+        logs/emf_logs:
+            exporters:
+                - awscloudwatchlogs/emf_logs
+            processors:
+                - batch/emf_logs
+            receivers:
+                - tcplog/emf_logs
+                - udplog/emf_logs
+        metrics/containerinsights:
+            exporters:
+                - awsemf/containerinsights
+            processors:
+                - metricstransform/containerinsights
+                - gpuattributes/containerinsights
+                - batch/containerinsights
+            receivers:
+                - awscontainerinsightreceiver
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            error_output_paths: []
+            level: info
+            output_paths: []
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            address: ""
+            level: None
+            readers: []
+        traces:
+            processors: []
+            propagators: []

--- a/translator/tocwconfig/sampleConfig/ignore_append_dimensions.yaml
+++ b/translator/tocwconfig/sampleConfig/ignore_append_dimensions.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -43,8 +42,8 @@ service:
             processors:
                 - ec2tagger
             receivers:
-                - telegraf_disk
                 - telegraf_mem
+                - telegraf_disk
     telemetry:
         logs:
             development: false
@@ -52,7 +51,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -65,7 +63,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/invalid_input_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/invalid_input_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -23,9 +22,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - InstanceType
             - ImageId
             - InstanceId
-            - InstanceType
         imds_retries: 1
         refresh_interval_seconds: 0s
 receivers:
@@ -47,8 +46,8 @@ service:
             processors:
                 - ec2tagger
             receivers:
-                - telegraf_disk
                 - telegraf_mem
+                - telegraf_disk
     telemetry:
         logs:
             development: false
@@ -56,7 +55,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -69,7 +67,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awsemf/containerinsights:
         certificate_file_path: ""
@@ -381,8 +380,8 @@ extensions:
             operations:
                 - PutLogEvents
             usage_flags:
-              mode: OP
-              region_type: ACJ
+                mode: OP
+                region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000
@@ -396,7 +395,6 @@ processors:
               aggregation_type: ""
               experimental_match_labels:
                 code: ^5.*
-              group_resource_labels: {}
               include: apiserver_request_total
               match_type: regexp
               new_name: apiserver_request_total_5xx
@@ -404,6 +402,7 @@ processors:
               submatch_case: ""
 receivers:
     awscontainerinsightreceiver:
+        accelerated_compute_metrics: false
         add_container_name_metric_label: true
         add_full_pod_name_metric_label: true
         add_service_as_attribute: true
@@ -429,7 +428,6 @@ receivers:
         role_arn: ""
         shared_credentials_file:
             - fake-path
-        accelerated_compute_metrics: false
 service:
     extensions:
         - agenthealth/logs
@@ -449,7 +447,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -461,7 +458,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
+++ b/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatchlogs/emf_logs:
         certificate_file_path: ""
@@ -118,6 +117,7 @@ processors:
         timeout: 5s
 receivers:
     awscontainerinsightreceiver:
+        accelerated_compute_metrics: true
         add_container_name_metric_label: false
         add_full_pod_name_metric_label: false
         add_service_as_attribute: true
@@ -142,15 +142,12 @@ receivers:
         resource_arn: ""
         role_arn: ""
         shared_credentials_file: []
-        accelerated_compute_metrics: true
     tcplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: tcp_input
         listen_address: 0.0.0.0:25888
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -158,7 +155,6 @@ receivers:
             max_interval: 0s
         type: tcp_input
     udplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: udp_input
         listen_address: 0.0.0.0:25888
@@ -168,7 +164,6 @@ receivers:
             omit_pattern: false
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -201,7 +196,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -213,7 +207,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatchlogs/emf_logs:
         certificate_file_path: ""
@@ -412,8 +411,8 @@ extensions:
             operations:
                 - PutLogEvents
             usage_flags:
-              mode: EC2
-              region_type: ACJ
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/containerinsights:
         metadata_cardinality_limit: 1000
@@ -433,7 +432,6 @@ processors:
               aggregation_type: ""
               experimental_match_labels:
                 code: ^5.*
-              group_resource_labels: {}
               include: apiserver_request_total
               match_type: regexp
               new_name: apiserver_request_total_5xx
@@ -441,6 +439,7 @@ processors:
               submatch_case: ""
 receivers:
     awscontainerinsightreceiver:
+        accelerated_compute_metrics: false
         add_container_name_metric_label: true
         add_full_pod_name_metric_label: true
         add_service_as_attribute: true
@@ -465,15 +464,12 @@ receivers:
         resource_arn: ""
         role_arn: ""
         shared_credentials_file: []
-        accelerated_compute_metrics: false
     tcplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: tcp_input
         listen_address: 0.0.0.0:25888
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -481,7 +477,6 @@ receivers:
             max_interval: 0s
         type: tcp_input
     udplog/emf_logs:
-        attributes: {}
         encoding: utf-8
         id: udp_input
         listen_address: 0.0.0.0:25888
@@ -491,7 +486,6 @@ receivers:
             omit_pattern: false
         operators: []
         output: []
-        resource: {}
         retry_on_failure:
             enabled: false
             initial_interval: 0s
@@ -525,7 +519,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -537,7 +530,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/prometheus_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awsemf/prometheus:
         certificate_file_path: ""
@@ -78,8 +77,8 @@ extensions:
             operations:
                 - PutLogEvents
             usage_flags:
-              mode: EC2
-              region_type: ACJ
+                mode: EC2
+                region_type: ACJ
 processors:
     batch/prometheus:
         metadata_cardinality_limit: 1000
@@ -110,7 +109,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -122,7 +120,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/prometheus_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_config_windows.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awsemf/prometheus:
         certificate_file_path: ""
@@ -92,7 +91,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths: []
             sampling:
@@ -104,7 +102,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -34,9 +33,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - ImageId
             - InstanceId
             - InstanceType
-            - ImageId
         refresh_interval_seconds: 0s
 receivers:
     telegraf_cpu:
@@ -69,10 +68,10 @@ service:
             processors:
                 - ec2tagger
             receivers:
+                - telegraf_mem
                 - telegraf_swap
                 - telegraf_cpu
                 - telegraf_disk
-                - telegraf_mem
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -88,7 +87,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -101,7 +99,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -93,7 +92,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -106,7 +104,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/standard_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_windows.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -63,11 +62,11 @@ service:
             processors:
                 - ec2tagger
             receivers:
+                - telegraf_win_perf_counters/4283769065
                 - telegraf_win_perf_counters/1492679118
                 - telegraf_win_perf_counters/3610923661
                 - telegraf_win_perf_counters/3446270237
                 - telegraf_win_perf_counters/3762679655
-                - telegraf_win_perf_counters/4283769065
     telemetry:
         logs:
             development: false
@@ -75,7 +74,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
@@ -88,7 +86,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/standard_config_windows_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_windows_with_common_config.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -25,9 +24,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - InstanceType
             - ImageId
             - InstanceId
-            - InstanceType
         imds_retries: 2
         profile: AmazonCloudWatchAgent
         refresh_interval_seconds: 0s
@@ -68,11 +67,11 @@ service:
             processors:
                 - ec2tagger
             receivers:
-                - telegraf_win_perf_counters/3446270237
                 - telegraf_win_perf_counters/3762679655
                 - telegraf_win_perf_counters/4283769065
                 - telegraf_win_perf_counters/1492679118
                 - telegraf_win_perf_counters/3610923661
+                - telegraf_win_perf_counters/3446270237
     telemetry:
         logs:
             development: false
@@ -80,7 +79,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
@@ -93,7 +91,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/statsd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/statsd_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -18,7 +17,6 @@ extensions:
             usage_flags:
                 mode: EC2
                 region_type: ACJ
-processors: {}
 receivers:
     telegraf_statsd:
         collection_interval: 10s
@@ -41,7 +39,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -54,7 +51,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/statsd_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/statsd_config_windows.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awscloudwatch:
         force_flush_interval: 1m0s
@@ -18,7 +17,6 @@ extensions:
             usage_flags:
                 mode: EC2
                 region_type: ACJ
-processors: {}
 receivers:
     telegraf_statsd:
         collection_interval: 10s
@@ -41,7 +39,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
@@ -54,7 +51,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_linux.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awsxray:
         aws_log_groups: []
@@ -71,7 +70,6 @@ receivers:
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
-                response_headers: {}
                 traces_url_path: /v1/traces
 service:
     extensions:
@@ -92,7 +90,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
@@ -105,7 +102,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []

--- a/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/trace_config_windows.yaml
@@ -1,4 +1,3 @@
-connectors: {}
 exporters:
     awsxray:
         aws_log_groups: []
@@ -71,7 +70,6 @@ receivers:
                 logs_url_path: /v1/logs
                 max_request_body_size: 0
                 metrics_url_path: /v1/metrics
-                response_headers: {}
                 traces_url_path: /v1/traces
 service:
     extensions:
@@ -92,7 +90,6 @@ service:
             disable_stacktrace: false
             encoding: console
             error_output_paths: []
-            initial_fields: {}
             level: info
             output_paths:
                 - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
@@ -105,7 +102,6 @@ service:
             address: ""
             level: None
             readers: []
-        resource: {}
         traces:
             processors: []
             propagators: []


### PR DESCRIPTION
# Description of the issue
The confighttp was forked to omit the `configtls.TLSClientSettings`. This requires manual syncing during version bumps.

# Description of changes
- Add `UnsupportedKind` hook function to skip functions/channels during marshaling.
- Add `NilZeroValue` hook function to force omit empty for specific types (e.g. `configtls.TLSClientSettings`).
- Add an option to omit empty maps.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Update unit tests to validate the new options.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




