### PR TITLE
Add terraform install to StopLocalStack

### DIFF
--- a/.github/workflows/stop-localstack.yml
+++ b/.github/workflows/stop-localstack.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Copy state
         run: aws s3 cp s3://${{inputs.s3_integration_bucket}}/integration-test/local-stack-terraform-state/${{inputs.github_sha}}/terraform.tfstate .
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Verify Terraform version
         run: terraform --version
 


### PR DESCRIPTION
# Description of the issue
The `StopLocalStack` workflow is failing with: `/home/runner/work/_temp/a9bdcdd2-65bc-4117-81be-cbad70401c8d.sh: line 1: terraform: command not found`.

To fix this, we must install terraform in our runner.

# Description of changes
- Add terraform install to StopLocalStack.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
![Workflow Status](https://github.com/aws/amazon-cloudwatch-agent/actions/workflows/integration-test.yml/badge.svg?run_id=13195436716)
[View Workflow Run #13195436716](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13195436716)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




