### PR TITLE
copy aws.log.group.names from resource attributes to attributes

### DIFF
--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer.go
@@ -70,6 +70,7 @@ var copyMapForMetric = map[string]string{
 	semconv.AttributeK8SJobName:         "K8s.Workload",
 	semconv.AttributeK8SCronJobName:     "K8s.Workload",
 	semconv.AttributeK8SPodName:         "K8s.Pod",
+	semconv.AttributeAWSLogGroupNames:   "aws.log.group.names",
 }
 
 const (


### PR DESCRIPTION
# Description of changes

Application Signals want to support metric-log correlations for EC2 and other customized platforms. In those platforms, we want users to specify the application log groups associated with a service by using the following command: 
```
export OTEL_RESOURCE_ATTRIBUTES="aws.log.group.names=log-group1&log-group2,service.name=my-service"
```
We want to save these information about log groups into the emf logs so that later the backend can find out the relevant log groups given a metric. The current change is just to copy the relevant field from resource attributes to the attributes so that aws emf exporter will write the info into emf logs. We are not attempting to do any parsing in cloudwatch agent to get the list of log groups because backend decides to handle that due to some limitation there. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
I have done the end to end test and confirmed that the additional field `aws.log.group.names` do show up in the emf logs. 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




