### PR TITLE
Added Security Group Clean Up Script

### DIFF
--- a/.github/workflows/clean-aws-resources.yml
+++ b/.github/workflows/clean-aws-resources.yml
@@ -288,3 +288,21 @@ jobs:
       - name: Clean old Log Groups
         working-directory: tool/clean
         run: go run ./clean_log_group/clean_log_group.go 
+  clean-security-groups:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Clean Old Security Groups
+        working-directory: tool/clean
+        run: go run ./clean_security_ygroup/clean_security_group.go

--- a/.github/workflows/clean-aws-resources.yml
+++ b/.github/workflows/clean-aws-resources.yml
@@ -305,4 +305,7 @@ jobs:
 
       - name: Clean Old Security Groups
         working-directory: tool/clean
-        run: go run ./clean_security_group/clean_security_group.go
+        run: |
+          set -e
+          go run ./clean_security_group/clean_security_group.go || { echo "Failed to clean security groups"; exit 1; }
+

--- a/.github/workflows/clean-aws-resources.yml
+++ b/.github/workflows/clean-aws-resources.yml
@@ -305,4 +305,4 @@ jobs:
 
       - name: Clean Old Security Groups
         working-directory: tool/clean
-        run: go run ./clean_security_ygroup/clean_security_group.go
+        run: go run ./clean_security_group/clean_security_group.go

