### PR TITLE
skip PutRetentionPolicy by checking existing policy 

### DIFF
--- a/plugins/outputs/cloudwatchlogs/internal/pusher/queue_test.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/queue_test.go
@@ -30,6 +30,7 @@ type stubLogsService struct {
 	clg func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error)
 	cls func(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error)
 	prp func(input *cloudwatchlogs.PutRetentionPolicyInput) (*cloudwatchlogs.PutRetentionPolicyOutput, error)
+	dlg func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
 }
 
 func (s *stubLogsService) PutLogEvents(in *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {
@@ -56,6 +57,13 @@ func (s *stubLogsService) CreateLogStream(in *cloudwatchlogs.CreateLogStreamInpu
 func (s *stubLogsService) PutRetentionPolicy(in *cloudwatchlogs.PutRetentionPolicyInput) (*cloudwatchlogs.PutRetentionPolicyOutput, error) {
 	if s.prp != nil {
 		return s.prp(in)
+	}
+	return nil, nil
+}
+
+func (s *stubLogsService) DescribeLogGroups(in *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	if s.dlg != nil {
+		return s.dlg(in)
 	}
 	return nil, nil
 }

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/sender.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/sender.go
@@ -19,6 +19,7 @@ type cloudWatchLogsService interface {
 	CreateLogStream(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error)
 	CreateLogGroup(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error)
 	PutRetentionPolicy(input *cloudwatchlogs.PutRetentionPolicyInput) (*cloudwatchlogs.PutRetentionPolicyOutput, error)
+	DescribeLogGroups(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
 }
 
 type Sender interface {

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/sender_test.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/sender_test.go
@@ -40,6 +40,11 @@ func (m *mockLogsService) PutRetentionPolicy(input *cloudwatchlogs.PutRetentionP
 	return args.Get(0).(*cloudwatchlogs.PutRetentionPolicyOutput), args.Error(1)
 }
 
+func (m *mockLogsService) DescribeLogGroups(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*cloudwatchlogs.DescribeLogGroupsOutput), args.Error(1)
+}
+
 type mockTargetManager struct {
 	mock.Mock
 }

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/target.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/target.go
@@ -5,7 +5,6 @@ package pusher
 
 import (
 	"fmt"
-	"math/rand"
 	"sync"
 	"time"
 
@@ -209,11 +208,14 @@ func (m *targetManager) updateRetentionPolicy(target Target) error {
 }
 
 func (m *targetManager) calculateBackoff(attempt int) time.Duration {
-	delay := baseDelay * time.Duration(1<<uint(attempt))
+	delay := baseDelay
+	for i := 0; i < attempt && delay < maxDelay; i++ {
+		delay *= 2
+	}
 	if delay > maxDelay {
 		delay = maxDelay
 	}
 
-	jitter := time.Duration(rand.Float64() * float64(delay) * jitterFactor)
+	jitter := time.Duration(float64(delay) * (float64(time.Now().UnixNano()%100) / 500.0 * jitterFactor))
 	return delay + jitter
 }

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/target.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/target.go
@@ -103,7 +103,7 @@ func (m *targetManager) createLogGroupAndStream(t Target) (bool, error) {
 
 		// attempt to create stream again if group created successfully.
 		if err == nil {
-			m.logger.Debugf("successfully created log group %v. Retrying log stream %v", t.Group, t.Stream)
+			m.logger.Debugf("retrying log stream %v", t.Stream)
 			err = m.createLogStream(t)
 		} else {
 			m.logger.Debugf("creating group fail due to : %v", err)
@@ -164,7 +164,6 @@ func (m *targetManager) processDescribeLogGroup() {
 			if currentRetention != target.Retention && target.Retention > 0 {
 				m.logger.Debugf("queueing log group %v to update retention policy", target.Group)
 				m.prp <- target
-				break
 			}
 			break // no change in retention
 		}

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/target.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/target.go
@@ -8,10 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/amazon-cloudwatch-agent/sdk/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/influxdata/telegraf"
+
+	"github.com/aws/amazon-cloudwatch-agent/sdk/service/cloudwatchlogs"
 )
 
 const (

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/target.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/target.go
@@ -166,6 +166,7 @@ func (m *targetManager) processDescribeLogGroup() {
 				m.prp <- target
 				break
 			}
+			break // no change in retention
 		}
 	}
 }

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go
@@ -112,6 +112,7 @@ func TestTargetManager(t *testing.T) {
 	})
 
 	t.Run("SetRetentionPolicy/LogGroupNotFound", func(t *testing.T) {
+		t.Parallel()
 		target := Target{Group: "G", Stream: "S", Retention: 7}
 
 		mockService := new(mockLogsService)
@@ -128,6 +129,7 @@ func TestTargetManager(t *testing.T) {
 	})
 
 	t.Run("SetRetentionPolicy/Error", func(t *testing.T) {
+		t.Parallel()
 		target := Target{Group: "G", Stream: "S", Retention: 7}
 
 		mockService := new(mockLogsService)
@@ -229,6 +231,7 @@ func TestTargetManager(t *testing.T) {
 	})
 
 	t.Run("NewLogGroup/RetentionError", func(t *testing.T) {
+		t.Parallel()
 		target := Target{Group: "G", Stream: "S", Retention: 7}
 
 		mockService := new(mockLogsService)

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
@@ -70,13 +71,45 @@ func TestTargetManager(t *testing.T) {
 
 		mockService := new(mockLogsService)
 		mockService.On("CreateLogStream", mock.Anything).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil).Once()
+		mockService.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []*cloudwatchlogs.LogGroup{
+				{
+					LogGroupName:    aws.String(target.Group),
+					RetentionInDays: aws.Int64(0),
+				},
+			},
+		}, nil).Once()
 		mockService.On("PutRetentionPolicy", mock.Anything).Return(&cloudwatchlogs.PutRetentionPolicyOutput{}, nil).Once()
 
 		manager := NewTargetManager(logger, mockService)
 		err := manager.InitTarget(target)
-
 		assert.NoError(t, err)
+		// Wait for async operations to complete
+		time.Sleep(100 * time.Millisecond)
 		mockService.AssertExpectations(t)
+	})
+
+	t.Run("SetRetentionPolicy/NoChange", func(t *testing.T) {
+		target := Target{Group: "G", Stream: "S", Retention: 7}
+
+		mockService := new(mockLogsService)
+		mockService.On("CreateLogStream", mock.Anything).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil).Once()
+		mockService.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []*cloudwatchlogs.LogGroup{
+				{
+					LogGroupName:    aws.String(target.Group),
+					RetentionInDays: aws.Int64(7),
+				},
+			},
+		}, nil).Once()
+
+		manager := NewTargetManager(logger, mockService)
+		err := manager.InitTarget(target)
+		assert.NoError(t, err)
+		// Wait for async operations to complete
+		time.Sleep(100 * time.Millisecond)
+		mockService.AssertExpectations(t)
+		mockService.AssertNotCalled(t, "PutRetentionPolicy")
 	})
 
 	t.Run("SetRetentionPolicy/LogGroupNotFound", func(t *testing.T) {
@@ -84,14 +117,16 @@ func TestTargetManager(t *testing.T) {
 
 		mockService := new(mockLogsService)
 		mockService.On("CreateLogStream", mock.Anything).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil).Once()
-		mockService.On("PutRetentionPolicy", mock.Anything).
-			Return(&cloudwatchlogs.PutRetentionPolicyOutput{}, &cloudwatchlogs.ResourceNotFoundException{}).Once()
+		mockService.On("DescribeLogGroups", mock.Anything).
+			Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, &cloudwatchlogs.ResourceNotFoundException{}).Times(maxAttempts)
 
 		manager := NewTargetManager(logger, mockService)
 		err := manager.InitTarget(target)
-
 		assert.NoError(t, err) // The overall operation should still succeed even if setting retention policy fails
+		// Wait for async operations to complete
+		time.Sleep(30 * time.Second)
 		mockService.AssertExpectations(t)
+		mockService.AssertNotCalled(t, "PutRetentionPolicy")
 	})
 
 	t.Run("SetRetentionPolicy/Error", func(t *testing.T) {
@@ -99,13 +134,23 @@ func TestTargetManager(t *testing.T) {
 
 		mockService := new(mockLogsService)
 		mockService.On("CreateLogStream", mock.Anything).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil).Once()
+		mockService.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []*cloudwatchlogs.LogGroup{
+				{
+					LogGroupName:    aws.String(target.Group),
+					RetentionInDays: aws.Int64(0),
+				},
+			},
+		}, nil).Times(maxAttempts) // Should be called for each retry attempt
 		mockService.On("PutRetentionPolicy", mock.Anything).
