### PR TITLE
Add data race test to PR build

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-2019, windows-latest, macos-12]
         include:
           - os: ubuntu-latest
             family: linux
@@ -136,3 +136,23 @@ jobs:
       - name: Build
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make amazon-cloudwatch-agent-${{ matrix.family }}
+
+  test-data-race:
+    needs: [lint, changes]
+    name: Test data race
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        if: needs.changes.outputs.build == 'true'
+        uses: actions/setup-go@v4
+        with:
+          go-version: ~1.22.2
+          cache: false
+
+      - name: Check out code
+        if: needs.changes.outputs.build == 'true'
+        uses: actions/checkout@v3
+
+      - name: Test data race
+        if: needs.changes.outputs.build == 'true'
+        run: make test-data-race

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,23 @@ lint: install-golangci-lint simple-lint
 test:
 	CGO_ENABLED=0 go test -timeout 15m -coverprofile coverage.txt -failfast ./...
 
+# List of existing packages with data races
+# TODO: Fix each
+PKG_WITH_DATA_RACE := extension/entitystore
+PKG_WITH_DATA_RACE += extension/server
+PKG_WITH_DATA_RACE += internal/publisher
+PKG_WITH_DATA_RACE += internal/retryer
+PKG_WITH_DATA_RACE += internal/tls
+PKG_WITH_DATA_RACE += plugins/inputs/logfile
+PKG_WITH_DATA_RACE += plugins/inputs/logfile/tail
+PKG_WITH_DATA_RACE += plugins/outputs/cloudwatch
+PKG_WITH_DATA_RACE += plugins/outputs/cloudwatchlogs
+PKG_WITH_DATA_RACE += plugins/processors/awsapplicationsignals
+PKG_WITH_DATA_RACE += plugins/processors/ec2tagger
+PKG_WITH_DATA_RACE_PATTERN := $(shell echo '$(PKG_WITH_DATA_RACE)' | tr ' ' '|')
+test-data-race:
+	CGO_ENABLED=1 go test -timeout 15m -race -parallel 4 $(shell go list ./... | grep -v -E '$(PKG_WITH_DATA_RACE_PATTERN)')
+
 clean::
 	rm -rf release/ build/
 	rm -f CWAGENT_VERSION


### PR DESCRIPTION
# Description of the issue
There have been cases of race conditions in the past that were not detected prior to merging the PRs. Go has race detectors built into `go test`.

# Description of changes
Adds a job to run the race detector with the `go tests`. There are several packages with data races either in the code or in the tests:
- `extension/entitystore`
- `extension/server`
- `internal/publisher`
- `internal/retryer`
- `internal/tls`
- `plugins/inputs/logfile`
- `plugins/inputs/logfile/tail`
- `plugins/outputs/cloudwatch`
- `plugins/outputs/cloudwatchlogs`
- `plugins/processors/awsapplicationsignals`
- `plugins/processors/ec2tagger`

Omits those packages.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the tests with the race detector without the package filter
```
==================
WARNING: DATA RACE
Read at 0x00c0004c3cf0 by goroutine 26:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.TestStartSuccessWithNoTagsVolumesUpdate()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger_test.go:315 +0xbe6
  testing.tRunner()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1742 +0x44

Previous write at 0x00c0004c3cf0 by goroutine 29:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*mockEC2Client).DescribeTags()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger_test.go:103 +0x48e
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).updateTags()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:170 +0x1ed
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).refreshLoop()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:227 +0x591
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).refreshLoopToUpdateTagsAndVolumes.func1()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:369 +0x64

Goroutine 26 (running) created at:
  testing.(*T).Run()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:103 +0x2e4

Goroutine 29 (finished) created at:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).refreshLoopToUpdateTagsAndVolumes()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:365 +0x508
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).Start.func1()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:332 +0x4e
==================
==================
WARNING: DATA RACE
Read at 0x00c00019ed20 by goroutine 26:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.TestStartSuccessWithNoTagsVolumesUpdate()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger_test.go:316 +0xc3c
  testing.tRunner()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1742 +0x44

Previous write at 0x00c00019ed20 by goroutine 27:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*mockVolumeCache).Refresh()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger_test.go:186 +0x39c
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).updateVolumes()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:380 +0x4ad
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).initialRetrievalOfTagsAndVolumes()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:473 +0x6eb
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).Start.func1()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:331 +0x44

Goroutine 26 (running) created at:
  testing.(*T).Run()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:103 +0x2e4

Goroutine 27 (finished) created at:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).Start()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:330 +0xf64
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.TestStartSuccessWithNoTagsVolumesUpdate()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger_test.go:311 +0xb78
  testing.tRunner()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1742 +0x44
==================
==================
WARNING: DATA RACE
Read at 0x00c0001deab8 by goroutine 26:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.TestStartSuccessWithNoTagsVolumesUpdate()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger_test.go:319 +0xea6
  testing.tRunner()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1742 +0x44

Previous write at 0x00c0001deab8 by goroutine 27:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).updateTags()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:189 +0x691
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).initialRetrievalOfTagsAndVolumes()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:465 +0x4e4
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).Start.func1()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:331 +0x44

Goroutine 26 (running) created at:
  testing.(*T).Run()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:103 +0x2e4

Goroutine 27 (finished) created at:
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.(*Tagger).Start()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger.go:330 +0xf64
  github.com/aws/amazon-cloudwatch-agent/plugins/processors/ec2tagger.TestStartSuccessWithNoTagsVolumesUpdate()
      /Volumes/workplace/amazon-cloudwatch-agent/plugins/processors/ec2tagger/ec2tagger_test.go:311 +0xb78
  testing.tRunner()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /Users/chienjef/.gobrew/versions/1.22.5/go/src/testing/testing.go:1742 +0x44
==================
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




