### PR TITLE
Optimize the memory utilization of Kubernetes resolver in Application Signals

### DIFF
--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
@@ -397,6 +397,11 @@ func (m *serviceToWorkloadMapper) Start(stopCh chan struct{}) {
 	}()
 }
 
+// filterPodIPFields removes fields that could contain large objects, and retain essential
+// fields needed for IP/name translation. The following fields must be kept:
+// - ObjectMeta: Namespace, Name, Labels, OwnerReference
+// - Spec: HostNetwork, ContainerPorts
+// - Status: PodIP/s, HostIP/s
 func filterPodIPFields(obj interface{}) (interface{}, error) {
 	if pod, ok := obj.(*corev1.Pod); ok {
 		pod.Annotations = nil
@@ -433,6 +438,10 @@ func filterPodIPFields(obj interface{}) (interface{}, error) {
 	return obj, nil
 }
 
+// filterServiceIPFields removes fields that could contain large objects, and retain essential
+// fields needed for IP/name translation. The following fields must be kept:
+// - ObjectMeta: Namespace, Name
+// - Spec: Selectors, ClusterIP
 func filterServiceIPFields(obj interface{}) (interface{}, error) {
 	if svc, ok := obj.(*corev1.Service); ok {
 		svc.Annotations = nil

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_test.go
@@ -241,8 +241,8 @@ func TestServiceToWorkloadMapper_MapServiceToWorkload(t *testing.T) {
 	serviceAndNamespaceToSelectors.Store("service1@namespace1", mapset.NewSet("label1=value1", "label2=value2"))
 	workloadAndNamespaceToLabels.Store("deployment1@namespace1", mapset.NewSet("label1=value1", "label2=value2", "label3=value3"))
 
-	mapper := NewServiceToWorkloadMapper(serviceAndNamespaceToSelectors, workloadAndNamespaceToLabels, serviceToWorkload, logger, mockDeleter)
-	mapper.MapServiceToWorkload()
+	mapper := newServiceToWorkloadMapper(serviceAndNamespaceToSelectors, workloadAndNamespaceToLabels, serviceToWorkload, logger, mockDeleter)
+	mapper.mapServiceToWorkload()
 
 	if _, ok := serviceToWorkload.Load("service1@namespace1"); !ok {
 		t.Errorf("Expected service1@namespace1 to be mapped to a workload, but it was not")
@@ -261,8 +261,8 @@ func TestServiceToWorkloadMapper_MapServiceToWorkload_NoWorkload(t *testing.T) {
 	serviceAndNamespaceToSelectors.Store(serviceAndNamespace, mapset.NewSet("label1=value1"))
 	serviceToWorkload.Store(serviceAndNamespace, "workload@namespace")
 
-	mapper := NewServiceToWorkloadMapper(serviceAndNamespaceToSelectors, workloadAndNamespaceToLabels, serviceToWorkload, logger, mockDeleter)
-	mapper.MapServiceToWorkload()
+	mapper := newServiceToWorkloadMapper(serviceAndNamespaceToSelectors, workloadAndNamespaceToLabels, serviceToWorkload, logger, mockDeleter)
+	mapper.mapServiceToWorkload()
 
 	// Check that the service was deleted from serviceToWorkload
 	if _, ok := serviceToWorkload.Load(serviceAndNamespace); ok {
@@ -284,8 +284,8 @@ func TestServiceToWorkloadMapper_MapServiceToWorkload_MultipleWorkloads(t *testi
 	workloadAndNamespaceToLabels.Store("workload1@namespace", mapset.NewSet("label1=value1", "label2=value2", "label3=value3"))
 	workloadAndNamespaceToLabels.Store("workload2@namespace", mapset.NewSet("label1=value1", "label2=value2", "label4=value4"))
 
-	mapper := NewServiceToWorkloadMapper(serviceAndNamespaceToSelectors, workloadAndNamespaceToLabels, serviceToWorkload, logger, mockDeleter)
-	mapper.MapServiceToWorkload()
+	mapper := newServiceToWorkloadMapper(serviceAndNamespaceToSelectors, workloadAndNamespaceToLabels, serviceToWorkload, logger, mockDeleter)
+	mapper.mapServiceToWorkload()
 
 	// Check that the service does not map to any workload
 	if _, ok := serviceToWorkload.Load(serviceAndNamespace); ok {
@@ -307,7 +307,7 @@ func TestMapServiceToWorkload_StopsWhenSignaled(t *testing.T) {
 		close(stopchan)
 	})
 
-	mapper := NewServiceToWorkloadMapper(serviceAndNamespaceToSelectors, workloadAndNamespaceToLabels, serviceToWorkload, logger, mockDeleter)
+	mapper := newServiceToWorkloadMapper(serviceAndNamespaceToSelectors, workloadAndNamespaceToLabels, serviceToWorkload, logger, mockDeleter)
 
 	start := time.Now()
 	mapper.Start(stopchan)
@@ -339,7 +339,8 @@ func TestOnAddOrUpdateService(t *testing.T) {
 	serviceAndNamespaceToSelectors := &sync.Map{}
 
 	// Call the function
-	onAddOrUpdateService(service, ipToServiceAndNamespace, serviceAndNamespaceToSelectors)
+	svcWatcher := newServiceWatcherForTesting(ipToServiceAndNamespace, serviceAndNamespaceToSelectors)
+	svcWatcher.onAddOrUpdateService(service)
 
 	// Check that the maps contain the expected entries
 	if _, ok := ipToServiceAndNamespace.Load("1.2.3.4"); !ok {
@@ -372,7 +373,8 @@ func TestOnDeleteService(t *testing.T) {
 	serviceAndNamespaceToSelectors.Store("myservice@mynamespace", mapset.NewSet("app=myapp"))
 
 	// Call the function
-	onDeleteService(service, ipToServiceAndNamespace, serviceAndNamespaceToSelectors, mockDeleter)
+	svcWatcher := newServiceWatcherForTesting(ipToServiceAndNamespace, serviceAndNamespaceToSelectors)
+	svcWatcher.onDeleteService(service, mockDeleter)
 
 	// Check that the maps do not contain the service
 	if _, ok := ipToServiceAndNamespace.Load("1.2.3.4"); ok {
@@ -384,8 +386,6 @@ func TestOnDeleteService(t *testing.T) {
 }
 
 func TestOnAddOrUpdatePod(t *testing.T) {
-	logger, _ := zap.NewProduction()
-
 	t.Run("pod with both PodIP and HostIP", func(t *testing.T) {
 		ipToPod := &sync.Map{}
 		podToWorkloadAndNamespace := &sync.Map{}
@@ -409,7 +409,8 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 			},
 		}
 
-		onAddOrUpdatePod(pod, nil, ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount, true, logger, mockDeleter)
+		poWatcher := newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount)
+		poWatcher.onAddOrUpdatePod(pod, nil, true)
 
 		// Test the mappings in ipToPod
 		if podName, _ := ipToPod.Load("1.2.3.4"); podName != "testPod" {
@@ -461,7 +462,8 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 			},
 		}
 
-		onAddOrUpdatePod(pod, nil, ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount, true, logger, mockDeleter)
+		poWatcher := newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount)
+		poWatcher.onAddOrUpdatePod(pod, nil, true)
 
 		// Test the mappings in ipToPod
 		if podName, _ := ipToPod.Load("5.6.7.8:8080"); podName != "testPod" {
@@ -483,7 +485,6 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 		ipToPod := &sync.Map{}
 		podToWorkloadAndNamespace := &sync.Map{}
 		workloadAndNamespaceToLabels := &sync.Map{}
-		workloadPodCount := map[string]int{}
 
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -516,7 +517,8 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 		}
 
 		// add the pod
-		onAddOrUpdatePod(pod, nil, ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount, true, logger, mockDeleter)
+		poWatcher := newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, map[string]int{})
+		poWatcher.onAddOrUpdatePod(pod, nil, true)
 
 		// Test the mappings in ipToPod
 		if podName, ok := ipToPod.Load("5.6.7.8:8080"); !ok && podName != "testPod" {
@@ -555,7 +557,7 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 		}
 
 		// add the pod
-		onAddOrUpdatePod(pod2, pod, ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount, false, logger, mockDeleter)
+		poWatcher.onAddOrUpdatePod(pod2, pod, false)
 
 		// Test the mappings in ipToPod
 		if _, ok := ipToPod.Load("5.6.7.8:8080"); ok {
@@ -577,8 +579,6 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 }
 
 func TestOnDeletePod(t *testing.T) {
-	logger, _ := zap.NewProduction()
-
 	t.Run("pod with both PodIP and HostIP", func(t *testing.T) {
 		ipToPod := &sync.Map{}
 		podToWorkloadAndNamespace := &sync.Map{}
@@ -609,7 +609,8 @@ func TestOnDeletePod(t *testing.T) {
 		workloadAndNamespaceToLabels.Store("testDeployment@testNamespace", "testLabels")
 		workloadPodCount["testDeployment@testNamespace"] = 1
 
-		onDeletePod(pod, ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount, logger, mockDeleter)
+		poWatcher := newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount)
+		poWatcher.onDeletePod(pod)
 
 		// Test if the entries in ipToPod and podToWorkloadAndNamespace have been deleted
 		if _, ok := ipToPod.Load("1.2.3.4"); ok {
@@ -671,7 +672,8 @@ func TestOnDeletePod(t *testing.T) {
 		workloadAndNamespaceToLabels.Store("testDeployment@testNamespace", "testLabels")
 		workloadPodCount["testDeployment@testNamespace"] = 1
 
-		onDeletePod(pod, ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount, logger, mockDeleter)
+		poWatcher := newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount)
+		poWatcher.onDeletePod(pod)
 
 		// Test if the entries in ipToPod and podToWorkloadAndNamespace have been deleted
 		if _, ok := ipToPod.Load("5.6.7.8:8080"); ok {
@@ -697,7 +699,7 @@ func TestEksResolver(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	ctx := context.Background()
 
-	t.Run("Test GetWorkloadAndNamespaceByIP", func(t *testing.T) {
+	t.Run("Test getWorkloadAndNamespaceByIP", func(t *testing.T) {
 		resolver := &kubernetesResolver{
 			logger:                    logger,
 			clusterName:               "test",
@@ -716,13 +718,13 @@ func TestEksResolver(t *testing.T) {
 		resolver.podToWorkloadAndNamespace.Store(pod, workloadAndNamespace)
 
 		// Test existing IP
-		workload, namespace, err := resolver.GetWorkloadAndNamespaceByIP(ip)
+		workload, namespace, err := resolver.getWorkloadAndNamespaceByIP(ip)
 		if err != nil || workload != "testDeployment" || namespace != "testNamespace" {
 			t.Errorf("Expected testDeployment@testNamespace, got %s@%s, error: %v", workload, namespace, err)
 		}
 
 		// Test non-existing IP
-		_, _, err = resolver.GetWorkloadAndNamespaceByIP("5.6.7.8")
+		_, _, err = resolver.getWorkloadAndNamespaceByIP("5.6.7.8")
 		if err == nil || !strings.Contains(err.Error(), "no kubernetes workload found for ip: 5.6.7.8") {
 			t.Errorf("Expected error, got %v", err)
 		}
@@ -732,7 +734,7 @@ func TestEksResolver(t *testing.T) {
 		serviceAndNamespace := "testService@testNamespace"
 		resolver.ipToServiceAndNamespace.Store(newIP, serviceAndNamespace)
 		resolver.serviceToWorkload.Store(serviceAndNamespace, workloadAndNamespace)
-		workload, namespace, err = resolver.GetWorkloadAndNamespaceByIP(newIP)
+		workload, namespace, err = resolver.getWorkloadAndNamespaceByIP(newIP)
 		if err != nil || workload != "testDeployment" || namespace != "testNamespace" {
 			t.Errorf("Expected testDeployment@testNamespace, got %s@%s, error: %v", workload, namespace, err)
 		}
@@ -812,13 +814,13 @@ func TestEksResolver(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "not-an-ip", getStrAttr(attributes, attr.AWSRemoteService, t))
 
-		// Test case 4: Process with valid IP but GetWorkloadAndNamespaceByIP returns error
+		// Test case 4: Process with valid IP but getWorkloadAndNamespaceByIP returns error
 		attributes = pcommon.NewMap()
 		attributes.PutStr(attr.AWSRemoteService, "192.168.1.2")
 		resourceAttributes = pcommon.NewMap()
 		err = resolver.Process(attributes, resourceAttributes)
 		assert.NoError(t, err)
-		assert.Equal(t, "UnknownRemoteService", getStrAttr(attributes, attr.AWSRemoteService, t))
+		assert.Equal(t, "192.168.1.2", getStrAttr(attributes, attr.AWSRemoteService, t))
 	})
 }
 
@@ -1073,19 +1075,38 @@ func TestExtractIPPort(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestGetHostNetworkPorts(t *testing.T) {
-	// Test Pod with no ports
+func TestFilterPodIPFields(t *testing.T) {
+	meta := metav1.ObjectMeta{
+		Name:      "test",
+		Namespace: "default",
+		Labels: map[string]string{
+			"name": "app",
+		},
+	}
 	pod := &corev1.Pod{
+		ObjectMeta: meta,
 		Spec: corev1.PodSpec{
+			HostNetwork: true,
 			Containers: []corev1.Container{
 				{},
 			},
 		},
+		Status: corev1.PodStatus{},
 	}
-	assert.Empty(t, getHostNetworkPorts(pod))
+	newPod, err := filterPodIPFields(pod)
+	assert.Nil(t, err)
+	assert.Empty(t, getHostNetworkPorts(newPod.(*corev1.Pod)))
 
-	// Test Pod with one port
+	podStatus := corev1.PodStatus{
+		PodIP: "192.168.0.12",
+		HostIPs: []corev1.HostIP{
+			{
+				IP: "132.168.3.12",
+			},
+		},
+	}
 	pod = &corev1.Pod{
+		ObjectMeta: meta,
 		Spec: corev1.PodSpec{
 			HostNetwork: true,
 			Containers: []corev1.Container{
@@ -1096,10 +1117,14 @@ func TestGetHostNetworkPorts(t *testing.T) {
 				},
 			},
 		},
+		Status: podStatus,
 	}
-	assert.Equal(t, []string{"8080"}, getHostNetworkPorts(pod))
+	newPod, err = filterPodIPFields(pod)
+	assert.Nil(t, err)
+	assert.Equal(t, "app", newPod.(*corev1.Pod).Labels["name"])
+	assert.Equal(t, []string{"8080"}, getHostNetworkPorts(newPod.(*corev1.Pod)))
+	assert.Equal(t, podStatus, newPod.(*corev1.Pod).Status)
 
-	// Test Pod with multiple ports
 	pod = &corev1.Pod{
 		Spec: corev1.PodSpec{
 			HostNetwork: true,
@@ -1112,8 +1137,32 @@ func TestGetHostNetworkPorts(t *testing.T) {
 				},
 			},
 		},
+		Status: podStatus,
 	}
-	assert.Equal(t, []string{"8080", "8081"}, getHostNetworkPorts(pod))
+	newPod, err = filterPodIPFields(pod)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"8080", "8081"}, getHostNetworkPorts(newPod.(*corev1.Pod)))
+	assert.Equal(t, podStatus, newPod.(*corev1.Pod).Status)
+}
+
+func TestFilterServiceIPFields(t *testing.T) {
+	meta := metav1.ObjectMeta{
+		Name:      "test",
+		Namespace: "default",
+	}
+	svc := &corev1.Service{
+		ObjectMeta: meta,
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"name": "app",
+			},
+			ClusterIP: "10.0.12.4",
+		},
+	}
+	newSvc, err := filterServiceIPFields(svc)
+	assert.Nil(t, err)
+	assert.Equal(t, "10.0.12.4", newSvc.(*corev1.Service).Spec.ClusterIP)
+	assert.Equal(t, "app", newSvc.(*corev1.Service).Spec.Selector["name"])
 }
 
 func TestHandlePodUpdate(t *testing.T) {
@@ -1323,7 +1372,8 @@ func TestHandlePodUpdate(t *testing.T) {
 			for k, v := range tc.initialIPToPod {
 				ipToPod.Store(k, v)
 			}
-			handlePodUpdate(tc.newPod, tc.oldPod, ipToPod, mockDeleter)
+			poWatcher := newPodWatcherForTesting(ipToPod, nil, nil, map[string]int{})
+			poWatcher.handlePodUpdate(tc.newPod, tc.oldPod)
 
 			// Now validate that ipToPod map has been updated correctly
 			for key, expectedValue := range tc.expectedIPToPod {
@@ -1341,5 +1391,23 @@ func TestHandlePodUpdate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func newServiceWatcherForTesting(ipToServiceAndNamespace, serviceAndNamespaceToSelectors *sync.Map) *serviceWatcher {
+	logger, _ := zap.NewDevelopment()
+	return &serviceWatcher{ipToServiceAndNamespace, serviceAndNamespaceToSelectors, logger, nil, nil}
+}
+
+func newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels *sync.Map, workloadPodCount map[string]int) *podWatcher {
+	logger, _ := zap.NewDevelopment()
+	return &podWatcher{
+		ipToPod:                      ipToPod,
+		podToWorkloadAndNamespace:    podToWorkloadAndNamespace,
+		workloadAndNamespaceToLabels: workloadAndNamespaceToLabels,
+		workloadPodCount:             workloadPodCount,
+		logger:                       logger,
+		informer:                     nil,
+		deleter:                      mockDeleter,
 	}
 }

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_test.go
@@ -410,7 +410,7 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 		}
 
 		poWatcher := newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount)
-		poWatcher.onAddOrUpdatePod(pod, nil, true)
+		poWatcher.onAddOrUpdatePod(pod, nil)
 
 		// Test the mappings in ipToPod
 		if podName, _ := ipToPod.Load("1.2.3.4"); podName != "testPod" {
@@ -463,7 +463,7 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 		}
 
 		poWatcher := newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, workloadPodCount)
-		poWatcher.onAddOrUpdatePod(pod, nil, true)
+		poWatcher.onAddOrUpdatePod(pod, nil)
 
 		// Test the mappings in ipToPod
 		if podName, _ := ipToPod.Load("5.6.7.8:8080"); podName != "testPod" {
@@ -518,7 +518,7 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 
 		// add the pod
 		poWatcher := newPodWatcherForTesting(ipToPod, podToWorkloadAndNamespace, workloadAndNamespaceToLabels, map[string]int{})
-		poWatcher.onAddOrUpdatePod(pod, nil, true)
+		poWatcher.onAddOrUpdatePod(pod, nil)
 
 		// Test the mappings in ipToPod
 		if podName, ok := ipToPod.Load("5.6.7.8:8080"); !ok && podName != "testPod" {
@@ -567,7 +567,7 @@ func TestOnAddOrUpdatePod(t *testing.T) {
 		}
 
 		// add the pod
-		poWatcher.onAddOrUpdatePod(pod2, pod, false)
+		poWatcher.onAddOrUpdatePod(pod2, pod)
 
 		// Test the mappings in ipToPod
 		if podName, ok := ipToPod.Load("5.6.7.8:8080"); !ok && podName != "testPod" {
@@ -1103,7 +1103,7 @@ func TestFilterPodIPFields(t *testing.T) {
 		},
 		Status: corev1.PodStatus{},
 	}
-	newPod, err := filterPodIPFields(pod)
+	newPod, err := minimizePod(pod)
 	assert.Nil(t, err)
 	assert.Empty(t, getHostNetworkPorts(newPod.(*corev1.Pod)))
 
@@ -1129,7 +1129,7 @@ func TestFilterPodIPFields(t *testing.T) {
 		},
 		Status: podStatus,
 	}
-	newPod, err = filterPodIPFields(pod)
+	newPod, err = minimizePod(pod)
 	assert.Nil(t, err)
 	assert.Equal(t, "app", newPod.(*corev1.Pod).Labels["name"])
 	assert.Equal(t, []string{"8080"}, getHostNetworkPorts(newPod.(*corev1.Pod)))
@@ -1149,7 +1149,7 @@ func TestFilterPodIPFields(t *testing.T) {
 		},
 		Status: podStatus,
 	}
-	newPod, err = filterPodIPFields(pod)
+	newPod, err = minimizePod(pod)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"8080", "8081"}, getHostNetworkPorts(newPod.(*corev1.Pod)))
 	assert.Equal(t, podStatus, newPod.(*corev1.Pod).Status)
@@ -1169,7 +1169,7 @@ func TestFilterServiceIPFields(t *testing.T) {
 			ClusterIP: "10.0.12.4",
 		},
 	}
-	newSvc, err := filterServiceIPFields(svc)
+	newSvc, err := minimizeService(svc)
 	assert.Nil(t, err)
 	assert.Equal(t, "10.0.12.4", newSvc.(*corev1.Service).Spec.ClusterIP)
 	assert.Equal(t, "app", newSvc.(*corev1.Service).Spec.Selector["name"])

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_utils.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_utils.go
@@ -136,18 +136,6 @@ func getHostNetworkPorts(pod *corev1.Pod) []string {
 	return ports
 }
 
-func copyHostNetworkPorts(newPod, oldPod *corev1.Pod) {
-	newPod.Spec.HostNetwork = oldPod.Spec.HostNetwork
-	containers := oldPod.Spec.Containers
-	for i := 0; i < len(containers); i++ {
-		c := containers[i]
-		newPod.Spec.Containers = append(newPod.Spec.Containers, corev1.Container{
-			Name:  c.Name,
-			Ports: c.Ports,
-		})
-	}
-}
-
 func isIP(ipString string) bool {
 	ip := net.ParseIP(ipString)
 	return ip != nil

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_utils.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_utils.go
@@ -1,0 +1,154 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package resolver
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// kubeAllowedStringAlphaNums holds the characters allowed in replicaset names from as parent deployment
+	// https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L121
+	kubeAllowedStringAlphaNums = "bcdfghjklmnpqrstvwxz2456789"
+)
+
+var (
+	// ReplicaSet name = Deployment name + "-" + up to 10 alphanumeric characters string, if the ReplicaSet was created through a deployment
+	// The suffix string of the ReplicaSet name is an int32 number (0 to 4,294,967,295) that is cast to a string and then
+	// mapped to an alphanumeric value with only the following characters allowed: "bcdfghjklmnpqrstvwxz2456789".
+	// The suffix string length is therefore nondeterministic. The regex accepts a suffix of length 6-10 to account for
+	// ReplicaSets not managed by deployments that may have similar names.
+	// Suffix Generation: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils.go#L1201
+	// Alphanumeric Mapping: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L121)
+	replicaSetWithDeploymentNamePattern = fmt.Sprintf(`^(.+)-[%s]{6,10}$`, kubeAllowedStringAlphaNums)
+	deploymentFromReplicaSetPattern     = regexp.MustCompile(replicaSetWithDeploymentNamePattern)
+	// if a pod is launched directly by a replicaSet (with a given name by users), its name has the following pattern:
+	// Pod name = ReplicaSet name + 5 alphanumeric characters long string
+	podWithReplicaSetNamePattern = fmt.Sprintf(`^(.+)-[%s]{5}$`, kubeAllowedStringAlphaNums)
+	replicaSetFromPodPattern     = regexp.MustCompile(podWithReplicaSetNamePattern)
+)
+
+func attachNamespace(resourceName, namespace string) string {
+	// character "@" is not allowed in kubernetes resource names: https://unofficial-kubernetes.readthedocs.io/en/latest/concepts/overview/working-with-objects/names/
+	return resourceName + "@" + namespace
+}
+
+func getServiceAndNamespace(service *corev1.Service) string {
+	return attachNamespace(service.Name, service.Namespace)
+}
+
+func extractResourceAndNamespace(serviceOrWorkloadAndNamespace string) (string, string) {
+	// extract service name and namespace from serviceAndNamespace
+	parts := strings.Split(serviceOrWorkloadAndNamespace, "@")
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+func extractWorkloadNameFromRS(replicaSetName string) (string, error) {
+	match := deploymentFromReplicaSetPattern.FindStringSubmatch(replicaSetName)
+	if match != nil {
+		return match[1], nil
+	}
+
+	return "", errors.New("failed to extract workload name from replicatSet name: " + replicaSetName)
+}
+
+func extractWorkloadNameFromPodName(podName string) (string, error) {
+	match := replicaSetFromPodPattern.FindStringSubmatch(podName)
+	if match != nil {
+		return match[1], nil
+	}
+
+	return "", errors.New("failed to extract workload name from pod name: " + podName)
+}
+
+func getWorkloadAndNamespace(pod *corev1.Pod) string {
+	var workloadAndNamespace string
+	if pod.ObjectMeta.OwnerReferences != nil {
+		for _, ownerRef := range pod.ObjectMeta.OwnerReferences {
+			if workloadAndNamespace != "" {
+				break
+			}
+
+			if ownerRef.Kind == "ReplicaSet" {
+				if workloadName, err := extractWorkloadNameFromRS(ownerRef.Name); err == nil {
+					// when the replicaSet is created by a deployment, use deployment name
+					workloadAndNamespace = attachNamespace(workloadName, pod.Namespace)
+				} else if workloadName, err := extractWorkloadNameFromPodName(pod.Name); err == nil {
+					// when the replicaSet is not created by a deployment, use replicaSet name directly
+					workloadAndNamespace = attachNamespace(workloadName, pod.Namespace)
+				}
+			} else if ownerRef.Kind == "StatefulSet" {
+				workloadAndNamespace = attachNamespace(ownerRef.Name, pod.Namespace)
+			} else if ownerRef.Kind == "DaemonSet" {
+				workloadAndNamespace = attachNamespace(ownerRef.Name, pod.Namespace)
+			}
+		}
+	}
+
+	return workloadAndNamespace
+}
+
+const IP_PORT_PATTERN = `^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d+)$`
+
+var ipPortRegex = regexp.MustCompile(IP_PORT_PATTERN)
+
+func extractIPPort(ipPort string) (string, string, bool) {
+	match := ipPortRegex.MatchString(ipPort)
+
+	if !match {
+		return "", "", false
+	}
+
+	result := ipPortRegex.FindStringSubmatch(ipPort)
+	if len(result) != 3 {
+		return "", "", false
+	}
+
+	ip := result[1]
+	port := result[2]
+
+	return ip, port, true
+}
+
+func getHostNetworkPorts(pod *corev1.Pod) []string {
+	var ports []string
+	if !pod.Spec.HostNetwork {
+		return ports
+	}
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.HostPort != 0 {
+				ports = append(ports, strconv.Itoa(int(port.HostPort)))
+			}
+		}
+	}
+	return ports
+}
+
+func copyHostNetworkPorts(newPod, oldPod *corev1.Pod) {
+	newPod.Spec.HostNetwork = oldPod.Spec.HostNetwork
+	containers := oldPod.Spec.Containers
+	for i := 0; i < len(containers); i++ {
+		c := containers[i]
+		newPod.Spec.Containers = append(newPod.Spec.Containers, corev1.Container{
+			Name:  c.Name,
+			Ports: c.Ports,
+		})
+	}
+}
+
+func isIP(ipString string) bool {
+	ip := net.ParseIP(ipString)
+	return ip != nil
+}


### PR DESCRIPTION
# Description of the issue
The memory utilization of CloudWatch Agent is high after enabling Application Signals. In an EKS cluster of ~7k Pods, the memory usage went up to 90% for leader instance, 70% for follower instances.

From heap profiling, it was confirmed that the issue was caused by `applicationsignalsprocessor` which list/watch Pods and Services cluster-wise for IP/Service translation.

# Description of changes
This PR does the following changes to `applicationsignalsprocessor`:
1. Reduce the memory usage of list/watching.
  It is achieved by customizing transformer in informers to empty fields that might contain big objects. By applying the changes, the memory usage went down from 90% to 50% for leader, 70% to 40% for followers.
1. Remove logics of setting RemoteService to UnknownRemoteService due to IP translation failure.
  Forcing low cardinality `RemoteService` is no longer needed as we have metrics limiting in place.
1. Fix bug in Pod IP cache with `hostNetwork` as true.
  In the current implementation, if a Pod is enabled with `hostNetwork`, its IP cache will never be cleared even after the Pod is deleted.
6. Code refactoring Kubernetes resolver.

# Result
## Baseline (w/o Application Signals)
<img width="1489" alt="image (1)" src="https://github.com/aws/amazon-cloudwatch-agent/assets/2612976/a22de1d2-0f1c-4900-bb24-2c42ef0b7b04">

## Before
<img width="1493" alt="image (2)" src="https://github.com/aws/amazon-cloudwatch-agent/assets/2612976/ae11d97d-9931-4729-85c2-066fbcd3320e">

## After
![image](https://github.com/aws/amazon-cloudwatch-agent/assets/2612976/7a24487e-683a-4282-9597-c55b4ee8e6cc)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
8. Run `make lint`




