### PR TITLE
Change App Signals Name To Application Signals In Agent Config

### DIFF
--- a/extension/agenthealth/handler/stats/agent/flag.go
+++ b/extension/agenthealth/handler/stats/agent/flag.go
@@ -27,7 +27,7 @@ const (
 
 	flagIMDSFallbackSuccessStr       = "imds_fallback_success"
 	flagSharedConfigFallbackStr      = "shared_config_fallback"
-	flagAppSignalsStr                = "app_signals"
+	flagAppSignalsStr                = "application_signals"
 	flagEnhancedContainerInsightsStr = "enhanced_container_insights"
 	flagRunningInContainerStr        = "running_in_container"
 	flagModeStr                      = "mode"

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -27,7 +27,7 @@ import (
 const (
 	flagRunAsUser                 = "run_as_user"
 	flagContainerInsights         = "container_insights"
-	flagAppSignals                = "app_signals"
+	flagAppSignals                = "application_signals"
 	flagEnhancedContainerInsights = "enhanced_container_insights"
 
 	separator = " "

--- a/extension/agenthealth/handler/useragent/useragent_test.go
+++ b/extension/agenthealth/handler/useragent/useragent_test.go
@@ -126,7 +126,7 @@ func TestEmf(t *testing.T) {
 
 	assert.Equal(t, "inputs:(nop run_as_user)", ua.inputsStr.Load())
 	assert.Equal(t, "", ua.processorsStr.Load())
-	assert.Equal(t, "outputs:(app_signals awsemf)", ua.outputsStr.Load())
+	assert.Equal(t, "outputs:(application_signals awsemf)", ua.outputsStr.Load())
 }
 
 func TestSingleton(t *testing.T) {

--- a/plugins/processors/awsappsignals/factory.go
+++ b/plugins/processors/awsappsignals/factory.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "awsappsignals"
+	typeStr = "awsapplicationsignals"
 	// The stability level of the processor.
 	stability = component.StabilityLevelBeta
 )

--- a/plugins/processors/awsappsignals/factory_test.go
+++ b/plugins/processors/awsappsignals/factory_test.go
@@ -78,7 +78,7 @@ func TestLoadEKSConfig(t *testing.T) {
 		errorMessage string
 	}{
 		{
-			id: component.NewIDWithName("awsappsignals", ""),
+			id: component.NewIDWithName("awsapplicationsignals", ""),
 			expected: &config.Config{
 				Resolvers: []config.Resolver{config.NewEKSResolver("test")},
 				Rules:     expectedRules,
@@ -119,7 +119,7 @@ func TestLoadGenericConfig(t *testing.T) {
 		errorMessage string
 	}{
 		{
-			id: component.NewIDWithName("awsappsignals", ""),
+			id: component.NewIDWithName("awsapplicationsignals", ""),
 			expected: &config.Config{
 				Resolvers: []config.Resolver{config.NewGenericResolver("")},
 				Rules:     expectedRules,

--- a/plugins/processors/awsappsignals/testdata/config_eks.yaml
+++ b/plugins/processors/awsappsignals/testdata/config_eks.yaml
@@ -1,4 +1,4 @@
-awsappsignals:
+awsapplicationsignals:
   resolvers:
     - platform: eks
       name: test

--- a/plugins/processors/awsappsignals/testdata/config_generic.yaml
+++ b/plugins/processors/awsappsignals/testdata/config_generic.yaml
@@ -1,4 +1,4 @@
-awsappsignals:
+awsapplicationsignals:
   resolvers:
     - platform: generic
   rules:

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -618,6 +618,90 @@
               },
               "additionalProperties": true
             },
+            "application_signals": {
+              "type": "object",
+              "properties": {
+                "hosted_in": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 1024
+                },
+                "rules": {
+                  "description": "Custom rules defined by customer",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "selectors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "dimension": {
+                              "description": "dimension used for matching",
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "match": {
+                              "description": "regex used for match",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "dimension",
+                            "match"
+                          ]
+                        }
+                      },
+                      "replacements": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "target_dimension": {
+                              "description": "dimension to be replaced",
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "value": {
+                              "description": "replacement value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "target_dimension",
+                            "value"
+                          ]
+                        }
+                      },
+                      "action": {
+                        "description": "action to be done, either keep, drop or replace",
+                        "type": "string",
+                        "enum": [
+                          "drop",
+                          "keep",
+                          "replace"
+                        ]
+                      },
+                      "rule_name": {
+                        "description": "name of rule",
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "selectors",
+                      "action"
+                    ]
+                  }
+                }
+              },
+              "tls": {
+                "$ref": "#/definitions/metricsDefinition/definitions/tlsDefinitions"
+              },
+              "additionalProperties": true
+            },
             "ecs": {
               "type": "object",
               "properties": {
@@ -931,6 +1015,11 @@
           "type": "object",
           "properties": {
             "app_signals": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "application_signals": {
               "type": "object",
               "properties": {},
               "additionalProperties": true

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -1,5 +1,5 @@
 exporters:
-    awsemf/app_signals:
+    awsemf/application_signals:
         certificate_file_path: ""
         detailed_metrics: false
         dimension_rollup_option: NoDimensionRollup
@@ -234,7 +234,7 @@ exporters:
         retain_initial_value_of_delta_metric: false
         role_arn: ""
         version: "0"
-    awsxray/app_signals:
+    awsxray/application_signals:
         certificate_file_path: ""
         endpoint: ""
         imds_retries: 1
@@ -280,7 +280,7 @@ extensions:
             usage_flags:
                 mode: EKS
                 region_type: ACJ
-    awsproxy/app_signals:
+    awsproxy/application_signals:
         aws_endpoint: ""
         certificate_file_path: ""
         endpoint: 0.0.0.0:2000
@@ -291,7 +291,7 @@ extensions:
         region: us-east-1
         role_arn: ""
 processors:
-    awsappsignals:
+    awsapplicationsignals:
         limiter:
             disabled: false
             drop_threshold: 500
@@ -596,7 +596,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
-    otlp/app_signals:
+    otlp/application_signals:
         protocols:
             grpc:
                 endpoint: 0.0.0.0:4315
@@ -633,18 +633,18 @@ receivers:
                 traces_url_path: /v1/traces
 service:
     extensions:
-        - awsproxy/app_signals
+        - awsproxy/application_signals
         - agenthealth/traces
         - agenthealth/logs
     pipelines:
-        metrics/app_signals:
+        metrics/application_signals:
             exporters:
-                - awsemf/app_signals
+                - awsemf/application_signals
             processors:
                 - resourcedetection
-                - awsappsignals
+                - awsapplicationsignals
             receivers:
-                - otlp/app_signals
+                - otlp/application_signals
         metrics/containerinsights:
             exporters:
                 - awsemf/containerinsights
@@ -652,14 +652,14 @@ service:
                 - batch/containerinsights
             receivers:
                 - awscontainerinsightreceiver
-        traces/app_signals:
+        traces/application_signals:
             exporters:
-                - awsxray/app_signals
+                - awsxray/application_signals
             processors:
                 - resourcedetection
-                - awsappsignals
+                - awsapplicationsignals
             receivers:
-                - otlp/app_signals
+                - otlp/application_signals
     telemetry:
         logs:
             development: false

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.json
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.json
@@ -4,7 +4,7 @@
   },
   "logs": {
     "metrics_collected": {
-      "app_signals": {
+      "application_signals": {
         "hosted_in": "TestCluster",
         "limiter": {
           "log_dropped_metrics": true,
@@ -24,7 +24,7 @@
   },
   "traces": {
     "traces_collected": {
-      "app_signals": {}
+      "application_signals": {}
     }
   }
 }

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -1,5 +1,5 @@
 exporters:
-    awsemf/app_signals:
+    awsemf/application_signals:
         certificate_file_path: ""
         detailed_metrics: false
         dimension_rollup_option: NoDimensionRollup
@@ -234,7 +234,7 @@ exporters:
         retain_initial_value_of_delta_metric: false
         role_arn: ""
         version: "0"
-    awsxray/app_signals:
+    awsxray/application_signals:
         certificate_file_path: ""
         endpoint: ""
         imds_retries: 1
@@ -280,7 +280,7 @@ extensions:
             usage_flags:
                 mode: K8E
                 region_type: ACJ
-    awsproxy/app_signals:
+    awsproxy/application_signals:
         aws_endpoint: ""
         certificate_file_path: ""
         endpoint: 0.0.0.0:2000
@@ -291,7 +291,7 @@ extensions:
         region: us-east-1
         role_arn: ""
 processors:
-    awsappsignals:
+    awsapplicationsignals:
         limiter:
             disabled: false
             drop_threshold: 500
@@ -596,7 +596,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
-    otlp/app_signals:
+    otlp/application_signals:
         protocols:
             grpc:
                 endpoint: 0.0.0.0:4315
@@ -615,18 +615,18 @@ receivers:
                 traces_url_path: /v1/traces
 service:
     extensions:
-        - awsproxy/app_signals
+        - awsproxy/application_signals
         - agenthealth/traces
         - agenthealth/logs
     pipelines:
-        metrics/app_signals:
+        metrics/application_signals:
             exporters:
-                - awsemf/app_signals
+                - awsemf/application_signals
             processors:
                 - resourcedetection
-                - awsappsignals
+                - awsapplicationsignals
             receivers:
-                - otlp/app_signals
+                - otlp/application_signals
         metrics/containerinsights:
             exporters:
                 - awsemf/containerinsights
@@ -634,14 +634,14 @@ service:
                 - batch/containerinsights
             receivers:
                 - awscontainerinsightreceiver
-        traces/app_signals:
+        traces/application_signals:
             exporters:
-                - awsxray/app_signals
+                - awsxray/application_signals
             processors:
                 - resourcedetection
-                - awsappsignals
+                - awsapplicationsignals
             receivers:
-                - otlp/app_signals
+                - otlp/application_signals
     telemetry:
         logs:
             development: false

--- a/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.conf
+++ b/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.conf
@@ -1,0 +1,27 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = "host_name_from_env"
+  interval = "60s"
+  logfile = ""
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    endpoint_override = "https://fake_endpoint"
+    force_flush_interval = "5s"
+    log_stream_name = "host_name_from_env"
+    region = "us-east-1"
+
+[processors]

--- a/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.json
+++ b/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.json
@@ -4,7 +4,7 @@
   },
   "logs": {
     "metrics_collected": {
-      "application_signals": {
+      "app_signals": {
         "tls": {
           "cert_file": "path/to/cert.crt",
           "key_file": "path/to/key.key"
@@ -28,7 +28,7 @@
   },
   "traces": {
     "traces_collected": {
-      "application_signals": {}
+      "app_signals": {}
     }
   }
 }

--- a/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.yaml
@@ -1,0 +1,678 @@
+exporters:
+  awsemf/application_signals:
+    certificate_file_path: ""
+    detailed_metrics: false
+    dimension_rollup_option: NoDimensionRollup
+    disable_metric_extraction: false
+    eks_fargate_container_insights_enabled: false
+    endpoint: https://fake_endpoint
+    enhanced_container_insights: false
+    imds_retries: 1
+    local_mode: false
+    log_group_name: /aws/appsignals/eks
+    log_retention: 0
+    log_stream_name: ""
+    max_retries: 2
+    metric_declarations:
+      - dimensions:
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - Operation
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - Service
+        label_matchers:
+          - label_names:
+              - aws.span.kind
+            regex: ^(SERVER|LOCAL_ROOT)$
+            separator: ;
+        metric_name_selectors:
+          - Latency
+          - Fault
+          - Error
+      - dimensions:
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - RemoteService
+            - RemoteTarget
+          - - RemoteService
+        label_matchers:
+          - label_names:
+              - aws.span.kind
+            regex: ^(CLIENT|PRODUCER|CONSUMER)$
+            separator: ;
+        metric_name_selectors:
+          - Latency
+          - Fault
+          - Error
+    middleware: agenthealth/logs
+    namespace: AppSignals
+    no_verify_ssl: false
+    num_workers: 8
+    output_destination: cloudwatch
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 30
+    resource_arn: ""
+    resource_to_telemetry_conversion:
+      enabled: false
+    retain_initial_value_of_delta_metric: false
+    role_arn: ""
+    version: "1"
+  awsemf/containerinsights:
+    certificate_file_path: ""
+    detailed_metrics: false
+    dimension_rollup_option: NoDimensionRollup
+    disable_metric_extraction: true
+    eks_fargate_container_insights_enabled: false
+    endpoint: https://fake_endpoint
+    enhanced_container_insights: false
+    imds_retries: 1
+    local_mode: false
+    log_group_name: /aws/containerinsights/{ClusterName}/performance
+    log_retention: 0
+    log_stream_name: '{NodeName}'
+    max_retries: 2
+    metric_declarations:
+      - dimensions:
+          - - ClusterName
+            - Namespace
+            - PodName
+          - - ClusterName
+          - - ClusterName
+            - Namespace
+            - Service
+          - - ClusterName
+            - Namespace
+        metric_name_selectors:
+          - pod_cpu_utilization
+          - pod_memory_utilization
+          - pod_network_rx_bytes
+          - pod_network_tx_bytes
+          - pod_cpu_utilization_over_pod_limit
+          - pod_memory_utilization_over_pod_limit
+      - dimensions:
+          - - ClusterName
+            - Namespace
+            - PodName
+        metric_name_selectors:
+          - pod_number_of_container_restarts
+      - dimensions:
+          - - ClusterName
+            - Namespace
+            - PodName
+          - - ClusterName
+        metric_name_selectors:
+          - pod_cpu_reserved_capacity
+          - pod_memory_reserved_capacity
+      - dimensions:
+          - - ClusterName
+            - InstanceId
+            - NodeName
+          - - ClusterName
+        metric_name_selectors:
+          - node_cpu_utilization
+          - node_memory_utilization
+          - node_network_total_bytes
+          - node_cpu_reserved_capacity
+          - node_memory_reserved_capacity
+          - node_number_of_running_pods
+          - node_number_of_running_containers
+      - dimensions:
+          - - ClusterName
+        metric_name_selectors:
+          - node_cpu_usage_total
+          - node_cpu_limit
+          - node_memory_working_set
+          - node_memory_limit
+      - dimensions:
+          - - ClusterName
+            - InstanceId
+            - NodeName
+          - - ClusterName
+        metric_name_selectors:
+          - node_filesystem_utilization
+      - dimensions:
+          - - ClusterName
+            - Namespace
+            - Service
+          - - ClusterName
+        metric_name_selectors:
+          - service_number_of_running_pods
+      - dimensions:
+          - - ClusterName
+            - Namespace
+          - - ClusterName
+        metric_name_selectors:
+          - namespace_number_of_running_pods
+      - dimensions:
+          - - ClusterName
+        metric_name_selectors:
+          - cluster_node_count
+          - cluster_failed_node_count
+    middleware: agenthealth/logs
+    namespace: ContainerInsights
+    no_verify_ssl: false
+    num_workers: 8
+    output_destination: cloudwatch
+    parse_json_encoded_attr_values:
+      - Sources
+      - kubernetes
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 30
+    resource_arn: ""
+    resource_to_telemetry_conversion:
+      enabled: true
+    retain_initial_value_of_delta_metric: false
+    role_arn: ""
+    version: "0"
+  awsxray/application_signals:
+    certificate_file_path: ""
+    endpoint: ""
+    imds_retries: 1
+    index_all_attributes: false
+    indexed_attributes:
+      - aws.local.service
+      - aws.local.operation
+      - aws.remote.service
+      - aws.remote.operation
+      - HostedIn.K8s.Namespace
+      - K8s.RemoteNamespace
+      - aws.remote.target
+      - HostedIn.Environment
+      - HostedIn.EKS.Cluster
+    local_mode: false
+    max_retries: 2
+    middleware: agenthealth/traces
+    no_verify_ssl: false
+    num_workers: 8
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 30
+    resource_arn: ""
+    role_arn: ""
+    telemetry:
+      enabled: true
+      include_metadata: true
+extensions:
+  agenthealth/logs:
+    is_usage_data_enabled: true
+    stats:
+      operations:
+        - PutLogEvents
+      usage_flags:
+        mode: EKS
+        region_type: ACJ
+  agenthealth/traces:
+    is_usage_data_enabled: true
+    stats:
+      operations:
+        - PutTraceSegments
+      usage_flags:
+        mode: EKS
+        region_type: ACJ
+  awsproxy/application_signals:
+    aws_endpoint: ""
+    certificate_file_path: ""
+    endpoint: 0.0.0.0:2000
+    imds_retries: 1
+    local_mode: false
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    role_arn: ""
+processors:
+  awsapplicationsignals:
+    limiter:
+      disabled: false
+      drop_threshold: 500
+      garbage_collection_interval: 10m0s
+      log_dropped_metrics: true
+      rotation_interval: 10m0s
+    resolvers:
+      - name: TestCluster
+        platform: eks
+  batch/containerinsights:
+    metadata_cardinality_limit: 1000
+    send_batch_max_size: 0
+    send_batch_size: 8192
+    timeout: 5s
+  resourcedetection:
+    aks:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+    azure:
+      resource_attributes:
+        azure.resourcegroup.name:
+          enabled: true
+        azure.vm.name:
+          enabled: true
+        azure.vm.scaleset.name:
+          enabled: true
+        azure.vm.size:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+    compression: ""
+    consul:
+      address: ""
+      datacenter: ""
+      namespace: ""
+      resource_attributes:
+        azure.resourcegroup.name:
+          enabled: true
+        azure.vm.name:
+          enabled: true
+        azure.vm.scaleset.name:
+          enabled: true
+        azure.vm.size:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+      token_file: ""
+    detectors:
+      - eks
+      - env
+      - ec2
+    disable_keep_alives: false
+    docker:
+      resource_attributes:
+        host.name:
+          enabled: true
+        os.type:
+          enabled: true
+    ec2:
+      resource_attributes:
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.image.id:
+          enabled: true
+        host.name:
+          enabled: true
+        host.type:
+          enabled: true
+      tags:
+        - ^kubernetes.io/cluster/.*$
+        - ^aws:autoscaling:groupName
+    ecs:
+      resource_attributes:
+        aws.ecs.cluster.arn:
+          enabled: true
+        aws.ecs.launchtype:
+          enabled: true
+        aws.ecs.task.arn:
+          enabled: true
+        aws.ecs.task.family:
+          enabled: true
+        aws.ecs.task.revision:
+          enabled: true
+        aws.log.group.arns:
+          enabled: true
+        aws.log.group.names:
+          enabled: true
+        aws.log.stream.arns:
+          enabled: true
+        aws.log.stream.names:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+    eks:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+    elasticbeanstalk:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        deployment.environment:
+          enabled: true
+        service.instance.id:
+          enabled: true
+        service.version:
+          enabled: true
+    endpoint: ""
+    gcp:
+      resource_attributes:
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        faas.id:
+          enabled: true
+        faas.instance:
+          enabled: true
+        faas.name:
+          enabled: true
+        faas.version:
+          enabled: true
+        gcp.cloud_run.job.execution:
+          enabled: true
+        gcp.cloud_run.job.task_index:
+          enabled: true
+        gcp.gce.instance.hostname:
+          enabled: false
+        gcp.gce.instance.name:
+          enabled: false
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+        host.type:
+          enabled: true
+        k8s.cluster.name:
+          enabled: true
+    heroku:
+      resource_attributes:
+        cloud.provider:
+          enabled: true
+        heroku.app.id:
+          enabled: true
+        heroku.dyno.id:
+          enabled: true
+        heroku.release.commit:
+          enabled: true
+        heroku.release.creation_timestamp:
+          enabled: true
+        service.instance.id:
+          enabled: true
+        service.name:
+          enabled: true
+        service.version:
+          enabled: true
+    idle_conn_timeout: 1m30s
+    k8snode:
+      auth_type: serviceAccount
+      context: ""
+      node_from_env_var: ""
+      resource_attributes:
+        k8s.node.name:
+          enabled: true
+        k8s.node.uid:
+          enabled: true
+    lambda:
+      resource_attributes:
+        aws.log.group.names:
+          enabled: true
+        aws.log.stream.names:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        faas.instance:
+          enabled: true
+        faas.max_memory:
+          enabled: true
+        faas.name:
+          enabled: true
+        faas.version:
+          enabled: true
+    max_idle_conns: 100
+    openshift:
+      address: ""
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        k8s.cluster.name:
+          enabled: true
+      token: ""
+    override: true
+    read_buffer_size: 0
+    system:
+      resource_attributes:
+        host.arch:
+          enabled: false
+        host.cpu.cache.l2.size:
+          enabled: false
+        host.cpu.family:
+          enabled: false
+        host.cpu.model.id:
+          enabled: false
+        host.cpu.model.name:
+          enabled: false
+        host.cpu.stepping:
+          enabled: false
+        host.cpu.vendor.id:
+          enabled: false
+        host.id:
+          enabled: false
+        host.name:
+          enabled: true
+        os.description:
+          enabled: false
+        os.type:
+          enabled: true
+    timeout: 2s
+    write_buffer_size: 0
+receivers:
+  awscontainerinsightreceiver:
+    accelerated_compute_metrics: false
+    add_container_name_metric_label: false
+    add_full_pod_name_metric_label: false
+    add_service_as_attribute: true
+    certificate_file_path: ""
+    cluster_name: TestCluster
+    collection_interval: 30s
+    container_orchestrator: eks
+    enable_control_plane_metrics: false
+    endpoint: ""
+    imds_retries: 1
+    leader_lock_name: cwagent-clusterleader
+    leader_lock_using_config_map_only: true
+    local_mode: false
+    max_retries: 0
+    no_verify_ssl: false
+    num_workers: 0
+    prefer_full_pod_name: false
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 0
+    resource_arn: ""
+    role_arn: ""
+  otlp/application_signals:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4315
+        include_metadata: false
+        max_concurrent_streams: 0
+        max_recv_msg_size_mib: 0
+        read_buffer_size: 524288
+        tls:
+          ca_file: ""
+          cert_file: path/to/cert.crt
+          client_ca_file: ""
+          client_ca_file_reload: false
+          key_file: path/to/key.key
+          max_version: ""
+          min_version: ""
+          reload_interval: 0s
+        transport: tcp
+        write_buffer_size: 0
+      http:
+        endpoint: 0.0.0.0:4316
+        include_metadata: false
+        logs_url_path: /v1/logs
+        max_request_body_size: 0
+        metrics_url_path: /v1/metrics
+        tls:
+          ca_file: ""
+          cert_file: path/to/cert.crt
+          client_ca_file: ""
+          client_ca_file_reload: false
+          key_file: path/to/key.key
+          max_version: ""
+          min_version: ""
+          reload_interval: 0s
+        traces_url_path: /v1/traces
+service:
+  extensions:
+    - awsproxy/application_signals
+    - agenthealth/traces
+    - agenthealth/logs
+  pipelines:
+    metrics/application_signals:
+      exporters:
+        - awsemf/application_signals
+      processors:
+        - resourcedetection
+        - awsapplicationsignals
+      receivers:
+        - otlp/application_signals
+    metrics/containerinsights:
+      exporters:
+        - awsemf/containerinsights
+      processors:
+        - batch/containerinsights
+      receivers:
+        - awscontainerinsightreceiver
+    traces/application_signals:
+      exporters:
+        - awsxray/application_signals
+      processors:
+        - resourcedetection
+        - awsapplicationsignals
+      receivers:
+        - otlp/application_signals
+  telemetry:
+    logs:
+      development: false
+      disable_caller: false
+      disable_stacktrace: false
+      encoding: console
+      level: info
+      sampling:
+        enabled: true
+        initial: 2
+        thereafter: 500
+        tick: 10s
+    metrics:
+      address: ""
+      level: None
+    traces: {}

--- a/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.conf
+++ b/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.conf
@@ -1,0 +1,27 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = "host_name_from_env"
+  interval = "60s"
+  logfile = ""
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    endpoint_override = "https://fake_endpoint"
+    force_flush_interval = "5s"
+    log_stream_name = "host_name_from_env"
+    region = "us-east-1"
+
+[processors]

--- a/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.json
+++ b/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.json
@@ -15,6 +15,17 @@
           "rotation_interval": "10m"
         }
       },
+      "app_signals": {
+        "tls": {
+          "cert_file": "/other/path/to/cert.crt",
+          "key_file": "/other/path/to/key.key"
+        },
+        "hosted_in": "OtherTestCluster",
+        "limiter": {
+          "log_dropped_metrics": false,
+          "rotation_interval": "20m"
+        }
+      },
       "kubernetes": {
         "cluster_name": "TestCluster",
         "metrics_collection_interval": 30,
@@ -28,7 +39,8 @@
   },
   "traces": {
     "traces_collected": {
-      "application_signals": {}
+      "application_signals": {},
+      "app_signals": {}
     }
   }
 }

--- a/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.yaml
@@ -1,0 +1,678 @@
+exporters:
+  awsemf/application_signals:
+    certificate_file_path: ""
+    detailed_metrics: false
+    dimension_rollup_option: NoDimensionRollup
+    disable_metric_extraction: false
+    eks_fargate_container_insights_enabled: false
+    endpoint: https://fake_endpoint
+    enhanced_container_insights: false
+    imds_retries: 1
+    local_mode: false
+    log_group_name: /aws/appsignals/eks
+    log_retention: 0
+    log_stream_name: ""
+    max_retries: 2
+    metric_declarations:
+      - dimensions:
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - Operation
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - Service
+        label_matchers:
+          - label_names:
+              - aws.span.kind
+            regex: ^(SERVER|LOCAL_ROOT)$
+            separator: ;
+        metric_name_selectors:
+          - Latency
+          - Fault
+          - Error
+      - dimensions:
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - K8s.RemoteNamespace
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.EKS.Cluster
+            - HostedIn.K8s.Namespace
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - RemoteService
+            - RemoteTarget
+          - - RemoteService
+        label_matchers:
+          - label_names:
+              - aws.span.kind
+            regex: ^(CLIENT|PRODUCER|CONSUMER)$
+            separator: ;
+        metric_name_selectors:
+          - Latency
+          - Fault
+          - Error
+    middleware: agenthealth/logs
+    namespace: AppSignals
+    no_verify_ssl: false
+    num_workers: 8
+    output_destination: cloudwatch
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 30
+    resource_arn: ""
+    resource_to_telemetry_conversion:
+      enabled: false
+    retain_initial_value_of_delta_metric: false
+    role_arn: ""
+    version: "1"
+  awsemf/containerinsights:
+    certificate_file_path: ""
+    detailed_metrics: false
+    dimension_rollup_option: NoDimensionRollup
+    disable_metric_extraction: true
+    eks_fargate_container_insights_enabled: false
+    endpoint: https://fake_endpoint
+    enhanced_container_insights: false
+    imds_retries: 1
+    local_mode: false
+    log_group_name: /aws/containerinsights/{ClusterName}/performance
+    log_retention: 0
+    log_stream_name: '{NodeName}'
+    max_retries: 2
+    metric_declarations:
+      - dimensions:
+          - - ClusterName
+            - Namespace
+            - PodName
+          - - ClusterName
+          - - ClusterName
+            - Namespace
+            - Service
+          - - ClusterName
+            - Namespace
+        metric_name_selectors:
+          - pod_cpu_utilization
+          - pod_memory_utilization
+          - pod_network_rx_bytes
+          - pod_network_tx_bytes
+          - pod_cpu_utilization_over_pod_limit
+          - pod_memory_utilization_over_pod_limit
+      - dimensions:
+          - - ClusterName
+            - Namespace
+            - PodName
+        metric_name_selectors:
+          - pod_number_of_container_restarts
+      - dimensions:
+          - - ClusterName
+            - Namespace
+            - PodName
+          - - ClusterName
+        metric_name_selectors:
+          - pod_cpu_reserved_capacity
+          - pod_memory_reserved_capacity
+      - dimensions:
+          - - ClusterName
+            - InstanceId
+            - NodeName
+          - - ClusterName
+        metric_name_selectors:
+          - node_cpu_utilization
+          - node_memory_utilization
+          - node_network_total_bytes
+          - node_cpu_reserved_capacity
+          - node_memory_reserved_capacity
+          - node_number_of_running_pods
+          - node_number_of_running_containers
+      - dimensions:
+          - - ClusterName
+        metric_name_selectors:
+          - node_cpu_usage_total
+          - node_cpu_limit
+          - node_memory_working_set
+          - node_memory_limit
+      - dimensions:
+          - - ClusterName
+            - InstanceId
+            - NodeName
+          - - ClusterName
+        metric_name_selectors:
+          - node_filesystem_utilization
+      - dimensions:
+          - - ClusterName
+            - Namespace
+            - Service
+          - - ClusterName
+        metric_name_selectors:
+          - service_number_of_running_pods
+      - dimensions:
+          - - ClusterName
+            - Namespace
+          - - ClusterName
+        metric_name_selectors:
+          - namespace_number_of_running_pods
+      - dimensions:
+          - - ClusterName
+        metric_name_selectors:
+          - cluster_node_count
+          - cluster_failed_node_count
+    middleware: agenthealth/logs
+    namespace: ContainerInsights
+    no_verify_ssl: false
+    num_workers: 8
+    output_destination: cloudwatch
+    parse_json_encoded_attr_values:
+      - Sources
+      - kubernetes
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 30
+    resource_arn: ""
+    resource_to_telemetry_conversion:
+      enabled: true
+    retain_initial_value_of_delta_metric: false
+    role_arn: ""
+    version: "0"
+  awsxray/application_signals:
+    certificate_file_path: ""
+    endpoint: ""
+    imds_retries: 1
+    index_all_attributes: false
+    indexed_attributes:
+      - aws.local.service
+      - aws.local.operation
+      - aws.remote.service
+      - aws.remote.operation
+      - HostedIn.K8s.Namespace
+      - K8s.RemoteNamespace
+      - aws.remote.target
+      - HostedIn.Environment
+      - HostedIn.EKS.Cluster
+    local_mode: false
+    max_retries: 2
+    middleware: agenthealth/traces
+    no_verify_ssl: false
+    num_workers: 8
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 30
+    resource_arn: ""
+    role_arn: ""
+    telemetry:
+      enabled: true
+      include_metadata: true
+extensions:
+  agenthealth/logs:
+    is_usage_data_enabled: true
+    stats:
+      operations:
+        - PutLogEvents
+      usage_flags:
+        mode: EKS
+        region_type: ACJ
+  agenthealth/traces:
+    is_usage_data_enabled: true
+    stats:
+      operations:
+        - PutTraceSegments
+      usage_flags:
+        mode: EKS
+        region_type: ACJ
+  awsproxy/application_signals:
+    aws_endpoint: ""
+    certificate_file_path: ""
+    endpoint: 0.0.0.0:2000
+    imds_retries: 1
+    local_mode: false
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    role_arn: ""
+processors:
+  awsapplicationsignals:
+    limiter:
+      disabled: false
+      drop_threshold: 500
+      garbage_collection_interval: 10m0s
+      log_dropped_metrics: true
+      rotation_interval: 10m0s
+    resolvers:
+      - name: TestCluster
+        platform: eks
+  batch/containerinsights:
+    metadata_cardinality_limit: 1000
+    send_batch_max_size: 0
+    send_batch_size: 8192
+    timeout: 5s
+  resourcedetection:
+    aks:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+    azure:
+      resource_attributes:
+        azure.resourcegroup.name:
+          enabled: true
+        azure.vm.name:
+          enabled: true
+        azure.vm.scaleset.name:
+          enabled: true
+        azure.vm.size:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+    compression: ""
+    consul:
+      address: ""
+      datacenter: ""
+      namespace: ""
+      resource_attributes:
+        azure.resourcegroup.name:
+          enabled: true
+        azure.vm.name:
+          enabled: true
+        azure.vm.scaleset.name:
+          enabled: true
+        azure.vm.size:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+      token_file: ""
+    detectors:
+      - eks
+      - env
+      - ec2
+    disable_keep_alives: false
+    docker:
+      resource_attributes:
+        host.name:
+          enabled: true
+        os.type:
+          enabled: true
+    ec2:
+      resource_attributes:
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.image.id:
+          enabled: true
+        host.name:
+          enabled: true
+        host.type:
+          enabled: true
+      tags:
+        - ^kubernetes.io/cluster/.*$
+        - ^aws:autoscaling:groupName
+    ecs:
+      resource_attributes:
+        aws.ecs.cluster.arn:
+          enabled: true
+        aws.ecs.launchtype:
+          enabled: true
+        aws.ecs.task.arn:
+          enabled: true
+        aws.ecs.task.family:
+          enabled: true
+        aws.ecs.task.revision:
+          enabled: true
+        aws.log.group.arns:
+          enabled: true
+        aws.log.group.names:
+          enabled: true
+        aws.log.stream.arns:
+          enabled: true
+        aws.log.stream.names:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+    eks:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+    elasticbeanstalk:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        deployment.environment:
+          enabled: true
+        service.instance.id:
+          enabled: true
+        service.version:
+          enabled: true
+    endpoint: ""
+    gcp:
+      resource_attributes:
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        faas.id:
+          enabled: true
+        faas.instance:
+          enabled: true
+        faas.name:
+          enabled: true
+        faas.version:
+          enabled: true
+        gcp.cloud_run.job.execution:
+          enabled: true
+        gcp.cloud_run.job.task_index:
+          enabled: true
+        gcp.gce.instance.hostname:
+          enabled: false
+        gcp.gce.instance.name:
+          enabled: false
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+        host.type:
+          enabled: true
+        k8s.cluster.name:
+          enabled: true
+    heroku:
+      resource_attributes:
+        cloud.provider:
+          enabled: true
+        heroku.app.id:
+          enabled: true
+        heroku.dyno.id:
+          enabled: true
+        heroku.release.commit:
+          enabled: true
+        heroku.release.creation_timestamp:
+          enabled: true
+        service.instance.id:
+          enabled: true
+        service.name:
+          enabled: true
+        service.version:
+          enabled: true
+    idle_conn_timeout: 1m30s
+    k8snode:
+      auth_type: serviceAccount
+      context: ""
+      node_from_env_var: ""
+      resource_attributes:
+        k8s.node.name:
+          enabled: true
+        k8s.node.uid:
+          enabled: true
+    lambda:
+      resource_attributes:
+        aws.log.group.names:
+          enabled: true
+        aws.log.stream.names:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        faas.instance:
+          enabled: true
+        faas.max_memory:
+          enabled: true
+        faas.name:
+          enabled: true
+        faas.version:
+          enabled: true
+    max_idle_conns: 100
+    openshift:
+      address: ""
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        k8s.cluster.name:
+          enabled: true
+      token: ""
+    override: true
+    read_buffer_size: 0
+    system:
+      resource_attributes:
+        host.arch:
+          enabled: false
+        host.cpu.cache.l2.size:
+          enabled: false
+        host.cpu.family:
+          enabled: false
+        host.cpu.model.id:
+          enabled: false
+        host.cpu.model.name:
+          enabled: false
+        host.cpu.stepping:
+          enabled: false
+        host.cpu.vendor.id:
+          enabled: false
+        host.id:
+          enabled: false
+        host.name:
+          enabled: true
+        os.description:
+          enabled: false
+        os.type:
+          enabled: true
+    timeout: 2s
+    write_buffer_size: 0
+receivers:
+  awscontainerinsightreceiver:
+    accelerated_compute_metrics: false
+    add_container_name_metric_label: false
+    add_full_pod_name_metric_label: false
+    add_service_as_attribute: true
+    certificate_file_path: ""
+    cluster_name: TestCluster
+    collection_interval: 30s
+    container_orchestrator: eks
+    enable_control_plane_metrics: false
+    endpoint: ""
+    imds_retries: 1
+    leader_lock_name: cwagent-clusterleader
+    leader_lock_using_config_map_only: true
+    local_mode: false
+    max_retries: 0
+    no_verify_ssl: false
+    num_workers: 0
+    prefer_full_pod_name: false
+    profile: ""
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 0
+    resource_arn: ""
+    role_arn: ""
+  otlp/application_signals:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4315
+        include_metadata: false
+        max_concurrent_streams: 0
+        max_recv_msg_size_mib: 0
+        read_buffer_size: 524288
+        tls:
+          ca_file: ""
+          cert_file: path/to/cert.crt
+          client_ca_file: ""
+          client_ca_file_reload: false
+          key_file: path/to/key.key
+          max_version: ""
+          min_version: ""
+          reload_interval: 0s
+        transport: tcp
+        write_buffer_size: 0
+      http:
+        endpoint: 0.0.0.0:4316
+        include_metadata: false
+        logs_url_path: /v1/logs
+        max_request_body_size: 0
+        metrics_url_path: /v1/metrics
+        tls:
+          ca_file: ""
+          cert_file: path/to/cert.crt
+          client_ca_file: ""
+          client_ca_file_reload: false
+          key_file: path/to/key.key
+          max_version: ""
+          min_version: ""
+          reload_interval: 0s
+        traces_url_path: /v1/traces
+service:
+  extensions:
+    - awsproxy/application_signals
+    - agenthealth/traces
+    - agenthealth/logs
+  pipelines:
+    metrics/application_signals:
+      exporters:
+        - awsemf/application_signals
+      processors:
+        - resourcedetection
+        - awsapplicationsignals
+      receivers:
+        - otlp/application_signals
+    metrics/containerinsights:
+      exporters:
+        - awsemf/containerinsights
+      processors:
+        - batch/containerinsights
+      receivers:
+        - awscontainerinsightreceiver
+    traces/application_signals:
+      exporters:
+        - awsxray/application_signals
+      processors:
+        - resourcedetection
+        - awsapplicationsignals
+      receivers:
+        - otlp/application_signals
+  telemetry:
+    logs:
+      development: false
+      disable_caller: false
+      disable_stacktrace: false
+      encoding: console
+      level: info
+      sampling:
+        enabled: true
+        initial: 2
+        thereafter: 500
+        tick: 10s
+    metrics:
+      address: ""
+      level: None
+    traces: {}

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -1,5 +1,5 @@
 exporters:
-    awsemf/app_signals:
+    awsemf/application_signals:
         certificate_file_path: ""
         detailed_metrics: false
         dimension_rollup_option: NoDimensionRollup
@@ -86,7 +86,7 @@ exporters:
         shared_credentials_file:
             - fake-path
         version: "1"
-    awsxray/app_signals:
+    awsxray/application_signals:
         certificate_file_path: ""
         endpoint: https://fake_endpoint
         imds_retries: 1
@@ -131,7 +131,7 @@ extensions:
             usage_flags:
                 mode: OP
                 region_type: ACJ
-    awsproxy/app_signals:
+    awsproxy/application_signals:
         aws_endpoint: https://fake_endpoint
         certificate_file_path: ""
         endpoint: 0.0.0.0:2000
@@ -144,7 +144,7 @@ extensions:
         shared_credentials_file:
             - fake-path
 processors:
-    awsappsignals:
+    awsapplicationsignals:
         resolvers:
             - name: ""
               platform: generic
@@ -413,7 +413,7 @@ processors:
         timeout: 2s
         write_buffer_size: 0
 receivers:
-    otlp/app_signals:
+    otlp/application_signals:
         protocols:
             grpc:
                 endpoint: 0.0.0.0:4315
@@ -432,26 +432,26 @@ receivers:
                 traces_url_path: /v1/traces
 service:
     extensions:
-        - awsproxy/app_signals
+        - awsproxy/application_signals
         - agenthealth/traces
         - agenthealth/logs
     pipelines:
-        metrics/app_signals:
+        metrics/application_signals:
             exporters:
-                - awsemf/app_signals
+                - awsemf/application_signals
             processors:
                 - resourcedetection
-                - awsappsignals
+                - awsapplicationsignals
             receivers:
-                - otlp/app_signals
-        traces/app_signals:
+                - otlp/application_signals
+        traces/application_signals:
             exporters:
-                - awsxray/app_signals
+                - awsxray/application_signals
             processors:
                 - resourcedetection
-                - awsappsignals
+                - awsapplicationsignals
             receivers:
-                - otlp/app_signals
+                - otlp/application_signals
     telemetry:
         logs:
             development: false

--- a/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.conf
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.conf
@@ -1,0 +1,27 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    endpoint_override = "https://fake_endpoint"
+    force_flush_interval = "5s"
+    log_stream_name = "host_name_from_env"
+    region = "us-east-1"
+
+[processors]

--- a/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.json
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.json
@@ -5,13 +5,13 @@
   "logs": {
     "log_stream_name": "host_name_from_env",
     "metrics_collected": {
-      "application_signals": {}
+      "app_signals": {}
     },
     "endpoint_override":"https://fake_endpoint"
   },
   "traces": {
     "traces_collected": {
-      "application_signals": {}
+      "app_signals": {}
     },
     "endpoint_override":"https://fake_endpoint"
   }

--- a/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.yaml
@@ -1,0 +1,472 @@
+exporters:
+  awsemf/application_signals:
+    certificate_file_path: ""
+    detailed_metrics: false
+    dimension_rollup_option: NoDimensionRollup
+    disable_metric_extraction: false
+    eks_fargate_container_insights_enabled: false
+    endpoint: https://fake_endpoint
+    enhanced_container_insights: false
+    imds_retries: 1
+    local_mode: true
+    log_group_name: /aws/appsignals/generic
+    log_retention: 0
+    log_stream_name: ""
+    max_retries: 2
+    metric_declarations:
+      - dimensions:
+          - - HostedIn.Environment
+            - Operation
+            - Service
+          - - HostedIn.Environment
+            - Service
+        label_matchers:
+          - label_names:
+              - aws.span.kind
+            regex: ^(SERVER|LOCAL_ROOT)$
+            separator: ;
+        metric_name_selectors:
+          - Latency
+          - Fault
+          - Error
+      - dimensions:
+          - - HostedIn.Environment
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.Environment
+            - Operation
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.Environment
+            - RemoteService
+            - Service
+          - - HostedIn.Environment
+            - RemoteOperation
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - HostedIn.Environment
+            - RemoteOperation
+            - RemoteService
+            - Service
+          - - HostedIn.Environment
+            - RemoteService
+            - RemoteTarget
+            - Service
+          - - RemoteService
+            - RemoteTarget
+          - - RemoteService
+        label_matchers:
+          - label_names:
+              - aws.span.kind
+            regex: ^(CLIENT|PRODUCER|CONSUMER)$
+            separator: ;
+        metric_name_selectors:
+          - Latency
+          - Fault
+          - Error
+    middleware: agenthealth/logs
+    namespace: AppSignals
+    no_verify_ssl: false
+    num_workers: 8
+    output_destination: cloudwatch
+    profile: AmazonCloudWatchAgent
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 30
+    resource_arn: ""
+    resource_to_telemetry_conversion:
+      enabled: false
+    retain_initial_value_of_delta_metric: false
+    role_arn: ""
+    shared_credentials_file:
+      - fake-path
+    version: "1"
+  awsxray/application_signals:
+    certificate_file_path: ""
+    endpoint: https://fake_endpoint
+    imds_retries: 1
+    index_all_attributes: false
+    indexed_attributes:
+      - aws.local.service
+      - aws.local.operation
+      - aws.remote.service
+      - aws.remote.operation
+      - aws.remote.target
+      - HostedIn.Environment
+    local_mode: true
+    max_retries: 2
+    middleware: agenthealth/traces
+    no_verify_ssl: false
+    num_workers: 8
+    profile: AmazonCloudWatchAgent
+    proxy_address: ""
+    region: us-east-1
+    request_timeout_seconds: 30
+    resource_arn: ""
+    role_arn: ""
+    shared_credentials_file:
+      - fake-path
+    telemetry:
+      enabled: true
+      include_metadata: true
+extensions:
+  agenthealth/logs:
+    is_usage_data_enabled: true
+    stats:
+      operations:
+        - PutLogEvents
+      usage_flags:
+        mode: OP
+        region_type: ACJ
+  agenthealth/traces:
+    is_usage_data_enabled: true
+    stats:
+      operations:
+        - PutTraceSegments
+      usage_flags:
+        mode: OP
+        region_type: ACJ
+  awsproxy/application_signals:
+    aws_endpoint: https://fake_endpoint
+    certificate_file_path: ""
+    endpoint: 0.0.0.0:2000
+    imds_retries: 1
+    local_mode: true
+    profile: AmazonCloudWatchAgent
+    proxy_address: ""
+    region: us-east-1
+    role_arn: ""
+    shared_credentials_file:
+      - fake-path
+processors:
+  awsapplicationsignals:
+    resolvers:
+      - name: ""
+        platform: generic
+  resourcedetection:
+    aks:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+    azure:
+      resource_attributes:
+        azure.resourcegroup.name:
+          enabled: true
+        azure.vm.name:
+          enabled: true
+        azure.vm.scaleset.name:
+          enabled: true
+        azure.vm.size:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+    compression: ""
+    consul:
+      address: ""
+      datacenter: ""
+      namespace: ""
+      resource_attributes:
+        azure.resourcegroup.name:
+          enabled: true
+        azure.vm.name:
+          enabled: true
+        azure.vm.scaleset.name:
+          enabled: true
+        azure.vm.size:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+      token_file: ""
+    detectors:
+      - eks
+      - env
+      - ec2
+    disable_keep_alives: false
+    docker:
+      resource_attributes:
+        host.name:
+          enabled: true
+        os.type:
+          enabled: true
+    ec2:
+      resource_attributes:
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        host.id:
+          enabled: true
+        host.image.id:
+          enabled: true
+        host.name:
+          enabled: true
+        host.type:
+          enabled: true
+      tags:
+        - ^kubernetes.io/cluster/.*$
+        - ^aws:autoscaling:groupName
+    ecs:
+      resource_attributes:
+        aws.ecs.cluster.arn:
+          enabled: true
+        aws.ecs.launchtype:
+          enabled: true
+        aws.ecs.task.arn:
+          enabled: true
+        aws.ecs.task.family:
+          enabled: true
+        aws.ecs.task.revision:
+          enabled: true
+        aws.log.group.arns:
+          enabled: true
+        aws.log.group.names:
+          enabled: true
+        aws.log.stream.arns:
+          enabled: true
+        aws.log.stream.names:
+          enabled: true
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+    eks:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+    elasticbeanstalk:
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        deployment.environment:
+          enabled: true
+        service.instance.id:
+          enabled: true
+        service.version:
+          enabled: true
+    endpoint: ""
+    gcp:
+      resource_attributes:
+        cloud.account.id:
+          enabled: true
+        cloud.availability_zone:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        faas.id:
+          enabled: true
+        faas.instance:
+          enabled: true
+        faas.name:
+          enabled: true
+        faas.version:
+          enabled: true
+        gcp.cloud_run.job.execution:
+          enabled: true
+        gcp.cloud_run.job.task_index:
+          enabled: true
+        gcp.gce.instance.hostname:
+          enabled: false
+        gcp.gce.instance.name:
+          enabled: false
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+        host.type:
+          enabled: true
+        k8s.cluster.name:
+          enabled: true
+    heroku:
+      resource_attributes:
+        cloud.provider:
+          enabled: true
+        heroku.app.id:
+          enabled: true
+        heroku.dyno.id:
+          enabled: true
+        heroku.release.commit:
+          enabled: true
+        heroku.release.creation_timestamp:
+          enabled: true
+        service.instance.id:
+          enabled: true
+        service.name:
+          enabled: true
+        service.version:
+          enabled: true
+    idle_conn_timeout: 1m30s
+    k8snode:
+      auth_type: serviceAccount
+      context: ""
+      node_from_env_var: ""
+      resource_attributes:
+        k8s.node.name:
+          enabled: true
+        k8s.node.uid:
+          enabled: true
+    lambda:
+      resource_attributes:
+        aws.log.group.names:
+          enabled: true
+        aws.log.stream.names:
+          enabled: true
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        faas.instance:
+          enabled: true
+        faas.max_memory:
+          enabled: true
+        faas.name:
+          enabled: true
+        faas.version:
+          enabled: true
+    max_idle_conns: 100
+    openshift:
+      address: ""
+      resource_attributes:
+        cloud.platform:
+          enabled: true
+        cloud.provider:
+          enabled: true
+        cloud.region:
+          enabled: true
+        k8s.cluster.name:
+          enabled: true
+      token: ""
+    override: true
+    read_buffer_size: 0
+    system:
+      resource_attributes:
+        host.arch:
+          enabled: false
+        host.cpu.cache.l2.size:
+          enabled: false
+        host.cpu.family:
+          enabled: false
+        host.cpu.model.id:
+          enabled: false
+        host.cpu.model.name:
+          enabled: false
+        host.cpu.stepping:
+          enabled: false
+        host.cpu.vendor.id:
+          enabled: false
+        host.id:
+          enabled: false
+        host.name:
+          enabled: true
+        os.description:
+          enabled: false
+        os.type:
+          enabled: true
+    timeout: 2s
+    write_buffer_size: 0
+receivers:
+  otlp/application_signals:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4315
+        include_metadata: false
+        max_concurrent_streams: 0
+        max_recv_msg_size_mib: 0
+        read_buffer_size: 524288
+        transport: tcp
+        write_buffer_size: 0
+      http:
+        endpoint: 0.0.0.0:4316
+        include_metadata: false
+        logs_url_path: /v1/logs
+        max_request_body_size: 0
+        metrics_url_path: /v1/metrics
+        traces_url_path: /v1/traces
+service:
+  extensions:
+    - awsproxy/application_signals
+    - agenthealth/traces
+    - agenthealth/logs
+  pipelines:
+    metrics/application_signals:
+      exporters:
+        - awsemf/application_signals
+      processors:
+        - resourcedetection
+        - awsapplicationsignals
+      receivers:
+        - otlp/application_signals
+    traces/application_signals:
+      exporters:
+        - awsxray/application_signals
+      processors:
+        - resourcedetection
+        - awsapplicationsignals
+      receivers:
+        - otlp/application_signals
+  telemetry:
+    logs:
+      development: false
+      disable_caller: false
+      disable_stacktrace: false
+      encoding: console
+      level: info
+      output_paths:
+        - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+      sampling:
+        enabled: true
+        initial: 2
+        thereafter: 500
+        tick: 10s
+    metrics:
+      address: ""
+      level: None
+    traces: {}

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -81,6 +81,17 @@ func TestGenericAppSignalsConfig(t *testing.T) {
 	checkTranslation(t, "base_appsignals_config", "windows", expectedEnvVars, "")
 }
 
+func TestGenericAppSignalsFallbackConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetRunInContainer(false)
+	context.CurrentContext().SetMode(config.ModeOnPremise)
+	t.Setenv(config.HOST_NAME, "host_name_from_env")
+	t.Setenv(config.HOST_IP, "127.0.0.1")
+	expectedEnvVars := map[string]string{}
+	checkTranslation(t, "base_appsignals_fallback_config", "linux", expectedEnvVars, "")
+	checkTranslation(t, "base_appsignals_fallback_config", "windows", expectedEnvVars, "")
+}
+
 func TestAppSignalsAndEKSConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(true)
@@ -94,6 +105,36 @@ func TestAppSignalsAndEKSConfig(t *testing.T) {
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "appsignals_and_eks_config", "linux", expectedEnvVars, "")
 	checkTranslation(t, "appsignals_and_eks_config", "windows", expectedEnvVars, "")
+}
+
+func TestAppSignalsFallbackAndEKSConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetRunInContainer(true)
+	t.Setenv(config.HOST_NAME, "host_name_from_env")
+	t.Setenv(config.HOST_IP, "127.0.0.1")
+	t.Setenv(common.KubernetesEnvVar, "use_appsignals_eks_config")
+	eksdetector.NewDetector = eksdetector.TestEKSDetector
+	context.CurrentContext().SetMode(config.ModeEC2)
+	context.CurrentContext().SetKubernetesMode(config.ModeEKS)
+
+	expectedEnvVars := map[string]string{}
+	checkTranslation(t, "appsignals_fallback_and_eks_config", "linux", expectedEnvVars, "")
+	checkTranslation(t, "appsignals_fallback_and_eks_config", "windows", expectedEnvVars, "")
+}
+
+func TestAppSignalsFavorOverFallbackConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetRunInContainer(true)
+	t.Setenv(config.HOST_NAME, "host_name_from_env")
+	t.Setenv(config.HOST_IP, "127.0.0.1")
+	t.Setenv(common.KubernetesEnvVar, "use_appsignals_eks_config")
+	eksdetector.NewDetector = eksdetector.TestEKSDetector
+	context.CurrentContext().SetMode(config.ModeEC2)
+	context.CurrentContext().SetKubernetesMode(config.ModeEKS)
+
+	expectedEnvVars := map[string]string{}
+	checkTranslation(t, "appsignals_over_fallback_config", "linux", expectedEnvVars, "")
+	checkTranslation(t, "appsignals_over_fallback_config", "windows", expectedEnvVars, "")
 }
 
 func TestAppSignalsAndNativeKubernetesConfig(t *testing.T) {

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -64,17 +64,20 @@ const (
 	PipelineNameHost             = "host"
 	PipelineNameHostDeltaMetrics = "hostDeltaMetrics"
 	PipelineNameEmfLogs          = "emf_logs"
-	AppSignals                   = "app_signals"
+	AppSignals                   = "application_signals"
+	AppSignalsFallback           = "app_signals"
 	AppSignalsRules              = "rules"
 )
 
 var (
-	AppSignalsTraces  = ConfigKey(TracesKey, TracesCollectedKey, AppSignals)
-	AppSignalsMetrics = ConfigKey(LogsKey, MetricsCollectedKey, AppSignals)
+	AppSignalsTraces          = ConfigKey(TracesKey, TracesCollectedKey, AppSignals)
+	AppSignalsMetrics         = ConfigKey(LogsKey, MetricsCollectedKey, AppSignals)
+	AppSignalsTracesFallback  = ConfigKey(TracesKey, TracesCollectedKey, AppSignalsFallback)
+	AppSignalsMetricsFallback = ConfigKey(LogsKey, MetricsCollectedKey, AppSignalsFallback)
 
-	AppSignalsConfigKeys = map[component.DataType]string{
-		component.DataTypeTraces:  AppSignalsTraces,
-		component.DataTypeMetrics: AppSignalsMetrics,
+	AppSignalsConfigKeys = map[component.DataType][]string{
+		component.DataTypeTraces:  {AppSignalsTraces, AppSignalsTracesFallback},
+		component.DataTypeMetrics: {AppSignalsMetrics, AppSignalsMetricsFallback},
 	}
 )
 

--- a/translator/translate/otel/exporter/awsemf/translator.go
+++ b/translator/translate/otel/exporter/awsemf/translator.go
@@ -153,7 +153,7 @@ func getAppSignalsConfig() string {
 }
 
 func (t *translator) isAppSignals(conf *confmap.Conf) bool {
-	return t.name == common.AppSignals && (conf.IsSet(common.AppSignalsMetrics) || conf.IsSet(common.AppSignalsTraces))
+	return (t.name == common.AppSignals || t.name == common.AppSignalsFallback) && (conf.IsSet(common.AppSignalsMetrics) || conf.IsSet(common.AppSignalsTraces) || conf.IsSet(common.AppSignalsMetricsFallback) || conf.IsSet(common.AppSignalsTracesFallback))
 }
 
 func isEcs(conf *confmap.Conf) bool {

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -834,7 +834,7 @@ func TestTranslateAppSignals(t *testing.T) {
 			input: map[string]any{
 				"logs": map[string]any{
 					"metrics_collected": map[string]any{
-						"app_signals": map[string]any{},
+						"application_signals": map[string]any{},
 					},
 				}},
 			want: testutil.GetConfWithOverrides(t, filepath.Join("appsignals_config_eks.yaml"), map[string]any{
@@ -850,7 +850,7 @@ func TestTranslateAppSignals(t *testing.T) {
 			input: map[string]any{
 				"logs": map[string]any{
 					"metrics_collected": map[string]any{
-						"app_signals": map[string]any{},
+						"application_signals": map[string]any{},
 					},
 				}},
 			want: testutil.GetConfWithOverrides(t, filepath.Join("appsignals_config_k8s.yaml"), map[string]any{
@@ -866,7 +866,7 @@ func TestTranslateAppSignals(t *testing.T) {
 			input: map[string]any{
 				"logs": map[string]any{
 					"metrics_collected": map[string]any{
-						"app_signals": map[string]any{},
+						"application_signals": map[string]any{},
 					},
 				}},
 			want: testutil.GetConfWithOverrides(t, filepath.Join("appsignals_config_generic.yaml"), map[string]any{
@@ -879,6 +879,70 @@ func TestTranslateAppSignals(t *testing.T) {
 			mode:           config.ModeOnPrem,
 		},
 		"WithAppSignalsEnabledEC2": {
+			input: map[string]any{
+				"logs": map[string]any{
+					"metrics_collected": map[string]any{
+						"application_signals": map[string]any{},
+					},
+				}},
+			want: testutil.GetConfWithOverrides(t, filepath.Join("appsignals_config_generic.yaml"), map[string]any{
+				"local_mode":            "false",
+				"region":                "us-east-1",
+				"role_arn":              "global_arn",
+				"certificate_file_path": "/ca/bundle",
+			}),
+			kubernetesMode: "",
+			mode:           config.ModeEC2,
+		},
+		"WithAppSignalsFallbackEnabledEKS": {
+			input: map[string]any{
+				"logs": map[string]any{
+					"metrics_collected": map[string]any{
+						"app_signals": map[string]any{},
+					},
+				}},
+			want: testutil.GetConfWithOverrides(t, filepath.Join("appsignals_config_eks.yaml"), map[string]any{
+				"local_mode":            "false",
+				"region":                "us-east-1",
+				"role_arn":              "global_arn",
+				"certificate_file_path": "/ca/bundle",
+			}),
+			kubernetesMode: config.ModeEKS,
+			mode:           config.ModeEC2,
+		},
+		"WithAppSignalsFallbackEnabledK8s": {
+			input: map[string]any{
+				"logs": map[string]any{
+					"metrics_collected": map[string]any{
+						"app_signals": map[string]any{},
+					},
+				}},
+			want: testutil.GetConfWithOverrides(t, filepath.Join("appsignals_config_k8s.yaml"), map[string]any{
+				"local_mode":            "true",
+				"region":                "us-east-1",
+				"role_arn":              "global_arn",
+				"certificate_file_path": "/ca/bundle",
+			}),
+			kubernetesMode: config.ModeK8sOnPrem,
+			mode:           config.ModeOnPrem,
+		},
+		"WithAppSignalsFallbackEnabledGeneric": {
+			input: map[string]any{
+				"logs": map[string]any{
+					"metrics_collected": map[string]any{
+						"app_signals": map[string]any{},
+					},
+				}},
+			want: testutil.GetConfWithOverrides(t, filepath.Join("appsignals_config_generic.yaml"), map[string]any{
+				"local_mode":            "true",
+				"region":                "us-east-1",
+				"role_arn":              "global_arn",
+				"certificate_file_path": "/ca/bundle",
+			}),
+			kubernetesMode: "",
+			mode:           config.ModeOnPrem,
+		},
+		"WithAppSignalsFallbackEnabledEC2": {
 			input: map[string]any{
 				"logs": map[string]any{
 					"metrics_collected": map[string]any{

--- a/translator/translate/otel/exporter/awsxray/translator.go
+++ b/translator/translate/otel/exporter/awsxray/translator.go
@@ -153,5 +153,5 @@ func getRegion(conf *confmap.Conf) string {
 }
 
 func isAppSignals(conf *confmap.Conf) bool {
-	return conf.IsSet(common.AppSignalsTraces)
+	return conf.IsSet(common.AppSignalsTraces) || conf.IsSet(common.AppSignalsTracesFallback)
 }

--- a/translator/translate/otel/pipeline/appsignals/translator.go
+++ b/translator/translate/otel/pipeline/appsignals/translator.go
@@ -40,8 +40,8 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 	if !ok {
 		return nil, fmt.Errorf("no config key defined for data type: %s", t.dataType)
 	}
-	if conf == nil || !conf.IsSet(configKey) {
-		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: configKey}
+	if conf == nil || (!conf.IsSet(configKey[0]) && !conf.IsSet(configKey[1])) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: configKey[0]}
 	}
 
 	translators := &common.ComponentTranslators{

--- a/translator/translate/otel/pipeline/appsignals/translator_test.go
+++ b/translator/translate/otel/pipeline/appsignals/translator_test.go
@@ -27,7 +27,7 @@ func TestTranslatorTraces(t *testing.T) {
 		extensions []string
 	}
 	tt := NewTranslator(component.DataTypeTraces)
-	assert.EqualValues(t, "traces/app_signals", tt.ID().String())
+	assert.EqualValues(t, "traces/application_signals", tt.ID().String())
 	testCases := map[string]struct {
 		input      map[string]interface{}
 		want       *want
@@ -48,10 +48,10 @@ func TestTranslatorTraces(t *testing.T) {
 				},
 			},
 			want: &want{
-				receivers:  []string{"otlp/app_signals"},
-				processors: []string{"resourcedetection", "awsappsignals"},
-				exporters:  []string{"awsxray/app_signals"},
-				extensions: []string{"awsproxy/app_signals", "agenthealth/traces"},
+				receivers:  []string{"otlp/application_signals"},
+				processors: []string{"resourcedetection", "awsapplicationsignals"},
+				exporters:  []string{"awsxray/application_signals"},
+				extensions: []string{"awsproxy/application_signals", "agenthealth/traces"},
 			},
 			detector:   eksdetector.TestEKSDetector,
 			isEKSCache: eksdetector.TestIsEKSCacheEKS,
@@ -65,10 +65,10 @@ func TestTranslatorTraces(t *testing.T) {
 				},
 			},
 			want: &want{
-				receivers:  []string{"otlp/app_signals"},
-				processors: []string{"resourcedetection", "awsappsignals"},
-				exporters:  []string{"awsxray/app_signals"},
-				extensions: []string{"awsproxy/app_signals", "agenthealth/traces"},
+				receivers:  []string{"otlp/application_signals"},
+				processors: []string{"resourcedetection", "awsapplicationsignals"},
+				exporters:  []string{"awsxray/application_signals"},
+				extensions: []string{"awsproxy/application_signals", "agenthealth/traces"},
 			},
 			detector:   eksdetector.TestK8sDetector,
 			isEKSCache: eksdetector.TestIsEKSCacheK8s,
@@ -103,7 +103,7 @@ func TestTranslatorMetricsForKubernetes(t *testing.T) {
 		extensions []string
 	}
 	tt := NewTranslator(component.DataTypeMetrics)
-	assert.EqualValues(t, "metrics/app_signals", tt.ID().String())
+	assert.EqualValues(t, "metrics/application_signals", tt.ID().String())
 	testCases := map[string]struct {
 		input      map[string]interface{}
 		want       *want
@@ -124,9 +124,9 @@ func TestTranslatorMetricsForKubernetes(t *testing.T) {
 				},
 			},
 			want: &want{
-				receivers:  []string{"otlp/app_signals"},
-				processors: []string{"resourcedetection", "awsappsignals"},
-				exporters:  []string{"awsemf/app_signals"},
+				receivers:  []string{"otlp/application_signals"},
+				processors: []string{"resourcedetection", "awsapplicationsignals"},
+				exporters:  []string{"awsemf/application_signals"},
 				extensions: []string{"agenthealth/logs"},
 			},
 			detector:   eksdetector.TestEKSDetector,
@@ -141,9 +141,9 @@ func TestTranslatorMetricsForKubernetes(t *testing.T) {
 				},
 			},
 			want: &want{
-				receivers:  []string{"otlp/app_signals"},
-				processors: []string{"resourcedetection", "awsappsignals"},
-				exporters:  []string{"awsemf/app_signals"},
+				receivers:  []string{"otlp/application_signals"},
+				processors: []string{"resourcedetection", "awsapplicationsignals"},
+				exporters:  []string{"awsemf/application_signals"},
 				extensions: []string{"agenthealth/logs"},
 			},
 			detector:   eksdetector.TestK8sDetector,
@@ -178,7 +178,7 @@ func TestTranslatorMetricsForEC2(t *testing.T) {
 		extensions []string
 	}
 	tt := NewTranslator(component.DataTypeMetrics)
-	assert.EqualValues(t, "metrics/app_signals", tt.ID().String())
+	assert.EqualValues(t, "metrics/application_signals", tt.ID().String())
 	testCases := map[string]struct {
 		input      map[string]interface{}
 		want       *want
@@ -199,9 +199,9 @@ func TestTranslatorMetricsForEC2(t *testing.T) {
 				},
 			},
 			want: &want{
-				receivers:  []string{"otlp/app_signals"},
-				processors: []string{"resourcedetection", "awsappsignals"},
-				exporters:  []string{"awsemf/app_signals"},
+				receivers:  []string{"otlp/application_signals"},
+				processors: []string{"resourcedetection", "awsapplicationsignals"},
+				exporters:  []string{"awsemf/application_signals"},
 				extensions: []string{"agenthealth/logs"},
 			},
 			detector:   eksdetector.TestEKSDetector,

--- a/translator/translate/otel/processor/awsappsignals/translator_test.go
+++ b/translator/translate/otel/processor/awsappsignals/translator_test.go
@@ -60,7 +60,7 @@ func TestTranslate(t *testing.T) {
 			input: map[string]interface{}{
 				"logs": map[string]interface{}{
 					"metrics_collected": map[string]interface{}{
-						"app_signals": map[string]interface{}{
+						"application_signals": map[string]interface{}{
 							"hosted_in": "test",
 						},
 					},
@@ -81,7 +81,7 @@ func TestTranslate(t *testing.T) {
 			input: map[string]interface{}{
 				"logs": map[string]interface{}{
 					"metrics_collected": map[string]interface{}{
-						"app_signals": map[string]interface{}{
+						"application_signals": map[string]interface{}{
 							"hosted_in": "test",
 						},
 					},
@@ -95,7 +95,7 @@ func TestTranslate(t *testing.T) {
 			input: map[string]interface{}{
 				"logs": map[string]interface{}{
 					"metrics_collected": map[string]interface{}{
-						"app_signals": map[string]interface{}{},
+						"application_signals": map[string]interface{}{},
 					},
 				}},
 			want:         validAppSignalsYamlGeneric,
@@ -114,6 +114,57 @@ func TestTranslate(t *testing.T) {
 			mode:    translatorConfig.ModeOnPrem,
 		},
 		"WithAppSignalsEnabledEC2": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"application_signals": map[string]interface{}{
+							"hosted_in": "",
+						},
+					},
+				}},
+			want: validAppSignalsYamlEC2,
+			mode: translatorConfig.ModeEC2,
+		},
+		"WithAppSignalsFallbackEnabledK8S": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"app_signals": map[string]interface{}{
+							"hosted_in": "test",
+						},
+					},
+				}},
+			want:           validAppSignalsYamlK8s,
+			isKubernetes:   true,
+			kubernetesMode: translatorConfig.ModeK8sEC2,
+			mode:           translatorConfig.ModeEC2,
+		},
+		"WithAppSignalsFallbackEnabledGeneric": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"app_signals": map[string]interface{}{},
+					},
+				}},
+			want:         validAppSignalsYamlGeneric,
+			isKubernetes: false,
+			mode:         translatorConfig.ModeOnPrem,
+		},
+		"WithAppSignalsFallbackEnabledEKS": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"app_signals": map[string]interface{}{
+							"hosted_in": "test",
+						},
+					},
+				}},
+			want:           validAppSignalsYamlEKS,
+			isKubernetes:   true,
+			kubernetesMode: translatorConfig.ModeEKS,
+			mode:           translatorConfig.ModeEC2,
+		},
+		"WithAppSignalsFallbackEnabledEC2": {
 			input: map[string]interface{}{
 				"logs": map[string]interface{}{
 					"metrics_collected": map[string]interface{}{

--- a/translator/translate/otel/receiver/otlp/translator.go
+++ b/translator/translate/otel/receiver/otlp/translator.go
@@ -97,6 +97,9 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg.HTTP.Endpoint = defaultHttpEndpoint
 	if t.name == common.AppSignals {
 		configKey = common.ConfigKey(configKeys[t.dataType], common.AppSignals)
+		if conf == nil || !conf.IsSet(configKey) {
+			configKey = common.ConfigKey(configBase, common.AppSignalsFallback)
+		}
 		cfg.GRPC.NetAddr.Endpoint = defaultAppSignalsGrpcEndpoint
 		cfg.HTTP.Endpoint = defaultAppSignalsHttpEndpoint
 	}

--- a/translator/translate/otel/receiver/otlp/translator_test.go
+++ b/translator/translate/otel/receiver/otlp/translator_test.go
@@ -105,7 +105,7 @@ func TestTranslateAppSignals(t *testing.T) {
 			input: map[string]interface{}{
 				"traces": map[string]interface{}{
 					"traces_collected": map[string]interface{}{
-						"app_signals": map[string]interface{}{},
+						"application_signals": map[string]interface{}{},
 					},
 				}},
 			want: confmap.NewFromStringMap(map[string]interface{}{
@@ -120,6 +120,55 @@ func TestTranslateAppSignals(t *testing.T) {
 			}),
 		},
 		"WithAppSignalsEnabledTracesWithTLS": {
+			input: map[string]interface{}{
+				"traces": map[string]interface{}{
+					"traces_collected": map[string]interface{}{
+						"application_signals": map[string]interface{}{
+							"tls": map[string]interface{}{
+								"cert_file": "path/to/cert.crt",
+								"key_file":  "path/to/key.key",
+							},
+						},
+					},
+				}},
+			want: confmap.NewFromStringMap(map[string]interface{}{
+				"protocols": map[string]interface{}{
+					"grpc": map[string]interface{}{
+						"endpoint": "0.0.0.0:4315",
+						"tls": map[string]interface{}{
+							"cert_file": "path/to/cert.crt",
+							"key_file":  "path/to/key.key",
+						},
+					},
+					"http": map[string]interface{}{
+						"endpoint": "0.0.0.0:4316",
+						"tls": map[string]interface{}{
+							"cert_file": "path/to/cert.crt",
+							"key_file":  "path/to/key.key",
+						},
+					},
+				},
+			}),
+		},
+		"WithAppSignalsFallbackEnabledTraces": {
+			input: map[string]interface{}{
+				"traces": map[string]interface{}{
+					"traces_collected": map[string]interface{}{
+						"app_signals": map[string]interface{}{},
+					},
+				}},
+			want: confmap.NewFromStringMap(map[string]interface{}{
+				"protocols": map[string]interface{}{
+					"grpc": map[string]interface{}{
+						"endpoint": "0.0.0.0:4315",
+					},
+					"http": map[string]interface{}{
+						"endpoint": "0.0.0.0:4316",
+					},
+				},
+			}),
+		},
+		"WithAppSignalsFallbackEnabledTracesWithTLS": {
 			input: map[string]interface{}{
 				"traces": map[string]interface{}{
 					"traces_collected": map[string]interface{}{

--- a/translator/translate/otel/translate_otel_test.go
+++ b/translator/translate/otel/translate_otel_test.go
@@ -53,7 +53,7 @@ func TestTranslator(t *testing.T) {
 			input: map[string]interface{}{
 				"logs": map[string]interface{}{
 					"metrics_collected": map[string]interface{}{
-						"app_signals": map[string]interface{}{},
+						"application_signals": map[string]interface{}{},
 					},
 				},
 			},
@@ -64,7 +64,7 @@ func TestTranslator(t *testing.T) {
 			input: map[string]interface{}{
 				"traces": map[string]interface{}{
 					"traces_collected": map[string]interface{}{
-						"app_signals": map[string]interface{}{},
+						"application_signals": map[string]interface{}{},
 					},
 				},
 			},
@@ -72,6 +72,63 @@ func TestTranslator(t *testing.T) {
 			isEKSDataStore: eksdetector.TestIsEKSCacheEKS,
 		},
 		"WithAppSignalsMetricsAndTracesEnabled": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"application_signals": map[string]interface{}{},
+					},
+				},
+				"traces": map[string]interface{}{
+					"traces_collected": map[string]interface{}{
+						"application_signals": map[string]interface{}{},
+					},
+				},
+			},
+			detector:       eksdetector.TestEKSDetector,
+			isEKSDataStore: eksdetector.TestIsEKSCacheEKS,
+		},
+		"WithAppSignalsMultipleMetricsReceiversConfig": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"application_signals": map[string]interface{}{},
+						"cpu":                 map[string]interface{}{},
+					},
+				},
+				"traces": map[string]interface{}{
+					"traces_collected": map[string]interface{}{
+						"application_signals": map[string]interface{}{},
+						"otlp":                map[string]interface{}{},
+						"otlp2":               map[string]interface{}{},
+					},
+				},
+			},
+			detector:       eksdetector.TestEKSDetector,
+			isEKSDataStore: eksdetector.TestIsEKSCacheEKS,
+		},
+		"WithAppSignalsFallbackMetricsEnabled": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"app_signals": map[string]interface{}{},
+					},
+				},
+			},
+			detector:       eksdetector.TestEKSDetector,
+			isEKSDataStore: eksdetector.TestIsEKSCacheEKS,
+		},
+		"WithAppSignalsFallbackTracesEnabled": {
+			input: map[string]interface{}{
+				"traces": map[string]interface{}{
+					"traces_collected": map[string]interface{}{
+						"app_signals": map[string]interface{}{},
+					},
+				},
+			},
+			detector:       eksdetector.TestEKSDetector,
+			isEKSDataStore: eksdetector.TestIsEKSCacheEKS,
+		},
+		"WithAppSignalsFallbackMetricsAndTracesEnabled": {
 			input: map[string]interface{}{
 				"logs": map[string]interface{}{
 					"metrics_collected": map[string]interface{}{
@@ -87,7 +144,7 @@ func TestTranslator(t *testing.T) {
 			detector:       eksdetector.TestEKSDetector,
 			isEKSDataStore: eksdetector.TestIsEKSCacheEKS,
 		},
-		"WithAppSignalsMultipleMetricsReceiversConfig": {
+		"WithAppSignalsFallbackMultipleMetricsReceiversConfig": {
 			input: map[string]interface{}{
 				"logs": map[string]interface{}{
 					"metrics_collected": map[string]interface{}{


### PR DESCRIPTION
# Description of the issue
Change configuration to application_signals from app_signals

# Description of changes
Change configuration to application_signals from app_signals


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests and starting the operator 
https://github.com/aws/amazon-cloudwatch-agent-operator/pull/144/files
<img width="1728" alt="Screenshot 2024-04-08 at 12 43 17 PM" src="https://github.com/aws/amazon-cloudwatch-agent/assets/81644108/cba0819a-9741-4d82-b430-4a0d4f109da7">


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




