### PR TITLE
Fix run integration tests on merge

### DIFF
--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -98,7 +98,7 @@ jobs:
 
   StartIntegrationTests:
     needs: [ BuildAndUploadPackages, BuildAndUploadITAR, BuildAndUploadCN, BuildDocker ]
-    if: ${{ inputs.test-image-before-upload }}
+    if: ${{ github.event_name == 'push' || inputs.test-image-before-upload }}
     runs-on: ubuntu-latest
     steps:
       - run: gh workflow run integration-test.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_run_id=${{ github.run_id }} -f build_sha=${{ github.sha }}
@@ -108,7 +108,7 @@ jobs:
   StartApplicationSignalsE2ETests:
     needs: [ BuildAndUploadPackages, BuildAndUploadITAR, BuildAndUploadCN, BuildDocker ]
     # Workflow only runs against main
-    if: ${{ contains(github.ref_name, 'main') && inputs.test-image-before-upload }}
+    if: ${{ contains(github.ref_name, 'main') && (github.event_name == 'push' || inputs.test-image-before-upload) }}
     runs-on: ubuntu-latest
     steps:
       - run: gh workflow run application-signals-e2e-test.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_run_id=${{ github.run_id }} -f build_sha=${{ github.sha }}


### PR DESCRIPTION
# Description of the issue
`inputs.test-image-before-upload` was added as part of https://github.com/aws/amazon-cloudwatch-agent/pull/1445 as a requirement to start the integration tests after a build. Push events will not have an `inputs` context.

# Description of changes
Update the workflow so it triggers the integration tests on merge again.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context

> `github.event_name` |	string	| The name of the event that triggered the workflow run.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




