### PR TITLE
Add null checks to service provider in entitystore extension

### DIFF
--- a/extension/entitystore/ec2Info.go
+++ b/extension/entitystore/ec2Info.go
@@ -41,6 +41,9 @@ type EC2Info struct {
 }
 
 func (ei *EC2Info) initEc2Info() {
+	if ei.metadataProvider == nil {
+		return
+	}
 	ei.logger.Debug("Initializing EC2Info")
 	if err := ei.setInstanceIDAccountID(); err != nil {
 		return

--- a/extension/entitystore/ec2Info_test.go
+++ b/extension/entitystore/ec2Info_test.go
@@ -205,3 +205,34 @@ func TestLogMessageDoesNotIncludeResourceInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestNotInitIfMetadataProviderIsEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "AutoScalingGroupWithInstanceTags",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a buffer to capture the logger output
+			var buf bytes.Buffer
+
+			logger := CreateTestLogger(&buf)
+			done := make(chan struct{})
+
+			ei := &EC2Info{
+				logger: logger,
+				done:   done,
+			}
+			go ei.initEc2Info()
+			time.Sleep(3 * time.Second)
+
+			logOutput := buf.String()
+			log.Println(logOutput)
+			assert.NotContains(t, logOutput, "Initializing EC2Info")
+			assert.NotContains(t, logOutput, "Finished initializing EC2Info")
+		})
+	}
+}

--- a/extension/entitystore/extension.go
+++ b/extension/entitystore/extension.go
@@ -48,6 +48,7 @@ type EntityStore struct {
 	logger *zap.Logger
 	config *Config
 	done   chan struct{}
+	ready  bool
 
 	// mode should be EC2, ECS, EKS, and K8S
 	mode string
@@ -101,6 +102,7 @@ func (e *EntityStore) Start(ctx context.Context, host component.Host) error {
 		// Starting the ttl cache will automatically evict all expired pods from the map
 		go e.StartPodToServiceEnvironmentMappingTtlCache()
 	}
+	e.ready = true
 	return nil
 }
 

--- a/extension/entitystore/extension.go
+++ b/extension/entitystore/extension.go
@@ -5,6 +5,7 @@ package entitystore
 
 import (
 	"context"
+	"go.uber.org/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,7 +49,7 @@ type EntityStore struct {
 	logger *zap.Logger
 	config *Config
 	done   chan struct{}
-	ready  bool
+	ready  atomic.Bool
 
 	// mode should be EC2, ECS, EKS, and K8S
 	mode string
@@ -102,7 +103,7 @@ func (e *EntityStore) Start(ctx context.Context, host component.Host) error {
 		// Starting the ttl cache will automatically evict all expired pods from the map
 		go e.StartPodToServiceEnvironmentMappingTtlCache()
 	}
-	e.ready = true
+	e.ready.Store(true)
 	return nil
 }
 

--- a/extension/entitystore/extension.go
+++ b/extension/entitystore/extension.go
@@ -198,7 +198,7 @@ func (e *EntityStore) AddPodServiceEnvironmentMapping(podName string, serviceNam
 
 func (e *EntityStore) StartPodToServiceEnvironmentMappingTtlCache() {
 	if e.eksInfo != nil && e.eksInfo.GetPodServiceEnvironmentMapping() != nil {
-		e.eksInfo.podToServiceEnvMap.Start()
+		e.eksInfo.GetPodServiceEnvironmentMapping().Start()
 	}
 }
 

--- a/extension/entitystore/extension.go
+++ b/extension/entitystore/extension.go
@@ -5,7 +5,6 @@ package entitystore
 
 import (
 	"context"
-	"go.uber.org/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,6 +14,7 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	configaws "github.com/aws/amazon-cloudwatch-agent/cfg/aws"

--- a/extension/entitystore/extension_test.go
+++ b/extension/entitystore/extension_test.go
@@ -619,7 +619,7 @@ func TestEntityStore_LogMessageDoesNotIncludeResourceInfo(t *testing.T) {
 			assertIfNonEmpty(t, logOutput, es.ec2Info.GetInstanceID())
 			assertIfNonEmpty(t, logOutput, es.ec2Info.GetAutoScalingGroup())
 			assertIfNonEmpty(t, logOutput, es.ec2Info.GetAccountID())
-
+			assert.True(t, es.ready)
 		})
 	}
 }

--- a/extension/entitystore/extension_test.go
+++ b/extension/entitystore/extension_test.go
@@ -619,7 +619,7 @@ func TestEntityStore_LogMessageDoesNotIncludeResourceInfo(t *testing.T) {
 			assertIfNonEmpty(t, logOutput, es.ec2Info.GetInstanceID())
 			assertIfNonEmpty(t, logOutput, es.ec2Info.GetAutoScalingGroup())
 			assertIfNonEmpty(t, logOutput, es.ec2Info.GetAccountID())
-			assert.True(t, es.ready)
+			assert.True(t, es.ready.Load(), "EntityStore should be ready")
 		})
 	}
 }

--- a/extension/entitystore/extension_test.go
+++ b/extension/entitystore/extension_test.go
@@ -344,6 +344,21 @@ func TestEntityStore_createLogFileRID(t *testing.T) {
 	assert.Equal(t, dereferenceMap(expectedEntity.Attributes), dereferenceMap(entity.Attributes))
 }
 
