### PR TITLE
update aws go sdk to v1.54.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Jeffail/gabs v1.4.0
 	github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware v0.0.0-20240604205355-82dc97164e88
-	github.com/aws/aws-sdk-go v1.51.17
+	github.com/aws/aws-sdk-go v1.54.6
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.30.2
 	github.com/bigkevmcd/go-configparser v0.0.0-20200217161103-d137835d2579
 	github.com/deckarep/golang-set/v2 v2.3.1


### PR DESCRIPTION
# Description of the issue
Updating the go is required for the agent to work with new ADC regions for EKS.

# Description of changes
This is just to ensure that the CW agent can successfully resolve endpoints successfully in the new ADC regions; see the endpoints update in the go SDK [here](https://github.com/aws/aws-sdk-go/blob/v1.54.6/models/endpoints/endpoints.json#L29089)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Since this is just a go SDK update no specific tests were done apart from building the package.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

These commands executed successfully.



