### PR TITLE
Add cumulative to delta conversion for JMX metrics.

### DIFF
--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -117,6 +117,13 @@ processors:
             match_type: ""
         initial_value: 0
         max_staleness: 0s
+    cumulativetodelta/jmx:
+        exclude:
+            match_type: ""
+        include:
+            match_type: ""
+        initial_value: 0
+        max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
@@ -384,6 +391,7 @@ service:
             processors:
                 - filter/jmx/0
                 - resource/jmx
+                - cumulativetodelta/jmx
                 - transform/jmx/0
                 - ec2tagger
             receivers:
@@ -394,6 +402,7 @@ service:
             processors:
                 - filter/jmx/1
                 - resource/jmx
+                - cumulativetodelta/jmx
                 - transform/jmx/1
                 - ec2tagger
             receivers:

--- a/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
@@ -21,6 +21,13 @@ extensions:
                 mode: EC2
                 region_type: ACJ
 processors:
+    cumulativetodelta/jmx:
+        exclude:
+            match_type: ""
+        include:
+            match_type: ""
+        initial_value: 0
+        max_staleness: 0s
     filter/jmx:
         error_mode: propagate
         logs: {}
@@ -106,6 +113,7 @@ service:
             processors:
                 - filter/jmx
                 - resource/jmx
+                - cumulativetodelta/jmx
                 - transform/jmx
             receivers:
                 - jmx

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -392,3 +392,13 @@ func GetMeasurements(m map[string]any) []string {
 	}
 	return results
 }
+
+// IsAnySet checks if any of the provided keys are present in the configuration.
+func IsAnySet(conf *confmap.Conf, keys []string) bool {
+	for _, key := range keys {
+		if conf.IsSet(key) {
+			return true
+		}
+	}
+	return false
+}

--- a/translator/translate/otel/common/options.go
+++ b/translator/translate/otel/common/options.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package common
+
+type TranslatorOption func(any)
+
+type NameSetter interface {
+	SetName(string)
+}
+
+func WithName(name string) TranslatorOption {
+	return func(target any) {
+		if setter, ok := target.(NameSetter); ok {
+			setter.SetName(name)
+		}
+	}
+}
+
+type NameProvider struct {
+	name string
+}
+
+func (p *NameProvider) Name() string {
+	return p.name
+}
+
+func (p *NameProvider) SetName(name string) {
+	p.name = name
+}

--- a/translator/translate/otel/common/options_test.go
+++ b/translator/translate/otel/common/options_test.go
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithName(t *testing.T) {
+	p := &NameProvider{name: "a"}
+	opt := WithName("b")
+	opt(p)
+	assert.Equal(t, "b", p.Name())
+}

--- a/translator/translate/otel/pipeline/host/translator.go
+++ b/translator/translate/otel/pipeline/host/translator.go
@@ -74,7 +74,7 @@ func (t translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators,
 	// we need to add delta processor because (only) diskio and net input plugins report delta metric
 	if common.PipelineNameHostDeltaMetrics == t.name {
 		log.Printf("D! delta processor required because metrics with diskio or net are set")
-		translators.Processors.Set(cumulativetodeltaprocessor.NewTranslatorWithName(t.name))
+		translators.Processors.Set(cumulativetodeltaprocessor.NewTranslator(common.WithName(t.name), cumulativetodeltaprocessor.WithDiskIONetKeys()))
 	}
 
 	if conf.IsSet(common.ConfigKey(common.MetricsKey, common.AppendDimensionsKey)) {

--- a/translator/translate/otel/pipeline/jmx/translator.go
+++ b/translator/translate/otel/pipeline/jmx/translator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awscloudwatch"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/cumulativetodeltaprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/ec2taggerprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/filterprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/metricsdecorator"
@@ -76,6 +77,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		Processors: common.NewTranslatorMap(
 			filterprocessor.NewTranslator(filterprocessor.WithName(common.PipelineNameJmx), filterprocessor.WithIndex(t.index)),
 			resourceprocessor.NewTranslator(resourceprocessor.WithName(common.PipelineNameJmx)),
+			cumulativetodeltaprocessor.NewTranslator(common.WithName(common.PipelineNameJmx), cumulativetodeltaprocessor.WithConfigKeys(common.JmxConfigKey)),
 		),
 		Exporters:  common.NewTranslatorMap(awscloudwatch.NewTranslator()),
 		Extensions: common.NewTranslatorMap(agenthealth.NewTranslator(component.DataTypeMetrics, []string{agenthealth.OperationPutMetricData})),

--- a/translator/translate/otel/pipeline/jmx/translator_test.go
+++ b/translator/translate/otel/pipeline/jmx/translator_test.go
@@ -123,7 +123,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx",
 				receivers:  []string{"jmx"},
-				processors: []string{"filter/jmx", "resource/jmx"},
+				processors: []string{"filter/jmx", "resource/jmx", "cumulativetodelta/jmx"},
 				exporters:  []string{"awscloudwatch"},
 				extensions: []string{"agenthealth/metrics"},
 			},
@@ -151,7 +151,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx",
 				receivers:  []string{"jmx"},
-				processors: []string{"filter/jmx", "resource/jmx", "transform/jmx"},
+				processors: []string{"filter/jmx", "resource/jmx", "cumulativetodelta/jmx", "transform/jmx"},
 				exporters:  []string{"awscloudwatch"},
 				extensions: []string{"agenthealth/metrics"},
 			},
@@ -185,7 +185,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx/0",
 				receivers:  []string{"jmx/0"},
-				processors: []string{"filter/jmx/0", "resource/jmx", "transform/jmx/0", "ec2tagger"},
+				processors: []string{"filter/jmx/0", "resource/jmx", "cumulativetodelta/jmx", "transform/jmx/0", "ec2tagger"},
 				exporters:  []string{"awscloudwatch"},
 				extensions: []string{"agenthealth/metrics"},
 			},

--- a/translator/translate/otel/processor/cumulativetodeltaprocessor/translator_test.go
+++ b/translator/translate/otel/processor/cumulativetodeltaprocessor/translator_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestTranslator(t *testing.T) {
-	cdpTranslator := NewTranslator()
-	require.EqualValues(t, "cumulativetodelta", cdpTranslator.ID().String())
+	cdpTranslator := NewTranslator(common.WithName("test"), WithDiskIONetKeys())
+	require.EqualValues(t, "cumulativetodelta/test", cdpTranslator.ID().String())
 	testCases := map[string]struct {
 		input   map[string]interface{}
 		want    *cumulativetodeltaprocessor.Config


### PR DESCRIPTION
# Description of the issue
There are quite a few JMX metrics (e.g. `kafka.message.count`, `kafka.network.io`, etc.) that are reported as cumulative sums/histograms. In CloudWatch, these metrics are more useful as deltas, which will allow for easier alarming and anomaly detection. We've made the decision to convert all applicable JMX metrics to deltas.

# Description of changes
Adds the cumulativetodelta processor to all JMX pipelines.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




