### PR TITLE
Support supplemental configuration on ECS

### DIFF
--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -30,6 +30,7 @@ const (
 	PodName                   = "POD_NAME"
 	HostIP                    = "HOST_IP"
 	CWConfigContent           = "CW_CONFIG_CONTENT"
+	CWOtelConfigContent       = "CW_OTEL_CONFIG_CONTENT"
 	CWAgentMergedOtelConfig   = "CWAGENT_MERGED_OTEL_CONFIG"
 )
 

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent_test.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent_test.go
@@ -5,15 +5,20 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-test/deep"
 	"github.com/influxdata/wlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/aws/amazon-cloudwatch-agent/internal/merge/confmap"
 	"github.com/aws/amazon-cloudwatch-agent/logger"
 )
 
@@ -59,4 +64,97 @@ func Test_getCollectorParams(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMergeConfigs(t *testing.T) {
+	testEnvValue := `receivers:
+  nop/1:
+exporters:
+  nop:
+extensions:
+  nop:
+service:
+  extensions: [nop]
+  pipelines:
+    traces:
+      receivers: [nop/1]
+      exporters: [nop]
+`
+	testCases := map[string]struct {
+		input                   []string
+		isContainer             bool
+		isOnlyDefaultConfigPath bool
+		envValue                string
+		want                    *confmap.Conf
+		wantErr                 bool
+	}{
+		"WithoutInvalidFile": {
+			input:   []string{filepath.Join("not", "a", "file")},
+			wantErr: true,
+		},
+		"WithoutEnv/Container": {
+			input:                   []string{filepath.Join("testdata", "base.yaml")},
+			isContainer:             true,
+			isOnlyDefaultConfigPath: true,
+			want:                    mustLoadFromFile(t, filepath.Join("testdata", "base.yaml")),
+		},
+		"WithEnv/NonContainer": {
+			input:                   []string{filepath.Join("testdata", "base.yaml")},
+			isContainer:             false,
+			isOnlyDefaultConfigPath: true,
+			envValue:                testEnvValue,
+			want:                    mustLoadFromFile(t, filepath.Join("testdata", "base.yaml")),
+		},
+		"WithEnv/Container": {
+			input:                   []string{filepath.Join("testdata", "base.yaml")},
+			isContainer:             true,
+			isOnlyDefaultConfigPath: true,
+			envValue:                testEnvValue,
+			want:                    mustLoadFromFile(t, filepath.Join("testdata", "base+env.yaml")),
+		},
+		"WithEmptyEnv/Container": {
+			input:                   []string{filepath.Join("testdata", "base.yaml")},
+			isContainer:             true,
+			isOnlyDefaultConfigPath: true,
+			envValue:                "",
+			want:                    mustLoadFromFile(t, filepath.Join("testdata", "base.yaml")),
+		},
+		"WithInvalidEnv/Container": {
+			input:                   []string{filepath.Join("testdata", "base.yaml")},
+			isContainer:             true,
+			isOnlyDefaultConfigPath: true,
+			envValue:                "test",
+			wantErr:                 true,
+		},
+		"WithIgnoredEnv/Container": {
+			input:                   []string{filepath.Join("testdata", "base.yaml")},
+			isContainer:             true,
+			isOnlyDefaultConfigPath: false,
+			envValue:                testEnvValue,
+			want:                    mustLoadFromFile(t, filepath.Join("testdata", "base.yaml")),
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if testCase.isContainer {
+				t.Setenv(envconfig.RunInContainer, envconfig.TrueValue)
+			}
+			t.Setenv(envconfig.CWOtelConfigContent, testCase.envValue)
+			got, err := mergeConfigs(testCase.input, testCase.isOnlyDefaultConfigPath)
+			if testCase.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, testCase.want.ToStringMap(), got.ToStringMap())
+			}
+		})
+	}
+}
+
+func mustLoadFromFile(t *testing.T, path string) *confmap.Conf {
+	conf, err := confmap.LoadFromFile(path)
+	require.NoError(t, err)
+	return conf
 }

