### PR TITLE
Update AMI cleaner script to properly handle macOS images

### DIFF
--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -59,13 +59,13 @@ func deregisterAMIs(ctx context.Context, ec2client *ec2.Client, images []types.I
     for _, image := range images {
 		if image.Name != nil && image.ImageId != nil && image.CreationDate != nil {
 			log.Printf("Try to delete ami %v tags %v image id %v image creation date raw %v", *image.Name, image.Tags, *image.ImageId, *image.CreationDate)
-			// deregisterImageInput := &ec2.DeregisterImageInput{ImageId: image.ImageId}
-			// _, err := ec2client.DeregisterImage(ctx, deregisterImageInput)
+			deregisterImageInput := &ec2.DeregisterImageInput{ImageId: image.ImageId}
+			_, err := ec2client.DeregisterImage(ctx, deregisterImageInput)
  
-			// if err != nil && errList != nil {
-			// 	log.Printf("Error while deregistering ami %v", *image.Name)
-			// 	*errList = append(*errList, err)
-			// }
+			if err != nil && errList != nil {
+				log.Printf("Error while deregistering ami %v", *image.Name)
+				*errList = append(*errList, err)
+			}
 		}
     }
 }

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -1,78 +1,176 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
-
+ 
 //go:build clean
 // +build clean
-
+ 
 package main
-
+ 
 import (
 	"context"
 	"fmt"
 	"log"
 	"time"
-
+	"strings"
+	"sort"
+	"errors"
+ 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	smithyTime "github.com/aws/smithy-go/time"
-
+ 
 	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
 )
-
+ 
 func main() {
-	err := cleanAMI()
+	err := cleanAMIs()
 	if err != nil {
 		log.Fatalf("errors cleaning %v", err)
 	}
 }
