### PR TITLE
Fix the StopLocalStackCN job

### DIFF
--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -626,7 +626,7 @@ jobs:
   StopLocalStackCN:
     name: 'StopLocalStackCN'
     if: ${{ always() && needs.StartLocalStackCN.result == 'success' }}
-    needs: [ StartLocalStackCN, EC2LinuxIntegrationTestCN ]
+    needs: [ StartLocalStackCN, EC2LinuxIntegrationTestCN, OutputEnvVariables]
     uses: ./.github/workflows/stop-localstack.yml
     secrets: inherit
     permissions:


### PR DESCRIPTION
# Description of the issue
The `StopLocalStackCN` job consistently fails

Example: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/12834512020/job/35934901829

# Description of changes
Add OutputEnvVariables job as dependency for `StopLocalStackCN`. This matches what we have for `StopLocalStack` and `StopLocalStackITAR`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
Integration Test: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13658401201/job/38188807290

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh` ✅ 
2. Run `make lint` ✅ 




