### PR TITLE
Drop container/pod level Nvidia GPU metrics when there is no active workload.

### DIFF
--- a/plugins/processors/gpuattributes/processor_test.go
+++ b/plugins/processors/gpuattributes/processor_test.go
@@ -24,12 +24,14 @@ func TestProcessMetrics(t *testing.T) {
 	testcases := map[string]struct {
 		resource string
 		metrics  pmetric.Metrics
+		wantCnt  int
 		want     map[string]string
 	}{
 		"nonNode": {
 			metrics: generateMetrics("prefix", map[string]string{
 				"ClusterName": "cluster",
 			}),
+			wantCnt: 1,
 			want: map[string]string{
 				"ClusterName": "cluster",
 			},
@@ -39,6 +41,7 @@ func TestProcessMetrics(t *testing.T) {
 				"ClusterName": "cluster",
 				"Drop":        "val",
 			}),
+			wantCnt: 1,
 			want: map[string]string{
 				"ClusterName": "cluster",
 			},
@@ -48,6 +51,7 @@ func TestProcessMetrics(t *testing.T) {
 				"ClusterName": "cluster",
 				"kubernetes":  "{\"host\":\"test\"}",
 			}),
+			wantCnt: 1,
 			want: map[string]string{
 				"ClusterName": "cluster",
 				"kubernetes":  "{\"host\":\"test\"}",
@@ -59,8 +63,51 @@ func TestProcessMetrics(t *testing.T) {
 				"Drop":        "val",
 				"kubernetes":  "{\"host\":\"test\",\"b\":\"2\"}",
 			}),
+			wantCnt: 1,
 			want: map[string]string{
 				"ClusterName": "cluster",
+				"kubernetes":  "{\"host\":\"test\"}",
+			},
+		},
+		"dropPodWithoutPodName": {
+			metrics: generateMetrics("pod", map[string]string{
+				"ClusterName": "cluster",
+				"kubernetes":  "{\"host\":\"test\",\"b\":\"2\"}",
+			}),
+			wantCnt: 0,
+			want:    map[string]string{},
+		},
+		"keepPodWithoutPodName": {
+			metrics: generateMetrics("pod", map[string]string{
+				"ClusterName": "cluster",
+				"PodName":     "pod",
+				"kubernetes":  "{\"host\":\"test\",\"b\":\"2\"}",
+			}),
+			wantCnt: 1,
+			want: map[string]string{
+				"ClusterName": "cluster",
+				"PodName":     "pod",
+				"kubernetes":  "{\"host\":\"test\"}",
+			},
+		},
+		"dropContainerWithoutPodName": {
+			metrics: generateMetrics("container", map[string]string{
+				"ClusterName": "cluster",
+				"kubernetes":  "{\"host\":\"test\",\"b\":\"2\"}",
+			}),
+			wantCnt: 0,
+			want:    map[string]string{},
+		},
+		"keepContainerWithoutPodName": {
+			metrics: generateMetrics("container", map[string]string{
+				"ClusterName": "cluster",
+				"PodName":     "pod",
+				"kubernetes":  "{\"host\":\"test\",\"b\":\"2\"}",
+			}),
+			wantCnt: 1,
+			want: map[string]string{
+				"ClusterName": "cluster",
+				"PodName":     "pod",
 				"kubernetes":  "{\"host\":\"test\"}",
 			},
 		},
@@ -69,12 +116,15 @@ func TestProcessMetrics(t *testing.T) {
 	for tname, tc := range testcases {
 		fmt.Printf("running %s\n", tname)
 		ms, _ := gp.processMetrics(ctx, tc.metrics)
-		attrs := ms.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes()
-		assert.Equal(t, len(tc.want), attrs.Len())
-		for k, v := range tc.want {
-			got, ok := attrs.Get(k)
-			assert.True(t, ok)
-			assert.Equal(t, v, got.Str())
+		assert.Equal(t, tc.wantCnt, ms.MetricCount())
+		if tc.wantCnt > 0 {
+			attrs := ms.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes()
+			assert.Equal(t, len(tc.want), attrs.Len())
+			for k, v := range tc.want {
+				got, ok := attrs.Get(k)
+				assert.True(t, ok)
+				assert.Equal(t, v, got.Str())
+			}
 		}
 	}
 }

--- a/plugins/processors/gpuattributes/processor_test.go
+++ b/plugins/processors/gpuattributes/processor_test.go
@@ -8,13 +8,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 )
-
-var normalizedNameRegex = regexp.MustCompile("^(container|pod|node)_gpu_[a-z_]+$")
 
 func TestProcessMetrics(t *testing.T) {
 	logger, _ := zap.NewDevelopment()


### PR DESCRIPTION
# Description of the issue
The bug is that we always emit pod_gpu_ metrics at the Cluster level for GPU Devices which are not assigned to any pod. This is wrong - there should be no metrics at the pod level because no pod owns the GPU.

# Description of changes
GPUAttribute processor will drop container/pod level nvidia GPU metrics when there is no active workload. It determines by checking `PodName` attribute on a DCGM metric.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit test and with a test cluster.

EMF log validations:
- Without an active workload
<img width="1249" alt="Screenshot 2024-04-08 at 9 19 31 AM" src="https://github.com/aws/amazon-cloudwatch-agent/assets/884273/297ca7d8-5c74-48f4-a3de-00096ff45f70">

---
- **WITH an ACTIVE WORKLOAD**
![Screenshot 2024-04-08 at 9 22 02 AM](https://github.com/aws/amazon-cloudwatch-agent/assets/884273/85f03bf0-face-4649-af3d-ce03be1e9250)
<img width="1161" alt="Screenshot 2024-04-08 at 9 23 20 AM" src="https://github.com/aws/amazon-cloudwatch-agent/assets/884273/a43e5109-2a87-41b6-b4a8-9ee4f4f64dc0">



# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




