### PR TITLE
Adding Lint Checker

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Check license and imports
         if: needs.changes.outputs.lint == 'true'
-        run: make simple-lint
+        run: make lint
 
   build:
     needs: [lint, changes]

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Check out code
         if: needs.changes.outputs.lint == 'true'
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Check format
         if: needs.changes.outputs.lint == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,11 +44,9 @@ linters-settings:
       - performancetest
     
 linters:
-  disable-all: true
-  enable:
+  disable:
     - errcheck
-    - goconst
-    - gocritic
+  enable:
     - gofmt
     - goimports
     - gosec
@@ -56,8 +54,9 @@ linters:
     - govet
     - ineffassign
     - misspell
-    - nolintlint
     - revive
+    - unused
+    - nonamedreturns
 
 issues:
   new-from-rev: 3221f76

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,5 @@ linters:
     - nolintlint
     - revive
 
-
 issues:
-  new-from-rev: 3221f769358168c0602e58918c1fb7b6083e33af
+  new-from-rev: 3221f76

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,9 +29,6 @@ output:
 
 # All available settings of specific linters
 linters-settings:
-  revive:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.7
   gofmt:
     # Simplify code: gofmt with `-s` option, true by default
     simplify: true
@@ -47,14 +44,21 @@ linters-settings:
       - performancetest
     
 linters:
-  disable:
+  disable-all: true
+  enable:
     - errcheck
+    - goconst
+    - gocritic
     - gofmt
     - goimports
-  enable:
-    - gosimple
     - gosec
-    - unused
+    - gosimple
+    - govet
+    - ineffassign
     - misspell
+    - nolintlint
     - revive
-    - nonamedreturns
+
+
+issues:
+  new-from-rev: 3221f769358168c0602e58918c1fb7b6083e33af

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ install-addlicense:
 install-golangci-lint:
 	#Install from source for golangci-lint is not recommended based on https://golangci-lint.run/usage/install/#install-from-source so using binary
 	#installation
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) v1.50.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) v1.62.2
 
 fmt: install-goimports addlicense
 	go fmt ./...


### PR DESCRIPTION

### Description of the Issue  
Currently, the CloudWatch Agent only performs basic linting checks. This pull request introduces an enhanced lint checker to ensure that all future code merges adhere to high standards of formatting and quality.  

Since the current codebase may contain existing linting conflicts, a parameter `new-from-dev` has been introduced, set to the commit `3221f769358168c0602e58918c1fb7b6083e33af`. This parameter ensures that lint checks are only applied to commits made after this point, avoiding unnecessary conflicts with legacy code.  

---

### Description of Changes  
- Added a lint checker to the CloudWatch Agent to enforce consistent code formatting and quality for future development.  

---

### License  
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.  


---

### Requirements  
Before committing the code, please complete the following steps:  
1. Run `make fmt` and `make fmt-sh`.  
2. Run `make lint`.  

---  

This version improves clarity, grammar, and professionalism while maintaining the necessary technical details.