### PR TITLE
Fix issues with PerformanceReport Page (commit data, hiding missing data)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "react": "^18.2.0",
         "react-apexcharts": "^1.4.0",
         "react-dom": "^18.2.0",
+        "react-markdown": "^9.0.1",
         "react-router-dom": "^6.8.1",
         "react-scripts": "5.0.1",
         "recoil": "^0.7.6",

--- a/src/common/Axios.ts
+++ b/src/common/Axios.ts
@@ -5,7 +5,8 @@ import axios from 'axios';
 
 export const AxiosConfig = axios.create({
     baseURL: process.env.REACT_APP_LAMBDA_URL,
-    timeout: 3000,
+    // timeout in milliseconds; increased from 3000ms due to large number of commit data requests
+    timeout: 4000,
     headers: {
         'Content-Type': 'application/json',
     },

--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -3,7 +3,6 @@
 
 export const USE_CASE: string[] = ['statsd', 'logs', 'disk'];
 export const REPORTED_METRICS: string[] = [
-    'cpu_usage',
     'procstat_cpu_usage',
     'procstat_memory_rss',
     'procstat_memory_swap',
@@ -18,8 +17,7 @@ export const TRANSACTION_PER_MINUTE: number[] = [100, 1000, 5000];
 export const OWNER_REPOSITORY: string = 'aws';
 export const SERVICE_NAME: string = 'AmazonCloudWatchAgent';
 export const CONVERT_REPORTED_METRICS_NAME: { [metric_name: string]: string } = {
-    cpu_usage: 'CPU Usage',
-    procstat_cpu_usage: 'Procstat CPU Usage',
+    procstat_cpu_usage: 'CPU Usage',
     procstat_memory_rss: 'Memory Resource',
     procstat_memory_swap: 'Memory Swap',
     procstat_memory_vms: 'Virtual Memory',

--- a/src/containers/PerformanceReport/data.d.ts
+++ b/src/containers/PerformanceReport/data.d.ts
@@ -43,11 +43,12 @@ export interface PerformanceMetricReport {
     };
 
     UseCase: { S: string };
+    Service: { S: string };
+    UniqueID: { S: string };
 }
 
 // PerformanceMetric shows all collected metrics when running performance metrics
 export interface PerformanceMetric {
-    cpu_usage?: { M: PerformanceMetricStatistic };
     procstat_cpu_usage?: { M: PerformanceMetricStatistic };
     procstat_memory_rss?: { M: PerformanceMetricStatistic };
     procstat_memory_swap?: { M: PerformanceMetricStatistic };
@@ -72,6 +73,7 @@ export interface PerformanceMetricStatistic {
 export interface ServiceLatestVersion {
     // Release version for the service
     tag_name: string;
+    body: string;
 }
 
 export interface ServicePRInformation {
@@ -79,6 +81,7 @@ export interface ServicePRInformation {
     title: string;
     html_url: string;
     number: number;
+    sha: string;
 }
 
 export interface UseCaseData {
@@ -87,7 +90,6 @@ export interface UseCaseData {
     instance_type?: string;
     data: {
         [data_rate: string]: {
-            cpu_usage?: string;
             procstat_cpu_usage?: string;
             procstat_memory_rss?: string;
             procstat_memory_swap?: string;

--- a/src/containers/PerformanceTrend/data.d.ts
+++ b/src/containers/PerformanceTrend/data.d.ts
@@ -77,9 +77,13 @@ export interface ServiceCommitInformation {
     // Release version for the service
     author: {
         login: string;
-        date: string;
     };
-    commit: { message: string };
+    commit: {
+        message: string;
+        author: {
+            date: string;
+        };
+    };
     sha: string;
 }
 

--- a/src/core/table.tsx
+++ b/src/core/table.tsx
@@ -154,21 +154,35 @@ export function PerformanceTable(props: { use_cases: UseCaseData[]; data_rate: s
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {use_cases?.map((use_case) => (
-                        <StyledTableRow key={use_case.name}>
-                            <StyledTableCell>{use_case.name}</StyledTableCell>
-                            <StyledTableCell>{use_case.instance_type}</StyledTableCell>
-                            <StyledTableCell>{Number(use_case.data?.[data_rate]?.procstat_cpu_usage).toFixed(2)}</StyledTableCell>
-                            <StyledTableCell>{(Number(use_case.data?.[data_rate]?.procstat_memory_rss) / Number(use_case.data?.[data_rate]?.mem_total)).toFixed(2)}</StyledTableCell>
-                            <StyledTableCell>{(Number(use_case.data?.[data_rate]?.procstat_memory_swap) / Number(use_case.data?.[data_rate]?.mem_total)).toFixed(2)}</StyledTableCell>
-                            <StyledTableCell>{(Number(use_case.data?.[data_rate]?.procstat_memory_data) / Number(use_case.data?.[data_rate]?.mem_total)).toFixed(2)}</StyledTableCell>
-                            <StyledTableCell>{(Number(use_case.data?.[data_rate]?.procstat_memory_vms) / Number(use_case.data?.[data_rate]?.mem_total)).toFixed(2)}</StyledTableCell>
-                            <StyledTableCell>{Number(use_case.data?.[data_rate]?.procstat_write_bytes).toFixed(2)}</StyledTableCell>
-                            <StyledTableCell>{Number(use_case.data?.[data_rate]?.procstat_num_fds).toFixed(2)}</StyledTableCell>
-                            <StyledTableCell>{Number(use_case.data?.[data_rate]?.net_bytes_sent).toFixed(2)}</StyledTableCell>
-                            <StyledTableCell>{Number(use_case.data?.[data_rate]?.net_packets_sent).toFixed(2)}</StyledTableCell>
-                        </StyledTableRow>
-                    ))}
+                    {use_cases
+                        ?.filter((use_case) => use_case.data?.[data_rate])
+                        .map((use_case: UseCaseData, index) => {
+                            const metrics = use_case.data[data_rate];
+                            const memTotal = Number(metrics?.mem_total);
+
+                            const getFormattedValue = (value: number | undefined, divisor?: number) => {
+                                if (!value) {
+                                    return '0.00';
+                                }
+                                return (divisor ? value / divisor : value).toFixed(2);
+                            };
+
+                            return (
+                                <StyledTableRow key={`${use_case.name}-${index}`}>
+                                    <StyledTableCell>{use_case.name}</StyledTableCell>
+                                    <StyledTableCell>{use_case.instance_type}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.procstat_cpu_usage))}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.procstat_memory_rss), memTotal)}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.procstat_memory_swap), memTotal)}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.procstat_memory_data), memTotal)}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.procstat_memory_vms), memTotal)}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.procstat_write_bytes))}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.procstat_num_fds))}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.net_bytes_sent))}</StyledTableCell>
+                                    <StyledTableCell>{getFormattedValue(Number(metrics?.net_packets_sent))}</StyledTableCell>
+                                </StyledTableRow>
+                            );
+                        })}
                 </TableBody>
             </Table>
         </TableContainer>


