### PR TITLE
Add support for per-process nvidia gpu memory usage.

### DIFF
--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -287,6 +287,26 @@ func TestGatherValidXML(t *testing.T) {
 						"vbios_version":                     "90.04.84.00.06",
 					},
 					time.Unix(0, 0)),
+				testutil.MustMetric(
+					"nvidia_smi",
+					map[string]string{
+						"process_name": "/usr/lib/xorg/Xorg",
+						"process_id":   "675",
+					},
+					map[string]interface{}{
+						"process_used_memory": 22,
+					},
+					time.Unix(0, 0)),
+				testutil.MustMetric(
+					"nvidia_smi",
+					map[string]string{
+						"process_name": "python",
+						"process_id":   "5762",
+					},
+					map[string]interface{}{
+						"process_used_memory": 1005,
+					},
+					time.Unix(0, 0)),
 			},
 		},
 		{
@@ -339,6 +359,16 @@ func TestGatherValidXML(t *testing.T) {
 						"vbios_version":                 "94.02.75.00.01",
 					},
 					time.Unix(0, 0)),
+				testutil.MustMetric(
+					"nvidia_smi",
+					map[string]string{
+						"process_name": "/usr/lib/xorg/Xorg",
+						"process_id":   "725",
+					},
+					map[string]interface{}{
+						"process_used_memory": 22,
+					},
+					time.Unix(0, 0)),
 			},
 		},
 		{
@@ -386,6 +416,26 @@ func TestGatherValidXML(t *testing.T) {
 						"utilization_decoder":           0,
 						"utilization_ofa":               0,
 						"vbios_version":                 "94.02.71.40.72",
+					},
+					time.Unix(1689872450, 0)),
+				testutil.MustMetric(
+					"nvidia_smi",
+					map[string]string{
+						"process_name": "/usr/lib/xorg/Xorg",
+						"process_id":   "675",
+					},
+					map[string]interface{}{
+						"process_used_memory": 22,
+					},
+					time.Unix(1689872450, 0)),
+				testutil.MustMetric(
+					"nvidia_smi",
+					map[string]string{
+						"process_name": "python",
+						"process_id":   "5762",
+					},
+					map[string]interface{}{
+						"process_used_memory": 1005,
 					},
 					time.Unix(1689872450, 0)),
 			},

--- a/plugins/inputs/nvidia_smi/schema_v11/parser.go
+++ b/plugins/inputs/nvidia_smi/schema_v11/parser.go
@@ -71,6 +71,17 @@ func Parse(acc telegraf.Accumulator, buf []byte) error {
 
 		common.SetIfUsed("float", fields, "power_draw", gpu.Power.PowerDraw)
 		acc.AddFields("nvidia_smi", fields, tags)
+
+		for _, process := range gpu.Processes.ProcessInfo {
+			tags := map[string]string{}
+			common.SetTagIfUsed(tags, "process_name", process.ProcessName)
+			common.SetTagIfUsed(tags, "process_id", process.Pid)
+
+			fields := map[string]interface{}{}
+			common.SetIfUsed("int", fields, "process_used_memory", process.UsedMemory)
+
+			acc.AddFields("nvidia_smi", fields, tags)
+		}
 	}
 
 	return nil

--- a/plugins/inputs/nvidia_smi/schema_v11/types.go
+++ b/plugins/inputs/nvidia_smi/schema_v11/types.go
@@ -32,6 +32,7 @@ type GPU struct {
 	Utilization   UtilizationStats   `xml:"utilization"`
 	UUID          string             `xml:"uuid"`
 	VbiosVersion  string             `xml:"vbios_version"`
+	Processes     ProcessesInfo      `xml:"processes"`
 }
 
 // ECCMode defines the structure of the ecc portions in the smi output.
@@ -118,4 +119,14 @@ type ClockStats struct {
 	SM       string `xml:"sm_clock"`       // int
 	Memory   string `xml:"mem_clock"`      // int
 	Video    string `xml:"video_clock"`    // int
+}
+
+// ProcessesInfo defines the structure of the processes portion of the smi output.
+type ProcessesInfo struct {
+	ProcessInfo []struct {
+		Pid         string `xml:"pid"`          // str
+		Type        string `xml:"type"`         // str
+		ProcessName string `xml:"process_name"` // str
+		UsedMemory  string `xml:"used_memory"`  // int
+	} `xml:"process_info"`
 }

