### PR TITLE
Modify graphs to ignore missing data and to retrieve commit data

### DIFF
--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -3,6 +3,7 @@
 
 export const USE_CASE: string[] = ['statsd', 'logs', 'disk'];
 export const REPORTED_METRICS: string[] = [
+    'cpu_usage',
     'procstat_cpu_usage',
     'procstat_memory_rss',
     'procstat_memory_swap',
@@ -17,7 +18,8 @@ export const TRANSACTION_PER_MINUTE: number[] = [100, 1000, 5000];
 export const OWNER_REPOSITORY: string = 'aws';
 export const SERVICE_NAME: string = 'AmazonCloudWatchAgent';
 export const CONVERT_REPORTED_METRICS_NAME: { [metric_name: string]: string } = {
-    procstat_cpu_usage: 'CPU Usage',
+    cpu_usage: 'CPU Usage',
+    procstat_cpu_usage: 'Procstat CPU Usage',
     procstat_memory_rss: 'Memory Resource',
     procstat_memory_swap: 'Memory Swap',
     procstat_memory_vms: 'Virtual Memory',

--- a/src/containers/PerformanceReport/data.d.ts
+++ b/src/containers/PerformanceReport/data.d.ts
@@ -47,6 +47,7 @@ export interface PerformanceMetricReport {
 
 // PerformanceMetric shows all collected metrics when running performance metrics
 export interface PerformanceMetric {
+    cpu_usage?: { M: PerformanceMetricStatistic };
     procstat_cpu_usage?: { M: PerformanceMetricStatistic };
     procstat_memory_rss?: { M: PerformanceMetricStatistic };
     procstat_memory_swap?: { M: PerformanceMetricStatistic };
@@ -86,6 +87,7 @@ export interface UseCaseData {
     instance_type?: string;
     data: {
         [data_rate: string]: {
+            cpu_usage?: string;
             procstat_cpu_usage?: string;
             procstat_memory_rss?: string;
             procstat_memory_swap?: string;

--- a/src/containers/PerformanceReport/index.tsx
+++ b/src/containers/PerformanceReport/index.tsx
@@ -170,6 +170,7 @@ function useStatePerformanceReport(password: string) {
                         (accu, tpm) => ({
                             ...accu,
                             [tpm]: {
+                                cpu_usage: pReport?.Results.M[tpm]?.M?.cpu_usage?.M?.Average?.N,
                                 procstat_cpu_usage: pReport?.Results.M[tpm]?.M?.procstat_cpu_usage?.M?.Average?.N,
                                 procstat_memory_rss: pReport?.Results.M[tpm]?.M?.procstat_memory_rss?.M?.Average?.N,
                                 procstat_memory_swap: pReport?.Results.M[tpm]?.M?.procstat_memory_swap?.M?.Average?.N,

--- a/src/containers/PerformanceTrend/data.d.ts
+++ b/src/containers/PerformanceTrend/data.d.ts
@@ -34,6 +34,8 @@ export interface PerformanceTrendData {
     CommitHash: { S: string };
 
     DataType: { S: string };
+    Service: { S: string };
+    UniqueID: { S: string };
 
     InstanceAMI: { S: string };
     InstanceType: { S: string };
@@ -55,7 +57,10 @@ export interface TrendData {
     data_tpm: number;
     data_series: {
         name: string;
-        data: number[];
+        data: {
+            y: number;
+            x: string;
+        }[];
     }[];
 }
 
@@ -70,8 +75,11 @@ export interface PerformanceMetricStatistic {
 
 export interface ServiceCommitInformation {
     // Release version for the service
-    author: { login: string };
-    commit: { message: string; committer: { date: string } };
+    author: {
+        login: string;
+        date: string;
+    };
+    commit: { message: string };
     sha: string;
 }
 


### PR DESCRIPTION
# Description of the issue
The Performance Page displays missing data values as `-1`, which causes confusion.  Also commit details are currently missing from the tooltip view

# Description of changes
1. Removes commits from graph if the displayed metric is missing a value.
2. Re-enables usage of Github api call to retrieve commit data

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
3. Run `make lint`
-----
![Screenshot 2024-12-03 at 2 27 37 PM](https://github.com/user-attachments/assets/d208869f-27c2-4735-bb7c-1a3ecda8e65b)
-----
![Screenshot 2024-12-03 at 2 31 27 PM](https://github.com/user-attachments/assets/5e3c1a56-7857-49a5-83cb-da99ee28c7d0)
-----
![Screenshot 2024-12-03 at 2 30 34 PM](https://github.com/user-attachments/assets/8c1becd6-e58c-4a17-9d82-e48c5e3d7a05)
