### PR TITLE
Fix flakiness for TestLongMessageGetsTruncated test

### DIFF
--- a/plugins/outputs/cloudwatchlogs/pusher_test.go
+++ b/plugins/outputs/cloudwatchlogs/pusher_test.go
@@ -204,7 +204,11 @@ func TestLongMessageGetsTruncated(t *testing.T) {
 
 	stop, p := testPreparation(-1, &s, 1*time.Hour, maxRetryTimeout)
 	p.AddEvent(evtMock{longMsg, time.Now(), nil})
-	time.Sleep(10 * time.Millisecond)
+
+	for len(p.events) < 1 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
 	p.send()
 	close(stop)
 	wg.Wait()


### PR DESCRIPTION
# Description of the issue
The test `TestLongMessageGetsTruncated` is flaky and failing in a lot of PRs, as an example https://github.com/aws/amazon-cloudwatch-agent/actions/runs/9653140668/job/26624834119.

The problem is that it is waiting 10ms after putting an event to a channel. This makes the test flaky because it might take more than 10ms for the event to be [added to the events array](https://github.com/aws/amazon-cloudwatch-agent/blob/70db9a331f0445a43ac4e2a5450fc06917b3ba1a/plugins/outputs/cloudwatchlogs/pusher.go#L176) because it runs in another goroutine.

**Why are other tests not affected by this?**
Other tests are not asserting the length of the events received, just that they don't exceed a certain threshold.

# Description of changes
Waiting in a loop after adding the event to the channel which will wait until event gets added to the events array.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the test with a sleep in the goroutine which adds the event to events array with and without my change and worked as expected:
- With change: succeeded
- Without change: failed

Also ran the test 5000 times and it passed:
```
$ go test -run TestLongMessageGetsTruncated -count 5000 -parallel 100
...
ok      github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs   52.052s
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`