### PR TITLE
[Bug Fix] Fix Excessive IMDS related error logging

### DIFF
--- a/extension/entitystore/ec2Info_test.go
+++ b/extension/entitystore/ec2Info_test.go
@@ -5,7 +5,6 @@ package entitystore
 
 import (
 	"bytes"
-	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"log"
 	"strings"
 	"testing"
@@ -16,6 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/ec2metadataprovider"
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 )
 
 var mockedInstanceIdentityDoc = &ec2metadata.EC2InstanceIdentityDocument{

--- a/internal/retryer/imdsretryer.go
+++ b/internal/retryer/imdsretryer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/influxdata/wlog"
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 )
@@ -43,7 +44,7 @@ func (r IMDSRetryer) ShouldRetry(req *request.Request) bool {
 	if awsError, ok := req.Error.(awserr.Error); r.DefaultRetryer.ShouldRetry(req) || (ok && awsError != nil && awsError.Code() == "EC2MetadataError") {
 		shouldRetry = true
 	}
-	fmt.Printf("D! should retry %t for imds error : %v", shouldRetry, req.Error)
+	fmtDebugLog(wlog.LogLevel(), "D! should retry %t for imds error : %v", shouldRetry, req.Error)
 	return shouldRetry
 }
 
@@ -54,4 +55,11 @@ func GetDefaultRetryNumber() int {
 		return imdsRetry
 	}
 	return DefaultImdsRetries
+}
+
+// fmtDebugLog logs the content only if the log level is DEBUG
+func fmtDebugLog(logLevel wlog.Level, format string, args ...interface{}) {
+	if logLevel == wlog.DEBUG {
+		fmt.Printf(format, args...)
+	}
 }


### PR DESCRIPTION
# Description of the issue
```
    status code: 404, request id: D! should retry true for imds error : EC2MetadataError: failed to make EC2Metadata request
<?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
  <title>404 - Not Found</title>
 </head>
 <body>
  <h1>404 - Not Found</h1>
 </body>
</html>
```
In version 1.300049.0 and above, the agent will log the above message regardless of log levels on a defined interval. This is because we recently enabled instance tags by default to retrieve ASG name and instance tag name for entity service names. This becomes an issue when instance metadata tags is not enabled which can be majority case since instance metadata tags is an opt-in feature. The issue is especially apparently in EKS since EKS does not support instance metadata tags

# Description of changes
1. Only log the error when debug mode is enabled
2. Only enable instance tag related features in strictly EC2 mode
3. Only retry up to 3 times for instance tag errors.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
4. Run `make lint`




