### PR TITLE
Removing Caching from integ test

### DIFF
--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -65,13 +65,6 @@ jobs:
           aws-region: ${{inputs.region}}
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: cache_if_success
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ${{inputs.region}}-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Echo Test Info
         run: |
           echo run cache_if_success os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}

--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -65,6 +65,13 @@ jobs:
           aws-region: ${{inputs.region}}
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: cache_if_success
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ${{inputs.region}}-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
       - name: Echo Test Info
         run: |
           echo run cache_if_success os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}

--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -65,13 +65,6 @@ jobs:
           aws-region: ${{inputs.region}}
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: cache_if_success
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ${{inputs.region}}-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Echo Test Info
         run: |
           echo run cache_if_success os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
@@ -85,7 +78,6 @@ jobs:
 
       # nick-fields/retry@v2 starts at base dir
       - name: Terraform apply
-        if: steps.cache_if_success.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 2

--- a/.github/workflows/eks-e2e-test.yml
+++ b/.github/workflows/eks-e2e-test.yml
@@ -90,24 +90,14 @@ jobs:
           aws-region: ${{ inputs.region }}
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: cache_if_success
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ${{inputs.region}}-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Login ECR
         id: login-ecr
-        if: steps.cache_if_success.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
-        if: steps.cache_if_success.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.cache_if_success.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply

--- a/.github/workflows/eks-e2e-test.yml
+++ b/.github/workflows/eks-e2e-test.yml
@@ -111,7 +111,6 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        if: steps.cache_if_success.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3

--- a/.github/workflows/eks-e2e-test.yml
+++ b/.github/workflows/eks-e2e-test.yml
@@ -90,14 +90,24 @@ jobs:
           aws-region: ${{ inputs.region }}
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: cache_if_success
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ${{inputs.region}}-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
       - name: Login ECR
         id: login-ecr
+        if: steps.cache_if_success.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
+        if: steps.cache_if_success.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.cache_if_success.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -654,24 +654,14 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: ecs-ec2-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ecs-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
-
       - name: Login ECR
         id: login-ecr
-        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
-        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -740,24 +730,14 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: ecs-fargate-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
-
       - name: Login ECR
         id: login-ecr
-        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
-        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -821,24 +801,14 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: eks-ec2-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ${{ matrix.arrays.terraform_dir }}-${{ matrix.arrays.k8sVersion }}-${{ matrix.arrays.instanceType }}-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
-
       - name: Login ECR
         id: login-ecr
-        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
-        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -906,24 +876,14 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: eks-ec2-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: eks-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
-
       - name: Login ECR
         id: login-ecr
-        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
-        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -989,19 +949,10 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: performance-tracking
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Install Terraform
-        if: steps.performance-tracking.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.performance-tracking.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -1060,19 +1011,10 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: performance-tracking
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Install Terraform
-        if: steps.performance-tracking.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.performance-tracking.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -1131,19 +1073,10 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: stress-tracking
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Install Terraform
-        if: steps.stress-tracking.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.stress-tracking.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Echo Test Info
@@ -1204,19 +1137,10 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: ec2-win-stress-tracking-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ec2-win-stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Install Terraform
-        if: steps.ec2-win-stress-tracking-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
-        if: steps.ec2-win-stress-tracking-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Echo Test Info

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -654,14 +654,24 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: ecs-ec2-integration-test
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ecs-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+
       - name: Login ECR
         id: login-ecr
+        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
+        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -730,14 +740,24 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: ecs-fargate-integration-test
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ecs-fargate-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+
       - name: Login ECR
         id: login-ecr
+        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
+        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -801,14 +821,24 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: eks-ec2-integration-test
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ${{ matrix.arrays.terraform_dir }}-${{ matrix.arrays.k8sVersion }}-${{ matrix.arrays.instanceType }}-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+
       - name: Login ECR
         id: login-ecr
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -876,14 +906,24 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: eks-ec2-integration-test
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: eks-ec2-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.test_dir }}
+
       - name: Login ECR
         id: login-ecr
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Terraform
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -949,10 +989,19 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: performance-tracking
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
       - name: Install Terraform
+        if: steps.performance-tracking.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.performance-tracking.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -1011,10 +1060,19 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: performance-tracking
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: performance-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
       - name: Install Terraform
+        if: steps.performance-tracking.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.performance-tracking.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Terraform apply
@@ -1073,10 +1131,19 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: stress-tracking
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
       - name: Install Terraform
