### PR TITLE
Suppress sessions unit warning

### DIFF
--- a/internal/cloudwatch/unit.go
+++ b/internal/cloudwatch/unit.go
@@ -75,6 +75,7 @@ var scaledBaseUnits = map[types.StandardUnit]map[unit.MetricPrefix]types.Standar
 
 var knownNonConvertibleUnits = collections.NewSet(
 	// JMX/Tomcat units
+	"sessions",
 	"errors",
 	"threads",
 	"requests",


### PR DESCRIPTION
# Description of the issue
The CloudWatch agent has a warning when units cannot be converted. We've previously added suppression for known JMX units (https://github.com/aws/amazon-cloudwatch-agent/pull/1244), but missed the "sessions" unit for `tomcat.sessions`.

- Tomcat (https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/src/main/resources/target-systems/tomcat.groovy):
  - `tomcat.sessions`: `session`
  - `tomcat.errors`: `errors`
  - `tomcat.request_count`: `requests`
  - `tomcat.threads`: `threads`

# Description of changes
Adds "sessions" to the list.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




