### PR TITLE
Updating tests to resolve lint errors

### DIFF
--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
@@ -4,7 +4,6 @@
 package normalizer
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals/common"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -220,7 +219,7 @@ func TestRenameAttributes_AWSRemoteDbUser_for_metric(t *testing.T) {
 		t.Errorf("AWSRemoteDbUser was not removed")
 	}
 
-	if value, ok := attributes.Get(common.MetricAttributeRemoteDbUser); !ok || value.AsString() != "remoteDbUser-value" {
+	if value, ok := attributes.Get("RemoteDbUser"); !ok || value.AsString() != "remoteDbUser-value" {
 		t.Errorf("MetricAttributeRemoteDbUser has incorrect value: got %v, want %v", value.AsString(), "remoteDbUser-value")
 	}
 }

--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
@@ -12,6 +12,7 @@ import (
 	semconv "go.opentelemetry.io/collector/semconv/v1.22.0"
 	"go.uber.org/zap"
 
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals/common"
 	attr "github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals/internal/attributes"
 )
 

--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
@@ -12,7 +12,6 @@ import (
 	semconv "go.opentelemetry.io/collector/semconv/v1.22.0"
 	"go.uber.org/zap"
 
-	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals/common"
 	attr "github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals/internal/attributes"
 )
 


### PR DESCRIPTION
# Description of the issue
Updating tests to resolve lint errors

# Description of changes
Updating tests to resolve lint errors from [PR-1230](https://github.com/aws/amazon-cloudwatch-agent/pull/1230)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran
- make build
- make check_secrets amazon-cloudwatch-agent-linux && make prepackage package-rpm

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




