### PR TITLE
Revert per events header bytes to 200

### DIFF
--- a/plugins/outputs/cloudwatchlogs/internal/pusher/batch.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/batch.go
@@ -22,7 +22,7 @@ const (
 	// The maximum number of log events in a batch.
 	reqEventsLimit = 10000
 	// The bytes required for metadata for each log event.
-	perEventHeaderBytes = 26
+	perEventHeaderBytes = 200
 	// A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
 	batchTimeRangeLimit = 24 * time.Hour
 )

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/batch_test.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/batch_test.go
@@ -70,20 +70,20 @@ func TestLogEventBatch(t *testing.T) {
 	t.Run("HasSpace", func(t *testing.T) {
 		batch := newLogEventBatch(Target{Group: "G", Stream: "S"}, nil)
 
+		event := newLogEvent(time.Now(), "Test message", nil)
+		maxEvents := reqSizeLimit / event.eventBytes
+
 		// Add events until close to the limit
-		for i := 0; i < reqEventsLimit-1; i++ {
-			event := newLogEvent(time.Now(), "Test message", nil)
+		for i := 0; i < maxEvents-1; i++ {
 			batch.append(event)
 		}
 
-		assert.True(t, batch.hasSpace(100), "Batch should have space for one more small event")
-		assert.False(t, batch.hasSpace(reqSizeLimit), "Batch should not have space for an event that exceeds the size limit")
+		assert.True(t, batch.hasSpace(event.eventBytes))
 
 		// Add one more event to reach the limit
-		event := newLogEvent(time.Now(), "Last message", nil)
 		batch.append(event)
 
-		assert.False(t, batch.hasSpace(1), "Batch should not have space after reaching event limit")
+		assert.False(t, batch.hasSpace(event.eventBytes))
 	})
 
 	t.Run("Build", func(t *testing.T) {


### PR DESCRIPTION
# Description of the issue
https://github.com/aws/amazon-cloudwatch-agent/pull/1499 changed the `perEventsHeaderBytes` from 200 to 26 to match the [PutLogEvents API specifications](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)

> The maximum batch size is 1,048,576 bytes. This size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.

The size was originally mistakenly raised in https://github.com/aws/amazon-cloudwatch-agent/pull/913.

This is causing the batches to be larger and have more log events, which is increasing the memory usage in the stress tests.

# Description of changes
- Reverts the per event header bytes to 200

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12895929100/job/35957950969

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




