### PR TITLE
Fix config detection when path is invalid.

### DIFF
--- a/internal/util/config/config.go
+++ b/internal/util/config/config.go
@@ -32,7 +32,7 @@ func GetOTELConfigArgs(dir string) []string {
 func getSortedYAMLs(dir string) []string {
 	var configs []string
 	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if d.IsDir() {
+		if d == nil || d.IsDir() {
 			return nil
 		}
 		if filepath.Ext(path) == constants.FileSuffixYAML {

--- a/internal/util/config/config_test.go
+++ b/internal/util/config/config_test.go
@@ -15,6 +15,12 @@ import (
 )
 
 func TestGetOTELConfigArgs(t *testing.T) {
+	got := GetOTELConfigArgs("/not/valid/path")
+	assert.Len(t, got, 2)
+	assert.Equal(t, []string{
+		"-otelconfig", paths.YamlConfigPath,
+	}, got)
+
 	dir := t.TempDir()
 	// skipped
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "bunchofyaml"), 0644))
@@ -32,7 +38,7 @@ func TestGetOTELConfigArgs(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 	}
-	got := GetOTELConfigArgs(dir)
+	got = GetOTELConfigArgs(dir)
 	assert.Len(t, got, 14)
 	assert.Equal(t, []string{
 		"-otelconfig", filepath.Join(dir, "1.yaml"),


### PR DESCRIPTION
# Description of the issue
On ECS, the `/etc/cwaconfig` directory may not be available. This currently causes a panic because the `DirEntry` is nil.

# Description of changes
Adds a check to make sure this doesn't change the current behavior.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




