### PR TITLE
Only add to cache if log stream is created

### DIFF
--- a/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go
@@ -32,6 +32,7 @@ func TestTargetManager(t *testing.T) {
 
 		assert.NoError(t, err)
 		mockService.AssertExpectations(t)
+		assertCacheLen(t, manager, 1)
 	})
 
 	t.Run("CreateLogGroupAndStream", func(t *testing.T) {
@@ -48,6 +49,58 @@ func TestTargetManager(t *testing.T) {
 
 		assert.NoError(t, err)
 		mockService.AssertExpectations(t)
+		assertCacheLen(t, manager, 1)
+	})
+
+	t.Run("CreateLogGroupAndStream/GroupAlreadyExists", func(t *testing.T) {
+		target := Target{Group: "G1", Stream: "S1"}
+
+		mockService := new(mockLogsService)
+		mockService.On("CreateLogStream", mock.Anything).
+			Return(&cloudwatchlogs.CreateLogStreamOutput{}, &cloudwatchlogs.ResourceNotFoundException{}).Once()
+		mockService.On("CreateLogGroup", mock.Anything).Return(&cloudwatchlogs.CreateLogGroupOutput{}, &cloudwatchlogs.ResourceAlreadyExistsException{}).Once()
+		mockService.On("CreateLogStream", mock.Anything).Return(&cloudwatchlogs.CreateLogStreamOutput{}, nil).Once()
+
+		manager := NewTargetManager(logger, mockService)
+		err := manager.InitTarget(target)
+
+		assert.NoError(t, err)
+		mockService.AssertExpectations(t)
+		assertCacheLen(t, manager, 1)
+	})
+
+	t.Run("CreateLogGroupAndStream/RetryStreamFail", func(t *testing.T) {
+		target := Target{Group: "G1", Stream: "S1"}
+
+		mockService := new(mockLogsService)
+		mockService.On("CreateLogStream", mock.Anything).
+			Return(&cloudwatchlogs.CreateLogStreamOutput{}, &cloudwatchlogs.ResourceNotFoundException{}).Once()
+		mockService.On("CreateLogGroup", mock.Anything).Return(&cloudwatchlogs.CreateLogGroupOutput{}, &cloudwatchlogs.ResourceAlreadyExistsException{}).Once()
+		mockService.On("CreateLogStream", mock.Anything).Return(&cloudwatchlogs.CreateLogStreamOutput{}, &cloudwatchlogs.AccessDeniedException{}).Once()
+
+		manager := NewTargetManager(logger, mockService)
+		err := manager.InitTarget(target)
+
+		assert.Error(t, err)
+		mockService.AssertExpectations(t)
+		assertCacheLen(t, manager, 0)
+	})
+
+	t.Run("CreateLogGroupAndStream/RetryStreamAlreadyExists", func(t *testing.T) {
+		target := Target{Group: "G1", Stream: "S1"}
+
+		mockService := new(mockLogsService)
+		mockService.On("CreateLogStream", mock.Anything).
+			Return(&cloudwatchlogs.CreateLogStreamOutput{}, &cloudwatchlogs.ResourceNotFoundException{}).Once()
+		mockService.On("CreateLogGroup", mock.Anything).Return(&cloudwatchlogs.CreateLogGroupOutput{}, nil).Once()
+		mockService.On("CreateLogStream", mock.Anything).Return(&cloudwatchlogs.CreateLogStreamOutput{}, &cloudwatchlogs.ResourceAlreadyExistsException{}).Once()
+
+		manager := NewTargetManager(logger, mockService)
+		err := manager.InitTarget(target)
+
+		assert.NoError(t, err)
+		mockService.AssertExpectations(t)
+		assertCacheLen(t, manager, 1)
 	})
 
 	t.Run("CreateLogGroup/Error", func(t *testing.T) {
@@ -64,6 +117,7 @@ func TestTargetManager(t *testing.T) {
 
 		assert.Error(t, err)
 		mockService.AssertExpectations(t)
+		assertCacheLen(t, manager, 0)
 	})
 
 	t.Run("SetRetentionPolicy", func(t *testing.T) {
@@ -87,6 +141,7 @@ func TestTargetManager(t *testing.T) {
 		// Wait for async operations to complete
 		time.Sleep(100 * time.Millisecond)
 		mockService.AssertExpectations(t)
+		assertCacheLen(t, manager, 1)
 	})
 
 	t.Run("SetRetentionPolicy/NoChange", func(t *testing.T) {
@@ -109,6 +164,7 @@ func TestTargetManager(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		mockService.AssertExpectations(t)
 		mockService.AssertNotCalled(t, "PutRetentionPolicy")
+		assertCacheLen(t, manager, 1)
 	})
 
 	t.Run("SetRetentionPolicy/LogGroupNotFound", func(t *testing.T) {
@@ -126,6 +182,7 @@ func TestTargetManager(t *testing.T) {
 		time.Sleep(30 * time.Second)
 		mockService.AssertExpectations(t)
 		mockService.AssertNotCalled(t, "PutRetentionPolicy")
+		assertCacheLen(t, manager, 1)
 	})
 
 	t.Run("SetRetentionPolicy/Error", func(t *testing.T) {
@@ -151,6 +208,7 @@ func TestTargetManager(t *testing.T) {
 		assert.NoError(t, err)
 		time.Sleep(30 * time.Second)
 		mockService.AssertExpectations(t)
+		assertCacheLen(t, manager, 1)
 	})
 
 	t.Run("SetRetentionPolicy/Negative", func(t *testing.T) {
@@ -162,6 +220,7 @@ func TestTargetManager(t *testing.T) {
 		manager.PutRetentionPolicy(target)
 
 		mockService.AssertNotCalled(t, "PutRetentionPolicy", mock.Anything)
+		assertCacheLen(t, manager, 0)
 	})
 
 	t.Run("ConcurrentInit", func(t *testing.T) {
@@ -191,6 +250,7 @@ func TestTargetManager(t *testing.T) {
 
 		wg.Wait()
 		assert.EqualValues(t, len(targets), count.Load())
+		assertCacheLen(t, manager, 2)
 	})
 
 	t.Run("InitTarget/ZeroRetention", func(t *testing.T) {
@@ -206,6 +266,7 @@ func TestTargetManager(t *testing.T) {
 		mockService.AssertExpectations(t)
 		mockService.AssertNotCalled(t, "DescribeLogGroups")
 		mockService.AssertNotCalled(t, "PutRetentionPolicy")
+		assertCacheLen(t, manager, 1)
 	})
 
 	t.Run("NewLogGroup/SetRetention", func(t *testing.T) {
@@ -228,6 +289,7 @@ func TestTargetManager(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		mockService.AssertExpectations(t)
 		mockService.AssertNotCalled(t, "DescribeLogGroups")
+		assertCacheLen(t, manager, 1)
 	})
 
 	t.Run("NewLogGroup/RetentionError", func(t *testing.T) {
@@ -249,6 +311,7 @@ func TestTargetManager(t *testing.T) {
 
 		mockService.AssertExpectations(t)
 		mockService.AssertNotCalled(t, "DescribeLogGroups")
+		assertCacheLen(t, manager, 1)
 	})
 }
 
@@ -261,4 +324,12 @@ func TestCalculateBackoff(t *testing.T) {
 		totalDelay += delay
 	}
 	assert.True(t, totalDelay <= 30*time.Second, "Total delay across all attempts should not exceed 30 seconds, but was %v", totalDelay)
+}
+
+func assertCacheLen(t *testing.T, manager TargetManager, count int) {
+	t.Helper()
+	tm := manager.(*targetManager)
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	assert.Len(t, tm.cache, count)
 }


### PR DESCRIPTION
Same change as https://github.com/aws/amazon-cloudwatch-agent/pull/1566

# Description of the issue
If there are multiple instances of the CloudWatch agent that are trying to create the same log group, there are cases where streams within those log groups will not be created because `CreateLogGroup` returns `ResourceAlreadyExists`.

https://github.com/aws/amazon-cloudwatch-agent/blob/af960d73a8df75ed2d23b53f34a5813727829018/plugins/outputs/cloudwatchlogs/internal/pusher/target.go#L72

# Description of changes
Resource already exists shouldn't be considered a failure to create the resource. Only add the target to the cache if the log stream was created or already exists.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added more unit test cases to cover the issue. Added checks for cache sizes after each test.

```
=== RUN   TestTargetManager/CreateLogGroupAndStream
=== RUN   TestTargetManager/CreateLogGroupAndStream/GroupAlreadyExists
=== RUN   TestTargetManager/CreateLogGroupAndStream/RetryStreamFail
=== RUN   TestTargetManager/CreateLogGroupAndStream/RetryStreamAlreadyExists
    --- PASS: TestTargetManager/CreateLogGroupAndStream (0.00s)
    --- PASS: TestTargetManager/CreateLogGroupAndStream/GroupAlreadyExists (0.00s)
    --- PASS: TestTargetManager/CreateLogGroupAndStream/RetryStreamFail (0.00s)
    --- PASS: TestTargetManager/CreateLogGroupAndStream/RetryStreamAlreadyExists (0.00s)
```

Added tests run before changes
```
=== RUN   TestTargetManager/CreateLogGroupAndStream
    --- PASS: TestTargetManager/CreateLogGroupAndStream (0.00s)
=== RUN   TestTargetManager/CreateLogGroupAndStream/GroupAlreadyExists
    target_test.go:68: FAIL:	CreateLogStream(string)
        		at: [/Volumes/workplace/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go:62]
    target_test.go:68: FAIL: 2 out of 3 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/Volumes/workplace/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go:68]
    --- FAIL: TestTargetManager/CreateLogGroupAndStream/GroupAlreadyExists (0.00s)

=== RUN   TestTargetManager/CreateLogGroupAndStream/RetryStreamFail
    target_test.go:84: 
        	Error Trace:	/Volumes/workplace/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go:84
        	Error:      	An error is expected but got nil.
        	Test:       	TestTargetManager/CreateLogGroupAndStream/RetryStreamFail
    target_test.go:85: FAIL:	CreateLogStream(string)
        		at: [/Volumes/workplace/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go:79]
    target_test.go:85: FAIL: 2 out of 3 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/Volumes/workplace/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go:85]
    target_test.go:86: 
        	Error Trace:	/Volumes/workplace/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go:334
        	            				/Volumes/workplace/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/internal/pusher/target_test.go:86
        	Error:      	"map[{G1 S1  0}:{}]" should have 0 item(s), but has 1
        	Test:       	TestTargetManager/CreateLogGroupAndStream/RetryStreamFail
    --- FAIL: TestTargetManager/CreateLogGroupAndStream/RetryStreamFail (0.00s)

=== RUN   TestTargetManager/CreateLogGroupAndStream/RetryStreamAlreadyExists
    --- PASS: TestTargetManager/CreateLogGroupAndStream/RetryStreamAlreadyExists (0.00s)
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`