### PR TITLE
Bug fix for duplicate log events by resetting the response body stream in agent health

### DIFF
--- a/extension/agenthealth/handler/stats/client/client.go
+++ b/extension/agenthealth/handler/stats/client/client.go
@@ -139,10 +139,13 @@ func rejectedEntityInfoExists(r *http.Response) bool {
 	if r == nil || r.Body == nil {
 		return false
 	}
-	defer r.Body.Close()
 	bodyBytes, err := io.ReadAll(r.Body)
+	r.Body.Close()
 	if err != nil {
 		return false
 	}
+	// Reset the response body stream since it can only be read once. Not doing this results in duplicate requests.
+	// See https://stackoverflow.com/questions/33532374/in-go-how-can-i-reuse-a-readcloser
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	return bytes.Contains(bodyBytes, rejectedEntityInfo)
 }


### PR DESCRIPTION
# Description of the issue
Duplicate log events are being published for all use-cases. This was determined to be due to the reading of the HTTP response body in the agent health extension. The body is being read elsewhere, but can only be read once. We reset the body to address the issue.

# Description of changes
Resets the response body stream with the content that was read.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manually tested to confirm that the log events are no longer duplicated.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




