### PR TITLE
Add setup terraform step to integration tests

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -51,6 +51,13 @@ jobs:
             terraform destroy -auto-approve
             aws s3api delete-object --bucket ${S3_INTEGRATION_BUCKET} --key canary/al2/terraform.tfstate
           fi
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Verify Terraform version
+        run: terraform --version
+
       # @TODO we can add a matrix in the future but for alpha we will only deploy to al2
       - name: Terraform apply
         uses: nick-fields/retry@v2

--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -76,6 +76,10 @@ jobs:
         run: |
           echo run cache_if_success os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
           echo localstack input ${{ inputs.localstack_host }}
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         run: terraform --version
 
@@ -93,7 +97,7 @@ jobs:
             else
               cd ${{inputs.test_dir}}
             fi
-            
+
             terraform init
             if terraform apply --auto-approve \
               -var="ssh_key_value=${{env.PRIVATE_KEY}}" -var="github_test_repo=${{ inputs.test_repo_url }}" \

--- a/.github/workflows/eks-e2e-test.yml
+++ b/.github/workflows/eks-e2e-test.yml
@@ -102,6 +102,10 @@ jobs:
         if: steps.cache_if_success.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Install Terraform
+        if: steps.cache_if_success.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         if: steps.cache_if_success.outputs.cache-hit != 'true'
         run: terraform --version
@@ -144,7 +148,7 @@ jobs:
             else
               terraform destroy --auto-approve && exit 1
             fi
-            
+
       - name: Terraform destroy
         if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -254,6 +254,9 @@ jobs:
       - name: Echo Test Info
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         run: terraform --version
 
@@ -472,6 +475,9 @@ jobs:
       - name: Echo Test Info
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} use ssm ${{ matrix.arrays.useSSM }} test ${{ matrix.arrays.test_dir }}
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         run: terraform --version
 
@@ -553,6 +559,9 @@ jobs:
 
       - name: Echo OS
         run: echo run on ec2 instance os ${{ matrix.arrays.os }}
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
         run: terraform --version
@@ -688,6 +697,10 @@ jobs:
         if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Install Terraform
+        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
@@ -705,7 +718,7 @@ jobs:
             else
               cd terraform/ecs_ec2/daemon
             fi
-            
+
             terraform init
             if terraform apply --auto-approve\
               -var="test_dir=${{ matrix.arrays.test_dir }}"\
@@ -771,6 +784,10 @@ jobs:
         if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Install Terraform
+        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
@@ -788,7 +805,7 @@ jobs:
             else
               cd terraform/ecs_fargate/linux
             fi
-            
+
             terraform init
             if terraform apply --auto-approve\
               -var="test_dir=${{ matrix.arrays.test_dir }}"\
@@ -848,6 +865,10 @@ jobs:
         id: login-ecr
         if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Install Terraform
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
         if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
@@ -1006,6 +1027,10 @@ jobs:
           path: go.mod
           key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
+      - name: Install Terraform
+        if: steps.performance-tracking.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         if: steps.performance-tracking.outputs.cache-hit != 'true'
         run: terraform --version
@@ -1074,6 +1099,10 @@ jobs:
           path: go.mod
           key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
+      - name: Install Terraform
+        if: steps.performance-tracking.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         if: steps.performance-tracking.outputs.cache-hit != 'true'
         run: terraform --version
@@ -1141,6 +1170,10 @@ jobs:
         with:
           path: go.mod
           key: stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
+      - name: Install Terraform
+        if: steps.stress-tracking.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
         if: steps.stress-tracking.outputs.cache-hit != 'true'
@@ -1212,6 +1245,10 @@ jobs:
           path: go.mod
           key: ec2-win-stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
 
+      - name: Install Terraform
+        if: steps.ec2-win-stress-tracking-test.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         if: steps.ec2-win-stress-tracking-test.outputs.cache-hit != 'true'
         run: terraform --version
@@ -1276,10 +1313,11 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
         run: terraform --version
-
 
       - name: Terraform apply and setup
         run: |
@@ -1288,7 +1326,7 @@ jobs:
           else
             cd terraform/eks/addon/gpu
           fi
-          
+
           terraform init
           if terraform apply --auto-approve \
             -var="beta=true" \
@@ -1296,7 +1334,7 @@ jobs:
             -var="instance_type=${{ matrix.arrays.instanceType }}" \
             -var="k8s_version=${{ matrix.arrays.k8sVersion }}"; then
             echo "Terraform apply successful."
-          
+
             # Capture the output
             echo "Getting EKS cluster name"
             EKS_CLUSTER_NAME=$(terraform output -raw eks_cluster_name)

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -79,6 +79,12 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Verify Terraform version
+        run: terraform --version
+
       # @TODO we can add a matrix in the future but for for now, we will only deploy to AL2.
       - name: Terraform apply
         uses: nick-fields/retry@v2

--- a/.github/workflows/start-localstack.yml
+++ b/.github/workflows/start-localstack.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Echo Localstack Config
         run: echo repo name ${{inputs.test_repo_name}} repo branch ${{ inputs.test_repo_branch }} region ${{ inputs.region }}
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         run: terraform --version
 


### PR DESCRIPTION
# Description of the issue
Integration tests are failing because of the following error:
```
/home/runner/work/_temp/850921c8-782b-4ebe-88ba-9a5873e052ae.sh: line 1: terraform: command not found
```

# Description of changes
It appears terraform isn't on the github runners by default, so we're adding a step to install terraform to each of the workflows using: https://github.com/hashicorp/setup-terraform. Thanks for paramadon for finding and solving this issue.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Terraform is working again in the integration test workflows: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12832239476

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




