### PR TITLE
[GA] Autofill ECS cluster info if it's missing

### DIFF
--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
 
 	attr "github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals/internal/attributes"
@@ -138,14 +138,14 @@ func Test_attributesNormalizer_appendNewAttributes(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
 	completeResourceAttributes := pcommon.NewMap()
-	completeResourceAttributes.PutStr(conventions.AttributeTelemetrySDKName, "opentelemetry")
-	completeResourceAttributes.PutStr(conventions.AttributeTelemetryAutoVersion, "0.0.1 auto")
-	completeResourceAttributes.PutStr(conventions.AttributeTelemetrySDKVersion, "0.0.1 test")
-	completeResourceAttributes.PutStr(conventions.AttributeTelemetrySDKLanguage, "go")
+	completeResourceAttributes.PutStr(semconv.AttributeTelemetrySDKName, "opentelemetry")
+	completeResourceAttributes.PutStr(semconv.AttributeTelemetryAutoVersion, "0.0.1 auto")
+	completeResourceAttributes.PutStr(semconv.AttributeTelemetrySDKVersion, "0.0.1 test")
+	completeResourceAttributes.PutStr(semconv.AttributeTelemetrySDKLanguage, "go")
 
 	incompleteResourceAttributes := pcommon.NewMap()
-	incompleteResourceAttributes.PutStr(conventions.AttributeTelemetrySDKName, "opentelemetry")
-	incompleteResourceAttributes.PutStr(conventions.AttributeTelemetrySDKVersion, "0.0.1 test")
+	incompleteResourceAttributes.PutStr(semconv.AttributeTelemetrySDKName, "opentelemetry")
+	incompleteResourceAttributes.PutStr(semconv.AttributeTelemetrySDKVersion, "0.0.1 test")
 
 	tests := []struct {
 		name                   string


### PR DESCRIPTION
# Description of issues
1. OTEL resource detection processor is unable to detect ECS cluster information.
```
2024-05-01T18:23:58Z I! {
    "caller": "internal/resourcedetection.go:139",
    "msg": "detected resource information",
    "kind": "processor",
    "name": "resourcedetection",
    "pipeline": "traces/application_signals",
    "resource": {}
}
```

# Description of changes
1. This PR reads ECS cluster name from CWA if it's not populated from SDK side.
3. This PR completes a TODO after semconv version has bumped to 1.22.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
4. Run `make lint`




