### PR TITLE
Run E2E tests weekly

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -14,6 +14,8 @@ env:
   OPERATOR_GITHUB_REPO_NAME: "aws/amazon-cloudwatch-agent-operator"
 
 on:
+  schedule:
+    - cron: '0 17 * * 1'
   workflow_dispatch:
     inputs:
       region:
@@ -47,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{env.OPERATOR_GITHUB_REPO_NAME}}
-          ref: ${{inputs.operator-branch}}
+          ref: ${{ inputs.operator-branch || 'main' }}
           path: operator-repo
 
       - name: Get latest commit SHA
@@ -73,7 +75,7 @@ jobs:
     needs: [GetLatestOperatorCommitSHA]
     uses: aws/amazon-cloudwatch-agent-operator/.github/workflows/build-and-upload.yml@main
     concurrency:
-      group: ${{ github.workflow }}-operator-${{ inputs.operator-branch}}
+      group: ${{ github.workflow }}-operator-${{ inputs.operator-branch || 'main' }}
       cancel-in-progress: true
     secrets: inherit
     with:
@@ -165,8 +167,8 @@ jobs:
       cloudwatch_agent_tag: ${{ github.sha }}
       cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
       cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
-      region: ${{ inputs.region }}
-      helm_charts_branch: ${{ inputs.helm-charts-branch }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
       terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
       agent_config: resources/cwagent_configs/jvm_tomcat.json
       sample_app: resources/sample_apps/tomcat.yaml
@@ -187,8 +189,8 @@ jobs:
       cloudwatch_agent_tag: ${{ github.sha }}
       cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
       cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
-      region: ${{ inputs.region }}
-      helm_charts_branch: ${{ inputs.helm-charts-branch }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
       terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
       agent_config: resources/cwagent_configs/kafka.json
       sample_app: resources/sample_apps/kafka.yaml
@@ -209,8 +211,8 @@ jobs:
       cloudwatch_agent_tag: ${{ github.sha }}
       cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
       cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
-      region: ${{ inputs.region }}
-      helm_charts_branch: ${{ inputs.helm-charts-branch }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
       terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
       agent_config: resources/cwagent_configs/containerinsights.json
       sample_app: resources/sample_apps/tomcat.yaml


### PR DESCRIPTION
# Description of the issue
We recently implemented comprehensive E2E tests that check complex monitoring configurations with the CloudWatch Agent across different branches of the agent, operator, and helm charts repositories on full customer environments (e.g. an EKS cluster) to validate proper resource creation and metric emission for robust regression detection. Currently, these E2E tests are only configured to be triggered manually, which makes sense for testing feature branches prior to a release. However, we don't have a scheduled run of our E2E tests across our main branches, which is important for detecting regressions for changes merged into main that weren't tested as part of feature branches.

# Description of changes
* Added `schedule` workflow trigger with a `cron` set to run every Monday at 12 PM EST.
* Added `|| '<DEFAULT_VALUE>'` to allow `schedule` workflow runs to use default values (i.e. `'main'`).

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A (we will see if the scheduled workflow runs properly)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




