### PR TITLE
Add setup terraform step to EKS integration test

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -40,6 +40,9 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Terminate Last Canary
         run: |
           if aws s3api wait object-exists --bucket ${S3_INTEGRATION_BUCKET} --key canary/al2/terraform.tfstate ;
@@ -51,9 +54,6 @@ jobs:
             terraform destroy -auto-approve
             aws s3api delete-object --bucket ${S3_INTEGRATION_BUCKET} --key canary/al2/terraform.tfstate
           fi
-
-      - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
         run: terraform --version

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -952,6 +952,10 @@ jobs:
         if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Install Terraform
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         run: terraform --version


### PR DESCRIPTION
# Description of the issue
EKSIntegrationTest fails because terraform is not installed: 

```bash
/home/runner/work/_temp/7f0421f7-4fb8-4bb9-bf66-99ddfc508068.sh: line 1: terraform: command not found
```

See job: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12834512020/job/35792035900

# Description of changes
Continuation of https://github.com/aws/amazon-cloudwatch-agent/pull/1507. Missed installing terraform for the EKS integration test workflow.

* Install terraform for EKS integration test workflow
* Move terraform installation step for deploy canary workflow in case the workflow needs to terminate the old canary first

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