+        if: steps.stress-tracking.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.stress-tracking.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Echo Test Info
@@ -1137,10 +1204,19 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
+      - name: Cache if success
+        id: ec2-win-stress-tracking-test
+        uses: actions/cache@v3
+        with:
+          path: go.mod
+          key: ec2-win-stress-tracking-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
+
       - name: Install Terraform
+        if: steps.ec2-win-stress-tracking-test.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v3
 
       - name: Verify Terraform version
+        if: steps.ec2-win-stress-tracking-test.outputs.cache-hit != 'true'
         run: terraform --version
 
       - name: Echo Test Info

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -154,15 +154,7 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: cf-integration-test
-        uses: actions/cache@v2
-        with:
-          path: go.mod
-          key: "cf-integration-${{ github.sha }}-test"
-
       - name: Test cf
-        if: steps.ec2-linux-integration-test.outputs.cache-hit != 'true'
         run: |
           cd test/test/cloudformation
           go test -timeout 1h -package_path=s3://${S3_INTEGRATION_BUCKET}/integration-test/binary/${{ github.sha }}/linux/amd64/amazon-cloudwatch-agent.rpm -iam_role=${CF_IAM_ROLE} -key_name=${CF_KEY_NAME} -metric_name=mem_used_percent
@@ -244,13 +236,6 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: ec2-linux-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ec2-nvidia-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Echo Test Info
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
 
@@ -262,7 +247,7 @@ jobs:
 
       # nick-fields/retry@v2 starts at base dir
       - name: Terraform apply
-        if: ${{ matrix.arrays.family == 'linux' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.arrays.family == 'linux' }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -295,7 +280,7 @@ jobs:
               terraform destroy -auto-approve && exit 1
             fi
       - name: Terraform apply
-        if: ${{ matrix.arrays.family == 'window' && steps.ec2-nvidia-integration-test.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.arrays.family == 'window' }}
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -465,13 +450,6 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: ec2-win-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ec2-win-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Echo Test Info
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} use ssm ${{ matrix.arrays.useSSM }} test ${{ matrix.arrays.test_dir }}
 
@@ -483,7 +461,6 @@ jobs:
 
         # nick-fields/retry@v2 starts at base dir
       - name: Terraform apply
-        if: steps.ec2-win-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -550,13 +527,6 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
-      - name: Cache if success
-        id: ec2-mac-integration-test
-        uses: actions/cache@v3
-        with:
-          path: go.mod
-          key: ec2-mac-integration-test-${{ github.sha }}-${{ matrix.arrays.os }}-${{ matrix.arrays.arc }}-${{ matrix.arrays.test_dir }}
-
       - name: Echo OS
         run: echo run on ec2 instance os ${{ matrix.arrays.os }}
 
@@ -568,7 +538,6 @@ jobs:
 
         # nick-fields/retry@v2 starts at base dir
       - name: Terraform apply
-        if: steps.ec2-mac-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -706,7 +675,6 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        if: steps.ecs-ec2-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -793,7 +761,6 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        if: steps.ecs-fargate-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -875,7 +842,6 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 2
@@ -961,7 +927,6 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        if: steps.eks-ec2-integration-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
@@ -1040,7 +1005,6 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        if: steps.performance-tracking.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 1
@@ -1112,7 +1076,6 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        if: steps.performance-tracking.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 1
@@ -1187,7 +1150,6 @@ jobs:
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }} values per minute ${{ matrix.arrays.values_per_minute }}
 
       - name: Terraform apply
-        if: steps.stress-tracking.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 1
@@ -1261,7 +1223,6 @@ jobs:
         run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }} values per minute ${{ matrix.arrays.values_per_minute }}
 
       - name: Terraform apply
-        if: steps.ec2-win-stress-tracking-test.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           max_attempts: 1


### PR DESCRIPTION
# Description of the issue
Caching was intially put in place to reduce the number of tests that needed to be re-run on partial failures in an effort to speed up testing. It currently is put in place to skip passing tests on re-runs. But since GitHub workflows supports [re-running failed jobs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/re-running-workflows-and-jobs#re-running-failed-jobs-in-a-workflow), which already covers the purpose of the caching. Caching conflicts have also resulted in false positives for passing tests like the stress tests.

# Description of changes
This pr removes caching to avoid false negatives.

Integration test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12997888061
