### PR TITLE
[chore] Replace workflow_run with workflow_dispatch

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -6,10 +6,12 @@
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
 name: Application Signals E2E Test
 on:
-  workflow_run:
-    workflows: [ Build Test Artifacts ]
-    types:
-      - completed
+  workflow_dispatch:
+    inputs:
+      build_run_id:
+        description: 'The ID of the build-test-artifacts workflow run'
+        type: number
+        required: true
 
 permissions:
   id-token: write
@@ -23,9 +25,17 @@ concurrency:
 jobs:
   CheckBuildTestArtifacts:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - run: echo 'The triggering build workflow succeeded'
+      - run: |
+          conclusion=$(gh run view ${{ inputs.build_run_id }} --repo $GITHUB_REPOSITORY --json conclusion -q '.conclusion')
+          if [[ $conclusion == "success" ]]; then
+            echo "Run succeeded"
+          else
+            echo "Run failed"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   java-eks-e2e-test:
     needs: CheckBuildTestArtifacts

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -83,3 +83,19 @@ jobs:
       Region: "cn-north-1"
       TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}
       Bucket: ${{ vars.S3_INTEGRATION_BUCKET_CN }}
+
+  StartIntegrationTests:
+    needs: [ BuildAndUploadPackages, BuildAndUploadITAR, BuildAndUploadCN, BuildDocker ]
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run integration-test.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_run_id=${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  StartApplicationSignalsE2ETests:
+    needs: [ BuildAndUpload, BuildDocker ]
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run application-signals-e2e-test.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_run_id=${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -3,6 +3,15 @@
 
 name: Build Test Artifacts
 on:
+  pull_request:
+    branches:
+      - main*
+      - feature*
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   push:
     branches:
       - main*

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -3,15 +3,6 @@
 
 name: Build Test Artifacts
 on:
-  pull_request:
-    branches:
-      - main*
-      - feature*
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
   push:
     branches:
       - main*

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,10 +20,12 @@ env:
   S3_INTEGRATION_BUCKET_CN: ${{ vars.S3_INTEGRATION_BUCKET_CN }}
 
 on:
-  workflow_run:
-    workflows: [ Build Test Artifacts ]
-    types:
-      - completed
+  workflow_dispatch:
+    inputs:
+      build_run_id:
+        description: 'The ID of the build-test-artifacts workflow run'
+        type: number
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -32,9 +34,17 @@ concurrency:
 jobs:
   CheckBuildTestArtifacts:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - run: echo 'The triggering build workflow succeeded'
+      - run: |
+          conclusion=$(gh run view ${{ inputs.build_run_id }} --repo $GITHUB_REPOSITORY --json conclusion -q '.conclusion')
+          if [[ $conclusion == "success" ]]; then
+            echo "Run succeeded"
+          else
+            echo "Run failed"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   GenerateTestMatrix:
     needs: [ CheckBuildTestArtifacts ]


### PR DESCRIPTION
# Description of the issue
The [`workflow_run` event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run) doesn't provide the necessary context to run on non-default branches. This makes it difficult to test changes prior to merging the code and doesn't prevents concurrent runs.

# Description of changes
Switches to the `workflow_dispatch` event for the dependent tests and uses the GitHub CLI [`workflow run` command](https://cli.github.com/manual/gh_workflow_run) to start them. Each of the tests will now use the GitHub CLI [`run view` command](https://cli.github.com/manual/gh_run_view) to check if the build-test-artifacts run has succeeded.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Did some tests on my fork to ensure that the commands work.
- `build-test-artifacts`: https://github.com/jefchien/amazon-cloudwatch-agent/actions/runs/10270204377/job/28417408531
- `integration-test`: https://github.com/jefchien/amazon-cloudwatch-agent/actions/runs/10270206563/job/28417415360
- https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10271658683

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




