### PR TITLE
Change cumulative to delta conversion to drop initial value

### DIFF
--- a/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_darwin.yaml
@@ -26,7 +26,7 @@ processors:
                 - diskio_iops_in_progress
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/advanced_config_linux.yaml
@@ -26,7 +26,7 @@ processors:
                 - diskio_iops_in_progress
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -110,7 +110,7 @@ processors:
                 - diskio_iops_in_progress
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -115,14 +115,14 @@ processors:
                 - diskio_iops_in_progress
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     cumulativetodelta/jmx:
         exclude:
             match_type: ""
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_config_linux.yaml
@@ -26,7 +26,7 @@ processors:
                 - diskio_iops_in_progress
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/delta_net_config_linux.yaml
@@ -23,7 +23,7 @@ processors:
             match_type: ""
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
@@ -26,7 +26,7 @@ processors:
             match_type: ""
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     filter/jmx:
         error_mode: propagate

--- a/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux.yaml
@@ -26,7 +26,7 @@ processors:
                 - diskio_iops_in_progress
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
+++ b/translator/tocwconfig/sampleConfig/standard_config_linux_with_common_config.yaml
@@ -28,7 +28,7 @@ processors:
                 - diskio_iops_in_progress
         include:
             match_type: ""
-        initial_value: 0
+        initial_value: 2
         max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/translate/otel/processor/cumulativetodeltaprocessor/translator.go
+++ b/translator/translate/otel/processor/cumulativetodeltaprocessor/translator.go
@@ -15,9 +15,12 @@ import (
 )
 
 const (
-	// Match types are in internal package from contrib
+	// Match types are in an internal package from contrib
 	// Strict is the FilterType for filtering by exact string matches.
 	strict = "strict"
+	// InitialValue types are in an internal package
+	// 2 is the int value for the enum
+	initialValueDrop = 2
 )
 
 var (
@@ -74,7 +77,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	}
 
 	cfg := t.factory.CreateDefaultConfig().(*cumulativetodeltaprocessor.Config)
