### PR TITLE
Add Confused Deputy Prevention

### DIFF
--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -92,9 +92,11 @@ jobs:
 
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${{env.PRIVATE_KEY}}" -var="github_test_repo=${{ inputs.test_repo_url }}" \
+              -var="ssh_key_value=${{env.PRIVATE_KEY}}" \
+              -var="github_test_repo=${{ inputs.test_repo_url }}" \
               -var="test_name=${{ matrix.arrays.os }}" \
-              -var="cwa_github_sha=${{inputs.github_sha}}" -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
+              -var="cwa_github_sha=${{inputs.github_sha}}" \
+              -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
               -var="github_test_repo_branch=${{inputs.test_repo_branch}}" \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
               -var="user=${{ matrix.arrays.username }}" \
@@ -121,4 +123,7 @@ jobs:
           max_attempts: 2
           timeout_minutes: 8
           retry_wait_seconds: 5
-          command: cd ${{ inputs.test_dir }} && terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" --auto-approve
+          command: |
+            cd ${{ inputs.test_dir }}
+            terraform init
+            terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" --auto-approve

--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -124,6 +124,10 @@ jobs:
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            cd ${{ inputs.test_dir }}
-            terraform init
+            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
+              cd "${{ matrix.arrays.terraform_dir }}"
+            else
+              cd ${{inputs.test_dir}}
+            fi
+
             terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" --auto-approve

--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -123,11 +123,4 @@ jobs:
           max_attempts: 2
           timeout_minutes: 8
           retry_wait_seconds: 5
-          command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
-            else
-              cd ${{inputs.test_dir}}
-            fi
-
-            terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" --auto-approve
+          command: cd ${{ inputs.test_dir }} && terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" --auto-approve

--- a/cfg/aws/credentials.go
+++ b/cfg/aws/credentials.go
@@ -16,9 +16,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 
+	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
 )
 
