### PR TITLE
Add ECS E2E entry to build-test.

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -90,6 +90,14 @@ jobs:
       aws-region: us-east-1
       caller-workflow-name: 'main-build'
 
+  java-ecs-e2e-test:
+    needs: [ CheckBuildTestArtifacts ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ecs-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+
   python-eks-e2e-test:
     needs: [ CheckBuildTestArtifacts, java-metric-limiter-e2e-test ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
@@ -118,6 +126,14 @@ jobs:
   python-k8s-e2e-test:
     needs: [ CheckBuildTestArtifacts, java-k8s-e2e-test ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-k8s-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+
+  python-ecs-e2e-test:
+    needs: [ CheckBuildTestArtifacts ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ecs-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1


### PR DESCRIPTION
# Description of the issue
[aws-application-signals-test-framework](https://github.com/zzhlogin/aws-application-signals-test-framework/tree/main) recently added ECS E2E support: [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/222), we want to add ECS E2E entry to build-test-artifacts workflow.

# Description of changes
Add ECS E2E entry to build-test-artifacts workflow.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Local test.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




