### PR TITLE
Add JMX pipeline for container environments

### DIFF
--- a/cmd/config-translator/translator_test.go
+++ b/cmd/config-translator/translator_test.go
@@ -68,6 +68,8 @@ func TestTracesConfig(t *testing.T) {
 func TestJMXConfig(t *testing.T) {
 	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/validJMX.json", true, map[string]int{})
 	expectedErrorMap := map[string]int{}
+	expectedErrorMap["additional_property_not_allowed"] = 1
+	expectedErrorMap["number_any_of"] = 1
 	expectedErrorMap["number_one_of"] = 1
 	expectedErrorMap["required"] = 1
 	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/invalidJMX.json", false, expectedErrorMap)

--- a/translator/config/sampleSchema/invalidJMX.json
+++ b/translator/config/sampleSchema/invalidJMX.json
@@ -2,9 +2,7 @@
   "metrics": {
     "metrics_collected": {
       "jmx": {
-        "jvm": {
-          "measurement": []
-        }
+        "measurement": []
       }
     }
   }

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1320,9 +1320,6 @@
         }
       },
       "additionalProperties": false,
-      "required": [
-        "endpoint"
-      ],
       "anyOf": [
         {
           "required": [

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -388,7 +388,7 @@ service:
             receivers:
                 - telegraf_net
                 - telegraf_diskio
-        metrics/jmx/0:
+        metrics/jmx/cloudwatch/0:
             exporters:
                 - awscloudwatch
             processors:
@@ -399,15 +399,15 @@ service:
                 - ec2tagger
             receivers:
                 - jmx/0
-        metrics/jmx/1:
+        metrics/jmx/cloudwatch/1:
             exporters:
                 - awscloudwatch
             processors:
                 - filter/jmx/1
                 - resource/jmx
-                - cumulativetodelta/jmx
                 - transform/jmx/1
                 - ec2tagger
+                - cumulativetodelta/jmx
             receivers:
                 - jmx/1
         traces/xray:

--- a/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
@@ -75,7 +75,7 @@ processors:
         send_batch_max_size: 0
         send_batch_size: 8192
         timeout: 1m0s
-    batch/jmx:
+    batch/jmx/amp:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
         send_batch_size: 8192
@@ -178,16 +178,24 @@ service:
             receivers:
                 - telegraf_cpu
                 - telegraf_disk
-        metrics/jmx:
+        metrics/jmx/amp:
             exporters:
-                - awscloudwatch
                 - prometheusremotewrite/amp
             processors:
                 - filter/jmx
                 - resource/jmx
-                - cumulativetodelta/jmx
-                - batch/jmx
+                - batch/jmx/amp
                 - transform/jmx
+            receivers:
+                - jmx
+        metrics/jmx/cloudwatch:
+            exporters:
+                - awscloudwatch
+            processors:
+                - filter/jmx
+                - resource/jmx
+                - transform/jmx
+                - cumulativetodelta/jmx
             receivers:
                 - jmx
     telemetry:

--- a/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.conf
+++ b/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.conf
@@ -1,0 +1,19 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = ""
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[outputs]
+
+  [[outputs.cloudwatch]]

--- a/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.json
+++ b/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.json
@@ -1,0 +1,43 @@
+{
+  "metrics": {
+    "metrics_destinations": {
+      "amp": {
+        "workspace_id": "ws-12345"
+      },
+      "cloudwatch": {}
+    },
+    "metrics_collected": {
+      "jmx": [
+        {
+          "jvm": {
+            "measurement": [
+              "jvm.memory.heap.init",
+              {
+                "name": "jvm.memory.heap.used",
+                "rename": "JVM_MEM_HEAP_USED",
+                "unit": "unit"
+              },
+              "jvm.memory.nonheap.init"
+            ]
+          },
+          "append_dimensions": {
+            "k1": "v1"
+          }
+        },
+        {
+          "kafka-consumer": {
+            "measurement": [
+              {
+                "name": "kafka.consumer.fetch-rate",
+                "rename": "kafka.fetch-rate"
+              }
+            ]
+          },
+          "append_dimensions": {
+            "k2": "v2"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.yaml
@@ -1,0 +1,216 @@
+exporters:
+    awscloudwatch:
+        force_flush_interval: 1m0s
+        max_datums_per_call: 1000
+        max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        namespace: CWAgent
+        region: us-west-2
+        resource_to_telemetry_conversion:
+            enabled: true
+    prometheusremotewrite/amp:
+        add_metric_suffixes: true
+        auth:
+            authenticator: sigv4auth
+        compression: ""
+        disable_keep_alives: false
+        endpoint: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345/api/v1/remote_write
+        export_created_metric:
+            enabled: false
+        http2_ping_timeout: 0s
+        http2_read_idle_timeout: 0s
+        max_batch_size_bytes: 3000000
+        namespace: ""
+        proxy_url: ""
+        read_buffer_size: 0
+        remote_write_queue:
+            enabled: true
+            num_consumers: 5
+            queue_size: 10000
+        resource_to_telemetry_conversion:
+            clear_after_copy: true
+            enabled: true
+        retry_on_failure:
+            enabled: true
+            initial_interval: 50ms
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        send_metadata: false
+        target_info:
+            enabled: true
+        timeout: 5s
+        tls:
+            ca_file: ""
+            cert_file: ""
+            include_system_ca_certs_pool: false
+            insecure: false
+            insecure_skip_verify: false
+            key_file: ""
+            max_version: ""
+            min_version: ""
+            reload_interval: 0s
+            server_name_override: ""
+        write_buffer_size: 524288
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    sigv4auth:
+        assume_role:
+            sts_region: us-west-2
+        region: us-west-2
+processors:
+    batch/jmx/amp/0:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 1m0s
+    batch/jmx/amp/1:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 1m0s
+    cumulativetodelta/jmx:
+        exclude:
+            match_type: ""
+        include:
+            match_type: ""
+        initial_value: 2
+        max_staleness: 0s
+    filter/jmx/0:
+        error_mode: propagate
+        logs: {}
+        metrics:
+            include:
+                match_type: strict
+                metric_names:
+                    - jvm.memory.heap.init
+                    - jvm.memory.heap.used
+                    - jvm.memory.nonheap.init
+        spans: {}
+        traces: {}
+    filter/jmx/1:
+        error_mode: propagate
+        logs: {}
+        metrics:
+            include:
+                match_type: strict
+                metric_names:
+                    - kafka.consumer.fetch-rate
+        spans: {}
+        traces: {}
+    resource/jmx/0:
+        attributes:
+            - action: upsert
+              converted_type: ""
+              from_attribute: ""
+              from_context: ""
+              key: k1
+              pattern: ""
+              value: v1
+    resource/jmx/1:
+        attributes:
+            - action: upsert
+              converted_type: ""
+              from_attribute: ""
+              from_context: ""
+              key: k2
+              pattern: ""
+              value: v2
+    transform/jmx/0:
+        error_mode: propagate
+        flatten_data: false
+        log_statements: []
+        metric_statements:
+            - context: metric
+              statements:
+                - set(unit, "unit") where name == "jvm.memory.heap.used"
+                - set(name, "JVM_MEM_HEAP_USED") where name == "jvm.memory.heap.used"
+        trace_statements: []
+    transform/jmx/1:
+        error_mode: propagate
+        flatten_data: false
+        log_statements: []
+        metric_statements:
+            - context: metric
+              statements:
+                - set(name, "kafka.fetch-rate") where name == "kafka.consumer.fetch-rate"
+        trace_statements: []
+receivers:
+    otlp/jmx:
+        protocols:
+            http:
+                endpoint: 0.0.0.0:4314
+                include_metadata: false
+                logs_url_path: /v1/logs
+                max_request_body_size: 0
+                metrics_url_path: /v1/metrics
+                traces_url_path: /v1/traces
+service:
+    extensions:
+        - agenthealth/metrics
+        - sigv4auth
+    pipelines:
+        metrics/jmx/amp/0:
+            exporters:
+                - prometheusremotewrite/amp
+            processors:
+                - filter/jmx/0
+                - resource/jmx/0
+                - transform/jmx/0
+                - batch/jmx/amp/0
+            receivers:
+                - otlp/jmx
+        metrics/jmx/amp/1:
+            exporters:
+                - prometheusremotewrite/amp
+            processors:
+                - filter/jmx/1
+                - resource/jmx/1
+                - transform/jmx/1
+                - batch/jmx/amp/1
+            receivers:
+                - otlp/jmx
+        metrics/jmx/cloudwatch/0:
+            exporters:
+                - awscloudwatch
+            processors:
+                - filter/jmx/0
+                - resource/jmx/0
+                - transform/jmx/0
+                - cumulativetodelta/jmx
+            receivers:
+                - otlp/jmx
+        metrics/jmx/cloudwatch/1:
+            exporters:
+                - awscloudwatch
+            processors:
+                - filter/jmx/1
+                - resource/jmx/1
+                - transform/jmx/1
+                - cumulativetodelta/jmx
+            receivers:
+                - otlp/jmx
+    telemetry:
+        logs:
+            development: false
+            disable_caller: false
+            disable_stacktrace: false
+            encoding: console
+            level: info
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            address: ""
+            level: None
+        traces: {}

--- a/translator/tocwconfig/tocwconfig_unix_test.go
+++ b/translator/tocwconfig/tocwconfig_unix_test.go
@@ -45,9 +45,17 @@ func TestJMXConfigLinux(t *testing.T) {
 	context.CurrentContext().SetMode(config.ModeEC2)
 	testutil.SetPrometheusRemoteWriteTestingEnv(t)
 	t.Setenv("JMX_JAR_PATH", "../../packaging/opentelemetry-jmx-metrics.jar")
-	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "jmx_config_linux", "linux", expectedEnvVars, "")
+}
+
+func TestJMXConfigEKS(t *testing.T) {
+	resetContext(t)
+	testutil.SetPrometheusRemoteWriteTestingEnv(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	context.CurrentContext().SetRunInContainer(true)
+	expectedEnvVars := map[string]string{}
+	checkTranslation(t, "jmx_eks_config_linux", "linux", expectedEnvVars, "")
 }
 
 func TestDeltaConfigLinux(t *testing.T) {

--- a/translator/translate/otel/common/options.go
+++ b/translator/translate/otel/common/options.go
@@ -28,3 +28,27 @@ func (p *NameProvider) Name() string {
 func (p *NameProvider) SetName(name string) {
 	p.name = name
 }
+
+type IndexSetter interface {
+	SetIndex(int)
+}
+
+func WithIndex(index int) TranslatorOption {
+	return func(target any) {
+		if setter, ok := target.(IndexSetter); ok {
+			setter.SetIndex(index)
+		}
+	}
+}
+
+type IndexProvider struct {
+	index int
+}
+
+func (p *IndexProvider) Index() int {
+	return p.index
+}
+
+func (p *IndexProvider) SetIndex(index int) {
+	p.index = index
+}

--- a/translator/translate/otel/common/options_test.go
+++ b/translator/translate/otel/common/options_test.go
@@ -15,3 +15,10 @@ func TestWithName(t *testing.T) {
 	opt(p)
 	assert.Equal(t, "b", p.Name())
 }
+
+func TestWithIndex(t *testing.T) {
+	p := &IndexProvider{index: -1}
+	opt := WithIndex(1)
+	opt(p)
+	assert.Equal(t, 1, p.Index())
+}

--- a/translator/translate/otel/exporter/debug/translator.go
+++ b/translator/translate/otel/exporter/debug/translator.go
@@ -23,12 +23,15 @@ type translator struct {
 var _ common.Translator[component.Config] = (*translator)(nil)
 
 func NewTranslator() common.Translator[component.Config] {
-	t := &translator{factory: debugexporter.NewFactory()}
-	return t
+	return NewTranslatorWithName("")
+}
+
+func NewTranslatorWithName(name string) common.Translator[component.Config] {
+	return &translator{name: name, factory: debugexporter.NewFactory()}
 }
 
 func (t *translator) ID() component.ID {
-	return component.NewIDWithName(t.factory.Type(), common.AppSignals)
+	return component.NewIDWithName(t.factory.Type(), t.name)
 }
 
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {

--- a/translator/translate/otel/exporter/debug/translator.go
+++ b/translator/translate/otel/exporter/debug/translator.go
@@ -16,22 +16,22 @@ import (
 const defaultSamplingThereafter = 500
 
 type translator struct {
-	name    string
+	common.NameProvider
 	factory exporter.Factory
 }
 
 var _ common.Translator[component.Config] = (*translator)(nil)
 
-func NewTranslator() common.Translator[component.Config] {
-	return NewTranslatorWithName("")
-}
-
-func NewTranslatorWithName(name string) common.Translator[component.Config] {
-	return &translator{name: name, factory: debugexporter.NewFactory()}
+func NewTranslator(opts ...common.TranslatorOption) common.Translator[component.Config] {
+	t := &translator{factory: debugexporter.NewFactory()}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 func (t *translator) ID() component.ID {
-	return component.NewIDWithName(t.factory.Type(), t.name)
+	return component.NewIDWithName(t.factory.Type(), t.Name())
 }
 
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {

--- a/translator/translate/otel/exporter/debug/translator_test.go
+++ b/translator/translate/otel/exporter/debug/translator_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestTranslator(t *testing.T) {
 	tt := NewTranslator()
-	assert.EqualValues(t, "debug/application_signals", tt.ID().String())
+	assert.EqualValues(t, "debug", tt.ID().String())
 	got, err := tt.Translate(confmap.New())
 	assert.Error(t, err)
 	assert.Nil(t, got)

--- a/translator/translate/otel/exporter/debug/translator_test.go
+++ b/translator/translate/otel/exporter/debug/translator_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 func TestTranslator(t *testing.T) {
-	tt := NewTranslator()
-	assert.EqualValues(t, "debug", tt.ID().String())
+	tt := NewTranslator(common.WithName("test"))
+	assert.EqualValues(t, "debug/test", tt.ID().String())
 	got, err := tt.Translate(confmap.New())
 	assert.Error(t, err)
 	assert.Nil(t, got)

--- a/translator/translate/otel/pipeline/applicationsignals/translator.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translator.go
@@ -46,7 +46,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 	}
 
 	translators := &common.ComponentTranslators{
-		Receivers:  common.NewTranslatorMap(otlp.NewTranslatorWithName(common.AppSignals, otlp.WithDataType(t.dataType))),
+		Receivers:  common.NewTranslatorMap(otlp.NewTranslator(common.WithName(common.AppSignals), otlp.WithDataType(t.dataType))),
 		Processors: common.NewTranslatorMap[component.Config](),
 		Exporters:  common.NewTranslatorMap[component.Config](),
 		Extensions: common.NewTranslatorMap[component.Config](),
@@ -56,7 +56,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 	translators.Processors.Set(awsapplicationsignals.NewTranslator(awsapplicationsignals.WithDataType(t.dataType)))
 
 	if enabled, _ := common.GetBool(conf, common.AgentDebugConfigKey); enabled {
-		translators.Exporters.Set(debug.NewTranslatorWithName(common.AppSignals))
+		translators.Exporters.Set(debug.NewTranslator(common.WithName(common.AppSignals)))
 	}
 
 	if t.dataType == component.DataTypeTraces {

--- a/translator/translate/otel/pipeline/applicationsignals/translator.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translator.go
@@ -56,7 +56,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 	translators.Processors.Set(awsapplicationsignals.NewTranslator(awsapplicationsignals.WithDataType(t.dataType)))
 
 	if enabled, _ := common.GetBool(conf, common.AgentDebugConfigKey); enabled {
-		translators.Exporters.Set(debug.NewTranslator())
+		translators.Exporters.Set(debug.NewTranslatorWithName(common.AppSignals))
 	}
 
 	if t.dataType == component.DataTypeTraces {

--- a/translator/translate/otel/pipeline/host/translators.go
+++ b/translator/translate/otel/pipeline/host/translators.go
@@ -45,7 +45,7 @@ func NewTranslators(conf *confmap.Conf, os string) (pipeline.TranslatorMap, erro
 		for index := range v {
 			deltaReceivers.Set(otlpreceiver.NewTranslator(
 				otlpreceiver.WithDataType(component.DataTypeMetrics),
-				otlpreceiver.WithIndex(index),
+				common.WithIndex(index),
 			))
 		}
 	case map[string]any:

--- a/translator/translate/otel/pipeline/jmx/translator.go
+++ b/translator/translate/otel/pipeline/jmx/translator.go
@@ -88,7 +88,6 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		Processors: common.NewTranslatorMap(
 			filterprocessor.NewTranslator(filterprocessor.WithName(common.PipelineNameJmx), filterprocessor.WithIndex(t.index)),
 			resourceprocessor.NewTranslator(resourceprocessor.WithName(common.PipelineNameJmx)),
-			cumulativetodeltaprocessor.NewTranslator(common.WithName(common.PipelineNameJmx), cumulativetodeltaprocessor.WithConfigKeys(common.JmxConfigKey)),
 		),
 		Exporters:  common.NewTranslatorMap[component.Config](),
 		Extensions: common.NewTranslatorMap[component.Config](),
@@ -125,6 +124,8 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 			translators.Processors.Set(rollupprocessor.NewTranslator())
 		}
 		translators.Extensions.Set(sigv4auth.NewTranslator())
+	} else {
+		translators.Processors.Set(cumulativetodeltaprocessor.NewTranslator(common.WithName(common.PipelineNameJmx), cumulativetodeltaprocessor.WithConfigKeys(common.JmxConfigKey)))
 	}
 
 	if enabled, _ := common.GetBool(conf, common.AgentDebugConfigKey); enabled {

--- a/translator/translate/otel/pipeline/jmx/translator.go
+++ b/translator/translate/otel/pipeline/jmx/translator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awscloudwatch"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/debug"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/prometheusremotewrite"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
@@ -124,6 +125,10 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 			translators.Processors.Set(rollupprocessor.NewTranslator())
 		}
 		translators.Extensions.Set(sigv4auth.NewTranslator())
+	}
+
+	if enabled, _ := common.GetBool(conf, common.AgentDebugConfigKey); enabled {
+		translators.Exporters.Set(debug.NewTranslatorWithName(common.JmxKey))
 	}
 
 	return &translators, nil

--- a/translator/translate/otel/pipeline/jmx/translator_test.go
+++ b/translator/translate/otel/pipeline/jmx/translator_test.go
@@ -178,7 +178,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx",
 				receivers:  []string{"jmx"},
-				processors: []string{"filter/jmx", "resource/jmx", "cumulativetodelta/jmx", "batch/jmx"},
+				processors: []string{"filter/jmx", "resource/jmx", "batch/jmx"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},
@@ -207,7 +207,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx",
 				receivers:  []string{"otlp/jmx"},
-				processors: []string{"filter/jmx", "resource/jmx", "cumulativetodelta/jmx", "batch/jmx"},
+				processors: []string{"filter/jmx", "resource/jmx", "batch/jmx"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},
@@ -235,7 +235,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx",
 				receivers:  []string{"jmx"},
-				processors: []string{"filter/jmx", "resource/jmx", "cumulativetodelta/jmx", "transform/jmx"},
+				processors: []string{"filter/jmx", "resource/jmx", "transform/jmx", "cumulativetodelta/jmx"},
 				exporters:  []string{"awscloudwatch"},
 				extensions: []string{"agenthealth/metrics"},
 			},
@@ -269,7 +269,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx/0",
 				receivers:  []string{"jmx/0"},
-				processors: []string{"filter/jmx/0", "resource/jmx", "cumulativetodelta/jmx", "transform/jmx/0", "ec2tagger"},
+				processors: []string{"filter/jmx/0", "resource/jmx", "transform/jmx/0", "ec2tagger", "cumulativetodelta/jmx"},
 				exporters:  []string{"awscloudwatch"},
 				extensions: []string{"agenthealth/metrics"},
 			},
@@ -305,7 +305,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx/0",
 				receivers:  []string{"otlp/jmx"},
-				processors: []string{"filter/jmx/0", "resource/jmx", "cumulativetodelta/jmx", "transform/jmx/0", "batch/jmx/0"},
+				processors: []string{"filter/jmx/0", "resource/jmx", "transform/jmx/0", "batch/jmx/0"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},

--- a/translator/translate/otel/pipeline/jmx/translator_test.go
+++ b/translator/translate/otel/pipeline/jmx/translator_test.go
@@ -321,7 +321,7 @@ func TestTranslator(t *testing.T) {
 			if testCase.isContainer {
 				t.Setenv(envconfig.RunInContainer, envconfig.TrueValue)
 			}
-			tt := NewTranslator(WithIndex(testCase.index), WithDestination(testCase.destination))
+			tt := NewTranslator(common.WithIndex(testCase.index), WithDestination(testCase.destination))
 			conf := confmap.NewFromStringMap(testCase.input)
 			got, err := tt.Translate(conf)
 			require.Equal(t, testCase.wantErr, err)

--- a/translator/translate/otel/pipeline/jmx/translator_test.go
+++ b/translator/translate/otel/pipeline/jmx/translator_test.go
@@ -27,6 +27,7 @@ func TestTranslator(t *testing.T) {
 	testCases := map[string]struct {
 		input       map[string]any
 		index       int
+		destination string
 		isContainer bool
 		want        *want
 		wantErr     error
@@ -174,11 +175,12 @@ func TestTranslator(t *testing.T) {
 					},
 				},
 			},
-			index: -1,
+			index:       -1,
+			destination: "amp",
 			want: &want{
-				pipelineID: "metrics/jmx",
+				pipelineID: "metrics/jmx/amp",
 				receivers:  []string{"jmx"},
-				processors: []string{"filter/jmx", "resource/jmx", "batch/jmx"},
+				processors: []string{"filter/jmx", "resource/jmx", "batch/jmx/amp"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},
@@ -203,11 +205,12 @@ func TestTranslator(t *testing.T) {
 				},
 			},
 			index:       -1,
+			destination: "amp",
 			isContainer: true,
 			want: &want{
-				pipelineID: "metrics/jmx",
+				pipelineID: "metrics/jmx/amp",
 				receivers:  []string{"otlp/jmx"},
-				processors: []string{"filter/jmx", "resource/jmx", "batch/jmx"},
+				processors: []string{"filter/jmx", "resource/jmx", "batch/jmx/amp"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},
@@ -231,9 +234,10 @@ func TestTranslator(t *testing.T) {
 					},
 				},
 			},
-			index: -1,
+			index:       -1,
+			destination: "cloudwatch",
 			want: &want{
-				pipelineID: "metrics/jmx",
+				pipelineID: "metrics/jmx/cloudwatch",
 				receivers:  []string{"jmx"},
 				processors: []string{"filter/jmx", "resource/jmx", "transform/jmx", "cumulativetodelta/jmx"},
 				exporters:  []string{"awscloudwatch"},
@@ -301,11 +305,12 @@ func TestTranslator(t *testing.T) {
 				},
 			},
 			index:       0,
+			destination: "amp",
 			isContainer: true,
 			want: &want{
-				pipelineID: "metrics/jmx/0",
+				pipelineID: "metrics/jmx/amp/0",
 				receivers:  []string{"otlp/jmx"},
-				processors: []string{"filter/jmx/0", "resource/jmx", "transform/jmx/0", "batch/jmx/0"},
+				processors: []string{"filter/jmx/0", "resource/jmx", "transform/jmx/0", "batch/jmx/amp/0"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},
@@ -316,7 +321,7 @@ func TestTranslator(t *testing.T) {
 			if testCase.isContainer {
 				t.Setenv(envconfig.RunInContainer, envconfig.TrueValue)
 			}
-			tt := NewTranslator(WithIndex(testCase.index))
+			tt := NewTranslator(WithIndex(testCase.index), WithDestination(testCase.destination))
 			conf := confmap.NewFromStringMap(testCase.input)
 			got, err := tt.Translate(conf)
 			require.Equal(t, testCase.wantErr, err)

--- a/translator/translate/otel/pipeline/jmx/translators.go
+++ b/translator/translate/otel/pipeline/jmx/translators.go
@@ -10,6 +10,11 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline"
 )
 
+const (
+	// defaultDestination if not defined
+	defaultDestination = ""
+)
+
 func NewTranslators(conf *confmap.Conf) pipeline.TranslatorMap {
 	translators := common.NewTranslatorMap[*common.ComponentTranslators]()
 	var destinations []string
@@ -20,13 +25,13 @@ func NewTranslators(conf *confmap.Conf) pipeline.TranslatorMap {
 		destinations = append(destinations, common.AMPKey)
 	}
 	if len(destinations) == 0 {
-		destinations = append(destinations, "")
+		destinations = append(destinations, defaultDestination)
 	}
 	switch v := conf.Get(common.JmxConfigKey).(type) {
 	case []any:
 		for index := range v {
 			for _, destination := range destinations {
-				translators.Set(NewTranslator(WithIndex(index), WithDestination(destination)))
+				translators.Set(NewTranslator(common.WithIndex(index), WithDestination(destination)))
 			}
 		}
 	case map[string]any:

--- a/translator/translate/otel/pipeline/jmx/translators_test.go
+++ b/translator/translate/otel/pipeline/jmx/translators_test.go
@@ -35,6 +35,23 @@ func TestTranslators(t *testing.T) {
 				component.MustNewIDWithName("metrics", "jmx"),
 			},
 		},
+		"WithSingle/Destinations": {
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_destinations": map[string]any{
+						"amp": map[string]any{
+							"workspace_id": "ws-12345",
+						},
+					},
+					"metrics_collected": map[string]any{
+						"jmx": map[string]any{},
+					},
+				},
+			},
+			want: []component.ID{
+				component.MustNewIDWithName("metrics", "jmx/amp"),
+			},
+		},
 		"WithMultiple": {
 			input: map[string]any{
 				"metrics": map[string]any{
@@ -49,6 +66,30 @@ func TestTranslators(t *testing.T) {
 			want: []component.ID{
 				component.MustNewIDWithName("metrics", "jmx/0"),
 				component.MustNewIDWithName("metrics", "jmx/1"),
+			},
+		},
+		"WithMultiple/Destinations": {
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_destinations": map[string]any{
+						"cloudwatch": map[string]any{},
+						"amp": map[string]any{
+							"workspace_id": "ws-12345",
+						},
+					},
+					"metrics_collected": map[string]any{
+						"jmx": []any{
+							map[string]any{},
+							map[string]any{},
+						},
+					},
+				},
+			},
+			want: []component.ID{
+				component.MustNewIDWithName("metrics", "jmx/cloudwatch/0"),
+				component.MustNewIDWithName("metrics", "jmx/amp/0"),
+				component.MustNewIDWithName("metrics", "jmx/cloudwatch/1"),
+				component.MustNewIDWithName("metrics", "jmx/amp/1"),
 			},
 		},
 	}

--- a/translator/translate/otel/processor/filterprocessor/translator_test.go
+++ b/translator/translate/otel/processor/filterprocessor/translator_test.go
@@ -119,7 +119,7 @@ func TestTranslator(t *testing.T) {
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			tt := NewTranslator(WithName("jmx"), WithIndex(testCase.index))
+			tt := NewTranslator(common.WithName("jmx"), common.WithIndex(testCase.index))
 			require.EqualValues(t, testCase.wantID, tt.ID().String())
 			conf := confmap.NewFromStringMap(testCase.input)
 			got, err := tt.Translate(conf)

--- a/translator/translate/otel/processor/resourceprocessor/translator.go
+++ b/translator/translate/otel/processor/resourceprocessor/translator.go
@@ -5,36 +5,34 @@ package resourceprocessor
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/processor"
 
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
 type translator struct {
-	name    string
+	common.NameProvider
+	common.IndexProvider
 	factory processor.Factory
-}
-
-type Option func(any)
-
-func WithName(name string) Option {
-	return func(a any) {
-		if t, ok := a.(*translator); ok {
-			t.name = name
-		}
-	}
 }
 
 var _ common.Translator[component.Config] = (*translator)(nil)
 
-func NewTranslator(opts ...Option) common.Translator[component.Config] {
+func NewTranslator(opts ...common.TranslatorOption) common.Translator[component.Config] {
 	t := &translator{factory: resourceprocessor.NewFactory()}
+	t.SetIndex(-1)
 	for _, opt := range opts {
 		opt(t)
+	}
+	if t.Index() != -1 {
+		t.SetName(t.Name() + "/" + strconv.Itoa(t.Index()))
 	}
 	return t
 }
@@ -42,7 +40,7 @@ func NewTranslator(opts ...Option) common.Translator[component.Config] {
 var _ common.Translator[component.Config] = (*translator)(nil)
 
 func (t *translator) ID() component.ID {
-	return component.NewIDWithName(t.factory.Type(), t.name)
+	return component.NewIDWithName(t.factory.Type(), t.Name())
 }
 
 // Translate creates a processor config based on the fields in the
@@ -53,9 +51,30 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	}
 
 	cfg := t.factory.CreateDefaultConfig().(*resourceprocessor.Config)
-
+	var attributes []any
+	if strings.HasPrefix(t.Name(), common.PipelineNameJmx) {
+		attributes = t.getJMXAttributes(conf)
+	}
+	if len(attributes) == 0 {
+		baseKey := common.JmxConfigKey
+		if t.Index() != -1 {
+			baseKey = fmt.Sprintf("%s[%d]", baseKey, t.Index())
+		}
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: common.ConfigKey(baseKey, common.AppendDimensionsKey)}
+	}
 	c := confmap.NewFromStringMap(map[string]any{
-		"attributes": []any{
+		"attributes": attributes,
+	})
+	if err := c.Unmarshal(&cfg); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal resource processor: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func (t *translator) getJMXAttributes(conf *confmap.Conf) []any {
+	if !context.CurrentContext().RunInContainer() {
+		return []any{
 			map[string]any{
 				"action":  "delete",
 				"pattern": "telemetry.sdk.*",
@@ -65,12 +84,20 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 				"key":    "service.name",
 				"value":  "unknown_service:java",
 			},
-		},
-	})
-
-	if err := c.Unmarshal(&cfg); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal resource processor: %w", err)
+		}
 	}
-
-	return cfg, nil
+	jmxMap := common.GetIndexedMap(conf, common.JmxConfigKey, t.Index())
+	appendDimensions, ok := jmxMap[common.AppendDimensionsKey].(map[string]any)
+	if !ok {
+		return nil
+	}
+	var attributes []any
+	for key, value := range appendDimensions {
+		attributes = append(attributes, map[string]any{
+			"action": "upsert",
+			"key":    key,
+			"value":  value,
+		})
+	}
+	return attributes
 }

--- a/translator/translate/otel/processor/resourceprocessor/translator_test.go
+++ b/translator/translate/otel/processor/resourceprocessor/translator_test.go
@@ -11,18 +11,21 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
 func TestTranslator(t *testing.T) {
 	testCases := map[string]struct {
-		name    string
-		input   map[string]any
-		wantID  string
-		want    *confmap.Conf
-		wantErr error
+		name        string
+		index       int
+		isContainer bool
+		input       map[string]any
+		wantID      string
+		want        *confmap.Conf
+		wantErr     error
 	}{
-		"ConfigWithNoJmxSet": {
+		"WithoutJMX": {
 			name: common.PipelineNameJmx,
 			input: map[string]any{
 				"metrics": map[string]any{
@@ -31,18 +34,24 @@ func TestTranslator(t *testing.T) {
 					},
 				},
 			},
+			index:   -1,
 			wantID:  "resource/jmx",
 			wantErr: &common.MissingKeyError{ID: component.MustNewIDWithName("resource", "jmx"), JsonKey: common.JmxConfigKey},
 		},
-		"ConfigWithJmx": {
+		"WithJMX": {
 			name: common.PipelineNameJmx,
 			input: map[string]any{
 				"metrics": map[string]any{
 					"metrics_collected": map[string]any{
-						"jmx": map[string]any{},
+						"jmx": map[string]any{
+							"append_dimensions": map[string]any{
+								"unused": "by resource processor",
+							},
+						},
 					},
 				},
 			},
+			index:  -1,
 			wantID: "resource/jmx",
 			want: confmap.NewFromStringMap(map[string]any{
 				"attributes": []any{
@@ -58,15 +67,115 @@ func TestTranslator(t *testing.T) {
 				},
 			}),
 		},
+		"WithJMX/EKS/NoAppendDimensions": {
+			name: common.PipelineNameJmx,
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_collected": map[string]any{
+						"jmx": map[string]any{},
+					},
+				},
+			},
+			index:       -1,
+			isContainer: true,
+			wantID:      "resource/jmx",
+			wantErr: &common.MissingKeyError{
+				ID:      component.MustNewIDWithName("resource", "jmx"),
+				JsonKey: "metrics::metrics_collected::jmx::append_dimensions",
+			},
+		},
+		"WithJMX/EKS/AppendDimensions": {
+			name: common.PipelineNameJmx,
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_collected": map[string]any{
+						"jmx": map[string]any{
+							"append_dimensions": map[string]any{
+								"k1": "v1",
+							},
+						},
+					},
+				},
+			},
+			index:       -1,
+			isContainer: true,
+			wantID:      "resource/jmx",
+			want: confmap.NewFromStringMap(map[string]any{
+				"attributes": []any{
+					map[string]any{
+						"action": "upsert",
+						"key":    "k1",
+						"value":  "v1",
+					},
+				},
+			}),
+		},
+		"WithJMX/Array/EKS/InvalidAppendDimensions": {
+			name: common.PipelineNameJmx,
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_collected": map[string]any{
+						"jmx": []any{
+							map[string]any{
+								"append_dimensions": []any{
+									"invalid",
+								},
+							},
+						},
+					},
+				},
+			},
+			index:       0,
+			isContainer: true,
+			wantID:      "resource/jmx/0",
+			wantErr: &common.MissingKeyError{
+				ID:      component.MustNewIDWithName("resource", "jmx/0"),
+				JsonKey: "metrics::metrics_collected::jmx[0]::append_dimensions",
+			},
+		},
+		"WithJMX/Array/EKS/AppendDimensions": {
+			name: common.PipelineNameJmx,
+			input: map[string]any{
+				"metrics": map[string]any{
+					"metrics_collected": map[string]any{
+						"jmx": []any{
+							map[string]any{
+								"append_dimensions": map[string]any{
+									"k1": "v1",
+								},
+							},
+							map[string]any{
+								"append_dimensions": map[string]any{
+									"k2": "v2",
+								},
+							},
+						},
+					},
+				},
+			},
+			index:       1,
+			isContainer: true,
+			wantID:      "resource/jmx/1",
+			want: confmap.NewFromStringMap(map[string]any{
+				"attributes": []any{
+					map[string]any{
+						"action": "upsert",
+						"key":    "k2",
+						"value":  "v2",
+					},
+				},
+			}),
+		},
 	}
 	factory := resourceprocessor.NewFactory()
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			tt := NewTranslator(WithName(testCase.name))
+			context.CurrentContext().SetRunInContainer(testCase.isContainer)
+			tt := NewTranslator(common.WithName(testCase.name), common.WithIndex(testCase.index))
 			conf := confmap.NewFromStringMap(testCase.input)
 			got, err := tt.Translate(conf)
 			assert.EqualValues(t, testCase.wantID, tt.ID().String())
-			assert.Equal(t, err, testCase.wantErr)
+			assert.Equal(t, testCase.wantErr, err)
 			if err == nil {
 				assert.NotNil(t, got)
 				gotCfg, ok := got.(*resourceprocessor.Config)

--- a/translator/translate/otel/receiver/otlp/translator.go
+++ b/translator/translate/otel/receiver/otlp/translator.go
@@ -22,6 +22,8 @@ const (
 	defaultHttpEndpoint           = "127.0.0.1:4318"
 	defaultAppSignalsGrpcEndpoint = "0.0.0.0:4315"
 	defaultAppSignalsHttpEndpoint = "0.0.0.0:4316"
+	defaultJMXGrpcEndpoint        = "0.0.0.0:4313"
+	defaultJMXHttpEndpoint        = "0.0.0.0:4314"
 )
 
 var (
@@ -87,7 +89,12 @@ func (t *translator) ID() component.ID {
 
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*otlpreceiver.Config)
-
+	if t.name == common.JmxKey {
+		cfg.GRPC.NetAddr.Endpoint = defaultJMXGrpcEndpoint
+		cfg.HTTP.Endpoint = defaultJMXHttpEndpoint
+		return cfg, nil
+	}
+	// init default configuration
 	configKey, ok := configKeys[t.dataType]
 	if !ok {
 		return nil, fmt.Errorf("no config key defined for data type: %s", t.dataType)

--- a/translator/translate/otel/receiver/otlp/translator_test.go
+++ b/translator/translate/otel/receiver/otlp/translator_test.go
@@ -175,7 +175,7 @@ func TestMetricsTranslator(t *testing.T) {
 			conf := confmap.NewFromStringMap(testCase.input)
 			tt := NewTranslator(WithDataType(component.DataTypeMetrics))
 			if testCase.index != -1 {
-				tt = NewTranslator(WithDataType(component.DataTypeMetrics), WithIndex(testCase.index))
+				tt = NewTranslator(WithDataType(component.DataTypeMetrics), common.WithIndex(testCase.index))
 			}
 			got, err := tt.Translate(conf)
 			assert.Equal(t, testCase.wantErr, err)
@@ -192,7 +192,7 @@ func TestMetricsTranslator(t *testing.T) {
 }
 
 func TestTranslateAppSignals(t *testing.T) {
-	tt := NewTranslatorWithName(common.AppSignals, WithDataType(component.DataTypeTraces))
+	tt := NewTranslator(common.WithName(common.AppSignals), WithDataType(component.DataTypeTraces))
 	testCases := map[string]struct {
 		input   map[string]interface{}
 		want    *confmap.Conf
@@ -313,4 +313,16 @@ func TestTranslateAppSignals(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTranslateJMX(t *testing.T) {
+	tt := NewTranslator(common.WithName(common.PipelineNameJmx))
+	got, err := tt.Translate(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	gotCfg, ok := got.(*otlpreceiver.Config)
+	require.True(t, ok)
+	assert.Nil(t, gotCfg.GRPC)
+	assert.NotNil(t, gotCfg.HTTP)
+	assert.Equal(t, "0.0.0.0:4314", gotCfg.HTTP.Endpoint)
 }


### PR DESCRIPTION
# Description of the issue
JMX on EKS relies on a different method to collect metrics, so the pipeline needs to be a bit different.

# Description of changes
In a container environment,
- Adds the OTLP receiver to the JMX pipeline.
- Adds a `resource` processor to support `append_dimensions` if configured.
- Separates the `cloudwatch` and `amp` exporters into separate pipelines.
  - Removes the `cumulativetodelta` processor from the AMP pipeline.
- Removes `endpoint` from the JSON schema requirements for `jmx`. This will be enforced by the translator instead on EC2.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests. Built and tested the image.

![image](https://github.com/user-attachments/assets/75ab123a-a727-433c-adde-57cc019fb53f)


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




