### PR TITLE
use protobuf content type instead of json for k8sClient

### DIFF
--- a/internal/k8sCommon/k8sclient/clientset.go
+++ b/internal/k8sCommon/k8sclient/clientset.go
@@ -58,6 +58,8 @@ func (c *K8sClient) init() {
 			return
 		}
 	}
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Printf("E! Failed to build ClientSet: %v", err)


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._

Use protobuf over json to help gain performance and reduce footprint on apiserver side.
Ref:  https://github.com/kubernetes/kube-state-metrics/pull/475
https://github.com/kubernetes/client-go/issues/76

# Description of changes
_How does this change address the problem?_



# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




