### PR TITLE
[BugFix] Include entity bytes in PutMetricData metric batch to ensure request payload does not exceed 1MB

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -177,7 +177,7 @@ func (c *CloudWatch) pushMetricDatum() {
 			for i := 0; i < numberOfPartitions; i++ {
 				entityStr := entityToString(entity)
 				c.metricDatumBatch.Partition[entityStr] = append(c.metricDatumBatch.Partition[entityStr], datums[i])
-				c.metricDatumBatch.Size += payload(datums[i])
+				c.metricDatumBatch.Size += payload(datums[i], &entity)
 				c.metricDatumBatch.Count++
 				if c.metricDatumBatch.isFull() {
 					// if batch is full

--- a/plugins/outputs/cloudwatch/util.go
+++ b/plugins/outputs/cloudwatch/util.go
@@ -93,7 +93,7 @@ func resize(dist distribution.Distribution, listMaxSize int) (distList []distrib
 	return
 }
 
-func payload(datum *cloudwatch.MetricDatum) (size int) {
+func payload(datum *cloudwatch.MetricDatum, entity *cloudwatch.Entity) (size int) {
 	size += timestampSize
 
 	for _, dimension := range datum.Dimensions {
@@ -118,6 +118,10 @@ func payload(datum *cloudwatch.MetricDatum) (size int) {
 
 	if datum.Unit != nil {
 		size += unitOverheads
+	}
+
+	if entity != nil {
+		size += len(entity.String())
 	}
 
 	return

--- a/plugins/outputs/cloudwatch/util_test.go
+++ b/plugins/outputs/cloudwatch/util_test.go
@@ -4,6 +4,7 @@
 package cloudwatch
 
 import (
+	"fmt"
 	"log"
 	"sort"
 	"testing"
@@ -118,7 +119,7 @@ func TestPayload_ValuesAndCounts(t *testing.T) {
 	datum.SetStorageResolution(1)
 	datum.SetTimestamp(time.Now())
 	datum.SetUnit("None")
-	assert.Equal(t, 867, payload(datum))
+	assert.Equal(t, 867, payload(datum, nil))
 }
 
 func TestPayload_Value(t *testing.T) {
@@ -131,7 +132,7 @@ func TestPayload_Value(t *testing.T) {
 	datum.SetStorageResolution(1)
 	datum.SetTimestamp(time.Now())
 	datum.SetUnit("None")
-	assert.Equal(t, 356, payload(datum))
+	assert.Equal(t, 356, payload(datum, nil))
 }
 
 func TestPayload_Min(t *testing.T) {
@@ -139,7 +140,29 @@ func TestPayload_Min(t *testing.T) {
 	datum.SetValue(1.23456789)
 	datum.SetMetricName("MetricName")
 	datum.SetTimestamp(time.Now())
-	assert.Equal(t, 148, payload(datum))
+	assert.Equal(t, 148, payload(datum, nil))
+}
+
+func TestPayload_Entity(t *testing.T) {
+	datum := new(cloudwatch.MetricDatum)
+	datum.SetValue(1.23456789)
+	datum.SetMetricName("MetricName")
+	datum.SetTimestamp(time.Now())
+
+	entity := cloudwatch.Entity{
+		KeyAttributes: map[string]*string{
+			"Environment": aws.String("Environment"),
+			"Service":     aws.String("Service"),
+		},
+		Attributes: map[string]*string{
+			"TestAttribute": aws.String("TestValue"),
+		},
+	}
+
+	expectedDatumSize := 148
+	expectedEntitySize := 133
+	fmt.Println(entity.String())
+	assert.Equal(t, expectedDatumSize+expectedEntitySize, payload(datum, &entity))
 }
 
 func TestEntityToString_StringToEntity(t *testing.T) {


### PR DESCRIPTION
# Description of the issue
The agent could make a PMD request of greater than 1MB due to the bytes in the Entity. This can cause RequestEntityTooLarge errors from CloudWatch. 

# Description of changes
* Modify the `payload` function to include the length of the entity string

Not sure if the `String()` method of the `cloudwatch.Entity` struct is good enough...need to confirm

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




