### PR TITLE
Update Workflow Job Names for Clarity

### DIFF
--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -43,7 +43,7 @@ on:
 
 jobs:
   EC2IntegrationTest:
-    name: 'Test'
+    name: ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,7 @@ env:
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_BRANCH: "add-test-name"
   TERRAFORM_AWS_ASSUME_ROLE_ITAR: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_ITAR }}
   S3_INTEGRATION_BUCKET_ITAR: ${{ vars.S3_INTEGRATION_BUCKET_ITAR }}
   TERRAFORM_AWS_ASSUME_ROLE_CN: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,7 @@ env:
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "add-test-name"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
   TERRAFORM_AWS_ASSUME_ROLE_ITAR: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_ITAR }}
   S3_INTEGRATION_BUCKET_ITAR: ${{ vars.S3_INTEGRATION_BUCKET_ITAR }}
   TERRAFORM_AWS_ASSUME_ROLE_CN: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -13,7 +13,7 @@ env:
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH:  "add-test-name"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
   TERRAFORM_AWS_ASSUME_ROLE_ITAR: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_ITAR }}
   S3_INTEGRATION_BUCKET_ITAR: ${{ vars.S3_INTEGRATION_BUCKET_ITAR }}
   TERRAFORM_AWS_ASSUME_ROLE_CN: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -249,7 +249,7 @@ jobs:
 
   EC2NvidiaGPUIntegrationTest:
     needs: [ StartLocalStack, GenerateTestMatrix, OutputEnvVariables ]
-    name: 'EC2NVIDIAGPUIntegrationTest'
+    name: ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -435,7 +435,7 @@ jobs:
 
   EC2WinIntegrationTest:
     needs: [OutputEnvVariables, GenerateTestMatrix]
-    name: 'EC2Win ' +  ${{matrix.arrays.testName}}
+    name:  ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -513,7 +513,7 @@ jobs:
 
   EC2DarwinIntegrationTest:
     needs: [GenerateTestMatrix, OutputEnvVariables]
-    name: 'EC2Darwin ' + ${{matrix.arrays.testName}}
+    name: ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -641,7 +641,7 @@ jobs:
       s3_integration_bucket: ${{ vars.S3_INTEGRATION_BUCKET_CN }}
 
   ECSEC2IntegrationTest:
-    name: 'ECSEC2 ' + ${{matrix.arrays.testName}}
+    name: ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     strategy:
@@ -717,7 +717,7 @@ jobs:
             terraform destroy --auto-approve
 
   ECSFargateIntegrationTest:
-    name: 'ECSFargate' + ${{matrix.arrays.testName}}
+    name: ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     needs: [GenerateTestMatrix, OutputEnvVariables]
     strategy:
@@ -788,7 +788,7 @@ jobs:
             terraform destroy --auto-approve
 
   EKSIntegrationTest:
-    name: 'EKS ' + ${{matrix.arrays.testName}}
+    name: ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     strategy:
@@ -863,7 +863,7 @@ jobs:
             terraform destroy --auto-approve
 
   EKSPrometheusIntegrationTest:
-    name: 'EKSPrometheus ' + ${{matrix.arrays.testName}}
+    name: ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     strategy:
@@ -1189,7 +1189,7 @@ jobs:
           command: cd terraform/stress && terraform destroy --auto-approve
 
   GPUEndToEndTest:
-    name: "GPU E2E Test " + ${{matrix.arrays.testName}}
+    name:  ${{matrix.arrays.testName}}
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -13,7 +13,7 @@ env:
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_BRANCH:  "add-test-name"
   TERRAFORM_AWS_ASSUME_ROLE_ITAR: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_ITAR }}
   S3_INTEGRATION_BUCKET_ITAR: ${{ vars.S3_INTEGRATION_BUCKET_ITAR }}
   TERRAFORM_AWS_ASSUME_ROLE_CN: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -435,7 +435,7 @@ jobs:
 
   EC2WinIntegrationTest:
     needs: [OutputEnvVariables, GenerateTestMatrix]
