### PR TITLE
Add support for OTLP Receiver for Metrics

### DIFF
--- a/cmd/config-translator/translator_test.go
+++ b/cmd/config-translator/translator_test.go
@@ -73,6 +73,14 @@ func TestJMXConfig(t *testing.T) {
 	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidJMX.json", false, expectedErrorMap)
 }
 
+func TestOTLPMetricsConfig(t *testing.T) {
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validOTLPMetrics.json", true, map[string]int{})
+	expectedErrorMap := map[string]int{}
+	expectedErrorMap["array_min_items"] = 1
+	expectedErrorMap["number_one_of"] = 1
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidOTLPMetrics.json", false, expectedErrorMap)
+}
+
 func TestLogFilesConfig(t *testing.T) {
 	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validLogFiles.json", true, map[string]int{})
 	expectedErrorMap := map[string]int{}

--- a/translator/config/sampleSchema/invalidOTLPMetrics.json
+++ b/translator/config/sampleSchema/invalidOTLPMetrics.json
@@ -1,0 +1,8 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "otlp": [
+      ]
+    }
+  }
+}

--- a/translator/config/sampleSchema/validOTLPMetrics.json
+++ b/translator/config/sampleSchema/validOTLPMetrics.json
@@ -1,0 +1,20 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "otlp": [
+        {
+          "grpc_endpoint": "0.0.0.0:1234",
+          "http_endpoint": "0.0.0.0:2345"
+        },
+        {
+          "grpc_endpoint": "0.0.0.0:3456",
+          "http_endpoint": "0.0.0.0:4567",
+          "tls": {
+            "cert_file": "/path/to/cert.pem",
+            "key_file": "/path/to/key.pem"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -137,6 +137,9 @@
             },
             "jmx": {
               "$ref": "#/definitions/metricsDefinition/definitions/jmxDefinitions"
+            },
+            "otlp": {
+              "$ref": "#/definitions/otlpDefinitions"
             }
           },
           "minProperties": 1,
@@ -352,29 +355,6 @@
             }
           },
           "additionalProperties": false
-        },
-        "tlsDefinitions": {
-          "type": "object",
-          "properties": {
-            "ca_file": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 255
-            },
-            "cert_file": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 255
-            },
-            "key_file": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 255
-            },
-            "insecure": {
-              "type": "boolean"
-            }
-          }
         },
         "swapDefinitions": {
           "$ref": "#/definitions/metricsDefinition/definitions/basicMetricDefinition"
@@ -653,7 +633,7 @@
                 }
               },
               "tls": {
-                "$ref": "#/definitions/metricsDefinition/definitions/tlsDefinitions"
+                "$ref": "#/definitions/tlsDefinitions"
               },
               "additionalProperties": true
             },
@@ -737,7 +717,7 @@
                 }
               },
               "tls": {
-                "$ref": "#/definitions/metricsDefinition/definitions/tlsDefinitions"
+                "$ref": "#/definitions/tlsDefinitions"
               },
               "additionalProperties": true
             },
@@ -772,7 +752,7 @@
               },
               "additionalProperties": true
             },
-            "prometheus":{
+            "prometheus": {
               "type": "object",
               "properties": {
                 "cluster_name": {
@@ -1067,10 +1047,7 @@
               "$ref": "#/definitions/tracesDefinition/definitions/xrayDefinition"
             },
             "otlp": {
-              "tls": {
-                "$ref": "#/definitions/metricsDefinition/definitions/tlsDefinitions"
-              },
-              "$ref": "#/definitions/tracesDefinition/definitions/otlpDefinitions"
+              "$ref": "#/definitions/otlpDefinitions"
             }
           },
           "minProperties": 1,
@@ -1133,21 +1110,6 @@
             }
           },
           "additionalProperties": false
-        },
-        "otlpDefinitions": {
-          "oneOf": [
-            {
-              "type": "array",
-              "minItems": 1,
-              "maxItems": 255,
-              "items": {
-                "$ref": "#/definitions/otlpObjectDefinition"
-              }
-            },
-            {
-              "$ref": "#/definitions/otlpObjectDefinition"
-            }
-          ]
         }
       }
     },
@@ -1203,6 +1165,44 @@
       },
       "additionalProperties": false
     },
