### PR TITLE
Improve cluster detection for entity and app signals processors

### DIFF
--- a/translator/translate/otel/common/appsignals.go
+++ b/translator/translate/otel/common/appsignals.go
@@ -3,11 +3,23 @@
 
 package common
 
-import "os"
+import (
+	"os"
+
+	"go.opentelemetry.io/collector/confmap"
+)
 
 const KubernetesEnvVar = "K8S_NAMESPACE"
 
 func IsAppSignalsKubernetes() bool {
 	_, isSet := os.LookupEnv(KubernetesEnvVar)
 	return isSet
+}
+
+func GetHostedIn(conf *confmap.Conf) (string, bool) {
+	hostedIn, hostedInConfigured := GetString(conf, ConfigKey(LogsKey, MetricsCollectedKey, AppSignals, "hosted_in"))
+	if !hostedInConfigured {
+		hostedIn, hostedInConfigured = GetString(conf, ConfigKey(LogsKey, MetricsCollectedKey, AppSignalsFallback, "hosted_in"))
+	}
+	return hostedIn, hostedInConfigured
 }

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -466,10 +466,8 @@ func GetClusterName(conf *confmap.Conf) string {
 
 	envVarClusterName := os.Getenv("K8S_CLUSTER_NAME")
 	if envVarClusterName != "" {
-		fmt.Printf("I! Successfully retrieved cluster name: %s", envVarClusterName)
 		return envVarClusterName
 	}
-	fmt.Printf("E! Failed to retrieve cluster name: %s", envVarClusterName)
 
 	return util.GetClusterNameFromEc2Tagger()
 }

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -469,6 +469,7 @@ func GetClusterName(conf *confmap.Conf) string {
 		fmt.Printf("I! Successfully retrieved cluster name: %s", envVarClusterName)
 		return envVarClusterName
 	}
+	fmt.Printf("E! Failed to retrieve cluster name: %s", envVarClusterName)
 
 	return util.GetClusterNameFromEc2Tagger()
 }

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -6,6 +6,7 @@ package common
 import (
 	"container/list"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"gopkg.in/yaml.v3"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 )
 
 const (
@@ -453,4 +456,18 @@ func IsAnySet(conf *confmap.Conf, keys []string) bool {
 
 func KueueContainerInsightsEnabled(conf *confmap.Conf) bool {
 	return GetOrDefaultBool(conf, ConfigKey(LogsKey, MetricsCollectedKey, KubernetesKey, EnableKueueContainerInsights), false)
+}
+
+func GetClusterName(conf *confmap.Conf) string {
+	val, ok := GetString(conf, ConfigKey(LogsKey, MetricsCollectedKey, KubernetesKey, "cluster_name"))
+	if ok && val != "" {
+		return val
+	}
+
+	envVarClusterName := os.Getenv("K8S_CLUSTER_NAME")
+	if envVarClusterName != "" {
+		return envVarClusterName
+	}
+
+	return util.GetClusterNameFromEc2Tagger()
 }

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -466,6 +466,7 @@ func GetClusterName(conf *confmap.Conf) string {
 
 	envVarClusterName := os.Getenv("K8S_CLUSTER_NAME")
 	if envVarClusterName != "" {
+		fmt.Printf("I! Successfully retrieved cluster name: %s", envVarClusterName)
 		return envVarClusterName
 	}
 

--- a/translator/translate/otel/exporter/awsemf/prometheus.go
+++ b/translator/translate/otel/exporter/awsemf/prometheus.go
@@ -40,7 +40,7 @@ func setPrometheusLogGroup(conf *confmap.Conf, cfg *awsemfexporter.Config) error
 			}
 		} else {
 
-			if clusterName := util.GetClusterNameFromEc2Tagger(); clusterName != "" {
+			if clusterName := common.GetClusterName(conf); clusterName != "" {
 				cfg.LogGroupName = fmt.Sprintf(eksDefaultLogGroupFormat, clusterName)
 			}
 		}

--- a/translator/translate/otel/exporter/awsemf/prometheus.go
+++ b/translator/translate/otel/exporter/awsemf/prometheus.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )

--- a/translator/translate/otel/processor/awsapplicationsignals/translator.go
+++ b/translator/translate/otel/processor/awsapplicationsignals/translator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals/rules"
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
@@ -64,15 +63,10 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	configKey := common.AppSignalsConfigKeys[t.dataType]
 	cfg := t.factory.CreateDefaultConfig().(*appsignalsconfig.Config)
 
-	hostedInConfigKey := common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.AppSignals, "hosted_in")
-	hostedIn, hostedInConfigured := common.GetString(conf, hostedInConfigKey)
-	if !hostedInConfigured {
-		hostedInConfigKey = common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.AppSignalsFallback, "hosted_in")
-		hostedIn, hostedInConfigured = common.GetString(conf, hostedInConfigKey)
-	}
+	hostedIn, hostedInConfigured := common.GetHostedIn(conf)
 	if common.IsAppSignalsKubernetes() {
 		if !hostedInConfigured {
-			hostedIn = util.GetClusterNameFromEc2Tagger()
+			hostedIn = common.GetClusterName(conf)
 		}
 	}
 

