### PR TITLE
set service provider tags to be case insensitive

### DIFF
--- a/extension/entitystore/extension_test.go
+++ b/extension/entitystore/extension_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/maps"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/ec2metadataprovider"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsentity/entityattributes"
@@ -108,15 +109,11 @@ func (m *mockMetadataProvider) InstanceID(ctx context.Context) (string, error) {
 	return "MockInstanceID", nil
 }
 
-func (m *mockMetadataProvider) InstanceTags(ctx context.Context) (string, error) {
+func (m *mockMetadataProvider) InstanceTags(ctx context.Context) ([]string, error) {
 	if m.InstanceTagError {
-		return "", errors.New("an error occurred for instance tag retrieval")
+		return nil, errors.New("an error occurred for instance tag retrieval")
 	}
-	var tagsString string
-	for key, val := range m.Tags {
-		tagsString += key + "=" + val + ","
-	}
-	return tagsString, nil
+	return maps.Keys(m.Tags), nil
 }
 
 func (m *mockMetadataProvider) ClientIAMRole(ctx context.Context) (string, error) {

--- a/extension/entitystore/serviceprovider_test.go
+++ b/extension/entitystore/serviceprovider_test.go
@@ -307,6 +307,16 @@ func Test_serviceprovider_scrapeAndgetImdsServiceNameAndASG(t *testing.T) {
 			wantTagServiceName: "test-service",
 		},
 		{
+			name:               "HappyPath_ServiceExistsCaseInsensitive",
+			metadataProvider:   &mockMetadataProvider{InstanceIdentityDocument: mockedInstanceIdentityDoc, Tags: map[string]string{"ServicE": "test-service"}},
+			wantTagServiceName: "test-service",
+		},
+		{
+			name:               "ServiceExistsRequiresExactMatch",
+			metadataProvider:   &mockMetadataProvider{InstanceIdentityDocument: mockedInstanceIdentityDoc, Tags: map[string]string{"sservicee": "test-service"}},
+			wantTagServiceName: "",
+		},
+		{
 			name:               "HappyPath_ApplicationExists",
 			metadataProvider:   &mockMetadataProvider{InstanceIdentityDocument: mockedInstanceIdentityDoc, Tags: map[string]string{"application": "test-application"}},
 			wantTagServiceName: "test-application",
@@ -357,6 +367,28 @@ func Test_serviceprovider_scrapeAndgetImdsServiceNameAndASG(t *testing.T) {
 					"name":                      "test-name",
 				}},
 			wantASGName: "",
+		},
+		{
+			name: "AutoScalingGroup case sensitive",
+			metadataProvider: &mockMetadataProvider{
+				InstanceIdentityDocument: mockedInstanceIdentityDoc,
+				Tags: map[string]string{
+					"aws:autoscaling:groupname": tagVal3,
+					"env":                       "test-env",
+					"name":                      "test-name",
+				}},
+			wantASGName: tagVal3,
+		},
+		{
+			name: "AutoScalingGroup exact match",
+			metadataProvider: &mockMetadataProvider{
+				InstanceIdentityDocument: mockedInstanceIdentityDoc,
+				Tags: map[string]string{
+					"aws:autoscaling:groupnamee": tagVal3,
+					"env":                        "test-env",
+					"name":                       "test-name",
+				}},
+			wantASGName: tagVal3,
 		},
 		{
 			name:             "Success IMDS tags call with no ASG",

--- a/internal/ec2metadataprovider/ec2metadataprovider.go
+++ b/internal/ec2metadataprovider/ec2metadataprovider.go
@@ -6,6 +6,7 @@ package ec2metadataprovider
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -20,7 +21,7 @@ type MetadataProvider interface {
 	Get(ctx context.Context) (ec2metadata.EC2InstanceIdentityDocument, error)
 	Hostname(ctx context.Context) (string, error)
 	InstanceID(ctx context.Context) (string, error)
-	InstanceTags(ctx context.Context) (string, error)
+	InstanceTags(ctx context.Context) ([]string, error)
 	ClientIAMRole(ctx context.Context) (string, error)
 	InstanceTagValue(ctx context.Context, tagKey string) (string, error)
 }
@@ -67,10 +68,14 @@ func (c *metadataClient) ClientIAMRole(ctx context.Context) (string, error) {
 	})
 }
 
-func (c *metadataClient) InstanceTags(ctx context.Context) (string, error) {
-	return withMetadataFallbackRetry(ctx, c, func(metadataClient *ec2metadata.EC2Metadata) (string, error) {
+func (c *metadataClient) InstanceTags(ctx context.Context) ([]string, error) {
+	if tags, err := withMetadataFallbackRetry(ctx, c, func(metadataClient *ec2metadata.EC2Metadata) (string, error) {
 		return metadataClient.GetMetadataWithContext(ctx, "tags/instance")
-	})
+	}); err != nil {
+		return nil, err
+	} else {
+		return strings.Fields(tags), nil
+	}
 }
 
 func (c *metadataClient) InstanceTagValue(ctx context.Context, tagKey string) (string, error) {


### PR DESCRIPTION
# Description of the issue
The `application`, `app` and `service` service name provider ec2 tags are currently case sensitive, there are also bugs in exactness in how these are being compared due to excessive use of `strings.Contains`

# Description of changes
Update `InstanceTags` to return a `[]string` with the tag keys instead of the raw newline delimited list.  This is a more friendly API to reason about.  We can then convert it to a map with lowercase keys that we use for comparison.

I also fixed the asg lookup to also be an exact match instead.  These matches are relatively efficient as I am converting the arrays to maps for O(1) lookups instead of having to repeatedly loop through the whole strings using Contains or slices.Contains

Related to: https://github.com/aws/amazon-cloudwatch-agent/pull/1474

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests updated

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




