### PR TITLE
Clean EKS E2E Tests

### DIFF
--- a/tool/clean/clean_eks/clean_eks.go
+++ b/tool/clean/clean_eks/clean_eks.go
@@ -25,6 +25,7 @@ var (
 		"cwagent-operator-helm-integ-",
 		"cwagent-helm-chart-integ-",
 		"cwagent-operator-eks-integ-",
+		"cwagent-monitoring-config-e2e-eks-",
 	}
 )
 


### PR DESCRIPTION
# Description of the issue
We don't have a mechanism to clean our EKS end-to-end tests.

# Description of changes
Add `"cwagent-monitoring-config-e2e-eks-"` to `ClustersToClean` string array to clean those clusters.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12451922519 and verified it cleared clusters.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




