### PR TITLE
fix 'date: illegal time format' error that occurs when the status command is executed on MacOS.

### DIFF
--- a/packaging/darwin/amazon-cloudwatch-agent-ctl
+++ b/packaging/darwin/amazon-cloudwatch-agent-ctl
@@ -123,7 +123,7 @@ cwa_status() {
      local pid=$(cwa_pid)
      if [[ $pid =~ ^[\-0-9]+$ ]] && [ "$pid" -gt 0 ]; then
           starttime="$(TZ=UTC LC_ALL=C ps -o lstart= "${pid}")"
-          starttime_fmt="$(TZ=UTC date -jf "%a %b %d %T %Y " "${starttime}" +%FT%T%z)"
+          starttime_fmt="$(TZ=UTC LC_ALL=C date -jf "%a %b %d %T %Y " "${starttime}" +%FT%T%z)"
      else
           echo ${pid}
      fi


### PR DESCRIPTION
# Description of the issue

When the amazon-cloudwatch-agent-ctl status command is executed on MacOS (x86-64) with the ja_JP locale set, it results in a 'date: illegal time format' error.

```
% locale
LANG="ja_JP.UTF-8"
LC_COLLATE="ja_JP.UTF-8"
LC_CTYPE="ja_JP.UTF-8"
LC_MESSAGES="ja_JP.UTF-8"
LC_MONETARY="ja_JP.UTF-8"
LC_NUMERIC="ja_JP.UTF-8"
LC_TIME="ja_JP.UTF-8"
LC_ALL=
% 
% ./packaging/darwin/amazon-cloudwatch-agent-ctl -a status
Failed conversion of ``Wed Apr 24 12:49:52 2024    '' using format ``%a %b %d %T %Y ''
date: illegal time format
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
```

# Description of changes

Call `date` with LC_ALL=C

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

```
% locale
LANG="ja_JP.UTF-8"
LC_COLLATE="ja_JP.UTF-8"
LC_CTYPE="ja_JP.UTF-8"
LC_MESSAGES="ja_JP.UTF-8"
LC_MONETARY="ja_JP.UTF-8"
LC_NUMERIC="ja_JP.UTF-8"
LC_TIME="ja_JP.UTF-8"
LC_ALL=
%
% ./packaging/darwin/amazon-cloudwatch-agent-ctl -a status
{
  "status": "running",
  "starttime": "2024-04-24T12:49:52+0000",
  "configstatus": "configured",
  "version": "1.300035.0b547"
}
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




