### PR TITLE
Case insensitive service provider

### DIFF
--- a/extension/entitystore/extension_test.go
+++ b/extension/entitystore/extension_test.go
@@ -109,7 +109,7 @@ func (m *mockMetadataProvider) InstanceID(ctx context.Context) (string, error) {
 	return "MockInstanceID", nil
 }
 
-func (m *mockMetadataProvider) InstanceTags(ctx context.Context) ([]string, error) {
+func (m *mockMetadataProvider) InstanceTags(_ context.Context) ([]string, error) {
 	if m.InstanceTagError {
 		return nil, errors.New("an error occurred for instance tag retrieval")
 	}

--- a/extension/entitystore/extension_test.go
+++ b/extension/entitystore/extension_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/maps"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/ec2metadataprovider"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsentity/entityattributes"
@@ -108,15 +109,11 @@ func (m *mockMetadataProvider) InstanceID(ctx context.Context) (string, error) {
 	return "MockInstanceID", nil
 }
 
-func (m *mockMetadataProvider) InstanceTags(ctx context.Context) (string, error) {
+func (m *mockMetadataProvider) InstanceTags(ctx context.Context) ([]string, error) {
 	if m.InstanceTagError {
-		return "", errors.New("an error occurred for instance tag retrieval")
+		return nil, errors.New("an error occurred for instance tag retrieval")
 	}
-	var tagsString string
-	for key, val := range m.Tags {
-		tagsString += key + "=" + val + ","
-	}
-	return tagsString, nil
+	return maps.Keys(m.Tags), nil
 }
 
 func (m *mockMetadataProvider) ClientIAMRole(ctx context.Context) (string, error) {

--- a/extension/entitystore/serviceprovider.go
+++ b/extension/entitystore/serviceprovider.go
@@ -266,7 +266,7 @@ func (s *serviceprovider) scrapeImdsServiceNameAndASG() error {
 		}
 	}
 	// case sensitive
-	if originalCaseKey, _ := lowerTagKeys[strings.ToLower(ec2tagger.Ec2InstanceTagKeyASG)]; originalCaseKey == ec2tagger.Ec2InstanceTagKeyASG {
+	if originalCaseKey := lowerTagKeys[strings.ToLower(ec2tagger.Ec2InstanceTagKeyASG)]; originalCaseKey == ec2tagger.Ec2InstanceTagKeyASG {
 		asg, err := s.metadataProvider.InstanceTagValue(context.Background(), ec2tagger.Ec2InstanceTagKeyASG)
 		if err == nil {
 			s.logger.Debug("AutoScalingGroup retrieved through IMDS")
@@ -279,6 +279,7 @@ func (s *serviceprovider) scrapeImdsServiceNameAndASG() error {
 			s.mutex.Unlock()
 		}
 	}
+
 	if s.GetIMDSServiceName() == "" {
 		s.logger.Debug("Service name not found through IMDS")
 	}

--- a/extension/entitystore/serviceprovider.go
+++ b/extension/entitystore/serviceprovider.go
@@ -40,8 +40,8 @@ const (
 )
 
 var (
-	//priorityMap is ranking in how we prioritize which IMDS tag determines the service name
-	priorityMap = []string{SERVICE, APPLICATION, APP}
+	//serviceProviderPriorities is ranking in how we prioritize which IMDS tag determines the service name
+	serviceProviderPriorities = []string{SERVICE, APPLICATION, APP}
 )
 
 type ServiceAttribute struct {
@@ -253,8 +253,8 @@ func (s *serviceprovider) scrapeImdsServiceNameAndASG() error {
 
 	// This will check whether the tags contains SERVICE, APPLICATION, APP, in that order (case insensitive)
 	lowerTagKeys := toLowerKeyMap(tagKeys)
-	for _, potentialServiceNameKey := range priorityMap {
-		if originalCaseKey, exists := lowerTagKeys[potentialServiceNameKey]; exists {
+	for _, potentialServiceProviderKey := range serviceProviderPriorities {
+		if originalCaseKey, exists := lowerTagKeys[potentialServiceProviderKey]; exists {
 			serviceName, err := s.metadataProvider.InstanceTagValue(context.Background(), originalCaseKey)
 			if err != nil {
 				continue

--- a/extension/entitystore/serviceprovider_test.go
+++ b/extension/entitystore/serviceprovider_test.go
@@ -377,7 +377,7 @@ func Test_serviceprovider_scrapeAndgetImdsServiceNameAndASG(t *testing.T) {
 					"env":                       "test-env",
 					"name":                      "test-name",
 				}},
-			wantASGName: tagVal3,
+			wantASGName: "",
 		},
 		{
 			name: "AutoScalingGroup exact match",
@@ -388,7 +388,7 @@ func Test_serviceprovider_scrapeAndgetImdsServiceNameAndASG(t *testing.T) {
 					"env":                        "test-env",
 					"name":                       "test-name",
 				}},
-			wantASGName: tagVal3,
+			wantASGName: "",
 		},
 		{
 			name:             "Success IMDS tags call with no ASG",

--- a/extension/entitystore/serviceprovider_test.go
+++ b/extension/entitystore/serviceprovider_test.go
@@ -307,6 +307,16 @@ func Test_serviceprovider_scrapeAndgetImdsServiceNameAndASG(t *testing.T) {
 			wantTagServiceName: "test-service",
 		},
 		{
+			name:               "HappyPath_ServiceExistsCaseInsensitive",
+			metadataProvider:   &mockMetadataProvider{InstanceIdentityDocument: mockedInstanceIdentityDoc, Tags: map[string]string{"ServicE": "test-service"}},
+			wantTagServiceName: "test-service",
+		},
+		{
+			name:               "ServiceExistsRequiresExactMatch",
+			metadataProvider:   &mockMetadataProvider{InstanceIdentityDocument: mockedInstanceIdentityDoc, Tags: map[string]string{"sservicee": "test-service"}},
+			wantTagServiceName: "",
+		},
+		{
 			name:               "HappyPath_ApplicationExists",
 			metadataProvider:   &mockMetadataProvider{InstanceIdentityDocument: mockedInstanceIdentityDoc, Tags: map[string]string{"application": "test-application"}},
 			wantTagServiceName: "test-application",
@@ -357,6 +367,28 @@ func Test_serviceprovider_scrapeAndgetImdsServiceNameAndASG(t *testing.T) {
 					"name":                      "test-name",
 				}},
 			wantASGName: "",
+		},
+		{
+			name: "AutoScalingGroup case sensitive",
+			metadataProvider: &mockMetadataProvider{
+				InstanceIdentityDocument: mockedInstanceIdentityDoc,
+				Tags: map[string]string{
+					"aws:autoscaling:groupname": tagVal3,
+					"env":                       "test-env",
+					"name":                      "test-name",
+				}},
+			wantASGName: tagVal3,
+		},
+		{
+			name: "AutoScalingGroup exact match",
+			metadataProvider: &mockMetadataProvider{
+				InstanceIdentityDocument: mockedInstanceIdentityDoc,
+				Tags: map[string]string{
+					"aws:autoscaling:groupnamee": tagVal3,
+					"env":                        "test-env",
+					"name":                       "test-name",
+				}},
+			wantASGName: tagVal3,
 		},
 		{
 			name:             "Success IMDS tags call with no ASG",

--- a/internal/ec2metadataprovider/ec2metadataprovider.go
+++ b/internal/ec2metadataprovider/ec2metadataprovider.go
@@ -69,13 +69,13 @@ func (c *metadataClient) ClientIAMRole(ctx context.Context) (string, error) {
 }
 
 func (c *metadataClient) InstanceTags(ctx context.Context) ([]string, error) {
-	if tags, err := withMetadataFallbackRetry(ctx, c, func(metadataClient *ec2metadata.EC2Metadata) (string, error) {
+	tags, err := withMetadataFallbackRetry(ctx, c, func(metadataClient *ec2metadata.EC2Metadata) (string, error) {
 		return metadataClient.GetMetadataWithContext(ctx, "tags/instance")
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
-	} else {
-		return strings.Fields(tags), nil
 	}
+	return strings.Fields(tags), nil
 }
 
 func (c *metadataClient) InstanceTagValue(ctx context.Context, tagKey string) (string, error) {

--- a/internal/ec2metadataprovider/ec2metadataprovider.go
+++ b/internal/ec2metadataprovider/ec2metadataprovider.go
@@ -6,6 +6,7 @@ package ec2metadataprovider
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -20,7 +21,7 @@ type MetadataProvider interface {
 	Get(ctx context.Context) (ec2metadata.EC2InstanceIdentityDocument, error)
 	Hostname(ctx context.Context) (string, error)
 	InstanceID(ctx context.Context) (string, error)
-	InstanceTags(ctx context.Context) (string, error)
+	InstanceTags(ctx context.Context) ([]string, error)
 	ClientIAMRole(ctx context.Context) (string, error)
 	InstanceTagValue(ctx context.Context, tagKey string) (string, error)
 }
@@ -67,10 +68,14 @@ func (c *metadataClient) ClientIAMRole(ctx context.Context) (string, error) {
 	})
 }
 
-func (c *metadataClient) InstanceTags(ctx context.Context) (string, error) {
-	return withMetadataFallbackRetry(ctx, c, func(metadataClient *ec2metadata.EC2Metadata) (string, error) {
+func (c *metadataClient) InstanceTags(ctx context.Context) ([]string, error) {
+	if tags, err := withMetadataFallbackRetry(ctx, c, func(metadataClient *ec2metadata.EC2Metadata) (string, error) {
 		return metadataClient.GetMetadataWithContext(ctx, "tags/instance")
-	})
+	}); err != nil {
+		return nil, err
+	} else {
+		return strings.Fields(tags), nil
+	}
 }
 
 func (c *metadataClient) InstanceTagValue(ctx context.Context, tagKey string) (string, error) {

--- a/plugins/processors/ec2tagger/ec2tagger_test.go
+++ b/plugins/processors/ec2tagger/ec2tagger_test.go
@@ -144,8 +144,8 @@ func (m *mockMetadataProvider) InstanceID(ctx context.Context) (string, error) {
 	return "MockInstanceID", nil
 }
 
-func (m *mockMetadataProvider) InstanceTags(ctx context.Context) (string, error) {
-	return "MockInstanceTag", nil
+func (m *mockMetadataProvider) InstanceTags(ctx context.Context) ([]string, error) {
+	return []string{"MockInstanceTag"}, nil
 }
 
 func (m *mockMetadataProvider) InstanceTagValue(ctx context.Context, tagKey string) (string, error) {

--- a/plugins/processors/ec2tagger/ec2tagger_test.go
+++ b/plugins/processors/ec2tagger/ec2tagger_test.go
@@ -144,7 +144,7 @@ func (m *mockMetadataProvider) InstanceID(ctx context.Context) (string, error) {
 	return "MockInstanceID", nil
 }
 
-func (m *mockMetadataProvider) InstanceTags(ctx context.Context) ([]string, error) {
+func (m *mockMetadataProvider) InstanceTags(_ context.Context) ([]string, error) {
 	return []string{"MockInstanceTag"}, nil
 }
 


### PR DESCRIPTION
# Description of the issue
The `application`, `app` and `service` service name provider ec2 tags are currently case sensitive, there are also bugs in exactness in how these are being compared due to excessive use of `strings.Contains`

# Description of changes
Update `InstanceTags` to return a `[]string` with the tag keys instead of the raw newline delimited list.  This is a more friendly API to reason about.  We can then convert it to a map with lowercase keys that we use for comparison.

I also fixed the asg lookup to also be an exact match instead.  These matches are relatively efficient as I am converting the arrays to maps for O(1) lookups instead of having to repeatedly loop through the whole strings using Contains or slices.Contains

Related to: https://github.com/aws/amazon-cloudwatch-agent/pull/1474

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests updated

Pooja tested manually for me on her cluster

```
Key
	
Value

APPLICATION
poojardy_test_application
```
```
Field	Value
@entity.Attributes.AWS.ServiceNameSource	
ResourceTags
@entity.Attributes.EC2.AutoScalingGroup	
asg-compass
@entity.Attributes.EC2.InstanceId	
i-0b6fe6aab9e76873b
@entity.Attributes.PlatformType	
AWS::EC2
@entity.KeyAttributes.Environment	
ec2:asg-compass
@entity.KeyAttributes.Name	
poojardy_test_application
@entity.KeyAttributes.Type	
Service
@ingestionTime	
1734719476173
@log	
957688854012:agent_log_group
@logStream	
agent_log_stream
@message	
2024-12-20T18:31:14Z I! CWAGENT_LOG_LEVEL is set to "DEBUG"
@timestamp	
1734719475179
```
```

Key
	
Value

APP
app_testing
```
```

1
2024-12-20T18:34:55.016Z
2024-12-20T18:34:53Z D! [logagent] open file count, 1
Field	Value
@entity.Attributes.AWS.ServiceNameSource	
ResourceTags
@entity.Attributes.EC2.AutoScalingGroup	
asg-compass
@entity.Attributes.EC2.InstanceId	
i-0b6fe6aab9e76873b
@entity.Attributes.PlatformType	
AWS::EC2
@entity.KeyAttributes.Environment	
ec2:asg-compass
@entity.KeyAttributes.Name	
app_testing
@entity.KeyAttributes.Type	
Service
@ingestionTime	
1734719695505
@log	
957688854012:agent_log_group
@logStream	
agent_log_stream
@message	
2024-12-20T18:34:53Z D! [logagent] open file count, 1
@timestamp	
1734719695016
```


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh` -- done
2. Run `make lint`




