### PR TITLE
Remove per-device EFA Container Insights metrics.

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
@@ -527,12 +527,6 @@ exporters:
                   - FullPodName
                   - Namespace
                   - PodName
-                - - ClusterName
-                  - ContainerName
-                  - EfaDevice
-                  - FullPodName
-                  - Namespace
-                  - PodName
               metric_name_selectors:
                 - container_efa_rx_bytes
                 - container_efa_tx_bytes
@@ -554,11 +548,6 @@ exporters:
                   - FullPodName
                   - Namespace
                   - PodName
-                - - ClusterName
-                  - EfaDevice
-                  - FullPodName
-                  - Namespace
-                  - PodName
               metric_name_selectors:
                 - pod_efa_rx_bytes
                 - pod_efa_tx_bytes
@@ -570,11 +559,6 @@ exporters:
                 - - ClusterName
                 - - ClusterName
                   - InstanceId
-                  - NodeName
-                - - ClusterName
-                  - EfaDevice
-                  - InstanceId
-                  - InstanceType
                   - NodeName
               metric_name_selectors:
                 - node_efa_rx_bytes

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -605,7 +605,7 @@ func getEFAMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 					{"ClusterName"},
 					{"ClusterName", "Namespace", "PodName", "ContainerName"},
 					{"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName"},
-					{"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName", "EfaDevice"}},
+				},
 				MetricNameSelectors: []string{
 					"container_efa_rx_bytes",
 					"container_efa_tx_bytes",
@@ -622,7 +622,6 @@ func getEFAMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 					{"ClusterName", "Namespace", "Service"},
 					{"ClusterName", "Namespace", "PodName"},
 					{"ClusterName", "Namespace", "PodName", "FullPodName"},
-					{"ClusterName", "Namespace", "PodName", "FullPodName", "EfaDevice"},
 				},
 				MetricNameSelectors: []string{
 					"pod_efa_rx_bytes",
@@ -637,7 +636,6 @@ func getEFAMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 				Dimensions: [][]string{
 					{"ClusterName"},
 					{"ClusterName", "NodeName", "InstanceId"},
-					{"ClusterName", "NodeName", "InstanceId", "InstanceType", "EfaDevice"},
 				},
 				MetricNameSelectors: []string{
 					"node_efa_rx_bytes",

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -492,19 +492,19 @@ func TestTranslator(t *testing.T) {
 						},
 					},
 					{
-						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "Namespace", "PodName", "ContainerName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName", "EfaDevice"}},
+						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "Namespace", "PodName", "ContainerName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "ContainerName"}},
 						MetricNameSelectors: []string{
 							"container_efa_rx_bytes", "container_efa_tx_bytes", "container_efa_rx_dropped", "container_efa_rdma_read_bytes", "container_efa_rdma_write_bytes", "container_efa_rdma_write_recv_bytes",
 						},
 					},
 					{
-						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "Namespace"}, {"ClusterName", "Namespace", "Service"}, {"ClusterName", "Namespace", "PodName"}, {"ClusterName", "Namespace", "PodName", "FullPodName"}, {"ClusterName", "Namespace", "PodName", "FullPodName", "EfaDevice"}},
+						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "Namespace"}, {"ClusterName", "Namespace", "Service"}, {"ClusterName", "Namespace", "PodName"}, {"ClusterName", "Namespace", "PodName", "FullPodName"}},
 						MetricNameSelectors: []string{
 							"pod_efa_rx_bytes", "pod_efa_tx_bytes", "pod_efa_rx_dropped", "pod_efa_rdma_read_bytes", "pod_efa_rdma_write_bytes", "pod_efa_rdma_write_recv_bytes",
 						},
 					},
 					{
-						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "NodeName", "InstanceId"}, {"ClusterName", "NodeName", "InstanceId", "InstanceType", "EfaDevice"}},
+						Dimensions: [][]string{{"ClusterName"}, {"ClusterName", "NodeName", "InstanceId"}},
 						MetricNameSelectors: []string{
 							"node_efa_rx_bytes", "node_efa_tx_bytes", "node_efa_rx_dropped", "node_efa_rdma_read_bytes", "node_efa_rdma_write_bytes", "node_efa_rdma_write_recv_bytes",
 						},


### PR DESCRIPTION
They were not very useful in the current format.