### PR TITLE
Add windows event log service restart detection and resubscribe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ifeq ($(shell uname -s),Darwin)
 endif
 endif
 
-amazon-cloudwatch-agent-windows:
+amazon-cloudwatch-agent-windows: copy-version-file
 	@echo Building CloudWatchAgent for Windows with AMD64
 	$(WIN_BUILD)/config-downloader.exe github.com/aws/amazon-cloudwatch-agent/cmd/config-downloader
 	$(WIN_BUILD)/config-translator.exe github.com/aws/amazon-cloudwatch-agent/cmd/config-translator

--- a/plugins/inputs/windows_event_log/service_monitor.go
+++ b/plugins/inputs/windows_event_log/service_monitor.go
@@ -7,7 +7,7 @@
 package windows_event_log
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"time"
 
@@ -20,6 +20,14 @@ const (
 
 	serviceName = "eventlog"
 )
+
+var (
+	errServiceNotRunning = errors.New("service is not running")
+)
+
+type statusChecker interface {
+	Query() (svc.Status, error)
+}
 
 type serviceMonitor struct {
 	listeners []chan struct{}
@@ -82,7 +90,7 @@ func (m *serviceMonitor) notify() {
 	}
 }
 
-func getPID(service *mgr.Service) (uint32, error) {
+func getPID(service statusChecker) (uint32, error) {
 	status, err := service.Query()
 	if err != nil {
 		return 0, err
@@ -90,5 +98,5 @@ func getPID(service *mgr.Service) (uint32, error) {
 	if status.State == svc.Running {
 		return status.ProcessId, nil
 	}
-	return 0, fmt.Errorf("service is not running")
+	return 0, errServiceNotRunning
 }

--- a/plugins/inputs/windows_event_log/service_monitor.go
+++ b/plugins/inputs/windows_event_log/service_monitor.go
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+// +build windows
+
+package windows_event_log
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const (
+	serviceCheckInterval = 10 * time.Second
+
+	serviceName = "eventlog"
+)
+
+type serviceMonitor struct {
+	listeners []chan struct{}
+	done      chan struct{}
+}
+
+func newServiceMonitor() *serviceMonitor {
+	return &serviceMonitor{
+		listeners: []chan struct{}{},
+	}
+}
+
+func (m *serviceMonitor) start() {
+	manager, err := mgr.Connect()
+	if err != nil {
+		log.Printf("E! [windows_event_log] Unable to connect to Windows service manager: %v", err)
+		return
+	}
+
+	service, err := manager.OpenService(serviceName)
+	if err != nil {
+		log.Printf("E! [windows_event_log] Unable to observe Windows event log service: %v", err)
+		return
+	}
+
+	ticker := time.NewTicker(serviceCheckInterval)
+	defer ticker.Stop()
+
+	// get initial service PID
+	oldPID, _ := getPID(service)
+	for {
+		select {
+		case <-ticker.C:
+			newPID, err := getPID(service)
+			if err == nil && oldPID != newPID {
+				log.Printf("D! [windows_event_log] Detected Windows event log service restart")
+				oldPID = newPID
+				m.notify()
+			}
+		case <-m.done:
+			return
+		}
+	}
+}
+
+func (m *serviceMonitor) stop() {
+	close(m.done)
+}
+
+func (m *serviceMonitor) addListener(listener chan struct{}) {
+	m.listeners = append(m.listeners, listener)
+}
+
+func (m *serviceMonitor) notify() {
+	for _, l := range m.listeners {
+		select {
+		case l <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func getPID(service *mgr.Service) (uint32, error) {
+	status, err := service.Query()
+	if err != nil {
+		return 0, err
+	}
+	if status.State == svc.Running {
+		return status.ProcessId, nil
+	}
+	return 0, fmt.Errorf("service is not running")
+}

--- a/plugins/inputs/windows_event_log/service_monitor_test.go
+++ b/plugins/inputs/windows_event_log/service_monitor_test.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+// +build windows
+
+package windows_event_log
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows/svc"
+)
+
+type mockStatusCheck struct {
+	status svc.Status
+	err    error
+}
+
+func (m *mockStatusCheck) Query() (svc.Status, error) {
+	return m.status, m.err
+}
+
+func TestGetPID(t *testing.T) {
+	testErr := errors.New("test error")
+	testCases := map[string]struct {
+		status  svc.Status
+		err     error
+		wantPID uint32
+		wantErr error
+	}{
+		"WithQueryError": {
+			err:     testErr,
+			wantPID: 0,
+			wantErr: testErr,
+		},
+		"WithStoppedService": {
+			status: svc.Status{
+				State:     svc.Stopped,
+				ProcessId: 0,
+			},
+			wantPID: 0,
+			wantErr: errServiceNotRunning,
+		},
+		"WithRunningService": {
+			status: svc.Status{
+				State:     svc.Running,
+				ProcessId: 123,
+			},
+			wantPID: 123,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotPID, gotErr := getPID(&mockStatusCheck{status: testCase.status, err: testCase.err})
+			assert.Equal(t, testCase.wantPID, gotPID)
+			assert.Equal(t, testCase.wantErr, gotErr)
+		})
+	}
+}

--- a/plugins/inputs/windows_event_log/windows_event_log.go
+++ b/plugins/inputs/windows_event_log/windows_event_log.go
@@ -88,6 +88,8 @@ func (s *Plugin) Start(acc telegraf.Accumulator) error {
 	if alreadyRan {
 		return nil
 	}
+
+	monitor := newServiceMonitor()
 	for _, eventConfig := range s.Events {
 		// Assume no 2 EventConfigs have the same combination of:
 		// LogGroupName, LogStreamName, Name.
@@ -115,8 +117,10 @@ func (s *Plugin) Start(acc telegraf.Accumulator) error {
 		if err != nil {
 			return err
 		}
+		monitor.addListener(eventLog.ResubscribeCh())
 		s.newEvents = append(s.newEvents, eventLog)
 	}
+	go monitor.start()
 	return nil
 }
 


### PR DESCRIPTION
# Description of the issue
Currently, if the Windows `EventLog` service crashes and gets restarted, the CloudWatch agent no longer picks up events. This is because the event handle used by the subscription is no longer valid. The CloudWatch agent needs a way to detect that the service has restarted and then re-open the subscription.

# Description of changes
Adds a service monitor that uses the [golang.org/x/sys/windows/svc/mgr](https://pkg.go.dev/golang.org/x/sys@v0.22.0/windows/svc/mgr) package to periodically (every 10 seconds) detect if the `eventlog` service's PID has changed. If it has changed, it notifies each of the `wineventlog` subscriptions to re-subscribe. This prevents the plugin from trying to re-subscribe if the service is down.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added a unit test. Deployed build to Windows 2022 instance and manually stopped the `EventLog` service through the task manager. After restarting the service:

```
2024-07-22T22:54:52Z D! [windows_event_log] Detected Windows event log service restart
2024-07-22T22:54:52Z D! [wineventlog] Re-subscribed to Security
2024-07-22T22:54:52Z D! [wineventlog] Re-subscribed to Application
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




