### PR TITLE
Fix jmx default filter for hyphenated targets

### DIFF
--- a/translator/translate/otel/processor/jmxfilterprocessor/translator.go
+++ b/translator/translate/otel/processor/jmxfilterprocessor/translator.go
@@ -6,6 +6,7 @@ package jmxfilterprocessor
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"go.opentelemetry.io/collector/component"
@@ -101,7 +102,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 				}
 			} else {
 				// target name is set and wildcard for all metrics
-				includeMetricNames = append(includeMetricNames, jmxTarget+"\\..*")
+				includeMetricNames = append(includeMetricNames, strings.Replace(jmxTarget, "-", ".", -1)+"\\..*")
 			}
 		}
 	}

--- a/translator/translate/otel/processor/jmxfilterprocessor/translator_test.go
+++ b/translator/translate/otel/processor/jmxfilterprocessor/translator_test.go
@@ -55,7 +55,6 @@ func TestTranslator(t *testing.T) {
 				},
 			}),
 		},
-
 		"ConfigWithJmxTargetWithMetricName": {
 			input: map[string]interface{}{
 				"metrics": map[string]interface{}{
@@ -150,6 +149,25 @@ func TestTranslator(t *testing.T) {
 							"jvm.threads.count",
 							"tomcat.sessions",
 							"tomcat.errors"},
+					},
+				},
+			}),
+		},
+		"ConfigWithJmxTargetHyphenated": {
+			input: map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"jmx": map[string]interface{}{
+							"kafka-producer": []interface{}{},
+						},
+					},
+				},
+			},
+			want: confmap.NewFromStringMap(map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"include": map[string]interface{}{
+						"match_type":   "regexp",
+						"metric_names": []interface{}{"kafka.producer\\..*"},
 					},
 				},
 			}),


### PR DESCRIPTION
# Description of the issue
For hyphenated targets such as `kafka-producer` and `kafka-consumer`, the current default filter that uses these target names ends up filtering out all the metrics since the actual metrics have the pattern `kafka.producer` and `kafka.consumer` respectively.

# Description of changes
Update default filter to replace `-` with `.`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Manually tested for the Kafka usecase
* Update unit tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




