### PR TITLE
Separate build jobs for artifacts and trigger tests with workflow_run

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -4,9 +4,12 @@
 # This is a reusable workflow for running the E2E test for Application Signals.
 # It is meant to be called from another workflow.
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
-name: E2E Testing
+name: Application Signals E2E Test
 on:
-  workflow_call:
+  workflow_run:
+    workflows: [ Build Test Artifacts ]
+    types:
+      - completed
 
 permissions:
   id-token: write
@@ -18,7 +21,14 @@ concurrency:
 
 
 jobs:
+  CheckBuildTestArtifacts:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering build workflow succeeded'
+
   java-eks-e2e-test:
+    needs: CheckBuildTestArtifacts
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-e2e-test.yml@main
     secrets: inherit
     with:
@@ -27,6 +37,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   java-ec2-default-e2e-test:
+    needs: CheckBuildTestArtifacts
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-default-e2e-test.yml@main
     secrets: inherit
     with:
@@ -34,6 +45,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   java-ec2-asg-e2e-test:
+    needs: [ CheckBuildTestArtifacts ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-asg-e2e-test.yml@main
     secrets: inherit
     with:
@@ -41,7 +53,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   java-metric-limiter-e2e-test:
-    needs: [ java-eks-e2e-test ]
+    needs: [ CheckBuildTestArtifacts, java-eks-e2e-test ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-metric-limiter-e2e-test.yml@main
     secrets: inherit
     with:
@@ -50,6 +62,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   java-k8s-e2e-test:
+    needs: [ CheckBuildTestArtifacts ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-k8s-e2e-test.yml@main
     secrets: inherit
     with:
@@ -57,7 +70,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   python-eks-e2e-test:
-    needs: [ java-metric-limiter-e2e-test ]
+    needs: [ CheckBuildTestArtifacts, java-metric-limiter-e2e-test ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-e2e-test.yml@main
     secrets: inherit
     with:
@@ -66,6 +79,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   python-ec2-default-e2e-test:
+    needs: [ CheckBuildTestArtifacts ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-default-e2e-test.yml@main
     secrets: inherit
     with:
@@ -73,6 +87,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   python-ec2-asg-e2e-test:
+    needs: [ CheckBuildTestArtifacts ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-asg-e2e-test.yml@main
     secrets: inherit
     with:
@@ -80,7 +95,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   python-k8s-e2e-test:
-    needs: [ java-k8s-e2e-test ]
+    needs: [ CheckBuildTestArtifacts, java-k8s-e2e-test ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-k8s-e2e-test.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+name: Build Test Artifacts
+on:
+  push:
+    branches:
+      - main*
+    paths-ignore:
+      - '**/*.md'
+      - 'NOTICE'
+      - 'RELEASE_NOTES'
+      - 'THIRD-PARTY'
+      - 'LICENSE'
+      - '.github/**'
+      - '!.github/workflows/build-test-artifacts.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  BuildAndUpload:
+    uses: ./.github/workflows/test-build.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      BucketKey: "integration-test/binary/${{ github.sha }}"
+      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
+      TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+      Bucket: ${{ vars.S3_INTEGRATION_BUCKET }}
+
+  BuildAndUploadPackages:
+    uses: ./.github/workflows/test-build-packages.yml
+    needs: [BuildAndUpload]
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      BucketKey: "integration-test/binary/${{ github.sha }}"
+      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
+      TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+      Bucket: ${{ vars.S3_INTEGRATION_BUCKET }}
+
+  BuildDocker:
+    needs: [BuildAndUpload]
+    uses: ./.github/workflows/test-build-docker.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      ContainerRepositoryNameAndTag: "cwagent-integration-test:${{ github.sha }}"
+      BucketKey: "integration-test/binary/${{ github.sha }}"
+      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
+
+  BuildAndUploadITAR:
+    uses: ./.github/workflows/test-build.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      BucketKey: "integration-test/binary/${{ github.sha }}"
+      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
+      Region: "us-gov-east-1"
+      TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_ITAR }}
+      Bucket: ${{ vars.S3_INTEGRATION_BUCKET_ITAR }}
+
+  BuildAndUploadCN:
+    uses: ./.github/workflows/test-build.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      BucketKey: "integration-test/binary/${{ github.sha }}"
+      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
+      Region: "cn-north-1"
+      TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}
+      Bucket: ${{ vars.S3_INTEGRATION_BUCKET_CN }}

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -3,6 +3,15 @@
 
 name: Build Test Artifacts
 on:
+  pull_request:
+    branches:
+      - main*
+      - feature*
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   push:
     branches:
       - main*

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -3,15 +3,6 @@
 
 name: Build Test Artifacts
 on:
-  pull_request:
-    branches:
-      - main*
-      - feature*
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
   push:
     branches:
       - main*

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,94 +20,24 @@ env:
   S3_INTEGRATION_BUCKET_CN: ${{ vars.S3_INTEGRATION_BUCKET_CN }}
 
 on:
-  push:
-    branches:
-      - main*
-    paths-ignore:
-      - '**/*.md'
-      - 'NOTICE'
-      - 'RELEASE_NOTES'
-      - 'THIRD-PARTY'
-      - 'LICENSE'
-      - '.github/**'
-      - '!.github/workflows/integration-test.yml'
-  workflow_dispatch:
-    inputs:
-      plugins:
-        description: 'Comma delimited list of plugins to test. Default is empty, and tests everything'
-        required: false
-        default: ''
-        type: string
+  workflow_run:
+    workflows: [ Build Test Artifacts ]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
-  BuildAndUpload:
-    uses: ./.github/workflows/test-build.yml
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      BucketKey: "integration-test/binary/${{ github.sha }}"
-      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
-      TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      Bucket: ${{ vars.S3_INTEGRATION_BUCKET }}
-
-  BuildAndUploadPackages:
-    uses: ./.github/workflows/test-build-packages.yml
-    needs: [BuildAndUpload]
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      BucketKey: "integration-test/binary/${{ github.sha }}"
-      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
-      TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      Bucket: ${{ vars.S3_INTEGRATION_BUCKET }}
-
-  BuildDocker:
-    needs: [BuildAndUpload]
-    uses: ./.github/workflows/test-build-docker.yml
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      ContainerRepositoryNameAndTag: "cwagent-integration-test:${{ github.sha }}"
-      BucketKey: "integration-test/binary/${{ github.sha }}"
-      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
-
-  BuildAndUploadITAR:
-    uses: ./.github/workflows/test-build.yml
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      BucketKey: "integration-test/binary/${{ github.sha }}"
-      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
-      Region: "us-gov-east-1"
-      TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_ITAR }}
-      Bucket: ${{ vars.S3_INTEGRATION_BUCKET_ITAR }}
-
-  BuildAndUploadCN:
-    uses: ./.github/workflows/test-build.yml
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      BucketKey: "integration-test/binary/${{ github.sha }}"
-      PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
-      Region: "cn-north-1"
-      TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}
-      Bucket: ${{ vars.S3_INTEGRATION_BUCKET_CN }}
+  CheckBuildTestArtifacts:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering build workflow succeeded'
 
   GenerateTestMatrix:
+    needs: [ CheckBuildTestArtifacts ]
     name: 'GenerateTestMatrix'
     runs-on: ubuntu-latest
     outputs:
@@ -126,8 +56,6 @@ jobs:
       ec2_linux_itar_matrix: ${{ steps.set-matrix.outputs.ec2_linux_itar_matrix }}
       ec2_linux_china_matrix: ${{ steps.set-matrix.outputs.ec2_linux_china_matrix }}
       eks_addon_matrix: ${{ steps.set-matrix.outputs.eks_addon_matrix }}
-
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -178,7 +106,7 @@ jobs:
           echo "ec2_linux_china_matrix: ${{ steps.set-matrix.outputs.ec2_linux_china_matrix }}"
 
   CloudformationTest:
-    needs: [BuildAndUpload, GenerateTestMatrix]
+    needs: [GenerateTestMatrix]
     name: 'CFTest'
     runs-on: ubuntu-latest
     strategy:
@@ -272,7 +200,7 @@ jobs:
 
 
   EC2NvidiaGPUIntegrationTest:
-    needs: [ BuildAndUpload, StartLocalStack, GenerateTestMatrix ]
+    needs: [ StartLocalStack, GenerateTestMatrix ]
     name: 'EC2NVIDIAGPUIntegrationTest'
     runs-on: ubuntu-latest
     strategy:
@@ -387,6 +315,7 @@ jobs:
             terraform destroy --auto-approve
 
   OutputEnvVariables:
+    needs: [CheckBuildTestArtifacts]
     name: 'OutputEnvVariables'
     runs-on: ubuntu-latest
     outputs:
@@ -418,7 +347,7 @@ jobs:
           echo "CWA_GITHUB_TEST_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}"
 
   EC2LinuxIntegrationTest:
-    needs: [ BuildAndUpload, StartLocalStack, GenerateTestMatrix, OutputEnvVariables ]
+    needs: [ StartLocalStack, GenerateTestMatrix, OutputEnvVariables ]
     name: 'EC2Linux'
     uses:  ./.github/workflows/ec2-integration-test.yml
     with:
@@ -436,7 +365,7 @@ jobs:
     secrets: inherit
 
   EC2LinuxIntegrationTestITAR:
-    needs: [ BuildAndUpload, BuildAndUploadITAR, StartLocalStackITAR, GenerateTestMatrix, OutputEnvVariables ]
+    needs: [ StartLocalStackITAR, GenerateTestMatrix, OutputEnvVariables ]
     name: 'EC2LinuxITAR'
     uses: ./.github/workflows/ec2-integration-test.yml
     with:
@@ -454,7 +383,7 @@ jobs:
     secrets: inherit
 
   EC2LinuxIntegrationTestCN:
-    needs: [ BuildAndUpload, BuildAndUploadCN, StartLocalStackCN, GenerateTestMatrix, OutputEnvVariables ]
+    needs: [ StartLocalStackCN, GenerateTestMatrix, OutputEnvVariables ]
     name: 'EC2LinuxCN'
     uses: ./.github/workflows/ec2-integration-test.yml
     with:
@@ -473,7 +402,7 @@ jobs:
 
 
   LinuxOnPremIntegrationTest:
-    needs: [BuildAndUpload, StartLocalStack, GenerateTestMatrix, OutputEnvVariables]
+    needs: [StartLocalStack, GenerateTestMatrix, OutputEnvVariables]
     name: 'OnpremLinux'
     uses: ./.github/workflows/ec2-integration-test.yml
     with:
@@ -489,7 +418,7 @@ jobs:
     secrets: inherit
 
   EC2WinIntegrationTest:
-    needs: [BuildAndUpload, BuildAndUploadPackages, GenerateTestMatrix]
+    needs: [GenerateTestMatrix]
     name: 'EC2WinIntegrationTest'
     runs-on: ubuntu-latest
     strategy:
@@ -571,7 +500,7 @@ jobs:
             terraform destroy --auto-approve
 
   EC2DarwinIntegrationTest:
-    needs: [BuildAndUpload, BuildAndUploadPackages, GenerateTestMatrix]
+    needs: [GenerateTestMatrix]
     name: 'EC2DarwinIntegrationTest'
     runs-on: ubuntu-latest
     strategy:
@@ -705,7 +634,7 @@ jobs:
   ECSEC2IntegrationTest:
     name: 'ECSEC2IntegrationTest'
     runs-on: ubuntu-latest
-    needs: [ BuildAndUpload, BuildDocker, GenerateTestMatrix ]
+    needs: [ GenerateTestMatrix ]
     strategy:
       fail-fast: false
       matrix:
@@ -788,7 +717,7 @@ jobs:
   ECSFargateIntegrationTest:
     name: 'ECSFargateIntegrationTest'
     runs-on: ubuntu-latest
-    needs: [BuildAndUpload, BuildDocker, GenerateTestMatrix]
+    needs: [GenerateTestMatrix]
     strategy:
       fail-fast: false
       matrix:
@@ -866,7 +795,7 @@ jobs:
   EKSIntegrationTest:
     name: 'EKSIntegrationTest'
     runs-on: ubuntu-latest
-    needs: [ BuildAndUpload, BuildDocker, GenerateTestMatrix ]
+    needs: [ GenerateTestMatrix ]
     strategy:
       fail-fast: false
       matrix:
@@ -948,7 +877,7 @@ jobs:
   EKSPrometheusIntegrationTest:
     name: 'EKSPrometheusIntegrationTest'
     runs-on: ubuntu-latest
-    needs: [ BuildAndUpload, BuildDocker, GenerateTestMatrix ]
+    needs: [ GenerateTestMatrix ]
     strategy:
       fail-fast: false
       matrix:
@@ -1027,7 +956,7 @@ jobs:
 
   PerformanceTrackingTest:
     name: "PerformanceTrackingTest"
-    needs: [BuildAndUpload, GenerateTestMatrix]
+    needs: [GenerateTestMatrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1095,7 +1024,7 @@ jobs:
 
   EC2WinPerformanceTest:
     name: "EC2WinPerformanceTest"
-    needs: [ BuildAndUpload, BuildAndUploadPackages, GenerateTestMatrix ]
+    needs: [ GenerateTestMatrix ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1163,7 +1092,7 @@ jobs:
 
   StressTrackingTest:
     name: "StressTrackingTest"
-    needs: [BuildAndUpload, GenerateTestMatrix]
+    needs: [GenerateTestMatrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1233,7 +1162,7 @@ jobs:
 
   EC2WinStressTrackingTest:
     name: "EC2WinStressTrackingTest"
-    needs: [BuildAndUpload, BuildAndUploadPackages, GenerateTestMatrix]
+    needs: [GenerateTestMatrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1302,18 +1231,9 @@ jobs:
           retry_wait_seconds: 5
           command: cd terraform/stress && terraform destroy --auto-approve
 
-  ApplicationSignalsEndToEndTest:
-    name: "Application Signals E2E Test"
-    needs: [ BuildAndUpload, BuildDocker ]
-    uses: ./.github/workflows/application-signals-e2e-test.yml
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-
   GPUEndToEndTest:
     name: "GPU E2E Test"
-    needs: [ BuildAndUpload, StartLocalStack, GenerateTestMatrix, OutputEnvVariables ]
+    needs: [ StartLocalStack, GenerateTestMatrix, OutputEnvVariables ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -582,7 +582,7 @@ jobs:
 
   StopLocalStack:
     name: 'StopLocalStack'
-    if: ${{ always() }}
+    if: ${{ always() && needs.StartLocalStack.result == 'success' }}
     needs: [ StartLocalStack, EC2LinuxIntegrationTest, LinuxOnPremIntegrationTest, OutputEnvVariables ]
     uses: ./.github/workflows/stop-localstack.yml
     secrets: inherit
@@ -599,8 +599,8 @@ jobs:
 
   StopLocalStackITAR:
     name: 'StopLocalStackITAR'
-    if: ${{ always() }}
-    needs: [ EC2LinuxIntegrationTestITAR, OutputEnvVariables ]
+    if: ${{ always() && needs.StartLocalStackITAR.result == 'success' }}
+    needs: [ StartLocalStackITAR, EC2LinuxIntegrationTestITAR, OutputEnvVariables ]
     uses: ./.github/workflows/stop-localstack.yml
     secrets: inherit
     permissions:
@@ -616,8 +616,8 @@ jobs:
 
   StopLocalStackCN:
     name: 'StopLocalStackCN'
-    if: ${{ always() }}
-    needs: [ EC2LinuxIntegrationTestCN ]
+    if: ${{ always() && needs.StartLocalStackCN.result == 'success' }}
+    needs: [ StartLocalStackCN, EC2LinuxIntegrationTestCN ]
     uses: ./.github/workflows/stop-localstack.yml
     secrets: inherit
     permissions:


### PR DESCRIPTION
# Description of the issue
The `integration-test.yml` workflow has exceeded the reusable workflow limit of 20 (https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#limitations) due to changes in the nested reusable workflows in the `application-signals-e2e-test.yml` workflow and no longer runs (https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10221982238).

>Invalid workflow file: .github/workflows/integration-test.yml#L1 too many workflows are referenced, total: 25, limit: 20

There isn't currently a way to increase the limit.

# Description of changes
One way around this limitation is to move the application signals E2E workflow out of the integration test workflow. The build jobs that were previously in the integration test workflow have been separated out into their own workflow since both test workflows rely on the build artifacts for the commit. The test workflows are now triggered on the build workflow completion and success.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Triggered the build with a PR event (https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10222942184?pr=1269), but am unable to test the workflow_run

> Note: This event will only trigger a workflow run if the workflow file is on the default branch.

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




