### PR TITLE
[processor/awsentity] Add awsentity processor into EMF pipeline

### DIFF
--- a/plugins/processors/awsentity/factory.go
+++ b/plugins/processors/awsentity/factory.go
@@ -26,7 +26,9 @@ func NewFactory() processor.Factory {
 	return processor.NewFactory(
 		TypeStr,
 		createDefaultConfig,
-		processor.WithMetrics(createMetricsProcessor, stability))
+		processor.WithMetrics(createMetricsProcessor, stability),
+		processor.WithLogs(createLogsProcessor, stability),
+	)
 }
 
 func createDefaultConfig() component.Config {
@@ -51,5 +53,25 @@ func createMetricsProcessor(
 		cfg,
 		nextConsumer,
 		metricsProcessor.processMetrics,
+		processorhelper.WithCapabilities(processorCapabilities))
+}
+
+func createLogsProcessor(
+	ctx context.Context,
+	set processor.CreateSettings,
+	cfg component.Config,
+	nextConsumer consumer.Logs,
+) (processor.Logs, error) {
+	processorConfig, ok := cfg.(*Config)
+	if !ok {
+		return nil, errors.New("configuration parsing error")
+	}
+	logProcessor := newAwsEntityProcessor(processorConfig, set.Logger)
+	return processorhelper.NewLogsProcessor(
+		ctx,
+		set,
+		cfg,
+		nextConsumer,
+		logProcessor.processLogs,
 		processorhelper.WithCapabilities(processorCapabilities))
 }

