### PR TITLE
Agent Health Metric for ROSA

### DIFF
--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -25,7 +25,7 @@ const (
 	RunAsHostProcessContainer = "RUN_AS_HOST_PROCESS_CONTAINER"
 	RunInAWS                  = "RUN_IN_AWS"
 	RunWithIRSA               = "RUN_WITH_IRSA"
-	RunWithROSA               = "RUN_ON_ROSA"
+	RunOnROSA                 = "RUN_ON_ROSA"
 	UseDefaultConfig          = "USE_DEFAULT_CONFIG"
 	HostName                  = "HOST_NAME"
 	PodName                   = "POD_NAME"
@@ -75,5 +75,5 @@ func IsWindowsHostProcessContainer() bool {
 }
 
 func IsRunningOnROSA() bool {
-	return os.Getenv(RunWithROSA) == TrueValue
+	return os.Getenv(RunOnROSA) == TrueValue
 }

--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -26,7 +26,7 @@ const (
 	RunInAWS                  = "RUN_IN_AWS"
 	RunWithIRSA               = "RUN_WITH_IRSA"
 	RunWithSELinux            = "RUN_WITH_SELINUX"
-	RunOnROSA                 = "RUN_ON_ROSA"
+	RunInROSA                 = "RUN_IN_ROSA"
 	UseDefaultConfig          = "USE_DEFAULT_CONFIG"
 	HostName                  = "HOST_NAME"
 	PodName                   = "POD_NAME"
@@ -79,6 +79,6 @@ func IsSelinuxEnabled() bool {
 	return os.Getenv(RunWithSELinux) == TrueValue
 }
 
-func IsRunningOnROSA() bool {
-	return os.Getenv(RunOnROSA) == TrueValue
+func IsRunningInROSA() bool {
+	return os.Getenv(RunInROSA) == TrueValue
 }

--- a/cfg/envconfig/envconfig.go
+++ b/cfg/envconfig/envconfig.go
@@ -25,6 +25,7 @@ const (
 	RunAsHostProcessContainer = "RUN_AS_HOST_PROCESS_CONTAINER"
 	RunInAWS                  = "RUN_IN_AWS"
 	RunWithIRSA               = "RUN_WITH_IRSA"
+	RunWithROSA               = "RUN_ON_ROSA"
 	UseDefaultConfig          = "USE_DEFAULT_CONFIG"
 	HostName                  = "HOST_NAME"
 	PodName                   = "POD_NAME"
@@ -71,4 +72,8 @@ func IsWindowsHostProcessContainer() bool {
 		return true
 	}
 	return false
+}
+
+func IsRunningOnROSA() bool {
+	return os.Getenv(RunWithROSA) == TrueValue
 }

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -309,8 +309,8 @@ func runAgent(ctx context.Context,
 			}()
 		}
 	}
-	if envconfig.IsRunningOnROSA() {
-		log.Println("I! Running on ROSA")
+	if envconfig.IsRunningInROSA() {
+		log.Println("I! Running in ROSA")
 	}
 
 	if envconfig.IsSelinuxEnabled() {

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -309,6 +309,9 @@ func runAgent(ctx context.Context,
 			}()
 		}
 	}
+	if envconfig.IsRunningOnROSA() {
+		log.Println("I! Running on ROSA")
+	}
 
 	if len(c.Inputs) != 0 && len(c.Outputs) != 0 {
 		log.Println("creating new logs agent")

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -31,7 +31,7 @@ const (
 	flagContainerInsights         = "container_insights"
 	flagAppSignals                = "application_signals"
 	flagEnhancedContainerInsights = "enhanced_container_insights"
-
+	flagROSA					  = "rosa"
 	separator = " "
 
 	typeInputs     = "inputs"
@@ -77,7 +77,12 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 	for _, output := range telegrafCfg.Outputs {
 		ua.outputs.Add(output.Config.Name)
 	}
-
+	//Adding ROSA status
+	if envconfig.IsRunningOnROSA(){
+		ua.inputs.Add(flagROSA)
+	
+	}
+	
 	for _, pipeline := range otelCfg.Service.Pipelines {
 		for _, receiver := range pipeline.Receivers {
 			// trim the adapter prefix from adapted Telegraf plugins

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -84,7 +84,7 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 		ua.outputs.Add(flagSELinux)
 	}
 	//Adding ROSA status
-	if envconfig.IsRunningOnROSA() {
+	if envconfig.IsRunningInROSA() {
 		ua.outputs.Add(flagROSA)
 	}
 

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -32,8 +32,8 @@ const (
 	flagAppSignals                = "application_signals"
 	flagEnhancedContainerInsights = "enhanced_container_insights"
 	flagSELinux                   = "selinux"
-	flagROSA					  = "rosa"
-	separator = " "
+	flagROSA                      = "rosa"
+	separator                     = " "
 
 	typeInputs     = "inputs"
 	typeProcessors = "processors"
@@ -84,11 +84,10 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 		ua.inputs.Add(flagSELinux)
 	}
 	//Adding ROSA status
-	if envconfig.IsRunningOnROSA(){
+	if envconfig.IsRunningOnROSA() {
 		ua.inputs.Add(flagROSA)
-	
 	}
-	
+
 	for _, pipeline := range otelCfg.Service.Pipelines {
 		for _, receiver := range pipeline.Receivers {
 			// trim the adapter prefix from adapted Telegraf plugins

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -81,11 +81,11 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 
 	// Adding SELinux status
 	if envconfig.IsSelinuxEnabled() {
-		ua.inputs.Add(flagSELinux)
+		ua.outputs.Add(flagSELinux)
 	}
 	//Adding ROSA status
 	if envconfig.IsRunningOnROSA() {
-		ua.inputs.Add(flagROSA)
+		ua.outputs.Add(flagROSA)
 	}
 
 	for _, pipeline := range otelCfg.Service.Pipelines {


### PR DESCRIPTION
# Description of the issue
Currently, there is no way to know the number of CloudWatch Agent's running on ROSA. This PR addressing this issue by introducing a new env. variable (`RUN_ON_ROSA`), which is set by helm charts. 

# Description of changes
### Discovering ROSA Cluster
- A new environment variable, **RUN_ON_ROSA**, is set to `true` or `false` based on whether  the cluster is ROSA.  
-  This variable is set by helm chart when ROSA flag is passed. 

### User-Agent Integration  
- The agent reads the **rosa** environment variable and includes it in the user-agent string.  

### Benefits  
- Enables visibility into Rosa adoption among CloudWatch Agent users.  
- Assists in debugging and understanding system security configurations.  
- Ensures the change is persistent across agent updates with minimal disruption.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
![image](https://github.com/user-attachments/assets/181c0f3d-2134-49b0-b182-c9560ca99b87)
```
2025-03-18T21:47:49Z I! Agent health HandleRequest being called CWAgent/Unknown (go1.22.5; linux; amd64) ID/e154f093-7963-4f84-b2db-c1b03ff68437 inputs:(awscontainerinsightreceiver otlp rosa) processors:(awsapplicationsignals awsentity batch filter gpuattributes metricstransform resourcedetection) outputs:(application_signals awsemf awsxray cloudwatchlogs debug enhanced_container_insights) aws-sdk-go/1.48.6 (go1.22.5; linux; amd64
```
This code change is based on #1602 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