-
+	cfg.InitialValue = initialValueDrop
 	excludeMetrics := t.getExcludeMetrics(conf)
 	if len(excludeMetrics) != 0 {
 		cfg.Exclude.MatchType = strict

--- a/translator/translate/otel/processor/cumulativetodeltaprocessor/translator_test.go
+++ b/translator/translate/otel/processor/cumulativetodeltaprocessor/translator_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 
@@ -18,47 +19,50 @@ func TestTranslator(t *testing.T) {
 	cdpTranslator := NewTranslator(common.WithName("test"), WithDiskIONetKeys())
 	require.EqualValues(t, "cumulativetodelta/test", cdpTranslator.ID().String())
 	testCases := map[string]struct {
-		input   map[string]interface{}
-		want    *cumulativetodeltaprocessor.Config
+		input   map[string]any
+		want    map[string]any
 		wantErr error
 	}{
 		"GenerateDeltaProcessorConfigWithCPU": {
-			input: map[string]interface{}{
-				"metrics": map[string]interface{}{
-					"metrics_collected": map[string]interface{}{
-						"cpu": map[string]interface{}{},
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_collected": map[string]any{
+						"cpu": map[string]any{},
 					},
 				},
 			},
 			wantErr: &common.MissingKeyError{ID: cdpTranslator.ID(), JsonKey: fmt.Sprint(diskioKey, " or ", netKey)},
 		},
 		"GenerateDeltaProcessorConfigWithNet": {
-			input: map[string]interface{}{
-				"metrics": map[string]interface{}{
-					"metrics_collected": map[string]interface{}{
-						"net": map[string]interface{}{},
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_collected": map[string]any{
+						"net": map[string]any{},
 					},
 				},
 			},
-			want: &cumulativetodeltaprocessor.Config{
-				Include: cumulativetodeltaprocessor.MatchMetrics{},
-				Exclude: cumulativetodeltaprocessor.MatchMetrics{},
+			want: map[string]any{
+				"initial_value": "drop",
 			},
 		},
 		"GenerateDeltaProcessorConfigWithDiskIO": {
-			input: map[string]interface{}{
-				"metrics": map[string]interface{}{
-					"metrics_collected": map[string]interface{}{
-						"diskio": map[string]interface{}{},
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_collected": map[string]any{
+						"diskio": map[string]any{},
 					},
 				},
 			},
-			want: &cumulativetodeltaprocessor.Config{
-				Include: cumulativetodeltaprocessor.MatchMetrics{},
-				Exclude: cumulativetodeltaprocessor.MatchMetrics{Metrics: []string{"iops_in_progress", "diskio_iops_in_progress"}},
+			want: map[string]any{
+				"exclude": map[string]any{
+					"match_type": "strict",
+					"metrics":    []string{"iops_in_progress", "diskio_iops_in_progress"},
+				},
+				"initial_value": "drop",
 			},
 		},
 	}
+	factory := cumulativetodeltaprocessor.NewFactory()
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			conf := confmap.NewFromStringMap(testCase.input)
@@ -68,8 +72,10 @@ func TestTranslator(t *testing.T) {
 				require.NotNil(t, got)
 				gotCfg, ok := got.(*cumulativetodeltaprocessor.Config)
 				require.True(t, ok)
-				require.Equal(t, testCase.want.Include.Metrics, gotCfg.Include.Metrics)
-				require.Equal(t, testCase.want.Exclude.Metrics, gotCfg.Exclude.Metrics)
+				wantCfg := factory.CreateDefaultConfig()
+				wantConf := confmap.NewFromStringMap(testCase.want)
+				require.NoError(t, wantConf.Unmarshal(&wantCfg))
+				assert.Equal(t, wantCfg, gotCfg)
 			}
 		})
 	}


### PR DESCRIPTION
# Description of the issue
The default configuration for the cumulativetodelta processor sets the initial value behavior to:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/cumulativetodeltaprocessor/README.md

> auto (default): Send if and only if the startime is set AND the starttime happens after the component started AND the starttime is different from the timestamp. Suitable for gateway deployments, this heuristic is like drop, but keeps values for newly started counters (which could not have had previous observed values).

This results in spikes during restarts of the agent. This does not match the behavior of the [prometheus plugin](https://github.com/aws/amazon-cloudwatch-agent/blob/main/plugins/inputs/prometheus/delta_calculator.go#L41) or the [telegraf delta processor](https://github.com/aws/amazon-cloudwatch-agent/blob/da27bf33f5338200135331c63d518f5e10b42428/plugins/processors/delta/delta.go#L113), which both dropped the initial value.

When the agent was using the telegraf delta processor (<= v1.247360.0), the translator would add [a `report_deltas` tag](https://github.com/aws/amazon-cloudwatch-agent/blob/v1.247360.0/translator/translate/metrics/util/deltasutil.go#L14) to the [diskio](https://github.com/aws/amazon-cloudwatch-agent/blob/v1.247360.0/translator/translate/metrics/metrics_collect/diskio/diskio.go#L51)/[net](https://github.com/aws/amazon-cloudwatch-agent/blob/v1.247360.0/translator/translate/metrics/metrics_collect/net/net.go#L52) plugins.

```toml
  [[inputs.diskio]]
    fieldpass = ["io_time", "write_bytes", "read_bytes", "writes", "reads"]
    [inputs.diskio.tags]
      metricPath = "metrics"
      report_deltas = "true" 
```

From there, the delta processor would pick it up and [process those metrics](https://github.com/aws/amazon-cloudwatch-agent/blob/v1.247360.0/plugins/processors/delta/delta.go#L95). The processor had a cache that would store the last value of a metric. If the metric didn't have a last value, [it would drop it](https://github.com/aws/amazon-cloudwatch-agent/blob/v1.247360.0/plugins/processors/delta/delta.go#L104-L107).

# Description of changes
Updates the translator to always configure the cumulative to delta conversion to drop the initial value.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