-			Return(&cloudwatchlogs.PutRetentionPolicyOutput{}, awserr.New("SomeAWSError", "Failed to set retention policy", nil)).Once()
+			Return(&cloudwatchlogs.PutRetentionPolicyOutput{},
+				awserr.New("SomeAWSError", "Failed to set retention policy", nil)).Times(maxAttempts) // Should be called for each retry attempt
 
 		manager := NewTargetManager(logger, mockService)
 		err := manager.InitTarget(target)
-
 		assert.NoError(t, err) // The overall operation should still succeed even if setting retention policy fails
+		// Wait for async operations to complete
+		time.Sleep(30 * time.Second)
 		mockService.AssertExpectations(t)
 	})
 
@@ -148,4 +193,40 @@ func TestTargetManager(t *testing.T) {
 		wg.Wait()
 		assert.EqualValues(t, len(targets), count.Load())
 	})
+
+	t.Run("InitTarget/ZeroRetention", func(t *testing.T) {
+		target := Target{Group: "G", Stream: "S", Retention: 0}
+
+		mockService := new(mockLogsService)
+		mockService.On("CreateLogStream", mock.Anything).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil).Once()
+
+		manager := NewTargetManager(logger, mockService)
+		err := manager.InitTarget(target)
+		assert.NoError(t, err)
+
+		mockService.AssertExpectations(t)
+		mockService.AssertNotCalled(t, "DescribeLogGroups")
+		mockService.AssertNotCalled(t, "PutRetentionPolicy")
+	})
+}
+
+func TestCalculateBackoff(t *testing.T) {
+	manager := &targetManager{}
+
+	delay := manager.calculateBackoff(0)
+	etd := baseDelay + time.Duration(float64(baseDelay)*jitterFactor)
+	assert.True(t, delay >= baseDelay && delay <= etd)
+
+	delay = manager.calculateBackoff(2)
+	expectedBaseDelay := 4 * time.Second
+	etd = expectedBaseDelay + time.Duration(float64(expectedBaseDelay)*jitterFactor)
+	assert.True(t, delay >= expectedBaseDelay && delay <= etd)
+
+	// we should never exceed 30sec of total wait time
+	totalDelay := time.Duration(0)
+	for i := 0; i < maxAttempts; i++ {
+		delay := manager.calculateBackoff(i)
+		totalDelay += delay
+	}
+	assert.True(t, totalDelay <= 30*time.Second, "Total delay across all attempts should not exceed 30 seconds, but was %v", totalDelay)
 }


