### PR TITLE
Fix terraform destroy for ec2 integration tests

### DIFF
--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -123,4 +123,11 @@ jobs:
           max_attempts: 2
           timeout_minutes: 8
           retry_wait_seconds: 5
-          command: cd ${{ inputs.test_dir }} && terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" --auto-approve
+          command: |
+            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
+              cd "${{ matrix.arrays.terraform_dir }}"
+            else
+              cd ${{inputs.test_dir}}
+            fi
+            
+            terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" --auto-approve


### PR DESCRIPTION
# Description of the issue
Whenever we cancel our EC2 integration tests that don't use the `terraform/ec2/linux` directory, we get the following error:
```
This module is not yet installed. Run "terraform init" to install all
modules required by this configuration.
```

This is caused by not going into the correct directory when we run `terraform destroy`.

# Description of changes
- Set to correct directory for destroy.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13232946491/job/36933626388

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




