### PR TITLE
Increase macOS integration test timeout duration

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -563,7 +563,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 60
           retry_wait_seconds: 5
           command: |
             if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then


### PR DESCRIPTION
# Description of the issue
We have flaky macOS test failures. The GitHub workflow fails even though the tests themselves passed. This is because current timeout duration is not long enough for terraform to destroy the macOS instances after the test is done, so terraform exit early which is considered as a failure for GitHub Action.

# Description of changes
- Increase timeout duration for macOS integration test.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12123087686
Ran twice to ensure not flaky

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