### PR DESCRIPTION
# Description of the issue
Fixes issues with PerformanceReport Page
1. replaces dummy commit data
2. hides missing performance data
3. Fixes bug where duplicate rows display

# Description of changes
1. Fixes issue where data is not correctly loading into the Performance report table

## Note:
Date shows as Dec 31, 1969, this is due to commit data missing in DynamoDB and will be resolved by another PR in the CWAgent Integ tests

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. Validated in local environment using data from lambda and github api

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
4. Run `make lint`

# Screenshots

### Before
<img width="941" alt="Screenshot 2025-01-08 at 4 12 26 PM" src="https://github.com/user-attachments/assets/22465fe3-af47-4dae-83e0-57f7380b3170" />
<img width="905" alt="Screenshot 2025-01-08 at 4 18 04 PM" src="https://github.com/user-attachments/assets/5be3e5b7-8b2d-40b7-9ef2-99cd79bf1df9" />


### After
<img width="937" alt="Screenshot 2025-01-03 at 2 40 53 PM" src="https://github.com/user-attachments/assets/7ca36667-664e-4484-815a-1d0c17dcceb7" />
<img width="933" alt="Screenshot 2025-01-03 at 2 41 03 PM" src="https://github.com/user-attachments/assets/01d4a716-513b-4a8a-9333-a9a45fb6175e" />



