### PR TITLE
Increase EKS Cluster Cleanup Frequency

### DIFF
--- a/tool/clean/clean_eks/clean_eks.go
+++ b/tool/clean/clean_eks/clean_eks.go
@@ -80,7 +80,7 @@ func clusterNameMatchesClustersToClean(clusterName string, clustersToClean []str
 
 func terminateClusters(ctx context.Context, client *eks.Client) {
 	listClusterInput := eks.ListClustersInput{}
-	expirationDateCluster := time.Now().UTC().Add(clean.KeepDurationFourDays)
+	expirationDateCluster := time.Now().UTC().Add(clean.KeepDurationOneDay)
 
 	clusters, err := client.ListClusters(ctx, &listClusterInput)
 	if err != nil {
@@ -93,7 +93,7 @@ func terminateClusters(ctx context.Context, client *eks.Client) {
 			return
 		}
 		if !expirationDateCluster.After(*describeClusterOutput.Cluster.CreatedAt) {
-			log.Printf("Ignoring cluster %s with a launch-date %s since it was created in the last %s", cluster, *describeClusterOutput.Cluster.CreatedAt, clean.KeepDurationFourDays)
+			log.Printf("Ignoring cluster %s with a launch-date %s since it was created in the last %s", cluster, *describeClusterOutput.Cluster.CreatedAt, clean.KeepDurationOneDay)
 			continue
 		}
 		if !clusterNameMatchesClustersToClean(*describeClusterOutput.Cluster.Name, ClustersToClean) {

--- a/tool/clean/clean_eks/clean_eks.go
+++ b/tool/clean/clean_eks/clean_eks.go
@@ -26,6 +26,7 @@ var (
 		"cwagent-helm-chart-integ-",
 		"cwagent-operator-eks-integ-",
 		"cwagent-monitoring-config-e2e-eks-",
+		"cwagent-addon-eks-integ-",
 	}
 )
 


### PR DESCRIPTION
# Description of the issue
_We need to clean up our clusters more frequently to ensure that resources are not being held for too long._

# Description of changes
_This change updates the expiration duration for clusters from four days to one day. I think we need to clean up more frequently to optimize resource usage and reduce costs._

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
[GHA Run](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13905834216/job/38908553206)

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`