--- a/translator/translate/otel/processor/awsentity/translator.go
+++ b/translator/translate/otel/processor/awsentity/translator.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsentity"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
@@ -55,8 +54,10 @@ func (t *translator) ID() component.ID {
 }
 
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
+	ctx := context.CurrentContext()
+
 	// Do not send entity for ECS
-	if context.CurrentContext().RunInContainer() && ecsutil.GetECSUtilSingleton().IsECS() {
+	if ctx.RunInContainer() && ecsutil.GetECSUtilSingleton().IsECS() {
 		return nil, nil
 	}
 
@@ -70,32 +71,22 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		cfg.ScrapeDatapointAttribute = true
 	}
 
-	hostedInConfigKey := common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.AppSignals, "hosted_in")
-	hostedIn, hostedInConfigured := common.GetString(conf, hostedInConfigKey)
-	if !hostedInConfigured {
-		hostedInConfigKey = common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.AppSignalsFallback, "hosted_in")
-		hostedIn, hostedInConfigured = common.GetString(conf, hostedInConfigKey)
-	}
-	if common.IsAppSignalsKubernetes() {
-		if !hostedInConfigured {
-			hostedIn = util.GetClusterNameFromEc2Tagger()
-		}
-	}
+	cfg.KubernetesMode = ctx.KubernetesMode()
 
-	//TODO: This logic is more or less identical to what AppSignals does. This should be moved to a common place for reuse
-	ctx := context.CurrentContext()
-	mode := ctx.KubernetesMode()
-	cfg.KubernetesMode = mode
-
-	mode = ctx.Mode()
 	if cfg.KubernetesMode != "" {
-		cfg.ClusterName = hostedIn
+		clusterName, clusterNameConfigured := common.GetHostedIn(conf)
+
+		if !clusterNameConfigured {
+			clusterName = common.GetClusterName(conf)
+		}
+
+		cfg.ClusterName = clusterName
 	}
 
 	// We want to keep platform config variable to be
 	// anything that is non-Kubernetes related so the
 	// processor can perform different logics for EKS
 	// in EC2 or Non-EC2
-	cfg.Platform = mode
+	cfg.Platform = ctx.Mode()
 	return cfg, nil
 }

--- a/translator/translate/otel/processor/awsentity/translator_test.go
+++ b/translator/translate/otel/processor/awsentity/translator_test.go
@@ -69,6 +69,45 @@ func TestTranslate(t *testing.T) {
 				Platform:       config.ModeEC2,
 			},
 		},
