### PR TITLE
Changing log level of cert watcher from error to debug

### DIFF
--- a/extension/server/extension.go
+++ b/extension/server/extension.go
@@ -51,7 +51,7 @@ func NewServer(logger *zap.Logger, config *Config) *Server {
 	// Initialize a new cert watcher with cert/key pair
 	watcher, err := tlsInternal.NewCertWatcher(config.TLSCertPath, config.TLSKeyPath, config.TLSCAPath, logger)
 	if err != nil {
-		s.logger.Error("failed to initialize cert watcher", zap.Error(err))
+		s.logger.Debug("failed to initialize cert watcher", zap.Error(err))
 		return s
 	}
 
@@ -86,7 +86,7 @@ func (s *Server) Start(context.Context, component.Host) error {
 		go func() {
 			err := s.httpsServer.ListenAndServeTLS("", "")
 			if err != nil {
-				s.logger.Error("failed to serve and listen", zap.Error(err))
+				s.logger.Debug("failed to serve and listen", zap.Error(err))
 			}
 		}()
 	}


### PR DESCRIPTION
# Description of the issue
When agent is installed using the Container Insights YAML as part of https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-metrics.html , this error log clutters up the agent logs and gives customers an impression that something is wrong with the agent 
```
2025-01-23T04:50:37Z E! {"caller":"tls/certWatcher.go:89","msg":"failed to read certificate","kind":"extension","name":"server","error":"could not read certificate \"/etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt\": open /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt: no such file or directory","stacktrace":"github.com/aws/amazon-cloudwatch-agent/internal/tls.(*CertWatcher).ReadTlsConfig\n\tgithub.com/aws/amazon-cloudwatch-agent/internal/tls/certWatcher.go:89\ngithub.com/aws/amazon-cloudwatch-agent/internal/tls.NewCertWatcher\n\tgithub.com/aws/amazon-cloudwatch-agent/internal/tls/certWatcher.go:56\ngithub.com/aws/amazon-cloudwatch-agent/extension/server.NewServer\n\tgithub.com/aws/amazon-cloudwatch-agent/extension/server/extension.go:52\ngithub.com/aws/amazon-cloudwatch-agent/extension/server.createExtension\n\tgithub.com/aws/amazon-cloudwatch-agent/extension/server/factory.go:31\ngo.opentelemetry.io/collector/extension.CreateFunc.CreateExtension\n\tgo.opentelemetry.io/collector/extension@v0.103.0/extension.go:86\ngo.opentelemetry.io/collector/extension.(*Builder).Create\n\tgo.opentelemetry.io/collector/extension@v0.103.0/extension.go:174\ngo.opentelemetry.io/collector/service/extensions.New\n\tgo.opentelemetry.io/collector/service@v0.103.0/extensions/extensions.go:193\ngo.opentelemetry.io/collector/service.(*Service).initExtensionsAndPipeline\n\tgo.opentelemetry.io/collector/service@v0.103.0/service.go:274\ngo.opentelemetry.io/collector/service.New\n\tgo.opentelemetry.io/collector/service@v0.103.0/service.go:145\ngo.opentelemetry.io/collector/otelcol.(*Collector).setupConfigurationComponents\n\tgo.opentelemetry.io/collector/otelcol@v0.103.0/collector.go:192\ngo.opentelemetry.io/collector/otelcol.(*Collector).Run\n\tgo.opentelemetry.io/collector/otelcol@v0.103.0/collector.go:277\ngo.opentelemetry.io/collector/otelcol.commandHelper.func1\n\tgo.opentelemetry.io/collector/otelcol@v0.103.0/command.go:51\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.8.0/command.go:983\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.8.0/command.go:1115\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.8.0/command.go:1039\nmain.runAgent\n\tgithub.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go:388\nmain.reloadLoop\n\tgithub.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go:180\nmain.main\n\tgithub.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go:666\nruntime.main\n\truntime/proc.go:272"}
```

# Description of changes
Changing log level of error statements to debug

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




