### PR TITLE
Increased timeout for win tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -481,7 +481,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 60
           retry_wait_seconds: 5
           command: |
             if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then


### PR DESCRIPTION
# Description of the issue
Windows EC2 integration test are failing due to test timing out.

```
Error: Final attempt failed. Timeout of 1800000ms hit
```

# Description of changes
* Increased timeout to an hour from 30 mins.  I believe this is happening because windows host takes longer to allocate a host. 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran integration tests: 


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




