### PR TITLE
Add nil check to user agent.

### DIFF
--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -84,11 +84,13 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 			name := strings.TrimPrefix(receiver.Type().String(), adapter.TelegrafPrefix)
 			ua.inputs.Add(name)
 			if name == common.JmxKey {
-				cfg := otelCfg.Receivers[receiver].(*jmxreceiver.Config)
-				targetSystems := strings.Split(cfg.TargetSystem, ",")
-				for _, system := range targetSystems {
-					targetSystem := name + "-" + system
-					ua.inputs.Add(targetSystem)
+				cfg, ok := otelCfg.Receivers[receiver].(*jmxreceiver.Config)
+				if ok {
+					targetSystems := strings.Split(cfg.TargetSystem, ",")
+					for _, system := range targetSystems {
+						targetSystem := name + "-" + system
+						ua.inputs.Add(targetSystem)
+					}
 				}
 			}
 		}
@@ -98,14 +100,16 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 		for _, exporter := range pipeline.Exporters {
 			ua.outputs.Add(exporter.Type().String())
 			if exporter.Type().String() == "awsemf" {
-				cfg := otelCfg.Exporters[exporter].(*awsemfexporter.Config)
-				if cfg.IsAppSignalsEnabled() {
-					ua.outputs.Add(flagAppSignals)
-					agent.UsageFlags().Set(agent.FlagAppSignal)
-				}
-				if cfg.IsEnhancedContainerInsights() {
-					ua.outputs.Add(flagEnhancedContainerInsights)
-					agent.UsageFlags().Set(agent.FlagEnhancedContainerInsights)
+				cfg, ok := otelCfg.Exporters[exporter].(*awsemfexporter.Config)
+				if ok {
+					if cfg.IsAppSignalsEnabled() {
+						ua.outputs.Add(flagAppSignals)
+						agent.UsageFlags().Set(agent.FlagAppSignal)
+					}
+					if cfg.IsEnhancedContainerInsights() {
+						ua.outputs.Add(flagEnhancedContainerInsights)
+						agent.UsageFlags().Set(agent.FlagEnhancedContainerInsights)
+					}
 				}
 			}
 		}

--- a/extension/agenthealth/handler/useragent/useragent_test.go
+++ b/extension/agenthealth/handler/useragent/useragent_test.go
@@ -139,6 +139,32 @@ func TestEmf(t *testing.T) {
 	assert.Equal(t, "outputs:(application_signals awsemf)", ua.outputsStr.Load())
 }
 
+func TestMissingEmfExporterConfig(t *testing.T) {
+	otelCfg := &otelcol.Config{
+		Service: service.Config{
+			Pipelines: map[component.ID]*pipelines.PipelineConfig{
+				component.NewID(component.MustNewType("metrics")): {
+					Receivers: []component.ID{
+						component.NewID(component.MustNewType("nop")),
+					},
+					Exporters: []component.ID{
+						component.NewID(component.MustNewType("awsemf")),
+					},
+				},
+			},
+		},
+	}
+	ua := newUserAgent()
+	ua.SetComponents(otelCfg, &telegraf.Config{})
+	assert.Len(t, ua.inputs, 2)
+	assert.Len(t, ua.processors, 0)
+	assert.Len(t, ua.outputs, 1)
+
+	assert.Equal(t, "inputs:(nop run_as_user)", ua.inputsStr.Load())
+	assert.Equal(t, "", ua.processorsStr.Load())
+	assert.Equal(t, "outputs:(awsemf)", ua.outputsStr.Load())
+}
+
 func TestJmx(t *testing.T) {
 	jmx := "jmx"
 	jmxOther := "jmxOther"


### PR DESCRIPTION
# Description of the issue
If the configuration has a JMX receiver or EMF exporter in the pipelines, but not in the components, the useragent check will panic when trying to de-reference a nil value.

# Description of changes
Adds a type assertion check before trying to access fields.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit test.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