-
-func cleanAMI() error {
+ 
+//  takes a list of AMIs and sorts them by creation date (youngest to oldest)
+func sortAMIsByCreationDate(amiList[] types.Image, errList *[]error)[] types.Image {
+    sort.Slice(amiList, func(i, j int) bool {
+        if amiList[i].CreationDate != nil && amiList[j].CreationDate != nil {
+            iCreationDate, iErr := smithyTime.ParseDateTime(*amiList[i].CreationDate)
+            jCreationDate, jErr := smithyTime.ParseDateTime(*amiList[j].CreationDate)
+ 
+			if err := errors.Join(iErr, jErr); err != nil && errList != nil {
+				*errList = append(*errList, err)
+				return false
+			}
+ 
+            return iCreationDate.After(jCreationDate)
+        } else {
+            return false
+        }
+    })
+ 
+    return amiList
+}
+ 
+ 
+ 
+// given a slice of AMIs, deregisters them one by one
+func deregisterAMIs(ctx context.Context, ec2client *ec2.Client, images []types.Image, errList *[]error) {
+    for _, image := range images {
+		if image.Name != nil && image.ImageId != nil && image.CreationDate != nil {
+			log.Printf("Try to delete ami %v tags %v image id %v image creation date raw %v", *image.Name, image.Tags, *image.ImageId, *image.CreationDate)
+			// deregisterImageInput := &ec2.DeregisterImageInput{ImageId: image.ImageId}
+			// _, err := ec2client.DeregisterImage(ctx, deregisterImageInput)
+ 
+			// if err != nil && errList != nil {
+			// 	log.Printf("Error while deregistering ami %v", *image.Name)
+			// 	*errList = append(*errList, err)
+			// }
+		}
+    }
+}
+ 
+// given a map of macos version/architecture to a list of corresponding AMIs, deregister AMIs that are no longer needed
+func cleanMacAMIs(ctx context.Context, ec2client *ec2.Client, macosImageAmiMap map[string][]types.Image, expirationDate time.Time, errList *[]error) {
+    for name, amiList := range macosImageAmiMap {
+		// don't delete an ami if it's the only one for that version/architecture 
+        if len(amiList) == 1 {
+            continue
+        }
+ 
+        // Sort AMIs by creation date (youngest to oldest)
+        amiList = sortAMIsByCreationDate(amiList, errList)
+ 
+		// find the youngest AMI in the list
+        youngestCreationDate, err := smithyTime.ParseDateTime(aws.ToString(amiList[0].CreationDate))
+ 
+        if err != nil && errList != nil {
+            *errList = append(*errList, err)
+            continue
+        }
+ 
+        if expirationDate.After(youngestCreationDate) {
+            // If the youngest AMI is over 60 days old, we keep one (the youngest) and can delete the rest
+            log.Printf("Youngest AMI for %s is over 60 days old. Deleting all but the youngest.", name)
+            deregisterAMIs(ctx, ec2client, amiList[1:], errList)
+        } else {
+            // If the youngest AMI is under 60 days old, keep incrementing until we find AMIs older than 60 days and delete them
+            for index, ami := range amiList {
+                creationDate, err := smithyTime.ParseDateTime(aws.ToString(ami.CreationDate))
+                if err != nil && errList != nil {
+                    *errList = append(*errList, err)
+                    continue
+                }
+                if expirationDate.After(creationDate) {
+					// once you find the first AMI that's over 60 days old, delete the ones that follow
+                    deregisterAMIs(ctx, ec2client, amiList[index:], errList)
+                    break
+                }
+            }
+        }
+    }
+}
+ 
+// given a single non macos image, determine its age and deregister if needed
+func cleanNonMacAMIs(ctx context.Context, ec2client *ec2.Client, image types.Image, expirationDate time.Time, errList *[]error) {
+    creationDate, err := smithyTime.ParseDateTime(aws.ToString(image.CreationDate))
+    if err != nil && errList != nil {
+        *errList = append(*errList, err)
+        return
+    }
+ 
+    if expirationDate.After(creationDate) {
+        deregisterAMIs(ctx, ec2client, []types.Image{image}, errList)
+    }
+}
+ 
+func cleanAMIs() error {
 	log.Print("Begin to clean EC2 AMI")
-
+ 
+	// sets expiration date to 60 days in the past
 	expirationDate := time.Now().UTC().Add(clean.KeepDurationSixtyDay)
-	cxt := context.Background()
-	defaultConfig, err := config.LoadDefaultConfig(cxt)
+	log.Printf("Expiration date set as %v", expirationDate)
+ 
+	// load default config
+	ctx := context.Background()
+	defaultConfig, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return err
 	}
 	ec2client := ec2.NewFromConfig(defaultConfig)
-
+ 
 	// Get list of ami
 	nameFilter := types.Filter{Name: aws.String("name"), Values: []string{
 		"cloudwatch-agent-integration-test*",
 	}}
-
+ 
 	//get instances to delete
 	describeImagesInput := ec2.DescribeImagesInput{Filters: []types.Filter{nameFilter}}
-	describeImagesOutput, err := ec2client.DescribeImages(cxt, &describeImagesInput)
+	describeImagesOutput, err := ec2client.DescribeImages(ctx, &describeImagesInput)
 	if err != nil {
 		return err
 	}
-
+ 
 	var errList []error
+	// stores a list of AMIs per each macos version/architecture
+	macosImageAmiMap := make(map[string][]types.Image)
+ 
 	for _, image := range describeImagesOutput.Images {
-		creationDate, err := smithyTime.ParseDateTime(*image.CreationDate)
-		if err != nil {
-			errList = append(errList, err)
-			continue
-		}
-		log.Printf("image name %v image id %v experation date %v creation date parsed %v image creation date raw %v",
-			*image.Name, *image.ImageId, creationDate, expirationDate, *image.CreationDate)
-		if expirationDate.After(creationDate) {
-			log.Printf("Try to delete ami %s tags %v launch-date %s", *image.Name, image.Tags, *image.CreationDate)
-			deregisterImageInput := ec2.DeregisterImageInput{ImageId: image.ImageId}
-			_, err := ec2client.DeregisterImage(cxt, &deregisterImageInput)
-			if err != nil {
-				errList = append(errList, err)
-			}
+		if image.Name != nil && strings.HasPrefix(*image.Name, "cloudwatch-agent-integration-test-mac")  {
+			// mac image - add it to the map and do nothing else for now
+			macosImageAmiMap[*image.Name] = append(macosImageAmiMap[*image.Name], image)
+		} else {
+			// non mac image - clean it if it's older than 60 days
+			cleanNonMacAMIs(ctx, ec2client, image, expirationDate, &errList)
 		}
 	}
-
+ 
+	// handle the mac AMIs
+	cleanMacAMIs(ctx, ec2client, macosImageAmiMap, expirationDate, &errList)
+ 
 	if len(errList) != 0 {
 		return fmt.Errorf("%v", errList)
 	}
-
+ 
 	return nil
 }

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -1,136 +1,134 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
- 
+
 //go:build clean
 // +build clean
- 
+
 package main
- 
+
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"time"
-	"strings"
 	"sort"
-	"errors"
- 
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	smithyTime "github.com/aws/smithy-go/time"
- 
+
 	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
 )