+		"AppSignalsPrecedence": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"app_signals": map[string]interface{}{
+							"hosted_in": "test",
+						},
+						"kubernetes": map[string]interface{}{
+							"cluster_name": "ci-logs",
+						},
+					},
+				}},
+			mode:           config.ModeEC2,
+			kubernetesMode: config.ModeEKS,
+			want: &awsentity.Config{
+				ClusterName:    "test",
+				KubernetesMode: config.ModeEKS,
+				Platform:       config.ModeEC2,
+			},
+		},
+		"KubernetesPrecedence": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"kubernetes": map[string]interface{}{
+							"cluster_name": "ci-logs",
+						},
+					},
+				},
+			},
+			mode:           config.ModeEC2,
+			kubernetesMode: config.ModeEKS,
+			envClusterName: "env-cluster",
+			want: &awsentity.Config{
+				ClusterName:    "ci-logs",
+				KubernetesMode: config.ModeEKS,
+				Platform:       config.ModeEC2,
+			},
+		},
 		"ECS": {
 			input: map[string]interface{}{},
 			mode:  config.ModeECS,

--- a/translator/translate/otel/processor/awsentity/translator_test.go
+++ b/translator/translate/otel/processor/awsentity/translator_test.go
@@ -20,6 +20,7 @@ func TestTranslate(t *testing.T) {
 		input          map[string]interface{}
 		mode           string
 		kubernetesMode string
+		envClusterName string
 		want           *awsentity.Config
 	}{
 		"OnlyProfile": {
@@ -35,6 +36,35 @@ func TestTranslate(t *testing.T) {
 			kubernetesMode: config.ModeEKS,
 			want: &awsentity.Config{
 				ClusterName:    "test",
+				KubernetesMode: config.ModeEKS,
+				Platform:       config.ModeEC2,
+			},
+		},
+		"KubernetesUnderLogs": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"kubernetes": map[string]interface{}{
+							"cluster_name": "ci-logs",
+						},
+					},
+				},
+			},
+			mode:           config.ModeEC2,
+			kubernetesMode: config.ModeEKS,
+			want: &awsentity.Config{
+				ClusterName:    "ci-logs",
+				KubernetesMode: config.ModeEKS,
+				Platform:       config.ModeEC2,
+			},
+		},
+		"EnvVar": {
+			input:          map[string]interface{}{},
+			mode:           config.ModeEC2,
+			kubernetesMode: config.ModeEKS,
+			envClusterName: "env-cluster",
+			want: &awsentity.Config{
+				ClusterName:    "env-cluster",
 				KubernetesMode: config.ModeEKS,
 				Platform:       config.ModeEC2,
 			},
@@ -55,6 +85,11 @@ func TestTranslate(t *testing.T) {
 				ecsutil.GetECSUtilSingleton().Region = ""
 				context.CurrentContext().SetMode(testCase.mode)
 				context.CurrentContext().SetKubernetesMode(testCase.kubernetesMode)
+			}
+			if testCase.envClusterName != "" {
+				t.Setenv("K8S_CLUSTER_NAME", testCase.envClusterName)
+			} else {
+				t.Setenv("K8S_CLUSTER_NAME", "")
 			}
 			tt := NewTranslator()
 			assert.Equal(t, "awsentity", tt.ID().String())

--- a/translator/translate/otel/processor/resourceprocessor/translator.go
+++ b/translator/translate/otel/processor/resourceprocessor/translator.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
@@ -113,11 +112,7 @@ func (t *translator) getJMXAttributes(conf *confmap.Conf) []any {
 }
 
 func (t *translator) getContainerInsightsJMXAttributes(conf *confmap.Conf) []any {
-	clusterName, ok := common.GetString(conf, common.ConfigKey(k8sKey, "cluster_name"))
-
-	if !ok {
-		clusterName = util.GetClusterNameFromEc2Tagger()
-	}
+	clusterName := common.GetClusterName(conf)
 	nodeName := os.Getenv(config.HOST_NAME)
 	return []any{
 		map[string]any{

--- a/translator/translate/otel/receiver/awscontainerinsight/translator.go
+++ b/translator/translate/otel/receiver/awscontainerinsight/translator.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	globallogs "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs"
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	logsutil "github.com/aws/amazon-cloudwatch-agent/translator/translate/util"
@@ -128,12 +127,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 }
 
 func (t *translator) setClusterName(conf *confmap.Conf, cfg *awscontainerinsightreceiver.Config) error {
-	clusterNameKey := common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.KubernetesKey, "cluster_name")
-	if clusterName, ok := common.GetString(conf, clusterNameKey); ok {
-		cfg.ClusterName = clusterName
-	} else {
-		cfg.ClusterName = util.GetClusterNameFromEc2Tagger()
-	}
+	cfg.ClusterName = common.GetClusterName(conf)
 
 	if cfg.ClusterName == "" {
 		return errors.New("cluster name is not provided and was not auto-detected from EC2 tags")

--- a/translator/translate/otel/receiver/awscontainerinsightskueue/translator.go
+++ b/translator/translate/otel/receiver/awscontainerinsightskueue/translator.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
@@ -60,12 +59,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 }
 
 func (t *translator) setClusterName(conf *confmap.Conf, cfg *awscontainerinsightskueuereceiver.Config) error {
-	clusterNameKey := common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.KubernetesKey, "cluster_name")
-	if clusterName, ok := common.GetString(conf, clusterNameKey); ok {
-		cfg.ClusterName = clusterName
-	} else {
-		cfg.ClusterName = util.GetClusterNameFromEc2Tagger()
-	}
+	cfg.ClusterName = common.GetClusterName(conf)
 
 	if cfg.ClusterName == "" {
 		return errors.New("cluster name is not provided and was not auto-detected from EC2 tags")


### PR DESCRIPTION
# Description of the issue
When running on a Kubernetes cluster, the only way the CloudWatch Agent can detect the cluster name is:

1) If it's provided in the configuration:
```
"kubernetes": {
  "cluster_name": "<cluster-name>",
  "enhanced_container_insights": true
},
"application_signals": {
  "hosted_in": "<cluster-name>"
}
```

2) By making a `ec2:DescribeTags` call.

Ideally, the agent should minimize external API calls, so we should implement a global way to retrieve the cluster name in case it isn't provided in the configuration. We can fetch the `K8S_CLUSTER_NAME` environmental variable, which is populated by the Amazon CloudWatch Observability EKS add-on / Helm chart.

# Description of changes
> [!IMPORTANT]
> **Co-PR:** https://github.com/aws-observability/helm-charts/pull/167

## [Revision 1](https://github.com/aws/amazon-cloudwatch-agent/compare/77aa32a3ce8b249df0b52888afd7d45ac936616a..d3871bd306c6d3a7164b42528382428f3b8dce3f)
- Create `GetHostedIn` function, which looks for cluster name under app signals.
- Create `GetClusterName` function, which looks for cluster name under kubernetes, in `K8S_CLUSTER_NAME` environmental variable, or by a `ec2:DescribeTags` call.
- Reference these functions in entity and app signals processors.
- Organize entity processor so that it only calls these functions when running in Kubernetes.
- Add unit tests for entity processor.

## [Revision 2](https://github.com/aws/amazon-cloudwatch-agent/compare/d3871bd306c6d3a7164b42528382428f3b8dce3f..99d7c0042417bc6fbd0dc559c724475825e7929c)
- Add `GetClusterName()` call for containerinsights.
- Add precedence testing.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
In an EKS cluster, I added a print statement to verify the environmental variable's value is accessed during translation:
<img width="403" alt="Screenshot 2025-02-03 at 2 14 23 AM" src="https://github.com/user-attachments/assets/487b0933-60f5-4277-8700-8e60eb997570" />

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




