### PR TITLE
Fix EKS cluster detection

### DIFF
--- a/translator/util/eksdetector/eksdetector.go
+++ b/translator/util/eksdetector/eksdetector.go
@@ -4,17 +4,20 @@
 package eksdetector
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 type Detector interface {
+	getConfigMap(namespace string, name string) (map[string]string, error)
 	getIssuer() (string, error)
 }
 
@@ -26,6 +29,11 @@ type IsEKSCache struct {
 	Value bool
 	Err   error
 }
+
+const (
+	authConfigNamespace = "kube-system"
+	authConfigConfigMap = "aws-auth"
+)
 
 var _ Detector = (*EksDetector)(nil)
 
@@ -50,8 +58,9 @@ var (
 		return detector, errors
 	}
 
-	// IsEKS checks if the agent is running on EKS by extracting the "iss"
-	// field from the service account token and checking if it contains "eks".
+	// IsEKS checks if the agent is running on EKS. This is done by using the kubernetes API to determine if the aws-auth
+	// configmap exists in the kube-system namespace or by extracting the "iss" field from the service account token and
+	// checking if it contains "eks" as a fall-back.
 	IsEKS = func() IsEKSCache {
 		once.Do(func() {
 			var errors error
@@ -63,10 +72,16 @@ var (
 			}
 
 			if eksDetector != nil {
-				issuer, err := eksDetector.getIssuer()
-				fmt.Println("issuer: ", issuer)
+				// Make HTTP GET request
+				awsAuth, err := eksDetector.getConfigMap(authConfigNamespace, authConfigConfigMap)
 				if err == nil {
-					value = strings.Contains(strings.ToLower(issuer), "eks")
+					value = awsAuth != nil
+				} else {
+					issuer, err := eksDetector.getIssuer()
+					fmt.Println("issuer: ", issuer)
+					if err == nil {
+						value = strings.Contains(strings.ToLower(issuer), "eks")
+					}
 				}
 			}
 			isEKSCacheSingleton = IsEKSCache{Value: value, Err: errors}
@@ -75,6 +90,16 @@ var (
 		return isEKSCacheSingleton
 	}
 )
+
+// getConfigMap retrieves the configmap with the provided name in the provided namespace
+func (d *EksDetector) getConfigMap(namespace string, name string) (map[string]string, error) {
+	configMap, err := d.Clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve ConfigMap %s/%s: %w", namespace, name, err)
+	}
+
+	return configMap.Data, nil
+}
 
 // getIssuer retrieves the issuer ("iss") from the service account token.
 func (d *EksDetector) getIssuer() (string, error) {

--- a/translator/util/eksdetector/eksdetector.go
+++ b/translator/util/eksdetector/eksdetector.go
@@ -78,7 +78,6 @@ var (
 					value = awsAuth != nil
 				} else {
 					issuer, err := eksDetector.getIssuer()
-					fmt.Println("fallback issuer: ", issuer)
 					if err == nil {
 						value = strings.Contains(strings.ToLower(issuer), "eks")
 					}

--- a/translator/util/eksdetector/eksdetector.go
+++ b/translator/util/eksdetector/eksdetector.go
@@ -78,7 +78,7 @@ var (
 					value = awsAuth != nil
 				} else {
 					issuer, err := eksDetector.getIssuer()
-					fmt.Println("issuer: ", issuer)
+					fmt.Println("fallback issuer: ", issuer)
 					if err == nil {
 						value = strings.Contains(strings.ToLower(issuer), "eks")
 					}

--- a/translator/util/eksdetector/eksdetector.go
+++ b/translator/util/eksdetector/eksdetector.go
@@ -60,7 +60,7 @@ var (
 
 	// IsEKS checks if the agent is running on EKS. This is done by using the kubernetes API to determine if the aws-auth
 	// configmap exists in the kube-system namespace or by extracting the "iss" field from the service account token and
-	// checking if it contains "eks" as a fall-back.
+	// checking if it contains "eks" as a fall-back
 	IsEKS = func() IsEKSCache {
 		once.Do(func() {
 			var errors error
@@ -101,7 +101,7 @@ func (d *EksDetector) getConfigMap(namespace string, name string) (map[string]st
 	return configMap.Data, nil
 }
 
-// getIssuer retrieves the issuer ("iss") from the service account token.
+// getIssuer retrieves the issuer ("iss") from the service account token
 func (d *EksDetector) getIssuer() (string, error) {
 	conf, err := getInClusterConfig()
 	if err != nil {

--- a/translator/util/eksdetector/eksdetector_test.go
+++ b/translator/util/eksdetector/eksdetector_test.go
@@ -61,7 +61,7 @@ func TestEKS(t *testing.T) {
 	assert.NoError(t, isEks.Err)
 
 	testDetector.On("getConfigMap", authConfigNamespace, authConfigConfigMap).Return(nil, fmt.Errorf("configmap not found"))
-	testDetector.On("getIssuer").Return("https://oidc.eks.us-west-2.amazonaws.com/id/EXAMPLE", nil)
+	testDetector.On("getIssuer").Return("https://oidc.eks.us-west-2.amazonaws.com/id/someid", nil)
 
 	isEks = IsEKS()
 	assert.True(t, isEks.Value)

--- a/translator/util/eksdetector/eksdetector_test.go
+++ b/translator/util/eksdetector/eksdetector_test.go
@@ -4,6 +4,7 @@
 package eksdetector
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -54,7 +55,15 @@ func TestEKS(t *testing.T) {
 	}
 
 	testDetector.On("getConfigMap", authConfigNamespace, authConfigConfigMap).Return(map[string]string{conventions.AttributeK8SClusterName: "my-cluster"}, nil)
+
 	isEks := IsEKS()
+	assert.True(t, isEks.Value)
+	assert.NoError(t, isEks.Err)
+
+	testDetector.On("getConfigMap", authConfigNamespace, authConfigConfigMap).Return(nil, fmt.Errorf("configmap not found"))
+	testDetector.On("getIssuer").Return("https://oidc.eks.us-west-2.amazonaws.com/id/EXAMPLE", nil)
+
+	isEks = IsEKS()
 	assert.True(t, isEks.Value)
 	assert.NoError(t, isEks.Err)
 }
@@ -80,6 +89,23 @@ func Test_getConfigMap(t *testing.T) {
 	res, err = testDetector.getConfigMap(authConfigNamespace, authConfigConfigMap)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
+}
+
+func Test_getIssuer(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	testDetector := &EksDetector{Clientset: client}
+
+	payload := `{"iss":"https://oidc.eks.us-west-2.amazonaws.com/id/someid"}`
+	encodedPayload := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	dummyToken := "header." + encodedPayload + ".signature"
+
+	getInClusterConfig = func() (*rest.Config, error) {
+		return &rest.Config{BearerToken: dummyToken}, nil
+	}
+
+	issuer, err := testDetector.getIssuer()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://oidc.eks.us-west-2.amazonaws.com/id/someid", issuer)
 }
 
 func Test_getClientError(t *testing.T) {

--- a/translator/util/eksdetector/eksdetectortestutil.go
+++ b/translator/util/eksdetector/eksdetectortestutil.go
@@ -5,20 +5,27 @@ package eksdetector
 
 import (
 	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 var (
 	// TestEKSDetector is used for unit testing EKS route
 	TestEKSDetector = func() (Detector, error) {
-		return &EksDetector{Clientset: fake.NewSimpleClientset()}, nil
+		cm := &v1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "aws-auth"},
+			Data:       make(map[string]string),
+		}
+		return &EksDetector{Clientset: fake.NewSimpleClientset(cm)}, nil
 	}
 	// TestK8sDetector is used for unit testing k8s route
 	TestK8sDetector = func() (Detector, error) {
 		return &EksDetector{Clientset: fake.NewSimpleClientset()}, nil
 	}
 
-	// TestIsEKSCacheEKS is used for unit testing EKS route
+	// TestIsEKSCacheEKS os used for unit testing EKS route
 	TestIsEKSCacheEKS = func() IsEKSCache {
 		return IsEKSCache{Value: true, Err: nil}
 	}
@@ -33,7 +40,7 @@ type MockDetector struct {
 	mock.Mock
 }
 
-func (detector *MockDetector) getIssuer() (string, error) {
-	args := detector.Called()
-	return args.Get(0).(string), args.Error(1)
+func (detector *MockDetector) getConfigMap(namespace string, name string) (map[string]string, error) {
+	args := detector.Called(namespace, name)
+	return args.Get(0).(map[string]string), args.Error(1)
 }

--- a/translator/util/eksdetector/eksdetectortestutil.go
+++ b/translator/util/eksdetector/eksdetectortestutil.go
@@ -5,27 +5,20 @@ package eksdetector
 
 import (
 	"github.com/stretchr/testify/mock"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 var (
 	// TestEKSDetector is used for unit testing EKS route
 	TestEKSDetector = func() (Detector, error) {
-		cm := &v1.ConfigMap{
-			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "aws-auth"},
-			Data:       make(map[string]string),
-		}
-		return &EksDetector{Clientset: fake.NewSimpleClientset(cm)}, nil
+		return &EksDetector{Clientset: fake.NewSimpleClientset()}, nil
 	}
 	// TestK8sDetector is used for unit testing k8s route
 	TestK8sDetector = func() (Detector, error) {
 		return &EksDetector{Clientset: fake.NewSimpleClientset()}, nil
 	}
 
-	// TestIsEKSCacheEKS os used for unit testing EKS route
+	// TestIsEKSCacheEKS is used for unit testing EKS route
 	TestIsEKSCacheEKS = func() IsEKSCache {
 		return IsEKSCache{Value: true, Err: nil}
 	}
@@ -38,11 +31,6 @@ var (
 
 type MockDetector struct {
 	mock.Mock
-}
-
-func (detector *MockDetector) getConfigMap(namespace string, name string) (map[string]string, error) {
-	args := detector.Called(namespace, name)
-	return args.Get(0).(map[string]string), args.Error(1)
 }
 
 func (detector *MockDetector) getServerVersion() (string, error) {

--- a/translator/util/eksdetector/eksdetectortestutil.go
+++ b/translator/util/eksdetector/eksdetectortestutil.go
@@ -47,5 +47,5 @@ func (detector *MockDetector) getConfigMap(namespace string, name string) (map[s
 
 func (detector *MockDetector) getIssuer() (string, error) {
 	args := detector.Called()
-	return args.String(0), args.Error(1)
+	return args.Get(0).(string), args.Error(1)
 }

--- a/translator/util/eksdetector/eksdetectortestutil.go
+++ b/translator/util/eksdetector/eksdetectortestutil.go
@@ -33,7 +33,7 @@ type MockDetector struct {
 	mock.Mock
 }
 
-func (detector *MockDetector) getServerVersion() (string, error) {
+func (detector *MockDetector) getIssuer() (string, error) {
 	args := detector.Called()
 	return args.Get(0).(string), args.Error(1)
 }

--- a/translator/util/eksdetector/eksdetectortestutil.go
+++ b/translator/util/eksdetector/eksdetectortestutil.go
@@ -44,3 +44,8 @@ func (detector *MockDetector) getConfigMap(namespace string, name string) (map[s
 	args := detector.Called(namespace, name)
 	return args.Get(0).(map[string]string), args.Error(1)
 }
+
+func (detector *MockDetector) getServerVersion() (string, error) {
+	args := detector.Called()
+	return args.Get(0).(string), args.Error(1)
+}

--- a/translator/util/eksdetector/eksdetectortestutil.go
+++ b/translator/util/eksdetector/eksdetectortestutil.go
@@ -25,7 +25,7 @@ var (
 		return &EksDetector{Clientset: fake.NewSimpleClientset()}, nil
 	}
 
-	// TestIsEKSCacheEKS os used for unit testing EKS route
+	// TestIsEKSCacheEKS is used for unit testing EKS route
 	TestIsEKSCacheEKS = func() IsEKSCache {
 		return IsEKSCache{Value: true, Err: nil}
 	}
@@ -43,4 +43,9 @@ type MockDetector struct {
 func (detector *MockDetector) getConfigMap(namespace string, name string) (map[string]string, error) {
 	args := detector.Called(namespace, name)
 	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+func (detector *MockDetector) getIssuer() (string, error) {
+	args := detector.Called()
+	return args.String(0), args.Error(1)
 }


### PR DESCRIPTION
# Description of the issue
To detect whether the CloudWatch Agent is running on EKS, we look for a ConfigMap named `aws-auth`, which is only supported for EKS and maps IAM users/roles to K8s RBAC for API access. However, `aws-auth` is now deprecated and isn't created on new EKS clusters, which marks the CloudWatch Agent as running on native K8s, not EKS, **which is not accurate.**

A suggestion from an issue is to inspect the `serviceaccount` token and look for the issuer field (`iss`). It contains the unique OIDC url for the EKS cluster.

> Relevant issue: https://github.com/aws/amazon-cloudwatch-agent/issues/1249.

# Description of changes
- Add logic to query API server for issuer field as a fall-back.
- Update unit tests to reflect changes.
  - `resetTestState()` forces re-evaluation of the `IsEKS()` singleton for each test.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
## Before
<img width="200" alt="Screenshot 2025-02-07 at 1 37 26 AM" src="https://github.com/user-attachments/assets/608cb3a7-b9d9-4323-b008-32e965a34297" />

## After
_For testing, added a debug line:_
<img width="610" alt="Screenshot 2025-02-11 at 1 21 30 AM" src="https://github.com/user-attachments/assets/96785f88-da53-48f9-aac0-fab281034113" />

<img width="176" alt="Screenshot 2025-02-07 at 1 35 31 AM" src="https://github.com/user-attachments/assets/85d77b33-e13e-4725-9519-a474757692c1" />

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