--- a/plugins/processors/awsentity/factory.go
+++ b/plugins/processors/awsentity/factory.go
@@ -58,7 +58,7 @@ func createMetricsProcessor(
 
 func createLogsProcessor(
 	ctx context.Context,
-	set processor.CreateSettings,
+	set processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (processor.Logs, error) {

--- a/plugins/processors/awsentity/factory_test.go
+++ b/plugins/processors/awsentity/factory_test.go
@@ -40,6 +40,6 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NotNil(t, mProcessor)
 
 	lProcessor, err := factory.CreateLogsProcessor(context.Background(), setting, cfg, consumertest.NewNop())
-	assert.Equal(t, err, component.ErrDataTypeIsNotSupported)
-	assert.Nil(t, lProcessor)
+	assert.NoError(t, err)
+	assert.NotNil(t, lProcessor)
 }

--- a/plugins/processors/awsentity/processor.go
+++ b/plugins/processors/awsentity/processor.go
@@ -5,6 +5,7 @@ package awsentity
 
 import (
 	"context"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
@@ -108,6 +109,10 @@ func newAwsEntityProcessor(config *Config, logger *zap.Logger) *awsEntityProcess
 		k8sscraper: k8sattributescraper.NewK8sAttributeScraper(config.ClusterName),
 		logger:     logger,
 	}
+}
+
+func (p *awsEntityProcessor) processLogs(_ context.Context, ld plog.Logs) (plog.Logs, error) {
+	return ld, nil
 }
 
 func (p *awsEntityProcessor) processMetrics(_ context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {

--- a/plugins/processors/awsentity/processor.go
+++ b/plugins/processors/awsentity/processor.go
@@ -5,11 +5,11 @@ package awsentity
 
 import (
 	"context"
-	"go.opentelemetry.io/collector/pdata/plog"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	semconv "go.opentelemetry.io/collector/semconv/v1.22.0"
 	"go.uber.org/zap"

--- a/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
@@ -159,6 +159,9 @@ extensions:
         mode: ec2
         region: us-east-1
 processors:
+    awsentity/service/emf:
+        entity_type: Service
+        platform: ec2
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -235,6 +238,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_darwin_config.yaml
@@ -105,6 +105,9 @@ processors:
     awsentity/resource:
         entity_type: Resource
         platform: ec2
+    awsentity/service/emf:
+        entity_type: Service
+        platform: ec2
     awsentity/service/telegraf:
         entity_type: Service
         platform: ec2
@@ -273,6 +276,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - udplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -111,6 +111,9 @@ processors:
     awsentity/resource:
         entity_type: Resource
         platform: ec2
+    awsentity/service/emf:
+        entity_type: Service
+        platform: ec2
     awsentity/service/telegraf:
         entity_type: Service
         platform: ec2
@@ -380,6 +383,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - udplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_windows_config.yaml
@@ -105,6 +105,9 @@ processors:
     awsentity/resource:
         entity_type: Resource
         platform: ec2
+    awsentity/service/emf:
+        entity_type: Service
+        platform: ec2
     awsentity/service/telegraf:
         entity_type: Service
         platform: ec2
@@ -260,6 +263,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - udplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/config_with_env.yaml
+++ b/translator/tocwconfig/sampleConfig/config_with_env.yaml
@@ -50,6 +50,9 @@ extensions:
         mode: ec2
         region: ${ENV_REGION}
 processors:
+    awsentity/service/emf:
+        entity_type: Service
+        platform: ec2
     batch/emf_logs:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -92,6 +95,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -411,6 +411,9 @@ extensions:
         region: us-east-1
         shared_credential_file: /root/.aws/credentials
 processors:
+    awsentity/service/emf:
+        entity_type: Service
+        platform: onPremise
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -499,6 +502,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
@@ -669,6 +669,9 @@ extensions:
         region: us-east-1
         shared_credential_file: /root/.aws/credentials
 processors:
+    awsentity/service/emf:
+        entity_type: Service
+        platform: onPremise
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -1171,6 +1174,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_kueue_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_kueue_config.yaml
@@ -491,6 +491,9 @@ extensions:
         region: us-east-1
         shared_credential_file: /root/.aws/credentials
 processors:
+    awsentity/service/emf:
+        entity_type: Service
+        platform: onPremise
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -588,6 +591,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/kueue_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kueue_container_insights_config.yaml
@@ -237,6 +237,9 @@ extensions:
         mode: ec2
         region: us-east-1
 processors:
+    awsentity/service/emf:
+        entity_type: Service
+        platform: ec2
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -322,6 +325,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
+++ b/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
@@ -105,6 +105,9 @@ extensions:
                 mode: EC2
                 region_type: ACJ
 processors:
+    awsentity/service/emf:
+        entity_type: Service
+        platform: ec2
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -180,6 +183,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
+++ b/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
@@ -105,9 +105,6 @@ extensions:
                 mode: EC2
                 region_type: ACJ
 processors:
-    awsentity/service/emf:
-        entity_type: Service
-        platform: ec2
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -183,7 +180,6 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
-                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -405,6 +405,9 @@ extensions:
         mode: ec2
         region: us-east-1
 processors:
+    awsentity/service/emf:
+        entity_type: Service
+        platform: ec2
     batch/containerinsights:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -491,6 +494,7 @@ service:
             exporters:
                 - awscloudwatchlogs/emf_logs
             processors:
+                - awsentity/service/emf
                 - batch/emf_logs
             receivers:
                 - tcplog/emf_logs

--- a/translator/translate/otel/pipeline/emf_logs/translator.go
+++ b/translator/translate/otel/pipeline/emf_logs/translator.go
@@ -4,7 +4,6 @@
 package emf_logs
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/awsentity"
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
@@ -13,6 +12,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awscloudwatchlogs"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/awsentity"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/tcplog"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/udplog"

--- a/translator/translate/otel/pipeline/emf_logs/translator.go
+++ b/translator/translate/otel/pipeline/emf_logs/translator.go
@@ -4,6 +4,7 @@
 package emf_logs
 
 import (
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/awsentity"
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
@@ -48,7 +49,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 	}
 	translators := common.ComponentTranslators{
 		Receivers:  common.NewTranslatorMap[component.Config](),
-		Processors: common.NewTranslatorMap(batchprocessor.NewTranslatorWithNameAndSection(common.PipelineNameEmfLogs, common.LogsKey)), // EMF logs sit under metrics_collected in "logs"
+		Processors: common.NewTranslatorMap(batchprocessor.NewTranslatorWithNameAndSection(common.PipelineNameEmfLogs, common.LogsKey), awsentity.NewTranslatorWithEntityType(awsentity.Service, "emf", false)), // EMF logs sit under metrics_collected in "logs"
 		Exporters:  common.NewTranslatorMap(awscloudwatchlogs.NewTranslatorWithName(common.PipelineNameEmfLogs)),
 		Extensions: common.NewTranslatorMap(agenthealth.NewTranslator(component.DataTypeLogs, []string{agenthealth.OperationPutLogEvents}),
 			agenthealth.NewTranslatorWithStatusCode(component.MustNewType("statuscode"), nil, true),

--- a/translator/translate/otel/pipeline/emf_logs/translator.go
+++ b/translator/translate/otel/pipeline/emf_logs/translator.go
@@ -4,13 +4,12 @@
 package emf_logs
 
 import (
-	"github.com/aws/amazon-cloudwatch-agent/translator/context"
-	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awscloudwatchlogs"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
@@ -18,6 +17,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/tcplog"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/udplog"
+	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
 
 var (

--- a/translator/translate/otel/pipeline/emf_logs/translator_test.go
+++ b/translator/translate/otel/pipeline/emf_logs/translator_test.go
@@ -46,7 +46,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineType: "logs/emf_logs",
 				receivers:    []string{"tcplog/emf_logs", "udplog/emf_logs"},
-				processors:   []string{"batch/emf_logs"},
+				processors:   []string{"batch/emf_logs", "awsentity/service/emf"},
 				exporters:    []string{"awscloudwatchlogs/emf_logs"},
 				extensions:   []string{"agenthealth/logs", "agenthealth/statuscode"},
 			},
@@ -62,7 +62,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineType: "logs/emf_logs",
 				receivers:    []string{"tcplog/emf_logs", "udplog/emf_logs"},
-				processors:   []string{"batch/emf_logs"},
+				processors:   []string{"batch/emf_logs", "awsentity/service/emf"},
 				exporters:    []string{"awscloudwatchlogs/emf_logs"},
 				extensions:   []string{"agenthealth/logs", "agenthealth/statuscode"},
 			},
@@ -80,7 +80,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineType: "logs/emf_logs",
 				receivers:    []string{"udplog/emf_logs"},
-				processors:   []string{"batch/emf_logs"},
+				processors:   []string{"batch/emf_logs", "awsentity/service/emf"},
 				exporters:    []string{"awscloudwatchlogs/emf_logs"},
 				extensions:   []string{"agenthealth/logs", "agenthealth/statuscode"},
 			},
@@ -98,7 +98,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineType: "logs/emf_logs",
 				receivers:    []string{"tcplog/emf_logs"},
-				processors:   []string{"batch/emf_logs"},
+				processors:   []string{"batch/emf_logs", "awsentity/service/emf"},
 				exporters:    []string{"awscloudwatchlogs/emf_logs"},
 				extensions:   []string{"agenthealth/logs", "agenthealth/statuscode"},
 			},


### PR DESCRIPTION
# Description of the issue
We want the ability to send entities for customers forwarding EMF logs using the EMF forwarding plugin: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Generation_CloudWatch_Agent.html

To do this, we should add the awsentity processor which contains logic providing entity attributes to cloudwatch exporters.

# Description of changes
- Add `awsentity` processor to EMF log pipeline.

Note that this change does not change the telemetry yet, it just sets up the pipeline for future modifications.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit test.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




