### PR TITLE
Fallback to UnknownNameSpace in default environment calculation in awsentity processor

### DIFF
--- a/plugins/processors/awsentity/processor.go
+++ b/plugins/processors/awsentity/processor.go
@@ -25,6 +25,7 @@ const (
 	attributeServiceName           = "service.name"
 	attributeService               = "Service"
 	EMPTY                          = ""
+	unknownNameSpace               = "UnknownNamespace"
 )
 
 type scraper interface {
@@ -163,6 +164,11 @@ func (p *awsEntityProcessor) processMetrics(_ context.Context, md pmetric.Metric
 				if entityServiceName == EMPTY && ok && podInfo != nil && podInfo.Workload != EMPTY {
 					entityServiceName = podInfo.Workload
 					entityServiceNameSource = entitystore.ServiceNameSourceK8sWorkload
+				}
+
+				//Referred https://github.com/aws/amazon-cloudwatch-agent/blob/main/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
+				if podInfo.Namespace == EMPTY {
+					podInfo.Namespace = unknownNameSpace
 				}
 
 				if entityEnvironmentName == EMPTY && ok && podInfo.Cluster != EMPTY && podInfo.Namespace != EMPTY {

--- a/plugins/processors/awsentity/processor_test.go
+++ b/plugins/processors/awsentity/processor_test.go
@@ -196,13 +196,13 @@ func TestProcessMetricsForAddingPodToServiceMap(t *testing.T) {
 		{
 			name:    "WithPodNameAndServiceNameNoSource",
 			metrics: generateMetrics(attributeServiceName, "test-service", semconv.AttributeK8SPodName, "cloudwatch-agent-adhgaf"),
-			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "test-service", ServiceNameSource: entitystore.ServiceNameSourceUnknown}},
+			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "test-service", Environment: "eks:test-cluster/UnknownNamespace", ServiceNameSource: entitystore.ServiceNameSourceUnknown}},
 			k8sMode: config.ModeEKS,
 		},
 		{
 			name:    "WithPodNameAndServiceNameHasSource",
 			metrics: generateMetrics(attributeServiceName, "test-service", semconv.AttributeK8SPodName, "cloudwatch-agent-adhgaf", entityattributes.AttributeEntityServiceNameSource, "Instrumentation"),
-			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "test-service", ServiceNameSource: entitystore.ServiceNameSourceInstrumentation}},
+			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "test-service", Environment: "eks:test-cluster/UnknownNamespace", ServiceNameSource: entitystore.ServiceNameSourceInstrumentation}},
 			k8sMode: config.ModeEKS,
 		},
 		{
@@ -238,20 +238,20 @@ func TestProcessMetricsForAddingPodToServiceMap(t *testing.T) {
 		{
 			name:    "WithPodNameAndAttributeService",
 			metrics: generateMetrics(attributeService, "test-service", semconv.AttributeK8SPodName, "cloudwatch-agent-adhgaf", entityattributes.AttributeEntityServiceNameSource, "Instrumentation"),
-			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "test-service", ServiceNameSource: entitystore.ServiceNameSourceInstrumentation}},
+			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "test-service", Environment: "k8s:test-cluster/UnknownNamespace", ServiceNameSource: entitystore.ServiceNameSourceInstrumentation}},
 			k8sMode: config.ModeK8sOnPrem,
 		},
 		{
 			name:    "WithPodNameAndWorkload",
 			metrics: generateMetrics(attributeServiceName, "cloudwatch-agent-adhgaf", semconv.AttributeK8SPodName, "cloudwatch-agent-adhgaf", entityattributes.AttributeEntityServiceNameSource, "K8sWorkload"),
-			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "cloudwatch-agent-adhgaf", ServiceNameSource: entitystore.ServiceNameSourceK8sWorkload}},
+			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "cloudwatch-agent-adhgaf", Environment: "eks:test-cluster/UnknownNamespace", ServiceNameSource: entitystore.ServiceNameSourceK8sWorkload}},
 			k8sMode: config.ModeEKS,
 		},
 		{
 			name:    "WithPodNameAndEmptyServiceAndEnvironmentName",
 			metrics: generateMetrics(semconv.AttributeK8SPodName, "cloudwatch-agent-adhgaf"),
 			k8sMode: config.ModeEKS,
-			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "cloudwatch-agent-adhgaf", ServiceNameSource: entitystore.ServiceNameSourceK8sWorkload}},
+			want:    map[string]entitystore.ServiceEnvironment{"cloudwatch-agent-adhgaf": {ServiceName: "cloudwatch-agent-adhgaf", Environment: "eks:test-cluster/UnknownNamespace", ServiceNameSource: entitystore.ServiceNameSourceK8sWorkload}},
 		},
 		{
 			name:    "WithEmptyPodName",
@@ -403,6 +403,25 @@ func TestProcessMetricsResourceAttributeScraping(t *testing.T) {
 				entityattributes.AttributeEntityInstanceID:            "i-123456789",
 				entityattributes.AttributeEntityAwsAccountId:          "0123456789012",
 				entityattributes.AttributeEntityServiceNameSource:     "Unknown",
+			},
+		},
+		{
+			name:           "ResourceAttributeWorkloadFallbackWithUnknownNameSpace",
+			kubernetesMode: config.ModeEKS,
+			clusterName:    "test-cluster",
+			metrics:        generateMetrics(semconv.AttributeK8SDeploymentName, "test-workload", semconv.AttributeK8SNodeName, "test-node"),
+			want: map[string]any{
+				entityattributes.AttributeEntityType:                  "Service",
+				entityattributes.AttributeEntityServiceName:           "test-workload",
+				entityattributes.AttributeEntityDeploymentEnvironment: "eks:test-cluster/" + unknownNameSpace,
+				entityattributes.AttributeEntityCluster:               "test-cluster",
+				entityattributes.AttributeEntityNamespace:             unknownNameSpace,
+				entityattributes.AttributeEntityNode:                  "test-node",
+				entityattributes.AttributeEntityWorkload:              "test-workload",
+				entityattributes.AttributeEntityServiceNameSource:     "K8sWorkload",
+				entityattributes.AttributeEntityPlatformType:          "AWS::EKS",
+				semconv.AttributeK8SDeploymentName:                    "test-workload",
+				semconv.AttributeK8SNodeName:                          "test-node",
 			},
 		},
 	}


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._
Current Application signals https://github.com/aws/amazon-cloudwatch-agent/blob/main/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go#L613 fallback to UnknownNamespace, but the entity processor doesn't have any fallback to namespace.

# Description of changes
_How does this change address the problem?_
Implemented the namespace fallback in aws entity processor in calculating the default environment.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
Unit Tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




