### PR TITLE
Update JMX default collection interval to be 60 secs

### DIFF
--- a/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
@@ -73,7 +73,7 @@ processors:
         trace_statements: []
 receivers:
     jmx:
-        collection_interval: 10s
+        collection_interval: 1m0s
         endpoint: localhost:8080
         jar_path: ../../packaging/opentelemetry-jmx-metrics.jar
         otlp:

--- a/translator/translate/otel/receiver/jmx/translator.go
+++ b/translator/translate/otel/receiver/jmx/translator.go
@@ -36,7 +36,7 @@ const (
 	remoteProfileKey          = "remote_profile"
 	realmKey                  = "realm"
 	passwordFileKey           = "password_file"
-	defaultCollectionInterval = 10 * time.Second
+	defaultCollectionInterval = time.Minute
 	envJmxJarPath             = "JMX_JAR_PATH"
 	attributeHost             = "host"
 )

--- a/translator/translate/otel/receiver/jmx/translator_test.go
+++ b/translator/translate/otel/receiver/jmx/translator_test.go
@@ -86,7 +86,7 @@ func TestTranslator(t *testing.T) {
 			want: confmap.NewFromStringMap(map[string]any{
 				"endpoint":            "localhost:8080",
 				"target_system":       "tomcat",
-				"collection_interval": "10s",
+				"collection_interval": "60s",
 				"otlp": map[string]any{
 					"endpoint": "0.0.0.0:0",
 					"timeout":  "5s",


### PR DESCRIPTION
# Description of the issue
The support for a JMX plugin was recently introduced, however, the default collection interval was set to 10 secs as opposed to the default collection interval of 60 secs used by all our other plugins.

# Description of changes
Updating the default collection interval for JMX to be inline with the rest of the plugins by setting it to 60 secs.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




