### PR TITLE
Reduce logging for known non-convertible JMX metric units.

### DIFF
--- a/internal/cloudwatch/unit_test.go
+++ b/internal/cloudwatch/unit_test.go
@@ -68,3 +68,13 @@ func TestScaledUnits(t *testing.T) {
 		assert.Equal(t, testCase.scale, scale)
 	}
 }
+
+func TestKnownNonStandardUnits(t *testing.T) {
+	testCases := []string{"errors", "{requests}"}
+	for _, testCase := range testCases {
+		unit, scale, err := ToStandardUnit(testCase)
+		assert.NoError(t, err)
+		assert.Equal(t, "None", unit)
+		assert.EqualValues(t, 1, scale)
+	}
+}


### PR DESCRIPTION
# Description of the issue
JMX Tomcat and Kafka metrics are sent to the agent with non-standard and non-convertible units. This currently results in consistent warning logs.

# Description of changes
Adds an allowlist of known non-convertible units and includes the Tomcat/Kafka ones. Reduced the warning to a debug log.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




