### PR TITLE
update telegraf module for disk usage metrics fix on macOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/amazon-cloudwatch-agent
 
 go 1.22.5
 
-replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20241003164222-69e43c131d55
+replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20250113150713-a2dfaa4cdf6d
 
 // Replace with https://github.com/amazon-contributing/opentelemetry-collector-contrib, there are no requirements for all receivers/processors/exporters
 // to be all replaced since there are some changes that will always be from upstream
@@ -47,7 +47,7 @@ replace (
 )
 
 // Temporary fix, pending PR https://github.com/shirou/gopsutil/pull/957
-replace github.com/shirou/gopsutil/v3 => github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20231109213610-a8c21c54a2be // indirect
+replace github.com/shirou/gopsutil/v3 => github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20250113150713-a2dfaa4cdf6d // indirect
 
 //pin consul to a newer version to fix the ambiguous import issue
 //see https://github.com/hashicorp/consul/issues/6019 and https://github.com/hashicorp/consul/issues/6414

--- a/go.sum
+++ b/go.sum
@@ -328,10 +328,10 @@ github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.13.6/go.mod h1:akrYtxss2
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
-github.com/aws/telegraf v0.10.2-0.20241003164222-69e43c131d55 h1:jZcQmduv+lpJnwfWd/kkd3jiqeCJHfgYY6/om99e3BE=
-github.com/aws/telegraf v0.10.2-0.20241003164222-69e43c131d55/go.mod h1:EuipXfoVhMPIMfNPLyHP9X2IQGwOXhwysPXUuosAFts=
-github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20231109213610-a8c21c54a2be h1:sF6OUdk1hpuX7lf74vn+zBUFtQRe+hky0jmMYyFp5Kk=
-github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20231109213610-a8c21c54a2be/go.mod h1:1W1wnODUDv+FBSAtAa878Kxto5kj8eV+kI0AF4LIjq4=
+github.com/aws/telegraf v0.10.2-0.20250113150713-a2dfaa4cdf6d h1:WQ+YwEMyIpKQOGtAtUyqq18RhERiAQGPYSXsSckRrsg=
+github.com/aws/telegraf v0.10.2-0.20250113150713-a2dfaa4cdf6d/go.mod h1:jrcGlkX91pXbwi4r7gpfd7UPQGMJDdv6tw1mCrzmIOE=
+github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20250113150713-a2dfaa4cdf6d h1:nCzziuk/prBwzhbEyP9onARem7LriIxqGrTFB9D532g=
+github.com/aws/telegraf/patches/gopsutil/v3 v3.0.0-20250113150713-a2dfaa4cdf6d/go.mod h1:1W1wnODUDv+FBSAtAa878Kxto5kj8eV+kI0AF4LIjq4=
 github.com/awslabs/kinesis-aggregation/go v0.0.0-20210630091500-54e17340d32f h1:Pf0BjJDga7C98f0vhw+Ip5EaiE07S3lTKpIYPNS0nMo=
 github.com/awslabs/kinesis-aggregation/go v0.0.0-20210630091500-54e17340d32f/go.mod h1:SghidfnxvX7ribW6nHI7T+IBbc9puZ9kk5Tx/88h8P4=
 github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 h1:6df1vn4bBlDDo4tARvBm7l6KA9iVMnE3NWizDeWSrps=


### PR DESCRIPTION
# Description of the issue
There is an issue in scraping disk usage on macOS systems. The problem stems from gopsutil's reliance on unix.Statfs, which is not accurately retrieving disk usage data on macOS. While unix.Statfs is generally reliable on many Unix systems, it seems to be incompatible with macOS's specific filesystem (APFS) implementation or reporting mechanisms. This leads to inaccurate disk usage metrics (where all reported mount points have same used space values), impacting macOS customers' observability to their resources.

# Description of changes
PR in aws/telegraf https://github.com/aws/telegraf/pull/167

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test results https://github.com/aws/telegraf/pull/167

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




