### PR TITLE
[chore] Remove Codecov Upload on every PR

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -133,12 +133,12 @@ jobs:
         if:  steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make test
 
-      - name: Upload coverage to Codecov
+      - name: Run Codecov
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         uses: codecov/codecov-action@v3
         with:
           verbose: true
-
+          dry_run: true
       - name: Build
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make amazon-cloudwatch-agent-${{ matrix.family }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,14 +76,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019, windows-latest, macos-13]
+        os: [ ubuntu-latest, windows-2019, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             family: linux
             cache-path: |
               ~/.cache/go-build
               ~/go/pkg/mod
-          - os: macos-12
+          - os: macos-latest
             family: darwin
             cache-path: |
               ~/Library/Caches/go-build
@@ -139,6 +139,7 @@ jobs:
         with:
           verbose: true
           dry_run: true
+          os: aarch64
       - name: Build
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make amazon-cloudwatch-agent-${{ matrix.family }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019, windows-latest, macos-12]
+        os: [ ubuntu-latest, windows-2019, windows-latest, macos-13]
         include:
           - os: ubuntu-latest
             family: linux

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,14 +76,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-2019, windows-latest, macos-12]
         include:
           - os: ubuntu-latest
             family: linux
             cache-path: |
               ~/.cache/go-build
               ~/go/pkg/mod
-          - os: macos-latest
+          - os: macos-12
             family: darwin
             cache-path: |
               ~/Library/Caches/go-build
@@ -132,7 +132,7 @@ jobs:
       - name: Unit Test
         if:  steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make test
-        
+
       - name: Build
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make amazon-cloudwatch-agent-${{ matrix.family }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -132,14 +132,7 @@ jobs:
       - name: Unit Test
         if:  steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make test
-
-      - name: Run Codecov
-        if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
-        uses: codecov/codecov-action@v3
-        with:
-          verbose: true
-          dry_run: true
-          os: aarch64
+        
       - name: Build
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make amazon-cloudwatch-agent-${{ matrix.family }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![codecov](https://codecov.io/gh/aws/amazon-cloudwatch-agent/branch/main/graph/badge.svg?token=79VYANUGOM)](https://codecov.io/gh/aws/amazon-cloudwatch-agent)
-
 # Amazon CloudWatch Agent
 The Amazon CloudWatch Agent is software developed for the [CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html)
 


### PR DESCRIPTION
# Description of the issue
Currently `codecov` tries to upload on every PR build and fails due to being outdated.

# Description of changes
Removed `codecov` for now to un-block PRs. We can add `codecov-4` later on. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran PR-build

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




