### PR TITLE
Bumping macos runner due to deprecation of macos-12

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -78,14 +78,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2019, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-2019, windows-latest, macos-13]
         include:
           - os: ubuntu-latest
             family: linux
             cache-path: |
               ~/.cache/go-build
               ~/go/pkg/mod
-          - os: macos-12
+          - os: macos-13
             family: darwin
             cache-path: |
               ~/Library/Caches/go-build

--- a/.github/workflows/test-build-packages.yml
+++ b/.github/workflows/test-build-packages.yml
@@ -62,7 +62,7 @@ on:
 jobs:
   MakeMacPkg:
     name: 'MakeMacPkg'
-    runs-on: macos-12
+    runs-on: macos-13
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
# Description of the issue
GitHub has deprecated the macos-12 runners (https://github.com/actions/runner-images/issues/10721).

# Description of changes
Swap them out for macos-13 runners (https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md). 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran PR tests. Validating package build is unimpacted by change: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12147539114

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




