### PR TITLE
Add SELinux Status using useragent

### DIFF
--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -74,6 +74,6 @@ func IsWindowsHostProcessContainer() bool {
 	return false
 }
 
-func IsSelinuxEnabled() (status bool) {
+func IsSelinuxEnabled() bool {
 	return os.Getenv(RunWithSELinux) == TrueValue
 }

--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -25,6 +25,7 @@ const (
 	RunAsHostProcessContainer = "RUN_AS_HOST_PROCESS_CONTAINER"
 	RunInAWS                  = "RUN_IN_AWS"
 	RunWithIRSA               = "RUN_WITH_IRSA"
+	RunWithSELinux            = "RUN_WITH_SELINUX"
 	UseDefaultConfig          = "USE_DEFAULT_CONFIG"
 	HostName                  = "HOST_NAME"
 	PodName                   = "POD_NAME"
@@ -71,4 +72,8 @@ func IsWindowsHostProcessContainer() bool {
 		return true
 	}
 	return false
+}
+
+func IsSelinuxEnabled() (status bool) {
+	return os.Getenv(RunWithSELinux) == TrueValue
 }

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -740,4 +740,3 @@ func checkRightForBinariesFileWithInputPlugins(inputPlugins []string) (string, e
 
 	return "", nil
 }
-

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -310,6 +310,10 @@ func runAgent(ctx context.Context,
 		}
 	}
 
+	if envconfig.IsSelinuxEnabled() {
+		log.Println("I! SELinux Status: Enabled")
+	}
+
 	if len(c.Inputs) != 0 && len(c.Outputs) != 0 {
 		log.Println("creating new logs agent")
 		logAgent := logs.NewLogAgent(c)
@@ -736,3 +740,4 @@ func checkRightForBinariesFileWithInputPlugins(inputPlugins []string) (string, e
 
 	return "", nil
 }
+

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -31,6 +31,7 @@ const (
 	flagContainerInsights         = "container_insights"
 	flagAppSignals                = "application_signals"
 	flagEnhancedContainerInsights = "enhanced_container_insights"
+	flagSELinux                   = "selinux"
 
 	separator = " "
 
@@ -76,6 +77,11 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 	}
 	for _, output := range telegrafCfg.Outputs {
 		ua.outputs.Add(output.Config.Name)
+	}
+
+	// Adding SELinux status
+	if envconfig.IsSelinuxEnabled() {
+		ua.inputs.Add(flagSELinux)
 	}
 
 	for _, pipeline := range otelCfg.Service.Pipelines {


### PR DESCRIPTION
# Description of the Issue  
Currently, there is no way to determine how many CloudWatch Agents (CWA) have SELinux enabled. This PR addresses that by introducing an environment variable (`SELINUX`), which is set using the SELinux installation script and stored in the systemd override file for the CloudWatch Agent service.  

# Details  

### Setting SELinux Status  
- A new environment variable, **SELINUX**, is set to `true` or `false` based on whether SELinux is enabled.  
- This variable is written to `/etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf`.  

### Persistence Across Updates  
- The systemd override file remains unchanged when the CloudWatch Agent is updated, ensuring SELinux status tracking persists across versions.  

### User-Agent Integration  
- The agent reads the **SELINUX** environment variable and includes it in the user-agent string.  
- This provides insight into SELinux usage within CloudWatch Agent deployments.  

### Benefits  
- Enables visibility into SELinux adoption among CloudWatch Agent users.  
- Assists in debugging and understanding system security configurations.  
- Ensures the change is persistent across agent updates with minimal disruption.


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested by running selinux installation script

by adding this to the selinux script
```
# Ensure the directory exists
mkdir -p /etc/systemd/system/amazon-cloudwatch-agent.service.d

# Create the override file with the Environment variable
cat <<EOF | tee /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
[Service]
Environment="SELINUX=true"
EOF

# Reload systemd and restart the CloudWatch agent
systemctl daemon-reload
systemctl restart amazon-cloudwatch-agent
```

### Result
<img width="682" alt="Screenshot 2025-03-17 at 9 43 01 PM" src="https://github.com/user-attachments/assets/ffabce99-7ac6-44ac-a021-5186bd754a6a" />

### User Agent output
<img width="1722" alt="Screenshot 2025-03-18 at 12 35 53 PM" src="https://github.com/user-attachments/assets/1cf8f564-7546-44e7-8dd2-0aaafd6b9b97" />

Selinux flag is in the inputs section of the user agent:

```
User-Agent: CWAgent/1.300052.1 (go1.24.0; linux; amd64) ID/a4f51326-a0f3-47b4-ab21-8492373e11e1 inputs:(logfile mem net procstat selinux) processors:(awsentity cumulativetodelta ec2tagger) outputs:(awscloudwatch cloudwatch cloudwatchlogs) aws-sdk-go/1.48.6 (go1.24.0; linux; amd64)
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




