### PR TITLE
Specifying region in EC2 and STS clients in entity store

### DIFF
--- a/extension/entitystore/extension.go
+++ b/extension/entitystore/extension.go
@@ -5,9 +5,12 @@ package entitystore
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -88,6 +91,7 @@ func (e *EntityStore) Start(ctx context.Context, host component.Host) error {
 	ec2CredentialConfig := &configaws.CredentialConfig{
 		Profile:  e.config.Profile,
 		Filename: e.config.Filename,
+		Region:   e.config.Region,
 	}
 	switch e.mode {
 	case config.ModeEC2:
@@ -203,9 +207,11 @@ func (e *EntityStore) shouldReturnEntity() bool {
 		e.stsClient = sts.New(
 			e.nativeCredential,
 			&aws.Config{
-				Region:   aws.String(e.config.Region),
-				LogLevel: configaws.SDKLogLevel(),
-				Logger:   configaws.SDKLogger{},
+				Region:              aws.String(e.config.Region),
+				LogLevel:            configaws.SDKLogLevel(),
+				Logger:              configaws.SDKLogger{},
+				STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
+				HTTPClient:          &http.Client{Timeout: 1 * time.Minute},
 			})
 	}
 	assumedRoleIdentity, err := e.stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
@@ -226,7 +232,6 @@ func getEC2Provider(region string, ec2CredentialConfig *configaws.CredentialConf
 	return ec2.New(
 		ec2CredentialConfig.Credentials(),
 		&aws.Config{
-			Region:   aws.String(region),
 			LogLevel: configaws.SDKLogLevel(),
 			Logger:   configaws.SDKLogger{},
 		})

--- a/extension/entitystore/extension.go
+++ b/extension/entitystore/extension.go
@@ -203,6 +203,7 @@ func (e *EntityStore) shouldReturnEntity() bool {
 		e.stsClient = sts.New(
 			e.nativeCredential,
 			&aws.Config{
+				Region:   aws.String(e.config.Region),
 				LogLevel: configaws.SDKLogLevel(),
 				Logger:   configaws.SDKLogger{},
 			})
@@ -225,6 +226,7 @@ func getEC2Provider(region string, ec2CredentialConfig *configaws.CredentialConf
 	return ec2.New(
 		ec2CredentialConfig.Credentials(),
 		&aws.Config{
+			Region:   aws.String(region),
 			LogLevel: configaws.SDKLogLevel(),
 			Logger:   configaws.SDKLogger{},
 		})


### PR DESCRIPTION
# Description of the issue
Resolving issue where the region is not specified when creating the STS and EC2 metadata clients.

# Description of changes
Adds region to the AWS config when instantiating the clients.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Manual in us-east-1

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




