### PR TITLE
Update macos version in GitHub actions

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,14 +76,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019, windows-latest, macos-11]
+        os: [ ubuntu-latest, windows-2019, windows-latest, macos-12]
         include:
           - os: ubuntu-latest
             family: linux
             cache-path: |
               ~/.cache/go-build
               ~/go/pkg/mod
-          - os: macos-11
+          - os: macos-12
             family: darwin
             cache-path: |
               ~/Library/Caches/go-build

--- a/.github/workflows/test-build-packages.yml
+++ b/.github/workflows/test-build-packages.yml
@@ -62,7 +62,7 @@ on:
 jobs:
   MakeMacPkg:
     name: 'MakeMacPkg'
-    runs-on: macos-11
+    runs-on: macos-12
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
# Description of the issue
GitHub has deprecated macOS 11 and is removing the runner image on 6/28/2024 (https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/). They have started a brownout of jobs using that image, so they will no longer run.

# Description of changes
Bumps the macOS version to 12, which is the oldest available version (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the PR build workflow.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