--- a/plugins/inputs/nvidia_smi/schema_v12/parser.go
+++ b/plugins/inputs/nvidia_smi/schema_v12/parser.go
@@ -82,7 +82,19 @@ func Parse(acc telegraf.Accumulator, buf []byte) error {
 		common.SetIfUsed("float", fields, "power_draw", gpu.PowerReadings.PowerDraw)
 		common.SetIfUsed("float", fields, "power_draw", gpu.GpuPowerReadings.PowerDraw)
 		common.SetIfUsed("float", fields, "module_power_draw", gpu.ModulePowerReadings.PowerDraw)
+
 		acc.AddFields("nvidia_smi", fields, tags, timestamp)
+
+		for _, process := range gpu.Processes.ProcessInfo {
+			tags := map[string]string{}
+			common.SetTagIfUsed(tags, "process_name", process.ProcessName)
+			common.SetTagIfUsed(tags, "process_id", process.Pid)
+
+			fields := map[string]interface{}{}
+			common.SetIfUsed("int", fields, "process_used_memory", process.UsedMemory)
+
+			acc.AddFields("nvidia_smi", fields, tags, timestamp)
+		}
 
 		for _, device := range gpu.MigDevices.MigDevice {
 			tags := map[string]string{}
@@ -107,6 +119,7 @@ func Parse(acc telegraf.Accumulator, buf []byte) error {
 
 			acc.AddFields("nvidia_smi_mig", fields, tags, timestamp)
 		}
+
 	}
 
 	return nil

--- a/plugins/inputs/nvidia_smi/schema_v12/types.go
+++ b/plugins/inputs/nvidia_smi/schema_v12/types.go
@@ -229,10 +229,17 @@ type smi struct {
 			MinPowerLimit      string `xml:"min_power_limit"`
 			MaxPowerLimit      string `xml:"max_power_limit"`
 		} `xml:"power_readings"`
-		Processes           struct{} `xml:"processes"`
-		ProductArchitecture string   `xml:"product_architecture"`
-		ProductBrand        string   `xml:"product_brand"`
-		ProductName         string   `xml:"product_name"`
+		Processes struct {
+			ProcessInfo []struct {
+				Pid         string `xml:"pid"`
+				Type        string `xml:"type"`
+				ProcessName string `xml:"process_name"`
+				UsedMemory  string `xml:"used_memory"`
+			} `xml:"process_info"`
+		} `xml:"processes"`
+		ProductArchitecture string `xml:"product_architecture"`
+		ProductBrand        string `xml:"product_brand"`
+		ProductName         string `xml:"product_name"`
 		RemappedRows        struct {
 			// Manually added
 			Correctable   string `xml:"remapped_row_corr"`

--- a/plugins/inputs/nvidia_smi/testdata/rtx-3080-v12.xml
+++ b/plugins/inputs/nvidia_smi/testdata/rtx-3080-v12.xml
@@ -280,7 +280,7 @@
 				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
 				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
 				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
-                                <supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
 				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
 				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
 				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
@@ -778,6 +778,22 @@
 			</supported_mem_clock>
 		</supported_clocks>
 		<processes>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>675</pid>
+				<type>G</type>
+				<process_name>/usr/lib/xorg/Xorg</process_name>
+				<used_memory>22 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>5762</pid>
+				<type>C</type>
+				<process_name>python</process_name>
+				<used_memory>1005 MiB</used_memory>
+			</process_info>
 		</processes>
 		<accounted_processes>
 		</accounted_processes>

--- a/translator/translate/metrics/config/registered_metrics.go
+++ b/translator/translate/metrics/config/registered_metrics.go
@@ -23,7 +23,7 @@ var Registered_Metrics_Linux = map[string][]string{
 		"rlimit_memory_rss_hard", "rlimit_memory_rss_soft", "rlimit_memory_stack_hard", "rlimit_memory_stack_soft", "rlimit_memory_vms_hard", "rlimit_memory_vms_soft", "rlimit_nice_priority_hard", "rlimit_nice_priority_soft", "rlimit_num_fds_hard", "rlimit_num_fds_soft",
 		"rlimit_realtime_priority_hard", "rlimit_realtime_priority_soft", "rlimit_signals_pending_hard", "rlimit_signals_pending_soft", "signals_pending", "voluntary_context_switches", "write_bytes", "write_count", "pid_count"},
 	"nvidia_smi": {"utilization_gpu", "temperature_gpu", "power_draw", "utilization_memory", "fan_speed", "memory_total", "memory_used", "memory_free", "temperature_gpu", "pcie_link_gen_current", "pcie_link_width_current",
-		"encoder_stats_session_count", "encoder_stats_average_fps", "encoder_stats_average_latency", "clocks_current_graphics", "clocks_current_sm", "clocks_current_memory", "clocks_current_video"},
+		"encoder_stats_session_count", "encoder_stats_average_fps", "encoder_stats_average_latency", "clocks_current_graphics", "clocks_current_sm", "clocks_current_memory", "clocks_current_video", "process_used_memory"},
 }
 
 // This served as the allowlisted metric name, which is registered under the plugin name
@@ -42,7 +42,7 @@ var Registered_Metrics_Darwin = map[string][]string{
 		"memory_data", "memory_locked", "memory_rss", "memory_stack", "memory_swap", "memory_vms", "pid",
 		"pid_count"},
 	"nvidia_smi": {"utilization_gpu", "temperature_gpu", "power_draw", "utilization_memory", "utilization_encoder", "utilization_decoder", "fan_speed", "memory_total", "memory_used", "memory_free", "temperature_gpu", "pcie_link_gen_current", "pcie_link_width_current",
-		"encoder_stats_session_count", "encoder_stats_average_fps", "encoder_stats_average_latency", "clocks_current_graphics", "clocks_current_sm", "clocks_current_memory", "clocks_current_video"},
+		"encoder_stats_session_count", "encoder_stats_average_fps", "encoder_stats_average_latency", "clocks_current_graphics", "clocks_current_sm", "clocks_current_memory", "clocks_current_video", "process_used_memory"},
 }
 
 var Registered_Metrics_Windows = map[string][]string{


### PR DESCRIPTION
# Description of the issue
- Add support for per-process nvidia gpu memory usage.

# Description of changes
- Extend current nvidia smi metrics to include per process gpu memory usage.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Added unit tests.
- Tested in personal account (build tested: linux/amd64/amazon-cloudwatch-agent.deb). See screenshots below.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`


![Screenshot 2024-07-07 at 1 06 23 AM](https://github.com/aws/amazon-cloudwatch-agent/assets/173515482/7e2abdc7-4ef4-4ffc-81f2-52761aec65e1)


![Screenshot 2024-07-07 at 1 05 54 AM](https://github.com/aws/amazon-cloudwatch-agent/assets/173515482/fd3714ef-9456-4b4b-a7ee-d5ade9f4a2e5)
