### PR TITLE
use service name if podname doesn't follow regex

### DIFF
--- a/plugins/processors/awsapplicationsignals/internal/resolver/endpointslicewatcher.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/endpointslicewatcher.go
@@ -92,6 +92,8 @@ func (w *endpointSliceWatcher) extractEndpointSliceKeyValuePairs(slice *discv1.E
 	var pairs []kvPair
 
 	isFirstPod := true
+	svcName := slice.Labels["kubernetes.io/service-name"]
+
 	for _, endpoint := range slice.Endpoints {
 		if endpoint.TargetRef != nil {
 			if endpoint.TargetRef.Kind != "Pod" {
@@ -101,7 +103,7 @@ func (w *endpointSliceWatcher) extractEndpointSliceKeyValuePairs(slice *discv1.E
 			podName := endpoint.TargetRef.Name
 			ns := endpoint.TargetRef.Namespace
 
-			derivedWorkload := inferWorkloadName(podName)
+			derivedWorkload := inferWorkloadName(podName, svcName)
 			if derivedWorkload == "" {
 				w.logger.Warn("failed to infer workload name from Pod name", zap.String("podName", podName))
 				continue
@@ -133,7 +135,6 @@ func (w *endpointSliceWatcher) extractEndpointSliceKeyValuePairs(slice *discv1.E
 			// Build service name -> "workload@namespace" pair from the first pod
 			if isFirstPod {
 				isFirstPod = false
-				svcName := slice.Labels["kubernetes.io/service-name"]
 				if svcName != "" {
 					pairs = append(pairs, kvPair{
 						key:       svcName + "@" + ns,

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_utils_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_utils_test.go
@@ -232,24 +232,24 @@ func TestInferWorkloadName(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    string
+		service  string
 		expected string
 	}{
-		{"StatefulSet single digit", "mysql-0", "mysql"},
-		{"StatefulSet multiple digits", "mysql-10", "mysql"},
-		{"ReplicaSet bare pod", "nginx-b2dfg", "nginx"},
-		{"Deployment-based ReplicaSet pod", "nginx-76977669dc-lwx64", "nginx"},
-		{"Non matching", "simplepod", "simplepod"},
-		{"ReplicaSet name with number suffix", "nginx-123-d9stt", "nginx-123"},
-		// in this case, the correct value should be "nginx-123456", but unfortunately the workload name matching the pattern, so we will get "nginx" instead
-		// however we think it's an edge case that we have to live with because we don't have any extra info for the pod to tell us the correct workload name
-		{"Some confusing case with a replicaSet/daemonset name matching the pattern", "nginx-245678-d9stt", "nginx"},
-		{"Some confusing case with a replicaSet/daemonset name not matching the pattern", "nginx-123456-d9stt", "nginx-123456"},
-		{"Empty", "", ""},
+		{"StatefulSet single digit", "mysql-0", "service", "mysql"},
+		{"StatefulSet multiple digits", "mysql-10", "service", "mysql"},
+		{"ReplicaSet bare pod", "nginx-b2dfg", "service", "nginx"},
+		{"Deployment-based ReplicaSet pod", "nginx-76977669dc-lwx64", "service", "nginx"},
+		{"Non matching", "simplepod", "service", "service"},
+		{"ReplicaSet name with number suffix", "nginx-123-d9stt", "service", "nginx-123"},
+		{"Some confusing case with a replicaSet/daemonset name matching the pattern", "nginx-245678-d9stt", "nginx-service", "nginx"},
+		// when the regex pattern doesn't matter, we just fall back to service name to handle all the edge cases
+		{"Some confusing case with a replicaSet/daemonset name not matching the pattern", "nginx-123456-d9stt", "nginx-service", "nginx-123456"},
+		{"Empty", "", "service", "service"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := inferWorkloadName(tc.input)
+			got := inferWorkloadName(tc.input, tc.service)
 			if got != tc.expected {
 				t.Errorf("inferWorkloadName(%q) = %q; expected %q", tc.input, got, tc.expected)
 			}


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._

# Description of changes
_How does this change address the problem?_

We found an issue with the pod name parsing logic. When the deployment name is longer than 47 characters, the normal regex pattern of `<something>-<9-char>-<5-chars>` is not followed. We will get weird pod name. In this case, we will fallback to use the service name. 

Reference: 
* https://pauldally.medium.com/why-you-try-to-keep-your-deployment-names-to-47-characters-or-less-1f93a848d34c
* https://github.com/kubernetes/kubernetes/issues/116447#issuecomment-1530652258

(I know relying on regex pattern is not a good solution. But if we decide not to use list pod API, we have to accept the limitation caused by lack of detail pod info. Anyway, I think the current parse logic should handle the majority of use cases).   

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