- 
+
 func main() {
 	err := cleanAMIs()
 	if err != nil {
 		log.Fatalf("errors cleaning %v", err)
 	}
 }
- 
-//  takes a list of AMIs and sorts them by creation date (youngest to oldest)
-func sortAMIsByCreationDate(amiList[] types.Image, errList *[]error)[] types.Image {
-    sort.Slice(amiList, func(i, j int) bool {
-        if amiList[i].CreationDate != nil && amiList[j].CreationDate != nil {
-            iCreationDate, iErr := smithyTime.ParseDateTime(*amiList[i].CreationDate)
-            jCreationDate, jErr := smithyTime.ParseDateTime(*amiList[j].CreationDate)
- 
+
+// takes a list of AMIs and sorts them by creation date (youngest to oldest)
+func sortAMIsByCreationDate(amiList []types.Image, errList *[]error) []types.Image {
+	sort.Slice(amiList, func(i, j int) bool {
+		if amiList[i].CreationDate != nil && amiList[j].CreationDate != nil {
+			iCreationDate, iErr := smithyTime.ParseDateTime(*amiList[i].CreationDate)
+			jCreationDate, jErr := smithyTime.ParseDateTime(*amiList[j].CreationDate)
+
 			if err := errors.Join(iErr, jErr); err != nil && errList != nil {
 				*errList = append(*errList, err)
 				return false
 			}
- 
-            return iCreationDate.After(jCreationDate)
-        } else {
-            return false
-        }
-    })
- 
-    return amiList
+
+			return iCreationDate.After(jCreationDate)
+		} else {
+			return false
+		}
+	})
+
+	return amiList
 }
- 
- 
- 
+
 // given a slice of AMIs, deregisters them one by one
 func deregisterAMIs(ctx context.Context, ec2client *ec2.Client, images []types.Image, errList *[]error) {
-    for _, image := range images {
+	for _, image := range images {
 		if image.Name != nil && image.ImageId != nil && image.CreationDate != nil {
 			log.Printf("Try to delete ami %v tags %v image id %v image creation date raw %v", *image.Name, image.Tags, *image.ImageId, *image.CreationDate)
 			deregisterImageInput := &ec2.DeregisterImageInput{ImageId: image.ImageId}
 			_, err := ec2client.DeregisterImage(ctx, deregisterImageInput)
- 
+
 			if err != nil && errList != nil {
 				log.Printf("Error while deregistering ami %v", *image.Name)
 				*errList = append(*errList, err)
 			}
 		}
-    }
+	}
 }
- 
+
 // given a map of macos version/architecture to a list of corresponding AMIs, deregister AMIs that are no longer needed
 func cleanMacAMIs(ctx context.Context, ec2client *ec2.Client, macosImageAmiMap map[string][]types.Image, expirationDate time.Time, errList *[]error) {
-    for name, amiList := range macosImageAmiMap {
-		// don't delete an ami if it's the only one for that version/architecture 
-        if len(amiList) == 1 {
-            continue
-        }
- 
-        // Sort AMIs by creation date (youngest to oldest)
-        amiList = sortAMIsByCreationDate(amiList, errList)
- 
+	for name, amiList := range macosImageAmiMap {
+		// don't delete an ami if it's the only one for that version/architecture
+		if len(amiList) == 1 {
+			continue
+		}
+
+		// Sort AMIs by creation date (youngest to oldest)
+		amiList = sortAMIsByCreationDate(amiList, errList)
+
 		// find the youngest AMI in the list
-        youngestCreationDate, err := smithyTime.ParseDateTime(aws.ToString(amiList[0].CreationDate))
- 
-        if err != nil && errList != nil {
-            *errList = append(*errList, err)
-            continue
-        }
- 
-        if expirationDate.After(youngestCreationDate) {
-            // If the youngest AMI is over 60 days old, we keep one (the youngest) and can delete the rest
-            log.Printf("Youngest AMI for %s is over 60 days old. Deleting all but the youngest.", name)
-            deregisterAMIs(ctx, ec2client, amiList[1:], errList)
-        } else {
-            // If the youngest AMI is under 60 days old, keep incrementing until we find AMIs older than 60 days and delete them
-            for index, ami := range amiList {
-                creationDate, err := smithyTime.ParseDateTime(aws.ToString(ami.CreationDate))
-                if err != nil && errList != nil {
-                    *errList = append(*errList, err)
-                    continue
-                }
-                if expirationDate.After(creationDate) {
+		youngestCreationDate, err := smithyTime.ParseDateTime(aws.ToString(amiList[0].CreationDate))
+
+		if err != nil && errList != nil {
+			*errList = append(*errList, err)
+			continue
+		}
+
+		if expirationDate.After(youngestCreationDate) {
+			// If the youngest AMI is over 60 days old, we keep one (the youngest) and can delete the rest
+			log.Printf("Youngest AMI for %s is over 60 days old. Deleting all but the youngest.", name)
+			deregisterAMIs(ctx, ec2client, amiList[1:], errList)
+		} else {
+			// If the youngest AMI is under 60 days old, keep incrementing until we find AMIs older than 60 days and delete them
+			for index, ami := range amiList {
+				creationDate, err := smithyTime.ParseDateTime(aws.ToString(ami.CreationDate))
+				if err != nil && errList != nil {
+					*errList = append(*errList, err)
+					continue
+				}
+				if expirationDate.After(creationDate) {
 					// once you find the first AMI that's over 60 days old, delete the ones that follow
-                    deregisterAMIs(ctx, ec2client, amiList[index:], errList)
-                    break
-                }
-            }
-        }
-    }
+					deregisterAMIs(ctx, ec2client, amiList[index:], errList)
+					break
+				}
+			}
+		}
+	}
 }
- 
+
 // given a single non macos image, determine its age and deregister if needed
 func cleanNonMacAMIs(ctx context.Context, ec2client *ec2.Client, image types.Image, expirationDate time.Time, errList *[]error) {
-    creationDate, err := smithyTime.ParseDateTime(aws.ToString(image.CreationDate))
-    if err != nil && errList != nil {
-        *errList = append(*errList, err)
-        return
-    }
- 
-    if expirationDate.After(creationDate) {
-        deregisterAMIs(ctx, ec2client, []types.Image{image}, errList)
-    }
+	creationDate, err := smithyTime.ParseDateTime(aws.ToString(image.CreationDate))
+	if err != nil && errList != nil {
+		*errList = append(*errList, err)
+		return
+	}
+
+	if expirationDate.After(creationDate) {
+		deregisterAMIs(ctx, ec2client, []types.Image{image}, errList)
+	}
 }
- 
+
 func cleanAMIs() error {
 	log.Print("Begin to clean EC2 AMI")
- 
+
 	// sets expiration date to 60 days in the past
 	expirationDate := time.Now().UTC().Add(clean.KeepDurationSixtyDay)
 	log.Printf("Expiration date set as %v", expirationDate)
- 
+
 	// load default config
 	ctx := context.Background()
 	defaultConfig, err := config.LoadDefaultConfig(ctx)
@@ -138,25 +136,25 @@ func cleanAMIs() error {
 		return err
 	}
 	ec2client := ec2.NewFromConfig(defaultConfig)
- 
+
 	// Get list of ami
 	nameFilter := types.Filter{Name: aws.String("name"), Values: []string{
 		"cloudwatch-agent-integration-test*",
 	}}
- 
+
 	//get instances to delete
 	describeImagesInput := ec2.DescribeImagesInput{Filters: []types.Filter{nameFilter}}
 	describeImagesOutput, err := ec2client.DescribeImages(ctx, &describeImagesInput)
 	if err != nil {
 		return err
 	}
- 
+
 	var errList []error
 	// stores a list of AMIs per each macos version/architecture
 	macosImageAmiMap := make(map[string][]types.Image)
- 
+
 	for _, image := range describeImagesOutput.Images {
-		if image.Name != nil && strings.HasPrefix(*image.Name, "cloudwatch-agent-integration-test-mac")  {
+		if image.Name != nil && strings.HasPrefix(*image.Name, "cloudwatch-agent-integration-test-mac") {
 			// mac image - add it to the map and do nothing else for now
 			macosImageAmiMap[*image.Name] = append(macosImageAmiMap[*image.Name], image)
 		} else {
@@ -164,13 +162,13 @@ func cleanAMIs() error {
 			cleanNonMacAMIs(ctx, ec2client, image, expirationDate, &errList)
 		}
 	}
- 
+
 	// handle the mac AMIs
 	cleanMacAMIs(ctx, ec2client, macosImageAmiMap, expirationDate, &errList)
- 
+
 	if len(errList) != 0 {
 		return fmt.Errorf("%v", errList)
 	}
- 
+
 	return nil
 }


### PR DESCRIPTION
# Description of the issue
We run a daily GitHub workflow ([AWS Daily Resources Cleaner](https://github.com/aws/amazon-cloudwatch-agent/actions/workflows/clean-aws-resources.yml)) to delete AMIs older than 60 days. This works for non-macOS AMIs because we use ImageBuilder to handle building them. However, macOS AMIs are not currently supported by ImageBuilder. As a result, our macOS AMIs are deleted by the workflow when they cross the 60 day threshold and are not automatically replaced, leaving a gap in our integration testing. 

# Description of changes
I modified the logic of the script to specifically handle macOS AMIs. If there is only one image, it won't be deleted regardless of age. If there are multiple images and they are all past the expiration date, the script will keep the youngest and delete the rest. Otherwise, it'll keep the images within the limit and delete those that are past it. The script also avoids the edge case where multiple AMIs are created on the same day (and set to be deleted together). It ensures that they don't get deleted at the same time, leaving a gap in our macOS images. 

To accomplish this, I use a map that has each macOS version and architecture as a key and a list of corresponding machine images as its value. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
 I ran the script with a lowered expiration threshold (60 days -> 7 days) to check that AMIs identified to be deleted were all older than 7 days—this was a quick verification that original functionality with non macOS AMIs was unchanged.

I also created multiple AMIs for each macOS version and architecture and ran the script with the following behavior:
  - 1 AMI - under the age limit (didn’t delete)
  - 1 AMI - over the age limit (didn’t delete)
  - 2 AMIs - both under the age limit (didn’t delete any)
  - 2 AMIs - one under the age limit, one over the age limit (deleted the one over, kept the one under)
  - 2 AMIs - both over the age limit (deleted the older one, kept the younger one)
  - 3 AMIs - all under the age limit (didn't delete any)
  - 3 AMIs - one over the age limit (deleted the older one, kept the two under the limit)
  - 3 AMIs - two over the age limit (deleted the two over, kept the one under)
  - 3 AMIs - all over the age limit (kept the youngest, deleted the older two)

This matched intended behavior. We can be confident that a situation with more AMIs would reduce to an example listed above.
