### PR TITLE
Bumping telegraf version to fix build constraint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/amazon-cloudwatch-agent
 
 go 1.22.5
 
-replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20241001150426-8cfe5bbba399
+replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20241003164222-69e43c131d55
 
 // Replace with https://github.com/amazon-contributing/opentelemetry-collector-contrib, there are no requirements for all receivers/processors/exporters
 // to be all replaced since there are some changes that will always be from upstream

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.13.6/go.mod h1:akrYtxss2
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.17.0 h1:wWJD7LX6PBV6etBUwO0zElG0nWN9rUhp0WdYeHSHAaI=
 github.com/aws/smithy-go v1.17.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
-github.com/aws/telegraf v0.10.2-0.20241001150426-8cfe5bbba399 h1:k/8+Ev59r+e1Ol1IMXwiWhedmTjbJFbCi73Y9sEvVNA=
-github.com/aws/telegraf v0.10.2-0.20241001150426-8cfe5bbba399/go.mod h1:EuipXfoVhMPIMfNPLyHP9X2IQGwOXhwysPXUuosAFts=
+github.com/aws/telegraf v0.10.2-0.20241003164222-69e43c131d55 h1:jZcQmduv+lpJnwfWd/kkd3jiqeCJHfgYY6/om99e3BE=
+github.com/aws/telegraf v0.10.2-0.20241003164222-69e43c131d55/go.mod h1:EuipXfoVhMPIMfNPLyHP9X2IQGwOXhwysPXUuosAFts=
 github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20231109213610-a8c21c54a2be h1:sF6OUdk1hpuX7lf74vn+zBUFtQRe+hky0jmMYyFp5Kk=
 github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20231109213610-a8c21c54a2be/go.mod h1:1W1wnODUDv+FBSAtAa878Kxto5kj8eV+kI0AF4LIjq4=
 github.com/awslabs/kinesis-aggregation/go v0.0.0-20210630091500-54e17340d32f h1:Pf0BjJDga7C98f0vhw+Ip5EaiE07S3lTKpIYPNS0nMo=


### PR DESCRIPTION
# Description of the issue
Bumping telegraf version so that we can fix mac os build constraint for the agent:

https://github.com/aws/telegraf/pull/162


