### PR TITLE
fixed the issue with endpointSliceUpdate handle in application signals

### DIFF
--- a/plugins/processors/awsapplicationsignals/internal/resolver/endpointslicewatcher.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/endpointslicewatcher.go
@@ -64,7 +64,7 @@ func (w *endpointSliceWatcher) Run(stopCh chan struct{}) {
 			w.handleSliceAdd(obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			w.handleSliceUpdate(newObj, oldObj)
+			w.handleSliceUpdate(oldObj, newObj)
 		},
 		DeleteFunc: func(obj interface{}) {
 			w.handleSliceDelete(obj)


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._
In the case when application signals is enabled, when the application pod restarts, the endpointSliceWatcher handleSliceUpdate function is passing the arguments in reverse order. This could mess the ipToWorkload and serviceToWorkload mapping used for generating the corresponding workload for appsignal metrics and traces

# Description of changes
_How does this change address the problem?_
Corrected the order to send arguments

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
Validated with OTLP custom metrics entity change using the same endpointslice watcher.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