+    "tlsDefinitions": {
+      "type": "object",
+      "properties": {
+        "ca_file": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "cert_file": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "key_file": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "insecure": {
+          "type": "boolean"
+        }
+      }
+    },
+    "otlpDefinitions": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 255,
+          "items": {
+            "$ref": "#/definitions/otlpObjectDefinition"
+          }
+        },
+        {
+          "$ref": "#/definitions/otlpObjectDefinition"
+        }
+      ]
+    },
     "otlpObjectDefinition": {
       "type": "object",
       "properties": {
@@ -1213,6 +1213,9 @@
         "http_endpoint": {
           "description": "HTTP endpoint to use to listen for OTLP JSON information",
           "$ref": "#/definitions/endpointOverrideDefinition"
+        },
+        "tls": {
+          "$ref": "#/definitions/tlsDefinitions"
         }
       },
       "additionalProperties": false
@@ -1431,7 +1434,7 @@
               "description": "Prometheus metrics port list of the exporters",
               "type": "string"
             },
-            "sd_service_name_pattern":{
+            "sd_service_name_pattern": {
               "description": "ECS service name pattern responsible for tasks which expose the Prometheus metrics",
               "type": "string"
             }

--- a/translator/tocwconfig/sampleConfig/otlp_metrics_config.conf
+++ b/translator/tocwconfig/sampleConfig/otlp_metrics_config.conf
@@ -1,0 +1,21 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+[outputs]
+
+  [[outputs.cloudwatch]]

--- a/translator/tocwconfig/sampleConfig/otlp_metrics_config.json
+++ b/translator/tocwconfig/sampleConfig/otlp_metrics_config.json
@@ -1,0 +1,20 @@
+{
+  "metrics": {
+    "append_dimensions": {
+      "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+      "ImageId": "${aws:ImageId}",
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}"
+    },
+    "metrics_collected": {
+      "otlp": {
+        "grpc_endpoint": "0.0.0.0:1234",
+        "http_endpoint": "0.0.0.0:2345",
+        "tls": {
+          "cert_file": "/path/to/cert.pem",
+          "key_file": "/path/to/key.pem"
+        }
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/otlp_metrics_config.yaml
+++ b/translator/tocwconfig/sampleConfig/otlp_metrics_config.yaml
@@ -1,0 +1,106 @@
+exporters:
+  awscloudwatch:
+    force_flush_interval: 1m0s
+    max_datums_per_call: 1000
+    max_values_per_datum: 150
+    middleware: agenthealth/metrics
+    namespace: CWAgent
+    region: us-west-2
+    resource_to_telemetry_conversion:
+      enabled: true
+extensions:
+  agenthealth/metrics:
+    is_usage_data_enabled: true
+    stats:
+      operations:
+        - PutMetricData
+      usage_flags:
+        mode: EC2
+        region_type: ACJ
+processors:
+  cumulativetodelta/hostDeltaMetrics:
+    exclude:
+      match_type: ""
+    include:
+      match_type: ""
+    initial_value: 2
+    max_staleness: 0s
+  ec2tagger:
+    ec2_instance_tag_keys:
+      - AutoScalingGroupName
+    ec2_metadata_tags:
+      - ImageId
+      - InstanceId
+      - InstanceType
+    imds_retries: 1
+    refresh_interval_seconds: 0s
+receivers:
+  otlp/metrics:
+    protocols:
+      grpc:
+        dialer:
+          timeout: 0s
+        endpoint: 0.0.0.0:1234
+        include_metadata: false
+        max_concurrent_streams: 0
+        max_recv_msg_size_mib: 0
+        read_buffer_size: 524288
+        transport: tcp
+        write_buffer_size: 0
+        tls:
+          ca_file: ""
+          cert_file: /path/to/cert.pem
+          client_ca_file: ""
+          client_ca_file_reload: false
+          include_system_ca_certs_pool: false
+          key_file: /path/to/key.pem
+          max_version: ""
+          min_version: ""
+          reload_interval: 0s
+      http:
+        endpoint: 0.0.0.0:2345
+        include_metadata: false
+        logs_url_path: /v1/logs
+        max_request_body_size: 0
+        metrics_url_path: /v1/metrics
+        traces_url_path: /v1/traces
+        tls:
+          ca_file: ""
+          cert_file: /path/to/cert.pem
+          client_ca_file: ""
+          client_ca_file_reload: false
+          include_system_ca_certs_pool: false
+          key_file: /path/to/key.pem
+          max_version: ""
+          min_version: ""
+          reload_interval: 0s
+service:
+  extensions:
+    - agenthealth/metrics
+  pipelines:
+    metrics/hostDeltaMetrics:
+      exporters:
+        - awscloudwatch
+      processors:
+        - cumulativetodelta/hostDeltaMetrics
+        - ec2tagger
+      receivers:
+        - otlp/metrics
+  telemetry:
+    logs:
+      development: false
+      disable_caller: false
+      disable_stacktrace: false
+      encoding: console
+      level: info
+      output_paths:
+        - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+      sampling:
+        enabled: true
+        initial: 2
+        thereafter: 500
+        tick: 10s
+    metrics:
+      address: ""
+      level: None
+    traces: { }

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -218,6 +218,14 @@ func TestLogsAndKubernetesConfig(t *testing.T) {
 	checkTranslation(t, "logs_and_kubernetes_config", "darwin", nil, "")
 }
 
+func TestOtlpMetricsConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	checkTranslation(t, "otlp_metrics_config", "linux", nil, "")
+	checkTranslation(t, "otlp_metrics_config", "darwin", nil, "")
+	checkTranslation(t, "otlp_metrics_config", "windows", nil, "")
+}
+
 func TestProcstatMemorySwapConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(false)

--- a/translator/translate/metrics/config/registered_metrics.go
+++ b/translator/translate/metrics/config/registered_metrics.go
@@ -58,4 +58,5 @@ var DisableWinPerfCounters = map[string]bool{
 	"procstat":    true,
 	"nvidia_smi":  true,
 	common.JmxKey: true,
+	"otlp":        true,
 }

--- a/translator/translate/otel/pipeline/host/translators.go
+++ b/translator/translate/otel/pipeline/host/translators.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline"
 	adaptertranslator "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/adapter"
+	otlpreceiver "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/otlp"
 )
 
 func NewTranslators(conf *confmap.Conf, os string) (pipeline.TranslatorMap, error) {
@@ -32,6 +33,18 @@ func NewTranslators(conf *confmap.Conf, os string) (pipeline.TranslatorMap, erro
 			hostReceivers.Set(translator)
 		}
 	})
+
+	switch v := conf.Get(common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey)).(type) {
+	case []interface{}:
+		for index := range v {
+			deltaReceivers.Set(otlpreceiver.NewTranslator(
+				otlpreceiver.WithDataType(component.DataTypeMetrics),
+				otlpreceiver.WithIndex(index),
+			))
+		}
+	case map[string]interface{}:
+		deltaReceivers.Set(otlpreceiver.NewTranslator(otlpreceiver.WithDataType(component.DataTypeMetrics)))
+	}
 
 	hasHostPipeline := hostReceivers.Len() != 0
 	hasDeltaPipeline := deltaReceivers.Len() != 0