-    name: 'EC2WinIntegrationTest'
+    name: 'EC2Win ' +  ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -513,7 +513,7 @@ jobs:
 
   EC2DarwinIntegrationTest:
     needs: [GenerateTestMatrix, OutputEnvVariables]
-    name: 'EC2DarwinIntegrationTest'
+    name: 'EC2Darwin ' + ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -641,7 +641,7 @@ jobs:
       s3_integration_bucket: ${{ vars.S3_INTEGRATION_BUCKET_CN }}
 
   ECSEC2IntegrationTest:
-    name: 'ECSEC2IntegrationTest'
+    name: 'ECSEC2 ' + ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     strategy:
@@ -717,7 +717,7 @@ jobs:
             terraform destroy --auto-approve
 
   ECSFargateIntegrationTest:
-    name: 'ECSFargateIntegrationTest'
+    name: 'ECSFargate' + ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     needs: [GenerateTestMatrix, OutputEnvVariables]
     strategy:
@@ -788,7 +788,7 @@ jobs:
             terraform destroy --auto-approve
 
   EKSIntegrationTest:
-    name: 'EKSIntegrationTest'
+    name: 'EKS ' + ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     strategy:
@@ -863,7 +863,7 @@ jobs:
             terraform destroy --auto-approve
 
   EKSPrometheusIntegrationTest:
-    name: 'EKSPrometheusIntegrationTest'
+    name: 'EKSPrometheus ' + ${{matrix.arrays.testName}}
     runs-on: ubuntu-latest
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     strategy:
@@ -936,7 +936,7 @@ jobs:
             terraform destroy --auto-approve
 
   PerformanceTrackingTest:
-    name: "PerformanceTrackingTest"
+    name: ${{matrix.arrays.testName}}
     needs: [GenerateTestMatrix, OutputEnvVariables]
     runs-on: ubuntu-latest
     strategy:
@@ -998,7 +998,7 @@ jobs:
           command: cd terraform/performance && terraform destroy --auto-approve
 
   EC2WinPerformanceTest:
-    name: "EC2WinPerformanceTest"
+    name: ${{matrix.arrays.testName}}
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     runs-on: ubuntu-latest
     strategy:
@@ -1060,7 +1060,7 @@ jobs:
           command: cd terraform/performance && terraform destroy --auto-approve
 
   StressTrackingTest:
-    name: "StressTrackingTest"
+    name: ${{matrix.arrays.testName}}
     needs: [GenerateTestMatrix, OutputEnvVariables ]
     runs-on: ubuntu-latest
     strategy:
@@ -1124,7 +1124,7 @@ jobs:
           command: cd terraform/stress && terraform destroy --auto-approve
 
   EC2WinStressTrackingTest:
-    name: "EC2WinStressTrackingTest"
+    name: ${{matrix.arrays.testName}}
     needs: [GenerateTestMatrix, OutputEnvVariables]
     runs-on: ubuntu-latest
     strategy:
@@ -1189,7 +1189,7 @@ jobs:
           command: cd terraform/stress && terraform destroy --auto-approve
 
   GPUEndToEndTest:
-    name: "GPU E2E Test"
+    name: "GPU E2E Test " + ${{matrix.arrays.testName}}
     needs: [ GenerateTestMatrix, OutputEnvVariables ]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
# Description of the issue
The current workflow job names are hardcoded above the character limit actions, making it difficult to identify individual test runs easily. This can lead to confusion when reviewing test results and logs.

# Description of changes
This change updates the job names in the workflow files to use dynamic names from the test matrix array (`${{matrix.arrays.testName}}`). This will allow each test to have a unique and descriptive name, improving clarity and traceability.
Needs: https://github.com/aws/amazon-cloudwatch-agent-test/pull/474

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
The following tests have been conducted:
- Verified that the workflow files successfully parse with the updated job names.
- Ensured that the jobs run correctly with dynamic names in a test environment.
- Test Run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13663515237
# Requirements
Before committing the code, please do the following steps:
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`