+func TestEntityStore_createLogFileRID_ServiceProviderIsEmpty(t *testing.T) {
+	instanceId := "i-abcd1234"
+	glob := LogFileGlob("glob")
+	group := LogGroupName("group")
+	e := EntityStore{
+		mode:             config.ModeEC2,
+		ec2Info:          EC2Info{InstanceID: instanceId},
+		nativeCredential: &session.Session{},
+	}
+
+	entity := e.CreateLogFileEntity(glob, group)
+
+	assert.Nil(t, entity)
+}
+
 func dereferenceMap(input map[string]*string) map[string]string {
 	result := make(map[string]string)
 	for k, v := range input {
@@ -537,6 +552,22 @@ func TestEntityStore_GetMetricServiceNameSource(t *testing.T) {
 
 	assert.Equal(t, "test-service-name", serviceName)
 	assert.Equal(t, "UserConfiguration", serviceNameSource)
+}
+
+func TestEntityStore_GetMetricServiceNameSource_ServiceProviderEmpty(t *testing.T) {
+	instanceId := "i-abcd1234"
+	accountId := "123456789012"
+	e := EntityStore{
+		mode:             config.ModeEC2,
+		ec2Info:          EC2Info{InstanceID: instanceId},
+		metadataprovider: mockMetadataProviderWithAccountId(accountId),
+		nativeCredential: &session.Session{},
+	}
+
+	serviceName, serviceNameSource := e.GetMetricServiceNameAndSource()
+
+	assert.Equal(t, "", serviceName)
+	assert.Equal(t, "", serviceNameSource)
 }
 
 func TestEntityStore_LogMessageDoesNotIncludeResourceInfo(t *testing.T) {

--- a/extension/entitystore/factory.go
+++ b/extension/entitystore/factory.go
@@ -20,7 +20,7 @@ var (
 func GetEntityStore() *EntityStore {
 	mutex.RLock()
 	defer mutex.RUnlock()
-	if entityStore != nil && entityStore.ready {
+	if entityStore != nil && entityStore.ready.Load() {
 		return entityStore
 	}
 	return nil

--- a/extension/entitystore/serviceprovider_test.go
+++ b/extension/entitystore/serviceprovider_test.go
@@ -32,6 +32,11 @@ func Test_serviceprovider_startServiceProvider(t *testing.T) {
 			wantIAM: "TestRole",
 			wantTag: "test-service",
 		},
+		{
+			name:    "EmptyServiceProvider",
+			wantIAM: "",
+			wantTag: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -64,10 +69,32 @@ func Test_serviceprovider_addEntryForLogFile(t *testing.T) {
 	assert.Equal(t, serviceAttr, actual)
 }
 
+func Test_serviceprovider_addEntryForLogFile_logFilesEmpty(t *testing.T) {
+	s := &serviceprovider{}
+	glob := LogFileGlob("glob")
+	serviceAttr := ServiceAttribute{ServiceName: "test-service"}
+
+	s.addEntryForLogFile(glob, serviceAttr)
+
+	actual := s.logFiles[glob]
+	assert.Equal(t, serviceAttr, actual)
+}
+
 func Test_serviceprovider_addEntryForLogGroup(t *testing.T) {
 	s := &serviceprovider{
 		logGroups: make(map[LogGroupName]ServiceAttribute),
 	}
+	group := LogGroupName("group")
+	serviceAttr := ServiceAttribute{ServiceName: "test-service"}
+
+	s.addEntryForLogGroup(group, serviceAttr)
+
+	actual := s.logGroups[group]
+	assert.Equal(t, serviceAttr, actual)
+}
+
+func Test_serviceprovider_addEntryForLogGroup_logGroupsEmpty(t *testing.T) {
+	s := &serviceprovider{}
 	group := LogGroupName("group")
 	serviceAttr := ServiceAttribute{ServiceName: "test-service"}
 
@@ -142,6 +169,8 @@ func Test_serviceprovider_serviceAttributeForLogGroup(t *testing.T) {
 	assert.Equal(t, ServiceAttribute{}, s.serviceAttributeForLogGroup(""))
 	assert.Equal(t, ServiceAttribute{}, s.serviceAttributeForLogGroup("othergroup"))
 	assert.Equal(t, ServiceAttribute{ServiceName: "test-service"}, s.serviceAttributeForLogGroup("group"))
+	s.logGroups = nil
+	assert.Equal(t, ServiceAttribute{}, s.serviceAttributeForLogGroup("group"))
 }
 
 func Test_serviceprovider_serviceAttributeForLogFile(t *testing.T) {
@@ -149,6 +178,8 @@ func Test_serviceprovider_serviceAttributeForLogFile(t *testing.T) {
 	assert.Equal(t, ServiceAttribute{}, s.serviceAttributeForLogFile(""))
 	assert.Equal(t, ServiceAttribute{}, s.serviceAttributeForLogFile("otherglob"))
 	assert.Equal(t, ServiceAttribute{ServiceName: "test-service"}, s.serviceAttributeForLogFile("glob"))
+	s.logFiles = nil
+	assert.Equal(t, ServiceAttribute{}, s.serviceAttributeForLogFile("glob"))
 }
 
 func Test_serviceprovider_serviceAttributeFromEc2Tags(t *testing.T) {


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._
With LogsAgent plugin, Agent has a race condition that can cause some customers to lose logs as the agent panics.

# Description of changes
_How does this change address the problem?_
The panic is due to LogsAgent calling the CreateLogFileEntity method in entity store extension before the extension is initialized/started. Added a null check for serviceProvider to return nil when it is not initialized.

Also added null checks in other methods of entitystore extension to avoid panics.
# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
Unit Tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




