### PR TITLE
[Bugfix] pass mode to resolve amazon-cloudwatch-agent-ctl restart panic

### DIFF
--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -154,7 +154,7 @@ agent_cond_restart() {
      agent_name="${1:-}"
      restart_file="${2:-}"
      if [ -f "${restart_file}" ]; then
-          agent_start "${agent_name}"
+          agent_start "${agent_name}" "${mode}"
           rm -f "${restart_file}"
      fi
 }


### PR DESCRIPTION
# Description of the issue
Some customers who do not have a toml config in the config directory are seeing a panic when running ` /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a cond-restart`

```
[ec2-user@ip-172-31-22-51 ~]$ sudo rm /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
[ec2-user@ip-172-31-22-51 ~]$ sudo touch /opt/aws/amazon-cloudwatch-agent/etc/restart
[ec2-user@ip-172-31-22-51 ~]$ sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a cond-restart
amazon-cloudwatch-agent is not configured. Applying amazon-cloudwatch-agent default configuration.
Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/default.tmp
Start configuration validation...
2024/05/08 17:43:55 Invalid mode --config. Valid mode values are ec2, onPrem, onPremise, and withIRSA.
panic: Invalid mode --config. Valid mode values are ec2, onPrem, onPremise, and withIRSA.

goroutine 1 [running]:
log.Panicf({0x40fbc0e?, 0x8?}, {0xc000bbfc60?, 0xc000bbfc70?, 0xc000b52ba0?})
        log/log.go:439 +0x65
github.com/aws/amazon-cloudwatch-agent/translator/context.(*Context).SetMode(0x7ffff69bd79d?, {0x7ffff69bd79d?, 0xc?})
        github.com/aws/amazon-cloudwatch-agent/translator/context/context.go:136 +0x271
main.initFlags()
        github.com/aws/amazon-cloudwatch-agent/cmd/config-translator/translator.go:66 +0x945
main.main()
        github.com/aws/amazon-cloudwatch-agent/cmd/config-translator/translator.go:80 +0x31
```

# Description of changes
Add ${mode} as a second command arg to `agent_start()`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the command again and saw the command succeeded:

```
[ec2-user@ip-172-31-22-51 ~]$ sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a cond-restart

amazon-cloudwatch-agent is not configured. Applying amazon-cloudwatch-agent default configuration.
I! Trying to detect region from ec2 D! [EC2] Found active network interface I! imds retry client will retry 1 timesSuccessfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/default.tmp
Start configuration validation...
2024/05/08 17:46:06 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/default.tmp ...
2024/05/08 17:46:06 I! Valid Json input schema.
2024/05/08 17:46:06 D! ec2tagger processor required because append_dimensions is set
2024/05/08 17:46:06 D! pipeline hostDeltaMetrics has no receivers
2024/05/08 17:46:06 Configuration validation first phase succeeded
I! Detecting run_as_user...
I! Trying to detect region from ec2
D! [EC2] Found active network interface
I! imds retry client will retry 1 times
/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -schematest -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
Configuration validation second phase succeeded
Configuration validation succeeded
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




