### PR TITLE
Add new aws resource cloudformation primary identifier attribute in EMF

### DIFF
--- a/plugins/processors/awsapplicationsignals/common/types.go
+++ b/plugins/processors/awsapplicationsignals/common/types.go
@@ -37,7 +37,8 @@ const (
 
 // Resource attributes used as CloudWatch EMF log fields.
 const (
-	MetricAttributeRemoteDbUser = "RemoteDbUser"
+	MetricAttributeRemoteDbUser                       = "RemoteDbUser"
+	MetricAttributeRemoteResourceCfnPrimaryIdentifier = "RemoteResourceCfnPrimaryIdentifier"
 )
 
 const (

--- a/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
+++ b/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
@@ -5,18 +5,19 @@ package attributes
 
 const (
 	// aws attributes
-	AWSSpanKind                 = "aws.span.kind"
-	AWSLocalService             = "aws.local.service"
-	AWSLocalEnvironment         = "aws.local.environment"
-	AWSLocalOperation           = "aws.local.operation"
-	AWSRemoteService            = "aws.remote.service"
-	AWSRemoteOperation          = "aws.remote.operation"
-	AWSRemoteEnvironment        = "aws.remote.environment"
-	AWSRemoteTarget             = "aws.remote.target"
-	AWSRemoteResourceIdentifier = "aws.remote.resource.identifier"
-	AWSRemoteResourceType       = "aws.remote.resource.type"
-	AWSHostedInEnvironment      = "aws.hostedin.environment"
-	AWSRemoteDbUser             = "aws.remote.db.user"
+	AWSSpanKind                           = "aws.span.kind"
+	AWSLocalService                       = "aws.local.service"
+	AWSLocalEnvironment                   = "aws.local.environment"
+	AWSLocalOperation                     = "aws.local.operation"
+	AWSRemoteService                      = "aws.remote.service"
+	AWSRemoteOperation                    = "aws.remote.operation"
+	AWSRemoteEnvironment                  = "aws.remote.environment"
+	AWSRemoteTarget                       = "aws.remote.target"
+	AWSRemoteResourceIdentifier           = "aws.remote.resource.identifier"
+	AWSRemoteResourceType                 = "aws.remote.resource.type"
+	AWSHostedInEnvironment                = "aws.hostedin.environment"
+	AWSRemoteDbUser                       = "aws.remote.db.user"
+	AWSRemoteResourceCfnPrimaryIdentifier = "aws.remote.resource.cfn.primary.identifier"
 
 	// resource detection processor attributes
 	ResourceDetectionHostId   = "host.id"

--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer.go
@@ -31,16 +31,17 @@ type attributesNormalizer struct {
 }
 
 var attributesRenamingForMetric = map[string]string{
-	attr.AWSLocalService:             common.CWMetricAttributeLocalService,
-	attr.AWSLocalOperation:           common.CWMetricAttributeLocalOperation,
-	attr.AWSLocalEnvironment:         common.CWMetricAttributeEnvironment,
-	attr.AWSRemoteService:            common.CWMetricAttributeRemoteService,
-	attr.AWSRemoteOperation:          common.CWMetricAttributeRemoteOperation,
-	attr.AWSRemoteEnvironment:        common.CWMetricAttributeRemoteEnvironment,
-	attr.AWSRemoteTarget:             common.CWMetricAttributeRemoteResourceIdentifier,
-	attr.AWSRemoteResourceIdentifier: common.CWMetricAttributeRemoteResourceIdentifier,
-	attr.AWSRemoteResourceType:       common.CWMetricAttributeRemoteResourceType,
-	attr.AWSRemoteDbUser:             common.MetricAttributeRemoteDbUser,
+	attr.AWSLocalService:                       common.CWMetricAttributeLocalService,
+	attr.AWSLocalOperation:                     common.CWMetricAttributeLocalOperation,
+	attr.AWSLocalEnvironment:                   common.CWMetricAttributeEnvironment,
+	attr.AWSRemoteService:                      common.CWMetricAttributeRemoteService,
+	attr.AWSRemoteOperation:                    common.CWMetricAttributeRemoteOperation,
+	attr.AWSRemoteEnvironment:                  common.CWMetricAttributeRemoteEnvironment,
+	attr.AWSRemoteTarget:                       common.CWMetricAttributeRemoteResourceIdentifier,
+	attr.AWSRemoteResourceIdentifier:           common.CWMetricAttributeRemoteResourceIdentifier,
+	attr.AWSRemoteResourceType:                 common.CWMetricAttributeRemoteResourceType,
+	attr.AWSRemoteDbUser:                       common.MetricAttributeRemoteDbUser,
+	attr.AWSRemoteResourceCfnPrimaryIdentifier: common.MetricAttributeRemoteResourceCfnPrimaryIdentifier,
 }
 
 var resourceAttributesRenamingForTrace = map[string]string{

--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
@@ -239,3 +239,22 @@ func TestTruncateAttributes_AWSRemoteDbUser(t *testing.T) {
 	val, _ := attributes.Get(attr.AWSRemoteDbUser)
 	assert.True(t, len(val.Str()) <= defaultMetricAttributeLength)
 }
+
+func TestRenameAttributes_AWSRemoteResourceCfnIdentifier_for_metric(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	normalizer := NewAttributesNormalizer(logger)
+
+	attributes := pcommon.NewMap()
+	attributes.PutStr(attr.AWSRemoteResourceCfnPrimaryIdentifier, "arn:123:abc-value")
+
+	resourceAttributes := pcommon.NewMap()
+	normalizer.renameAttributes(attributes, resourceAttributes, false)
+
+	if _, ok := attributes.Get(attr.AWSRemoteResourceCfnPrimaryIdentifier); ok {
+		t.Errorf("AWSRemoteResourceCfnPrimaryIdentifier was not removed")
+	}
+
+	if value, ok := attributes.Get("RemoteResourceCfnPrimaryIdentifier"); !ok || value.AsString() != "arn:123:abc-value" {
+		t.Errorf("RemoteResourceCfnPrimaryIdentifier has incorrect value: got %v, want %v", value.AsString(), "arn:123:abc-value")
+	}
+}


### PR DESCRIPTION
# Description of changes
Add a new log attribute in EMF logs which is to store AWS Resource CloudFormation Primary Identifier value for AWS resources recognized by AppSignals instrumentation SDKs. https://github.com/aws-observability/aws-otel-python-instrumentation/pull/264
 
Rename SDK attribute `aws.remote.resource.cfn.primary.identifier` to EMF logs attribute `RemoteResourceCfnPrimaryIdentifier`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
unit test

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