--- a/translator/translate/otel/pipeline/host/translators_test.go
+++ b/translator/translate/otel/pipeline/host/translators_test.go
@@ -57,6 +57,20 @@ func TestTranslators(t *testing.T) {
 				},
 			},
 		},
+		"WithOtlpMetrics": {
+			input: map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"otlp": map[string]interface{}{},
+					},
+				},
+			},
+			want: map[string]want{
+				"metrics/hostDeltaMetrics": {
+					receivers: []string{"otlp/metrics"},
+				},
+			},
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/translator/translate/otel/processor/cumulativetodeltaprocessor/translator.go
+++ b/translator/translate/otel/processor/cumulativetodeltaprocessor/translator.go
@@ -26,6 +26,7 @@ const (
 var (
 	netKey    = common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.NetKey)
 	diskioKey = common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.DiskIOKey)
+	otlpKey   = common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey)
 
 	exclusions = map[string][]string{
 		// DiskIO and Net Metrics are cumulative metrics
@@ -36,8 +37,8 @@ var (
 	}
 )
 
-func WithDiskIONetKeys() common.TranslatorOption {
-	return WithConfigKeys(diskioKey, netKey)
+func WithDefaultKeys() common.TranslatorOption {
+	return WithConfigKeys(diskioKey, netKey, otlpKey)
 }
 
 func WithConfigKeys(keys ...string) common.TranslatorOption {

--- a/translator/translate/otel/processor/cumulativetodeltaprocessor/translator_test.go
+++ b/translator/translate/otel/processor/cumulativetodeltaprocessor/translator_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestTranslator(t *testing.T) {
-	cdpTranslator := NewTranslator(common.WithName("test"), WithDiskIONetKeys())
+	cdpTranslator := NewTranslator(common.WithName("test"), WithDefaultKeys())
 	require.EqualValues(t, "cumulativetodelta/test", cdpTranslator.ID().String())
 	testCases := map[string]struct {
 		input   map[string]any
@@ -31,7 +31,7 @@ func TestTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantErr: &common.MissingKeyError{ID: cdpTranslator.ID(), JsonKey: fmt.Sprint(diskioKey, " or ", netKey)},
+			wantErr: &common.MissingKeyError{ID: cdpTranslator.ID(), JsonKey: fmt.Sprint(diskioKey, " or ", netKey, " or ", otlpKey)},
 		},
 		"GenerateDeltaProcessorConfigWithNet": {
 			input: map[string]any{

--- a/translator/translate/otel/receiver/adapter/translators.go
+++ b/translator/translate/otel/receiver/adapter/translators.go
@@ -33,7 +33,7 @@ const (
 var (
 	logKey           = common.ConfigKey(common.LogsKey, common.LogsCollectedKey)
 	metricKey        = common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey)
-	skipInputSet     = collections.NewSet[string](common.JmxKey, files.SectionKey, windows_events.SectionKey)
+	skipInputSet     = collections.NewSet[string](files.SectionKey, windows_events.SectionKey)
 	multipleInputSet = collections.NewSet[string](
 		procstat.SectionKey,
 	)
@@ -159,7 +159,9 @@ func fromInputs(conf *confmap.Conf, validInputs map[string]bool, baseKey string)
 				continue
 			}
 			if validInputs != nil {
-				if _, ok := validInputs[inputName]; !ok {
+				if _, ok := OtelReceivers[inputName]; ok {
+					continue
+				} else if _, ok := validInputs[inputName]; !ok {
 					log.Printf("W! Ignoring unrecognized input %s", inputName)
 					continue
 				}

--- a/translator/translate/otel/receiver/otlp/testdata/metrics/config.json
+++ b/translator/translate/otel/receiver/otlp/testdata/metrics/config.json
@@ -1,0 +1,14 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "otlp": {
+        "grpc_endpoint": "0.0.0.0:1234",
+        "http_endpoint": "0.0.0.0:2345",
+        "tls": {
+          "cert_file": "/path/to/cert.pem",
+          "key_file": "/path/to/key.pem"
+        }
+      }
+    }
+  }
+}

--- a/translator/translate/otel/receiver/otlp/testdata/metrics/config.yaml
+++ b/translator/translate/otel/receiver/otlp/testdata/metrics/config.yaml
@@ -1,0 +1,11 @@
+protocols:
+  grpc:
+    endpoint: 0.0.0.0:1234
+    tls:
+      cert_file: /path/to/cert.pem
+      key_file: /path/to/key.pem
+  http:
+    endpoint: 0.0.0.0:2345
+    tls:
+      cert_file: /path/to/cert.pem
+      key_file: /path/to/key.pem

--- a/translator/translate/otel/receiver/otlp/translator.go
+++ b/translator/translate/otel/receiver/otlp/translator.go
@@ -98,7 +98,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	if t.name == common.AppSignals {
 		appSignalsConfigKeys, ok := common.AppSignalsConfigKeys[t.dataType]
 		if !ok {
-			return nil, fmt.Errorf("no appplication_signals config key defined for data type: %s", t.dataType)
+			return nil, fmt.Errorf("no application_signals config key defined for data type: %s", t.dataType)
 		}
 		if conf.IsSet(appSignalsConfigKeys[0]) {
 			configKey = appSignalsConfigKeys[0]

--- a/translator/translate/otel/receiver/otlp/translator.go
+++ b/translator/translate/otel/receiver/otlp/translator.go
@@ -26,16 +26,16 @@ const (
 
 var (
 	configKeys = map[component.DataType]string{
-		component.DataTypeTraces:  common.ConfigKey(common.TracesKey, common.TracesCollectedKey),
-		component.DataTypeMetrics: common.ConfigKey(common.LogsKey, common.MetricsCollectedKey),
+		component.DataTypeTraces:  common.ConfigKey(common.TracesKey, common.TracesCollectedKey, common.OtlpKey),
+		component.DataTypeMetrics: common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey),
 	}
 )
 
 type translator struct {
-	name        string
-	dataType    component.DataType
-	instanceNum int
-	factory     receiver.Factory
+	name     string
+	dataType component.DataType
+	index    int
+	factory  receiver.Factory
 }
 
 type Option interface {
@@ -55,9 +55,9 @@ func WithDataType(dataType component.DataType) Option {
 		t.dataType = dataType
 	})
 }
-func WithInstanceNum(instanceNum int) Option {
+func WithIndex(index int) Option {
 	return optionFunc(func(t *translator) {
-		t.instanceNum = instanceNum
+		t.index = index
 	})
 }
 
@@ -68,14 +68,14 @@ func NewTranslator(opts ...Option) common.Translator[component.Config] {
 }
 
 func NewTranslatorWithName(name string, opts ...Option) common.Translator[component.Config] {
-	t := &translator{name: name, instanceNum: -1, factory: otlpreceiver.NewFactory()}
+	t := &translator{name: name, index: -1, factory: otlpreceiver.NewFactory()}
 	for _, opt := range opts {
 		opt.apply(t)
 	}
 	if name == "" && t.dataType.String() != "" {
 		t.name = t.dataType.String()
-		if t.instanceNum != -1 {
-			t.name += strconv.Itoa(t.instanceNum)
+		if t.index != -1 {
+			t.name += strconv.Itoa(t.index)
 		}
 	}
 	return t
@@ -87,32 +87,39 @@ func (t *translator) ID() component.ID {
 
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*otlpreceiver.Config)
-	// init default configuration
-	configBase, ok := configKeys[t.dataType]
+
+	configKey, ok := configKeys[t.dataType]
 	if !ok {
 		return nil, fmt.Errorf("no config key defined for data type: %s", t.dataType)
 	}
-	configKey := common.ConfigKey(configBase, common.OtlpKey)
 	cfg.GRPC.NetAddr.Endpoint = defaultGrpcEndpoint
 	cfg.HTTP.Endpoint = defaultHttpEndpoint
+
 	if t.name == common.AppSignals {
-		configKey = common.ConfigKey(configKeys[t.dataType], common.AppSignals)
-		if conf == nil || !conf.IsSet(configKey) {
-			configKey = common.ConfigKey(configBase, common.AppSignalsFallback)
+		appSignalsConfigKeys, ok := common.AppSignalsConfigKeys[t.dataType]
+		if !ok {
+			return nil, fmt.Errorf("no appplication_signals config key defined for data type: %s", t.dataType)
+		}
+		if conf.IsSet(appSignalsConfigKeys[0]) {
+			configKey = appSignalsConfigKeys[0]
+		} else {
+			configKey = appSignalsConfigKeys[1]
 		}
 		cfg.GRPC.NetAddr.Endpoint = defaultAppSignalsGrpcEndpoint
 		cfg.HTTP.Endpoint = defaultAppSignalsHttpEndpoint
 	}
+
 	if conf == nil || !conf.IsSet(configKey) {
 		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: configKey}
 	}
 
 	var otlpKeyMap map[string]interface{}
-	if otlpSlice := common.GetArray[any](conf, configKey); t.instanceNum != -1 && len(otlpSlice) > t.instanceNum {
-		otlpKeyMap = otlpSlice[t.instanceNum].(map[string]interface{})
+	if otlpSlice := common.GetArray[any](conf, configKey); t.index != -1 && len(otlpSlice) > t.index {
+		otlpKeyMap = otlpSlice[t.index].(map[string]interface{})
 	} else {
 		otlpKeyMap = conf.Get(configKey).(map[string]interface{})
 	}
+
 	var tlsSettings *configtls.ServerConfig
 	if tls, ok := otlpKeyMap["tls"].(map[string]interface{}); ok {
 		tlsSettings = &configtls.ServerConfig{}


### PR DESCRIPTION
# Description of changes
Introduce support for the OTLP receiver for Metrics. This change adds the OTLP receiver to the existing `hostDeltaMetrics` pipeline that also uses a Cumulative to Delta processor and an AWS CloudWatch exporter.

* Introduces new `otlp` section under `metrics -> metrics_collected` that can either be a json blob or an array of json blobs for multiple listeners.
* OTLP Metrics are setup to flow through our current `hostDeltaMetrics` pipeline using:
  * `otlpreceiver` - to receive the metrics on both HTTP and gRPC endpoints
  * `cummulativetodelta` processor - to convert cumulatives to deltas by default when publishing to CloudWatch
  * AWS `cloudwatch` exporter - to publish via PutMetricData API calls to CloudWatch
* Supports `append_dimensions` as expected.
* We treat this as a passthrough plugin where the agent does minimal modifications. Accordingly:
  * Does NOT support agent features such as measurement renames, units, aggregation_dimensions or drop_original_metrics at this time.
  * Does NOT append `host` as a default dimension even if `InstanceId` is not present in `append_dimensions`.
* Supports TLS configuration.

Sample config:
```
{
  "metrics": {
    "metrics_collected": {
      "otlp": {
        "grpc_endpoint": "0.0.0.0:1234",
        "http_endpoint": "0.0.0.0:2345",
        "tls": {
          "cert_file": "/path/to/cert.pem",
          "key_file": "/path/to/key.pem"
        }
      }
    }
  }
}
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Updated unit tests
* Test using a sample app as per https://opentelemetry.io/docs/languages/python/getting-started/
![image](https://github.com/user-attachments/assets/9c8ba0b7-03b8-483d-8ce6-68f55019dbfd)
* 


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