--- a/tool/clean/clean_security_group/clean_security_group.go
+++ b/tool/clean/clean_security_group/clean_security_group.go
@@ -1,0 +1,395 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
+)
+
+type ec2Client interface {
+	DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+	DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error)
+	DeleteSecurityGroup(ctx context.Context, params *ec2.DeleteSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)
+	RevokeSecurityGroupIngress(ctx context.Context, params *ec2.RevokeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	RevokeSecurityGroupEgress(ctx context.Context, params *ec2.RevokeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error)
+}
+
+const (
+	SecurityGroupProcessChanSize = 500
+)
+
+// Config holds the application configuration
+type Config struct {
+	ageThreshold    time.Duration
+	numWorkers      int
+	deleteBatchCap  int
+	exceptionList   []string
+	dryRun          bool
+	skipVpcSGs      bool
+	skipWithRules   bool
+}
+
+// Global configuration
+var (
+	cfg Config
+)
+
+func init() {
+	// Set default configuration
+	cfg = Config{
+		ageThreshold:   3 * clean.KeepDurationOneDay,
+		numWorkers:     30,
+		exceptionList:  []string{"default"},
+		dryRun:         true,
+		skipVpcSGs:     false,
+		skipWithRules:  false,
+	}
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	
+	// Parse command line flags
+	flag.BoolVar(&cfg.dryRun, "dry-run", true, "Enable dry-run mode (no actual deletion)")
+	flag.DurationVar(&cfg.ageThreshold, "age", 3*clean.KeepDurationOneDay, "Age threshold for security groups (e.g. 72h)")
+	flag.BoolVar(&cfg.skipVpcSGs, "skip-vpc", false, "Skip security groups associated with VPCs")
+	flag.BoolVar(&cfg.skipWithRules, "skip-with-rules", false, "Skip security groups that have ingress or egress rules")
+	flag.Parse()
+	
+	// Load AWS configuration
+	awsCfg, err := loadAWSConfig(ctx)
+	if err != nil {
+		log.Fatalf("Error loading AWS config: %v", err)
+	}
+
+	// Create EC2 client
+	client := ec2.NewFromConfig(awsCfg)
+
+	log.Printf("🔍 Searching for unused Security Groups older than %v in %s region\n",
+		cfg.ageThreshold, awsCfg.Region)
+
+	// Delete old security groups
+	deletedGroups := deleteUnusedSecurityGroups(ctx, client)
+	log.Printf("Total security groups deleted: %d", len(deletedGroups))
+}
+
+func loadAWSConfig(ctx context.Context) (aws.Config, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("loading AWS config: %w", err)
+	}
+	cfg.RetryMode = aws.RetryModeAdaptive
+	return cfg, nil
+}
+
+func deleteUnusedSecurityGroups(ctx context.Context, client ec2Client) []string {
+	var (
+		wg                      sync.WaitGroup
+		deletedSecurityGroups   []string
+		foundSecurityGroupChan  = make(chan types.SecurityGroup, SecurityGroupProcessChanSize)
+		deletedSecurityGroupChan = make(chan string, SecurityGroupProcessChanSize)
+		handlerWg               sync.WaitGroup
+	)
+
+	// Start worker pool
+	log.Printf("👷 Creating %d workers\n", cfg.numWorkers)
+	for i := 0; i < cfg.numWorkers; i++ {
+		wg.Add(1)
+		w := worker{
+			id:                      i,
+			wg:                      &wg,
+			incomingSecurityGroupChan: foundSecurityGroupChan,
+			deletedSecurityGroupChan:  deletedSecurityGroupChan,
+		}
+		go w.processSecurityGroup(ctx, client)
+	}
+
+	// Start handler with its own WaitGroup
+	handlerWg.Add(1)
+	go func() {
+		handleDeletedSecurityGroups(&deletedSecurityGroups, deletedSecurityGroupChan)
+		handlerWg.Done()
+	}()
+
+	// Process security groups in batches
+	if err := fetchAndProcessSecurityGroups(ctx, client, foundSecurityGroupChan); err != nil {
+		log.Printf("Error processing security groups: %v", err)
+	}
+
+	close(foundSecurityGroupChan)
+	wg.Wait()
+	close(deletedSecurityGroupChan)
+	handlerWg.Wait()
+
+	return deletedSecurityGroups
+}
+
+func handleDeletedSecurityGroups(deletedSecurityGroups *[]string, deletedSecurityGroupChan chan string) {
+	for securityGroupId := range deletedSecurityGroupChan {
+		*deletedSecurityGroups = append(*deletedSecurityGroups, securityGroupId)
+		log.Printf("🔍 Processed %d security groups so far\n", len(*deletedSecurityGroups))
+	}
+}
+
+type worker struct {
+	id                        int
+	wg                        *sync.WaitGroup
+	incomingSecurityGroupChan <-chan types.SecurityGroup
+	deletedSecurityGroupChan  chan<- string
+}
+
+func (w *worker) processSecurityGroup(ctx context.Context, client ec2Client) {
+	defer w.wg.Done()
+
+	for securityGroup := range w.incomingSecurityGroupChan {
+		if err := w.handleSecurityGroup(ctx, client, securityGroup); err != nil {
+			log.Printf("Worker %d: Error processing security group: %v", w.id, err)
+		}
+	}
+}
+
+func (w *worker) handleSecurityGroup(ctx context.Context, client ec2Client, securityGroup types.SecurityGroup) error {
+	sgID := *securityGroup.GroupId
+	sgName := *securityGroup.GroupName
+	
+	// Skip default security groups
+	if isDefaultSecurityGroup(securityGroup) {
+		log.Printf("⏭️ Worker %d: Skipping default security group: %s (%s)", w.id, sgID, sgName)
+		return nil
+	}
+	
+	// Skip security groups in exception list
+	if isSecurityGroupException(securityGroup) {
+		log.Printf("⏭️ Worker %d: Skipping security group in exception list: %s (%s)", w.id, sgID, sgName)
+		return nil
+	}
+	
+	// Check if security group is in use
+	isInUse, err := isSecurityGroupInUse(ctx, client, sgID)
+	if err != nil {
+		return fmt.Errorf("checking if security group is in use: %w", err)
+	}
+	
+	if isInUse {
+		log.Printf("⏭️ Worker %d: Security group is in use: %s (%s)", w.id, sgID, sgName)
+		return nil
+	}
+	
+	// Check if security group has rules and we're configured to skip those
+	if cfg.skipWithRules && hasRules(securityGroup) {
+		log.Printf("⏭️ Worker %d: Skipping security group with rules: %s (%s)", w.id, sgID, sgName)
+		return nil
+	}
+	
+	log.Printf("🚨 Worker %d: Found unused security group: %s (%s)", w.id, sgID, sgName)
+	
+	// Clean up any rules before deletion
+	if hasRules(securityGroup) {
+		if err := cleanSecurityGroupRules(ctx, client, securityGroup); err != nil {
+			return fmt.Errorf("cleaning security group rules: %w", err)
+		}
+	}
+	
+	w.deletedSecurityGroupChan <- sgID
+	
+	if cfg.dryRun {
+		log.Printf("🛑 Dry-Run: Would delete security group: %s (%s)", sgID, sgName)
+		return nil
+	}
+	
+	return deleteSecurityGroup(ctx, client, sgID)
+}
+
+func deleteSecurityGroup(ctx context.Context, client ec2Client, securityGroupID string) error {
+	_, err := client.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{
+		GroupId: aws.String(securityGroupID),
+	})
+	if err != nil {
+		return fmt.Errorf("deleting security group %s: %w", securityGroupID, err)
+	}
+	log.Printf("✅ Deleted security group: %s", securityGroupID)
+	return nil
+}
+
+func cleanSecurityGroupRules(ctx context.Context, client ec2Client, securityGroup types.SecurityGroup) error {
+	sgID := *securityGroup.GroupId
+	
+	// Clean ingress rules if any exist
+	if len(securityGroup.IpPermissions) > 0 {
+		if cfg.dryRun {
+			log.Printf("🛑 Dry-Run: Would revoke %d ingress rules from security group: %s", 
+				len(securityGroup.IpPermissions), sgID)
+		} else {
+			// Use a different approach - describe the security group first to get fresh rules
+			describeOutput, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+				GroupIds: []string{sgID},
+			})
+			if err != nil {
+				log.Printf("⚠️ Warning: Failed to describe security group %s: %v", sgID, err)
+				return nil // Continue with deletion anyway
+			}
+			
+			if len(describeOutput.SecurityGroups) > 0 && len(describeOutput.SecurityGroups[0].IpPermissions) > 0 {
+				_, err := client.RevokeSecurityGroupIngress(ctx, &ec2.RevokeSecurityGroupIngressInput{
+					GroupId:       aws.String(sgID),
+					IpPermissions: describeOutput.SecurityGroups[0].IpPermissions,
+				})
+				if err != nil {
+					log.Printf("⚠️ Warning: Failed to revoke ingress rules for security group %s: %v", sgID, err)
+					// Continue with deletion anyway
+				} else {
+					log.Printf("✅ Revoked ingress rules from security group: %s", sgID)
+				}
+			}
+		}
+	}
+	
+	// Clean egress rules if any exist
+	if len(securityGroup.IpPermissionsEgress) > 0 {
+		if cfg.dryRun {
+			log.Printf("🛑 Dry-Run: Would revoke %d egress rules from security group: %s", 
+				len(securityGroup.IpPermissionsEgress), sgID)
+		} else {
+			// Use a different approach - describe the security group first to get fresh rules
+			describeOutput, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+				GroupIds: []string{sgID},
+			})
+			if err != nil {
+				log.Printf("⚠️ Warning: Failed to describe security group %s: %v", sgID, err)
+				return nil // Continue with deletion anyway
+			}
+			
+			if len(describeOutput.SecurityGroups) > 0 && len(describeOutput.SecurityGroups[0].IpPermissionsEgress) > 0 {
+				_, err := client.RevokeSecurityGroupEgress(ctx, &ec2.RevokeSecurityGroupEgressInput{
+					GroupId:       aws.String(sgID),
+					IpPermissions: describeOutput.SecurityGroups[0].IpPermissionsEgress,
+				})
+				if err != nil {
+					log.Printf("⚠️ Warning: Failed to revoke egress rules for security group %s: %v", sgID, err)
+					// Continue with deletion anyway
+				} else {
+					log.Printf("✅ Revoked egress rules from security group: %s", sgID)
+				}
+			}
+		}
+	}
+	
+	return nil
+}
+
+func fetchAndProcessSecurityGroups(ctx context.Context, client ec2Client,
+	securityGroupChan chan<- types.SecurityGroup) error {
+
+	var nextToken *string
+	describeCount := 0
+
+	for {
+		output, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("describing security groups: %w", err)
+		}
+
+		log.Printf("🔍 Described %d times | Found %d security groups\n", describeCount, len(output.SecurityGroups))
+
+		for _, securityGroup := range output.SecurityGroups {
+			securityGroupChan <- securityGroup
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		nextToken = output.NextToken
+		describeCount++
+	}
+
+	return nil
+}
+
+func isSecurityGroupInUse(ctx context.Context, client ec2Client, securityGroupID string) (bool, error) {
+	// Check if security group is attached to any network interfaces
+	output, err := client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("group-id"),
+				Values: []string{securityGroupID},
+			},
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("describing network interfaces: %w", err)
+	}
+	
+	if len(output.NetworkInterfaces) > 0 {
+		return true, nil
+	}
+	
+	// Check if security group is referenced by other security groups
+	sgOutput, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{})
+	if err != nil {
+		return false, fmt.Errorf("describing security groups: %w", err)
+	}
+	
+	// Check if this security group is referenced in any other security group's rules
+	for _, sg := range sgOutput.SecurityGroups {
+		// Skip self-references
+		if *sg.GroupId == securityGroupID {
+			continue
+		}
+		
+		// Check ingress rules
+		for _, permission := range sg.IpPermissions {
+			for _, userIdGroupPair := range permission.UserIdGroupPairs {
+				if userIdGroupPair.GroupId != nil && *userIdGroupPair.GroupId == securityGroupID {
+					return true, nil
+				}
+			}
+		}
+		
+		// Check egress rules
+		for _, permission := range sg.IpPermissionsEgress {
+			for _, userIdGroupPair := range permission.UserIdGroupPairs {
+				if userIdGroupPair.GroupId != nil && *userIdGroupPair.GroupId == securityGroupID {
+					return true, nil
+				}
+			}
+		}
+	}
+	
+	return false, nil
+}
+
+func isDefaultSecurityGroup(securityGroup types.SecurityGroup) bool {
+	return *securityGroup.GroupName == "default"
+}
+
+func isSecurityGroupException(securityGroup types.SecurityGroup) bool {
+	sgName := *securityGroup.GroupName
+	for _, exception := range cfg.exceptionList {
+		if strings.Contains(sgName, exception) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRules(securityGroup types.SecurityGroup) bool {
+	return len(securityGroup.IpPermissions) > 0 || len(securityGroup.IpPermissionsEgress) > 0
+}

--- a/tool/clean/clean_security_group/clean_security_group.go
+++ b/tool/clean/clean_security_group/clean_security_group.go
@@ -84,6 +84,9 @@ func main() {
 
 	// Delete old security groups
 	deletedGroups, err := deleteUnusedSecurityGroups(ctx, client)
+	if err != nil {
+		log.Printf("Error deleting security groups: %v", err)
+	}
 	log.Printf("Total security groups deleted: %d", len(deletedGroups))
 }
 
@@ -96,7 +99,7 @@ func loadAWSConfig(ctx context.Context) (aws.Config, error) {
 	return cfg, nil
 }
 
-func deleteUnusedSecurityGroups(ctx context.Context, client ec2Client) ([]string,error) {
+func deleteUnusedSecurityGroups(ctx context.Context, client ec2Client) ([]string, error) {
 	var (
 		wg                       sync.WaitGroup
 		deletedSecurityGroups    []string
@@ -136,7 +139,7 @@ func deleteUnusedSecurityGroups(ctx context.Context, client ec2Client) ([]string
 	close(deletedSecurityGroupChan)
 	handlerWg.Wait()
 
-	return deletedSecurityGroups,nil
+	return deletedSecurityGroups, nil
 }
 
 func handleDeletedSecurityGroups(deletedSecurityGroups *[]string, deletedSecurityGroupChan chan string) {

--- a/tool/clean/clean_security_group/clean_security_group.go
+++ b/tool/clean/clean_security_group/clean_security_group.go
@@ -50,8 +50,8 @@ var (
 func init() {
 	// Set default configuration
 	cfg = Config{
-		ageThreshold:  3 * clean.KeepDurationOneDay,
-		numWorkers:    30,
+		ageThreshold:  1 * clean.KeepDurationOneDay,
+		numWorkers:    10,
 		exceptionList: []string{"default"},
 		dryRun:        true,
 		skipVpcSGs:    false,
@@ -60,7 +60,7 @@ func init() {
 }
 
 func main() {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer cancel()
 
 	// Parse command line flags

--- a/tool/clean/clean_security_group/clean_security_group.go
+++ b/tool/clean/clean_security_group/clean_security_group.go
@@ -60,7 +60,7 @@ func init() {
 }
 
 func main() {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	// Parse command line flags

--- a/tool/clean/clean_security_group/clean_security_group.go
+++ b/tool/clean/clean_security_group/clean_security_group.go
@@ -51,7 +51,7 @@ func init() {
 	// Set default configuration
 	cfg = Config{
 		ageThreshold:  1 * clean.KeepDurationOneDay,
-		numWorkers:    10,
+		numWorkers:    30,
 		exceptionList: []string{"default"},
 		dryRun:        true,
 		skipVpcSGs:    false,
@@ -65,7 +65,7 @@ func main() {
 
 	// Parse command line flags
 	flag.BoolVar(&cfg.dryRun, "dry-run", true, "Enable dry-run mode (no actual deletion)")
-	flag.DurationVar(&cfg.ageThreshold, "age", 3*clean.KeepDurationOneDay, "Age threshold for security groups (e.g. 72h)")
+	flag.DurationVar(&cfg.ageThreshold, "age", 1*clean.KeepDurationOneDay, "Age threshold for security groups (e.g. 24h)")
 	flag.BoolVar(&cfg.skipVpcSGs, "skip-vpc", false, "Skip security groups associated with VPCs")
 	flag.BoolVar(&cfg.skipWithRules, "skip-with-rules", false, "Skip security groups that have ingress or egress rules")
 	flag.Parse()

--- a/tool/clean/clean_security_group/clean_security_group_test.go
+++ b/tool/clean/clean_security_group/clean_security_group_test.go
@@ -1,0 +1,280 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"testing"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// Mock EC2 client for testing
+type mockEC2Client struct {
+	describeSecurityGroupsOutput *ec2.DescribeSecurityGroupsOutput
+	describeNetworkInterfacesOutput *ec2.DescribeNetworkInterfacesOutput
+	deleteSecurityGroupCalled bool
+	deleteSecurityGroupInput *ec2.DeleteSecurityGroupInput
+	revokeIngressCalled bool
+	revokeEgressCalled bool
+}
+
+func (m *mockEC2Client) DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return m.describeSecurityGroupsOutput, nil
+}
+
+func (m *mockEC2Client) DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	return m.describeNetworkInterfacesOutput, nil
+}
+
+func (m *mockEC2Client) DeleteSecurityGroup(ctx context.Context, params *ec2.DeleteSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error) {
+	m.deleteSecurityGroupCalled = true
+	m.deleteSecurityGroupInput = params
+	return &ec2.DeleteSecurityGroupOutput{}, nil
+}
+
+func (m *mockEC2Client) RevokeSecurityGroupIngress(ctx context.Context, params *ec2.RevokeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	m.revokeIngressCalled = true
+	return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+}
+
+func (m *mockEC2Client) RevokeSecurityGroupEgress(ctx context.Context, params *ec2.RevokeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	m.revokeEgressCalled = true
+	return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+}
+
+func TestIsDefaultSecurityGroup(t *testing.T) {
+	tests := []struct {
+		name          string
+		securityGroup types.SecurityGroup
+		expected      bool
+	}{
+		{
+			name: "Default security group",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-12345"),
+				GroupName: aws.String("default"),
+			},
+			expected: true,
+		},
+		{
+			name: "Non-default security group",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-67890"),
+				GroupName: aws.String("my-security-group"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDefaultSecurityGroup(tt.securityGroup)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsSecurityGroupException(t *testing.T) {
+	// Set up test exception list
+	cfg.exceptionList = []string{"default", "special"}
+
+	tests := []struct {
+		name          string
+		securityGroup types.SecurityGroup
+		expected      bool
+	}{
+		{
+			name: "Security group in exception list",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-12345"),
+				GroupName: aws.String("special-group"),
+			},
+			expected: true,
+		},
+		{
+			name: "Security group not in exception list",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-67890"),
+				GroupName: aws.String("my-security-group"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSecurityGroupException(tt.securityGroup)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasRules(t *testing.T) {
+	tests := []struct {
+		name          string
+		securityGroup types.SecurityGroup
+		expected      bool
+	}{
+		{
+			name: "Security group with ingress rules",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-12345"),
+				GroupName: aws.String("test-group"),
+				IpPermissions: []types.IpPermission{
+					{
+						IpProtocol: aws.String("tcp"),
+						FromPort:   aws.Int32(22),
+						ToPort:     aws.Int32(22),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Security group with egress rules",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-67890"),
+				GroupName: aws.String("test-group"),
+				IpPermissionsEgress: []types.IpPermission{
+					{
+						IpProtocol: aws.String("-1"),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Security group with no rules",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-abcde"),
+				GroupName: aws.String("test-group"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasRules(tt.securityGroup)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHandleSecurityGroup(t *testing.T) {
+	// Save original dry run setting and restore after test
+	originalDryRun := cfg.dryRun
+	defer func() { cfg.dryRun = originalDryRun }()
+
+	tests := []struct {
+		name                string
+		securityGroup       types.SecurityGroup
+		dryRun              bool
+		hasNetworkInterfaces bool
+		expectDelete        bool
+		expectRevokeRules   bool
+	}{
+		{
+			name: "Default security group - should not delete",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-12345"),
+				GroupName: aws.String("default"),
+			},
+			dryRun:              false,
+			hasNetworkInterfaces: false,
+			expectDelete:        false,
+			expectRevokeRules:   false,
+		},
+		{
+			name: "Security group with network interfaces - should not delete",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-67890"),
+				GroupName: aws.String("test-group"),
+			},
+			dryRun:              false,
+			hasNetworkInterfaces: true,
+			expectDelete:        false,
+			expectRevokeRules:   false,
+		},
+		{
+			name: "Unused security group with rules - should delete and revoke rules",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-abcde"),
+				GroupName: aws.String("test-group"),
+				IpPermissions: []types.IpPermission{
+					{
+						IpProtocol: aws.String("tcp"),
+						FromPort:   aws.Int32(22),
+						ToPort:     aws.Int32(22),
+					},
+				},
+				IpPermissionsEgress: []types.IpPermission{
+					{
+						IpProtocol: aws.String("-1"),
+					},
+				},
+			},
+			dryRun:              false,
+			hasNetworkInterfaces: false,
+			expectDelete:        true,
+			expectRevokeRules:   true,
+		},
+		{
+			name: "Dry run - should not actually delete",
+			securityGroup: types.SecurityGroup{
+				GroupId:   aws.String("sg-abcde"),
+				GroupName: aws.String("test-group"),
+			},
+			dryRun:              true,
+			hasNetworkInterfaces: false,
+			expectDelete:        false,
+			expectRevokeRules:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.dryRun = tt.dryRun
+			
+			// Create mock client
+			mockClient := &mockEC2Client{
+				describeNetworkInterfacesOutput: &ec2.DescribeNetworkInterfacesOutput{
+					NetworkInterfaces: make([]types.NetworkInterface, 0),
+				},
+			}
+			
+			if tt.hasNetworkInterfaces {
+				mockClient.describeNetworkInterfacesOutput.NetworkInterfaces = append(
+					mockClient.describeNetworkInterfacesOutput.NetworkInterfaces,
+					types.NetworkInterface{
+						NetworkInterfaceId: aws.String("eni-12345"),
+					},
+				)
+			}
+			
+			// Create worker
+			w := worker{
+				id: 1,
+				wg: &sync.WaitGroup{},
+				deletedSecurityGroupChan: make(chan string, 1),
+			}
+			
+			// Call the function
+			err := w.handleSecurityGroup(context.Background(), mockClient, tt.securityGroup)
+			
+			// Check results
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectDelete && !tt.dryRun, mockClient.deleteSecurityGroupCalled)
+			assert.Equal(t, tt.expectRevokeRules && !tt.dryRun, mockClient.revokeIngressCalled || mockClient.revokeEgressCalled)
+			
+			// Clean up channel
+			close(w.deletedSecurityGroupChan)
+		})
+	}
+}


### PR DESCRIPTION
# Description of the issue
This pull request adds a new workflow job to clean up old security groups in AWS. The issue is related to managing outdated security groups to maintain a clean and secure AWS environment.

# Description of changes
- Added a new job `clean-security-groups` in the GitHub Actions workflow `.github/workflows/clean-aws-resources.yml`.
- Created a new Go file `clean_security_group.go` with a function to clean security groups and adjusted the context timeout to 10 minutes.
- Created a new test file `clean_security_group_test.go` for the security group cleaning functionality.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[GHA Run](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13930209980)
And ran unittest
```
ok  	github.com/aws/amazon-cloudwatch-agent/tool/clean/clean_security_group	0.429s	coverage: 44.5% of statements
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`