@@ -174,7 +176,7 @@ func (s *stsCredentialProvider) Retrieve() (credentials.Value, error) {
 
 func newStsCredentials(c client.ConfigProvider, roleARN string, region string) *credentials.Credentials {
 	regional := &stscreds.AssumeRoleProvider{
-		Client: sts.New(c, &aws.Config{
+		Client: newStsClient(c, &aws.Config{
 			Region:              aws.String(region),
 			STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 			HTTPClient:          &http.Client{Timeout: 1 * time.Minute},
@@ -188,7 +190,7 @@ func newStsCredentials(c client.ConfigProvider, roleARN string, region string) *
 	fallbackRegion := getFallbackRegion(region)
 
 	partitional := &stscreds.AssumeRoleProvider{
-		Client: sts.New(c, &aws.Config{
+		Client: newStsClient(c, &aws.Config{
 			Region:              aws.String(fallbackRegion),
 			Endpoint:            aws.String(getFallbackEndpoint(fallbackRegion)),
 			STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
@@ -201,6 +203,37 @@ func newStsCredentials(c client.ConfigProvider, roleARN string, region string) *
 	}
 
 	return credentials.NewCredentials(&stsCredentialProvider{regional: regional, partitional: partitional})
+}
+
+const (
+	SourceArnHeaderKey     = "x-amz-source-arn"
+	SourceAccountHeaderKey = "x-amz-source-account"
+)
+
+var (
+	sourceAccount = os.Getenv(envconfig.AmzSourceAccount) // populates the "x-amz-source-account" header
+	sourceArn     = os.Getenv(envconfig.AmzSourceArn)     // populates the "x-amz-source-arn" header
+)
+
+// newStsClient creates a new STS client with the provided config and options.
+// Additionally, if specific environment variables are set, it also appends the confused deputy headers to requests
+// made by the client. These headers allow resource-based policies to limit the permissions that a service has to
+// a specific resource. Note that BOTH environment variables need to contain non-empty values in order for the headers
+// to be set.
+//
+// See https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html#cross-service-confused-deputy-prevention
+func newStsClient(p client.ConfigProvider, cfgs ...*aws.Config) *sts.STS {
+	client := sts.New(p, cfgs...)
+	if sourceAccount != "" && sourceArn != "" {
+		client.Handlers.Sign.PushFront(func(r *request.Request) {
+			r.HTTPRequest.Header.Set(SourceArnHeaderKey, sourceArn)
+			r.HTTPRequest.Header.Set(SourceAccountHeaderKey, sourceAccount)
+		})
+
+		log.Printf("I! Found confused deputy header environment variables: source account: %q, source arn: %q", sourceAccount, sourceArn)
+	}
+
+	return client
 }
 
 // The partitional STS endpoint used to fallback when regional STS endpoint is not activated.

--- a/cfg/aws/credentials.go
+++ b/cfg/aws/credentials.go
@@ -210,11 +210,6 @@ const (
 	SourceAccountHeaderKey = "x-amz-source-account"
 )
 
-var (
-	sourceAccount = os.Getenv(envconfig.AmzSourceAccount) // populates the "x-amz-source-account" header
-	sourceArn     = os.Getenv(envconfig.AmzSourceArn)     // populates the "x-amz-source-arn" header
-)
-
 // newStsClient creates a new STS client with the provided config and options.
 // Additionally, if specific environment variables are set, it also appends the confused deputy headers to requests
 // made by the client. These headers allow resource-based policies to limit the permissions that a service has to
@@ -223,6 +218,10 @@ var (
 //
 // See https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html#cross-service-confused-deputy-prevention
 func newStsClient(p client.ConfigProvider, cfgs ...*aws.Config) *sts.STS {
+
+	sourceAccount := os.Getenv(envconfig.AmzSourceAccount)
+	sourceArn := os.Getenv(envconfig.AmzSourceArn)
+
 	client := sts.New(p, cfgs...)
 	if sourceAccount != "" && sourceArn != "" {
 		client.Handlers.Sign.PushFront(func(r *request.Request) {

--- a/cfg/aws/credentials_test.go
+++ b/cfg/aws/credentials_test.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/awstesting/mock"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfusedDeputyHeaders(t *testing.T) {
+	tests := []struct {
+		name                  string
+		envSourceArn          string
+		envSourceAccount      string
+		expectedHeaderArn     string
+		expectedHeaderAccount string
+	}{
+		{
+			name:                  "unpopulated",
+			envSourceArn:          "",
+			envSourceAccount:      "",
+			expectedHeaderArn:     "",
+			expectedHeaderAccount: "",
+		},
+		{
+			name:                  "both populated",
+			envSourceArn:          "arn:aws:ec2:us-east-1:474668408639:instance/i-08293cd9825754f7c",
+			envSourceAccount:      "539247453986",
+			expectedHeaderArn:     "arn:aws:ec2:us-east-1:474668408639:instance/i-08293cd9825754f7c",
+			expectedHeaderAccount: "539247453986",
+		},
+		{
+			name:                  "only source arn populated",
+			envSourceArn:          "arn:aws:ec2:us-east-1:474668408639:instance/i-08293cd9825754f7c",
+			envSourceAccount:      "",
+			expectedHeaderArn:     "",
+			expectedHeaderAccount: "",
+		},
+		{
+			name:                  "only source account populated",
+			envSourceArn:          "",
+			envSourceAccount:      "539247453986",
+			expectedHeaderArn:     "",
+			expectedHeaderAccount: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set global variables which will get picked up by newStsClient
+			sourceArn = tt.envSourceArn
+			sourceAccount = tt.envSourceAccount
+
+			client := newStsClient(mock.Session, &aws.Config{
+				// These are examples credentials pulled from:
+				// https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html
+				Credentials: credentials.NewStaticCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", ""),
+				Region:      aws.String("us-east-1"),
+			})
+
+			request, _ := client.AssumeRoleRequest(&sts.AssumeRoleInput{
+				// We aren't going to actually make the assume role call, we are just going
+				// to verify the headers are present once signed so the RoleArn and RoleSessionName
+				// arguments are irrelevant. Fill them out with something so the request is valid.
+				RoleArn:         aws.String("arn:aws:iam::012345678912:role/XXXXXXXX"),
+				RoleSessionName: aws.String("MockSession"),
+			})
+
+			// Headers are generated after the request is signed (but before it's sent)
+			err := request.Sign()
+			require.NoError(t, err)
+
+			headerSourceArn := request.HTTPRequest.Header.Get("x-amz-source-arn")
+			assert.Equal(t, tt.expectedHeaderArn, headerSourceArn)
+
+			headerSourceAccount := request.HTTPRequest.Header.Get("x-amz-source-account")
+			assert.Equal(t, tt.expectedHeaderAccount, headerSourceAccount)
+		})
+	}
+
+	sourceArn = ""
+	sourceAccount = ""
+}

--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -32,6 +32,10 @@ const (
 	CWConfigContent           = "CW_CONFIG_CONTENT"
 	CWOtelConfigContent       = "CW_OTEL_CONFIG_CONTENT"
 	CWAgentMergedOtelConfig   = "CWAGENT_MERGED_OTEL_CONFIG"
+
+	// confused deputy prevention related headers
+	AmzSourceAccount = "AMZ_SOURCE_ACCOUNT" // populates the "x-amz-source-account" header
+	AmzSourceArn     = "AMZ_SOURCE_ARN"     // populates the "x-amz-source-arn" header
 )
 
 const (


### PR DESCRIPTION
# Description of the issue
To support confused deputy prevention, the CloudWatch Agent needs to be able to pass confused deputy context keys in the headers of STS AssumeRole calls so that dependent service teams can allow their customers to use confused deputy context keys in their role policies.

For background on the confused deputy problem, see: https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html

# Description of changes
Enable the CloudWatch Agent to resource confused deputy context keys from environment variables and include the key values in the STS AssumeRole request headers.

I noticed while testing my new integration test that the destroy step was always failing because terraform wasn't initialized. Example: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13013756921/job/36303755191. This wound up leaving a ton of resources behind that didn't get cleaned up automatically. Added a `terraform init` step to the terraform destroy step to fix this

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
New `assume_role` integration test created in test repo. Example run:  https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13020191778. See `assume_role` test, e.g. https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13065824342/job/36483181515. See PR for amazon-cloudwatch-agent-test for more details: https://github.com/aws/amazon-cloudwatch-agent-test/pull/449

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




