### PR TITLE
Ci neuron missing datapoint fix

### DIFF
--- a/plugins/processors/gpuattributes/internal/awsneuron_metric_modifier.go
+++ b/plugins/processors/gpuattributes/internal/awsneuron_metric_modifier.go
@@ -160,13 +160,12 @@ func (md *AwsNeuronMetricModifier) ModifyMetric(originalMetric pmetric.Metric, m
 	md.duplicateMetrics(modifiedMetricSlice, originalMetricName, originalMetric.Sum().DataPoints(), metrics)
 }
 
+// This method converts gauges to sum so that all metrics can be grouped in the same grouped metrics.
+// The default value of temporality is undefined so even after conversion from gauge to sum the agent won't take delta.
 func convertGaugeToSum(originalMetric pmetric.Metric) {
 	datapoints := originalMetric.Gauge().DataPoints()
 	originalMetric.SetEmptySum()
 	datapoints.MoveAndAppendTo(originalMetric.Sum().DataPoints())
-
-	// default value of temporality is undefined so even after conversion from gauge to sum
-	// the agent won't take delta.
 }
 
 func addUnit(originalMetric pmetric.Metric) {


### PR DESCRIPTION
# Description of the issue
We found an issue where the scrapper pushes a 0 datapoint with empty type and NoRecordedValue flag as true. This leads to a missing datapoint when the scrapper doesn't find a metric at a scrape because the logic to fill empty metric sees that the metric is present and doesn't fill anything and since the metric is stale it is dropped.

To fix this issue we are updating the metric modifier to reset stale datapoints by converting the exisiting value to a double and resetting the NoRecordedValue flag.

before vs after fix 
![image](https://github.com/aws/amazon-cloudwatch-agent/assets/44022838/59bebab4-b9a2-4763-a96b-2816f581f185)


# Description of changes
updating the metric modifier to reset the stale datapoints

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
tested in test cluster, unit test added





