### PR TITLE
[CleanAMI] Ensure at least 1 AMI exists for each test image architecture

### DIFF
--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -50,6 +50,7 @@ var imagePrefixes = []string{
 	"cloudwatch-agent-integration-test-win-2022",
 	"cloudwatch-agent-integration-test-x86-al2023",
 	"cloudwatch-agent-integration-test-mac",
+	"cloudwatch-agent-integration-test-nvidia-gpu",
 }
 
 func main() {

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"sort"
 	"strings"
@@ -169,6 +170,7 @@ func cleanAMIs() error {
 	macosImageAmiMap := make(map[string][]types.Image)
 
 	// Cleanup for each AMI image type
+	var errList []error
 	for _, filter := range imagePrefixes {
 		nameFilter := types.Filter{Name: aws.String("name"), Values: []string{
 			fmt.Sprintf("%s*", filter),

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -183,6 +183,7 @@ func cleanAMIs() error {
 			continue
 		}
 
+		log.Printf("%s: %d images found", filter, len(describeImagesOutput.Images))
 		if len(describeImagesOutput.Images) <= 1 {
 			log.Printf("1 or less image found for filter %s, skipping", filter)
 			continue

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -23,10 +23,33 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
 )
 
+// Image Prefixes are taken from checking the Image Builder Pipelines in us-west-2
 var imagePrefixes = []string{
-	"cloudwatch-agent-integration-test-mac*",
-	"cloudwatch-agent-integration-test-al2*",
-	"cloudwatch-agent-integration-test-ubuntu*",g
+	"cloudwatch-agent-integration-test-aarch64-al2023",
+	"cloudwatch-agent-integration-test-al2",
+	"cloudwatch-agent-integration-test-alma-linux-8",
+	"cloudwatch-agent-integration-test-alma-linux-9",
+	"cloudwatch-agent-integration-test-arm64-al2",
+	"cloudwatch-agent-integration-test-debian-11-arm64",
+	"cloudwatch-agent-integration-test-debian-12-arm64",
+	"cloudwatch-agent-integration-test-nvidia-gpu-al2",
+	"cloudwatch-agent-integration-test-ol7",
+	"cloudwatch-agent-integration-test-ol8",
+	"cloudwatch-agent-integration-test-ol9",
+	"cloudwatch-agent-integration-test-rocky-linux-8",
+	"cloudwatch-agent-integration-test-rocky-linux-9",
+	"cloudwatch-agent-integration-test-sles-15",
+	"cloudwatch-agent-integration-test-ubuntu-23",
+	"cloudwatch-agent-integration-test-ubuntu-24",
+	"cloudwatch-agent-integration-test-ubuntu",
+	"cloudwatch-agent-integration-test-ubuntu-LTS-22",
+	"cloudwatch-agent-integration-test-win-10",
+	"cloudwatch-agent-integration-test-win-11",
+	"cloudwatch-agent-integration-test-win-2016",
+	"cloudwatch-agent-integration-test-win-2019",
+	"cloudwatch-agent-integration-test-win-2022",
+	"cloudwatch-agent-integration-test-x86-al2023",
+	"cloudwatch-agent-integration-test-mac",
 }
 
 func main() {
@@ -148,7 +171,7 @@ func cleanAMIs() error {
 	// Cleanup for each AMI image type
 	for _, filter := range imagePrefixes {
 		nameFilter := types.Filter{Name: aws.String("name"), Values: []string{
-			filter,
+			fmt.Sprintf("%s*", filter),
 		}}
 
 		//get instances to delete

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"log"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -184,13 +183,13 @@ func cleanAMIs() error {
 			continue
 		}
 
-		if len(describeImagesOutput.Images) == 1 {
-			log.Printf("Only 1 image found for filter %s, skipping", filter)
+		if len(describeImagesOutput.Images) <= 1 {
+			log.Printf("1 or less image found for filter %s, skipping", filter)
 			continue
 		}
 
 		for _, image := range describeImagesOutput.Images {
-			if image.Name != nil && strings.HasPrefix(*image.Name, "cloudwatch-agent-integration-test-mac") {
+			if image.Name != nil && filter == "cloudwatch-agent-integration-test-mac" {
 				// mac image - add it to the map and do nothing else for now
 				macosImageAmiMap[*image.Name] = append(macosImageAmiMap[*image.Name], image)
 			} else {
@@ -204,15 +203,4 @@ func cleanAMIs() error {
 	cleanMacAMIs(ctx, ec2client, macosImageAmiMap, expirationDate, &errList)
 
 	return nil
-}
-
-func getAMIsForFilter(string filter) ([]types.Image, error) {
-	//get instances to delete
-	describeImagesInput := ec2.DescribeImagesInput{Filters: []types.Filter{filter}}
-	describeImagesOutput, err := ec2client.DescribeImages(ctx, &describeImagesInput)
-	if err != nil {
-		return []types.Image{}, err
-	}
-
-	return describeImagesOutput.Images, error
 }


### PR DESCRIPTION
# Description of the issue
Some of our integration tests fail due to no AMI existing for the particular architecture. This is because our ami cleanup script deletes any AMI older than 60 days.

# Description of changes
Refactor the clean ami script to use selected filters from our image builder pipeline to determine the list of images used for testing for each architecture, then check if at least 1 exists even if its older than 60 days to ensure tests pass.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Workflow: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12145498729/job/33867278441

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