--- a/cmd/amazon-cloudwatch-agent/testdata/base+env.yaml
+++ b/cmd/amazon-cloudwatch-agent/testdata/base+env.yaml
@@ -1,0 +1,19 @@
+receivers:
+  nop:
+  nop/1:
+
+exporters:
+  nop:
+
+extensions:
+  nop:
+
+service:
+  extensions: [nop]
+  pipelines:
+    metrics:
+      receivers: [nop]
+      exporters: [nop]
+    traces:
+      receivers: [nop/1]
+      exporters: [nop]

--- a/cmd/amazon-cloudwatch-agent/testdata/base.yaml
+++ b/cmd/amazon-cloudwatch-agent/testdata/base.yaml
@@ -1,0 +1,11 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [nop]
+      exporters: [nop]

--- a/internal/merge/confmap/confmap.go
+++ b/internal/merge/confmap/confmap.go
@@ -35,6 +35,9 @@ func NewFromStringMap(data map[string]any) *Conf {
 }
 
 func (c *Conf) Merge(in *Conf) error {
+	if in == nil {
+		return nil
+	}
 	return c.mergeFromStringMap(in.ToStringMap())
 }
 
@@ -46,17 +49,19 @@ func (c *Conf) ToStringMap() map[string]any {
 	return maps.Unflatten(c.k.All(), KeyDelimiter)
 }
 
-func LoadConf(path string) (*Conf, error) {
+func LoadFromFile(path string) (*Conf, error) {
 	// Clean the path before using it.
 	content, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, fmt.Errorf("unable to read the file %v: %w", path, err)
 	}
+	return LoadFromBytes(content)
+}
 
+func LoadFromBytes(content []byte) (*Conf, error) {
 	var rawConf map[string]any
-	if err = yaml.Unmarshal(content, &rawConf); err != nil {
+	if err := yaml.Unmarshal(content, &rawConf); err != nil {
 		return nil, err
 	}
-
 	return NewFromStringMap(rawConf), nil
 }

--- a/internal/merge/confmap/confmap_test.go
+++ b/internal/merge/confmap/confmap_test.go
@@ -37,13 +37,13 @@ func TestMerge(t *testing.T) {
 				filepath.Join("testdata", "base.yaml"),
 				filepath.Join("testdata", "merge.yaml"),
 			},
-			wantConf: mustLoadConf(t, filepath.Join("testdata", "base+merge.yaml")),
+			wantConf: mustLoadFromFile(t, filepath.Join("testdata", "base+merge.yaml")),
 		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			base := mustLoadConf(t, testCase.fileNames[0])
-			conf := mustLoadConf(t, testCase.fileNames[1])
+			base := mustLoadFromFile(t, testCase.fileNames[0])
+			conf := mustLoadFromFile(t, testCase.fileNames[1])
 			assert.Equal(t, testCase.wantErr, base.Merge(conf))
 			if testCase.wantConf != nil {
 				got := toyamlconfig.ToYamlConfig(base.ToStringMap())
@@ -52,10 +52,12 @@ func TestMerge(t *testing.T) {
 			}
 		})
 	}
+	conf := New()
+	assert.NoError(t, conf.Merge(nil))
 }
 
-func mustLoadConf(t *testing.T, path string) *Conf {
-	conf, err := LoadConf(path)
+func mustLoadFromFile(t *testing.T, path string) *Conf {
+	conf, err := LoadFromFile(path)
 	require.NoError(t, err)
 	return conf
 }


### PR DESCRIPTION
# Description of the issue
On ECS, the agent can be configured by setting the `CW_CONFIG_CONTENT` environment variable to a valid JSON string. The `/etc/cwagentconfig` directory that is available on EKS is not used.

# Description of changes
Adds a `CW_OTEL_CONFIG_CONTENT` environment variable that can be used in a container environment if no other supplemental YAML is provided. Must be a valid YAML formatted string.

Follows the `CW_CONFIG_CONTENT` usage conditions
https://github.com/aws/amazon-cloudwatch-agent/blob/5cdba47e87d55f65d31ba8162c8c91cc151ec4a5/translator/cmdutil/translatorutil.go#L196-L198

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




