### PR TITLE
Fix GPU E2E test failures

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1303,7 +1303,7 @@ jobs:
             echo "Cluster name is ${EKS_CLUSTER_NAME}"
             kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
             kubectl patch amazoncloudwatchagents -n amazon-cloudwatch cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": ${{ secrets.AWS_ECR_PRIVATE_REGISTRY }}/${{ env.ECR_INTEGRATION_TEST_REPO }}:${{ github.sha }}}]'
-            # wiat nvidia device plugin to be ready
+            # wait nvidia device plugin to be ready
             sleep 10
             kubectl apply -f ./gpuBurner.yaml
           else

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1303,10 +1303,11 @@ jobs:
             echo "Cluster name is ${EKS_CLUSTER_NAME}"
             kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
             kubectl patch amazoncloudwatchagents -n amazon-cloudwatch cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": ${{ secrets.AWS_ECR_PRIVATE_REGISTRY }}/${{ env.ECR_INTEGRATION_TEST_REPO }}:${{ github.sha }}}]'
-            kubectl rollout status daemonset nvidia-device-plugin-daemonset -n kube-system --timeout 10s
+            # wiat nvidia device plugin to be ready
+            sleep 10
             kubectl apply -f ./gpuBurner.yaml
           else
-            terraform destroy -var="beta=${{ github.event.inputs.run_in_beta }}" -auto-approve && exit 1
+            terraform destroy -auto-approve && exit 1
           fi
 
       - name: Run Go tests with retry
@@ -1345,4 +1346,4 @@ jobs:
             else
               cd terraform/eks/addon/gpu
             fi
-            terraform destroy -var="beta=${{ github.event.inputs.run_in_beta }}" -auto-approve
+            terraform destroy -auto-approve


### PR DESCRIPTION
# Description of the issue
- `kubectl rollout` fails with timeout when checking the status of nvidia device plugin
```
Waiting for daemon set "nvidia-device-plugin-daemonset" rollout to finish: 0 of 1 updated pods are available...
error: timed out waiting for the condition
```
- destroy fails with unknown `beta` var
```
╷
│ Error: Invalid value for input variable
│ 
│   on variables.tf line 39:
│   39: variable "beta" {
│ 
│ Unsuitable value for var.beta set using -var="beta=...": a bool is
│ required.
```

# Description of changes
- Replace `kubectl rollout` with simple sleep
- Drop `beta` vars in terraform commands

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12165006108

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