### PR DESCRIPTION
# Description of the issue
The agent processes PutRetentionPolicy on monitored log groups synchronously every time it restarts, which can lead to API throttling in large deployments. This throttling may cause delays in pushing logs while it is active.

# Description of changes
- Add a new goroutine in TargetManager to process PRP using a retention processing channel
- Make the retention update channel as blocking channel so no updates get dropped when it's full
- Check existing retention policy of a target using `DecribeLogGroups` then skip PRP is there is no change
- Add backoff and jittering which don't exceed max wait time of 30sec

#### Rev1
- Use `rand` when calculating jitter
- Skip DLG for newly created log groups
- Add unit tests to cover this new path
#### Rev2
- Separate channels for DLG and PRP and process them separately
- Use `seededRand` which already exists in the package for jitter
- rebase with upstream
#### Rev3
- Add missing condition in `processDescribeLogGroup`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Configure the agent to monitor 120 log groups (20 more than the default channel size). The expectation for the agent is to update retention policies on all log group for the first time, but they are skipped in subsequent agent restarts. 
```
# running the agent for the first time
[logs]# grep -irn "updating retention policy for target" amazon-cloudwatch-agent.log 
6671:2025-02-11T17:32:38Z D! [outputs.cloudwatchlogs] updating retention policy for target {DLG-Test-0 ip-[ip].us-west-2.compute.internal  30}: <nil>
6672:2025-02-11T17:32:38Z D! [outputs.cloudwatchlogs] updating retention policy for target {DLG-Test-1 ip-[ip].us-west-2.compute.internal  30}: <nil>
... (trimmed)

[logs]# grep -irn "updating retention policy for target" amazon-cloudwatch-agent.log | wc -l
120

# delete agent log file then restart the agent
[logs]# grep -irn "updating retention policy for target" amazon-cloudwatch-agent.log | wc -l
0
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




