### PR TITLE
Remove telemetry.sdk.* Resource Attributes From JMX Metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.89.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.89.0

--- a/go.sum
+++ b/go.sum
@@ -954,6 +954,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterproces
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.89.0/go.mod h1:rv4vyVGE+UheFtYDPrCfQd7LakG6SkGFvINfOkSRVrI=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.89.0 h1:JimsaOmtYrYOAA35JzkqnkDFGZi9D50GfaHVG5W7iUQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.89.0/go.mod h1:dMuzeobFNwvW7TgxHVVF1UH2HMK4jcU1JxzGdv+WZVk=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.89.0 h1:i5U2YimHGoSP2QtNiqyuKi1mJkWUy4DVVOKcyt8MPHo=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.89.0/go.mod h1:aXDTHdr5yPHRoEh9lbGrPSngOEHQCUnyaTtsdvuIsHg=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.89.0 h1:aX/JOO9uRSuu1QXOw6pgKoofobxkFqz0nkevwctbkFU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.89.0/go.mod h1:AUxeyAuaT9fxbjMmCzZkbEJsxmdKo1Fe7BhWwfbzRq8=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.89.0 h1:D6kSn1hw5DMfQVspWSYmofWks1RP0wci9VJbLTckwdQ=

--- a/service/defaultcomponents/components.go
+++ b/service/defaultcomponents/components.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
@@ -56,6 +57,7 @@ func Factories() (otelcol.Factories, error) {
 		filterprocessor.NewFactory(),
 		ec2tagger.NewFactory(),
 		metricstransformprocessor.NewFactory(),
+		resourceprocessor.NewFactory(),
 		resourcedetectionprocessor.NewFactory(),
 		transformprocessor.NewFactory(),
 		gpuattributes.NewFactory(),

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -137,6 +137,14 @@ processors:
                     - tomcat\..*
         spans: {}
         traces: {}
+    resource/jmx:
+        attributes:
+            - action: delete
+              key: ""
+              converted_type: ""
+              from_attribute: ""
+              from_context: ""
+              pattern: "telemetry.sdk.*"
     transform:
         error_mode: propagate
         log_statements: []
@@ -332,6 +340,7 @@ service:
             exporters:
                 - awscloudwatch
             processors:
+                - resource/jmx
                 - filter/jmx/0
                 - ec2tagger
             receivers:
@@ -340,6 +349,7 @@ service:
             exporters:
                 - awscloudwatch
             processors:
+                - resource/jmx
                 - ec2tagger
             receivers:
                 - jmx/1

--- a/translator/translate/otel/processor/jmxresourceattributeprocessor/translator.go
+++ b/translator/translate/otel/processor/jmxresourceattributeprocessor/translator.go
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package jmxresourceattributeprocessor
+
+import (
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+var (
+	jmxKey = common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.JmxKey)
+)
+
+type translator struct {
+	name    string
+	factory processor.Factory
+}
+
+var _ common.Translator[component.Config] = (*translator)(nil)
+
+func NewTranslator() common.Translator[component.Config] {
+	return NewTranslatorWithName(common.PipelineNameJmx)
+}
+
+func NewTranslatorWithName(name string) common.Translator[component.Config] {
+	t := &translator{name: name, factory: resourceprocessor.NewFactory()}
+	return t
+}
+
+var _ common.Translator[component.Config] = (*translator)(nil)
+
+func (t *translator) ID() component.ID {
+	return component.NewIDWithName(t.factory.Type(), t.name)
+}
+
+// Translate creates a processor config based on the fields in the
+// Metrics section of the JSON config.
+func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
+	if conf == nil || !conf.IsSet(jmxKey) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: jmxKey}
+	}
+
+	cfg := t.factory.CreateDefaultConfig().(*resourceprocessor.Config)
+
+	c := confmap.NewFromStringMap(map[string]interface{}{
+		"attributes": []interface{}{
+			map[string]interface{}{
+				"action":  "delete",
+				"pattern": "telemetry.sdk.*",
+			},
+		},
+	})
+
+	if err := c.Unmarshal(&cfg); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal jmx processor: %w", err)
+	}
+
+	return cfg, nil
+}


### PR DESCRIPTION
# Description of the issue
telemetry.sdk.version and telemetry.sdk.name dimensions are not needed for jmx metrics

# Description of changes
Remove them from resource attributes in collector

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
<img width="1728" alt="Screenshot 2024-05-01 at 3 41 03 PM" src="https://github.com/aws/amazon-cloudwatch-agent/assets/81644108/943a7d39-1fe9-4c84-b071-a6348d45f806">



# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




