### PR TITLE
Remove ethtool change from Release Notes for 1.300041.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -8,7 +8,6 @@ Features:
 Enhancements:
 * [ContainerInsights] Add NVIDIA GPU count metrics
 * [Application Signals] Enable detailed logging for metrics/traces when debug is enabled
-* [Metrics/Ethtool] Support append dimensions
 
 Bug fixes:
 * [Logs/Windows Event] Fix load state offset parsing to support unsigned int


### PR DESCRIPTION
# Description of the issue
To keep in line with other releases of this version.

# Description of changes
Removes ethtool change from release notes.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




