### PR TITLE
Caches result of shouldReturnEntity() function to reduce number of STS GetCallerIdentity requests.

### DIFF
--- a/extension/entitystore/factory.go
+++ b/extension/entitystore/factory.go
@@ -5,6 +5,7 @@ package entitystore
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -36,6 +37,9 @@ func createExtension(_ context.Context, settings extension.CreateSettings, cfg c
 	entityStore = &EntityStore{
 		logger: settings.Logger,
 		config: cfg.(*Config),
+		currentTime: func() time.Time {
+			return time.Now()
+		},
 	}
 	return entityStore, nil
 }


### PR DESCRIPTION
# Description of the issue
In the current implementation, we currently make a request to the `sts:GetCallerIdentity` so that we can verify that the account ID for the instance matches the account ID that is assuming the role for the current credential. 

However, this check was being done at every time a PutLogEvent call was being made, causing impact to the STS service.

# Description of changes
The logic of checking instance account vs. the account assuming the role remains untouched. This PR instead caches that result, and now only periodically checks the match on an interval. 

With the current implementation, a successful match will set the interval to 24 hours, and a failed match will set the interval to 5 minutes. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit testing has shown that the agent is not making calls to STS as aggressively.

Manual testing: I added a debug line right after a successful GetCallerIdentity call is made. Agent Logs show that while we still continue to successfully publish logs to CWL, we are clearly reducing the number of `GetCallerIdentity` calls.
```
[ec2-user@ip-172-31-75-235 amazon-cloudwatch-agent]$ sudo less /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log | grep GetCallerIdentity
2024-09-13T14:40:10Z I! {"caller":"entitystore/extension.go:244","msg":"Made call to STS GetCallerIdentity","kind":"extension","name":"entitystore"}

[ec2-user@ip-172-31-75-235 amazon-cloudwatch-agent]$ sudo less /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log | grep 'Pusher published' |tail -n 5
2024-09-13T14:44:59Z D! [outputs.cloudwatchlogs] Pusher published 1 log events to group: i-03b6ab25131f0f8a0 stream: i-03b6ab25131f0f8a0 with size 0 KB in 23.811657ms.
2024-09-13T14:45:04Z D! [outputs.cloudwatchlogs] Pusher published 2 log events to group: i-03b6ab25131f0f8a0 stream: i-03b6ab25131f0f8a0 with size 0 KB in 10.225546ms.
2024-09-13T14:45:14Z D! [outputs.cloudwatchlogs] Pusher published 1 log events to group: i-03b6ab25131f0f8a0 stream: i-03b6ab25131f0f8a0 with size 0 KB in 31.33703ms.
2024-09-13T14:45:19Z D! [outputs.cloudwatchlogs] Pusher published 2 log events to group: i-03b6ab25131f0f8a0 stream: i-03b6ab25131f0f8a0 with size 0 KB in 13.017723ms.
2024-09-13T14:45:29Z D! [outputs.cloudwatchlogs] Pusher published 2 log events to group: i-03b6ab25131f0f8a0 stream: i-03b6ab25131f0f8a0 with size 0 KB in 31.463429ms.


[ec2-user@ip-172-31-75-235 amazon-cloudwatch-agent]$ sudo less /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log | grep GetCallerIdentity
2024-09-13T14:40:10Z I! {"caller":"entitystore/extension.go:244","msg":"Made call to STS GetCallerIdentity","kind":"extension","name":"entitystore"}
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




