### PR TITLE
Take JMX Receiver Support JMX When RMI SSL Is Turned On

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/reso
 replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20240402194231-045cf3583d72
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-20240402194231-045cf3583d72
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20240402194231-045cf3583d72
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20240404201757-65efa226158b
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20240402194231-045cf3583d72
 )
 

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsconta
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20240402194231-045cf3583d72/go.mod h1:DcP/1ryOlCCS68y72PCTfCipvVvx7sWv0QYSc8sVbIg=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-20240402194231-045cf3583d72 h1:flFoFPGIGPWX3WSbc/U5YYIp9b95bMh6zoGCplNtF6s=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-20240402194231-045cf3583d72/go.mod h1:4IMYeZjU+IgZdXHuiLOIVtdp42lrMjk+rtlQpENeGSM=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20240402194231-045cf3583d72 h1:XZzcF5z27UJPQz+0SKu1ZM4zXWdYeXPSQ7tYks0edxI=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20240402194231-045cf3583d72/go.mod h1:ytPWRZGbGsa2YBzBfMX1fcApPruYODPjttyaxHHUd/A=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20240404201757-65efa226158b h1:9UzFPFC1WRl6SgvpN+sDgCXxl0OhFJQ1E9vbYvn4Uls=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20240404201757-65efa226158b/go.mod h1:ytPWRZGbGsa2YBzBfMX1fcApPruYODPjttyaxHHUd/A=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20240402194231-045cf3583d72 h1:UVz8um423LxJU0mEd8+1OBg3lWYQ72qB9mMY3RJsRvM=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20240402194231-045cf3583d72/go.mod h1:fnNxw30DVmpiS3tt1nUETZH3g/boGnBLx7+hYwYd9EU=
 github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9 h1:FXrPTd8Rdlc94dKccl7KPmdmIbVh/OjelJ8/vgMRzcQ=

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1147,6 +1147,10 @@
           "description": "The truststore type if required by SSL",
           "type": "string"
         },
+        "jmx_registry_ssl_enabled": {
+          "description": "Enable when JMX registry ssl is enabled",
+          "type": "boolean"
+        },
         "remote_profile": {
           "description": "Supported JMX remote profiles in combination with SASL profiles",
           "type": "string"

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.json
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.json
@@ -59,6 +59,7 @@
           "keystore_type": "PKCS",
           "truststore_path": "/truststore",
           "truststore_type": "PKCS12",
+          "jmx_registry_ssl_enabled": true,
           "remote_profile": "SASL/PLAIN",
           "realm": "test_realm",
           "append_dimensions": {

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -210,6 +210,7 @@ receivers:
         target_system: activemq,cassandra,hbase,hadoop,jetty,jvm,kafka,kafka-consumer,kafka-producer,solr,tomcat,wildfly
         truststore_path: /truststore
         truststore_type: PKCS12
+        jmx_registry_ssl_enabled: true
         username: cwagent
     otlp/traces:
         protocols:

--- a/translator/translate/otel/receiver/jmx/translator.go
+++ b/translator/translate/otel/receiver/jmx/translator.go
@@ -22,18 +22,19 @@ import (
 )
 
 const (
-	jarPathKey        = "jar_path"
-	targetSystemKey   = "target_system"
-	usernameKey       = "username"
-	keystorePathKey   = "keystore_path"
-	keystoreTypeKey   = "keystore_type"
-	truststorePathKey = "truststore_path"
-	truststoreTypeKey = "truststore_type"
-	remoteProfileKey  = "remote_profile"
-	realmKey          = "realm"
-	passwordFileKey   = "password_file"
-	otlpTimeoutKey    = "timeout"
-	otlpHeadersKey    = "headers"
+	jarPathKey            = "jar_path"
+	targetSystemKey       = "target_system"
+	usernameKey           = "username"
+	keystorePathKey       = "keystore_path"
+	keystoreTypeKey       = "keystore_type"
+	truststorePathKey     = "truststore_path"
+	truststoreTypeKey     = "truststore_type"
+	jMXRegistrySSLEnabled = "jmx_registry_ssl_enabled"
+	remoteProfileKey      = "remote_profile"
+	realmKey              = "realm"
+	passwordFileKey       = "password_file"
+	otlpTimeoutKey        = "timeout"
+	otlpHeadersKey        = "headers"
 
 	defaultTargetSystem = "activemq,cassandra,hbase,hadoop,jetty,jvm,kafka,kafka-consumer,kafka-producer,solr,tomcat,wildfly"
 
@@ -157,6 +158,10 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 
 	if truststorePath, ok := jmxKeyMap[truststorePathKey].(string); ok {
 		cfg.TruststorePath = truststorePath
+	}
+
+	if jMXRegistrySSLEnabled, ok := jmxKeyMap[jMXRegistrySSLEnabled].(bool); ok {
+		cfg.JMXRegistrySSLEnabled = jMXRegistrySSLEnabled
 	}
 
 	if truststoreType, ok := jmxKeyMap[truststoreTypeKey].(string); ok {


### PR DESCRIPTION
# Description of the issue
When rmi ssl is enabled the agent needs to be able to still get metrics

# Description of changes
Enable rmi ssl 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Turn on rmi ssl in jar. Enable rmi ssl in collector. Test to see we get metrics

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




