### PR TITLE
Stop converting nanosecond metrics

### DIFF
--- a/internal/cloudwatch/unit.go
+++ b/internal/cloudwatch/unit.go
@@ -40,7 +40,6 @@ var uniqueConversions = map[string]struct {
 	scale        float64
 }{
 	// time
-	"ns":  {types.StandardUnitMicroseconds, 1 / float64(time.Microsecond.Nanoseconds())},
 	"min": {types.StandardUnitSeconds, time.Minute.Seconds()},
 	"h":   {types.StandardUnitSeconds, time.Hour.Seconds()},
 	"d":   {types.StandardUnitSeconds, 24 * time.Hour.Seconds()},

--- a/internal/cloudwatch/unit.go
+++ b/internal/cloudwatch/unit.go
@@ -40,6 +40,7 @@ var uniqueConversions = map[string]struct {
 	scale        float64
 }{
 	// time
+	"ns":  {types.StandardUnitNone, 1},
 	"min": {types.StandardUnitSeconds, time.Minute.Seconds()},
 	"h":   {types.StandardUnitSeconds, time.Hour.Seconds()},
 	"d":   {types.StandardUnitSeconds, 24 * time.Hour.Seconds()},

--- a/internal/cloudwatch/unit_test.go
+++ b/internal/cloudwatch/unit_test.go
@@ -56,7 +56,6 @@ func TestScaledUnits(t *testing.T) {
 		{"kB", "Kilobytes", 1},
 		{"kib/s", "Kilobytes/Second", 1.024},
 		{"ms", "Milliseconds", 1},
-		{"ns", "Microseconds", 0.001},
 		{"min", "Seconds", 60},
 		{"h", "Seconds", 60 * 60},
 		{"d", "Seconds", 24 * 60 * 60},

--- a/internal/cloudwatch/unit_test.go
+++ b/internal/cloudwatch/unit_test.go
@@ -56,6 +56,7 @@ func TestScaledUnits(t *testing.T) {
 		{"kB", "Kilobytes", 1},
 		{"kib/s", "Kilobytes/Second", 1.024},
 		{"ms", "Milliseconds", 1},
+		{"ns", "None", 1},
 		{"min", "Seconds", 60},
 		{"h", "Seconds", 60 * 60},
 		{"d", "Seconds", 24 * 60 * 60},


### PR DESCRIPTION
# Description of the issue
Currently, nanosecond metrics are converted to microseconds before being published to CloudWatch because CloudWatch does not support nanosecond unit. The closest unit is microseconds.

Unfortunately, this implicit conversion can be confusing for metrics with `ns` in the name like `kafka.producer.io-wait-time-ns-avg` because the value/unit in CloudWatch will actually be Microseconds which is inconsistent with the metric name. This also results in a loss of precision.

# Description of changes
This change removes the conversion of nanosecond metrics. Instead, they are published unmodified with a unit of "None".

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Kicked off integration tests for that branch. Checked the `metric_value_benchmark` integ test outputs, search for `kafka.producer.io-wait-time-ns-avg`, find [log messages](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/10619074357/job/29435990231#step:7:3781) like:
```
null_resource.integration_test_run (remote-exec): 2024/08/29 17:05:18 Metric query input dimensions
null_resource.integration_test_run (remote-exec): 2024/08/29 17:05:18 	Dimensions:
null_resource.integration_test_run (remote-exec): 2024/08/29 17:05:18 		Dim(name="InstanceId", val="i-078550b055ab2cccb")
null_resource.integration_test_run (remote-exec): 2024/08/29 17:05:18 Metric data input: namespace MetricValueBenchmarkJMXTest, name kafka.producer.io-wait-time-ns-avg, stat Average, period 10
null_resource.integration_test_run (remote-exec): 2024/08/29 17:05:18 Metric values are : [643476.2933982722 1.3033429029366784e+06 1.5008771342337618e+07]
null_resource.integration_test_run (remote-exec): 2024/08/29 17:05:18 metric values are [643476.2933982722 1.3033429029366784e+06 1.5008771342337618e+07]
```

Plot the `kafka.producer.io-wait-time-ns-avg` metric with that instance ID in CloudWatch. Do that for a few OS types for both my branch and main branch to compare. The updated metrics are about 1000x larger, which is expected. Also noted that the updated metrics do not have a unit associated.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




