### PR TITLE
Add Default JMX HTTP Endpoint To OTLP Receiver

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,14 +76,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019, windows-latest, macos-11]
+        os: [ ubuntu-latest, windows-2019, windows-latest, macos-12]
         include:
           - os: ubuntu-latest
             family: linux
             cache-path: |
               ~/.cache/go-build
               ~/go/pkg/mod
-          - os: macos-11
+          - os: macos-12
             family: darwin
             cache-path: |
               ~/Library/Caches/go-build

--- a/.github/workflows/test-build-packages.yml
+++ b/.github/workflows/test-build-packages.yml
@@ -62,7 +62,7 @@ on:
 jobs:
   MakeMacPkg:
     name: 'MakeMacPkg'
-    runs-on: macos-11
+    runs-on: macos-12
     permissions:
       id-token: write
       contents: read

--- a/translator/translate/otel/receiver/otlp/translator.go
+++ b/translator/translate/otel/receiver/otlp/translator.go
@@ -22,6 +22,7 @@ const (
 	defaultHttpEndpoint           = "127.0.0.1:4318"
 	defaultAppSignalsGrpcEndpoint = "0.0.0.0:4315"
 	defaultAppSignalsHttpEndpoint = "0.0.0.0:4316"
+	defaultJMXHttpEndpoint        = "0.0.0.0:4314"
 )
 
 var (
@@ -102,6 +103,10 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		}
 		cfg.GRPC.NetAddr.Endpoint = defaultAppSignalsGrpcEndpoint
 		cfg.HTTP.Endpoint = defaultAppSignalsHttpEndpoint
+	} else if t.name == common.JmxKey {
+		cfg.HTTP.Endpoint = defaultJMXHttpEndpoint
+		cfg.GRPC = nil
+		return cfg, nil
 	}
 	if conf == nil || !conf.IsSet(configKey) {
 		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: configKey}


### PR DESCRIPTION
# Description of the issue
Need to receiver jmx metrics over otlp

# Description of changes
Add default jmx metrics over otlp to otlp receiver

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit Tests 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




