### PR TITLE
Sync endpoint slices changes from contrib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-20250313160903-790751417220
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/containerinsight v0.0.0-20250313160903-790751417220
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs v0.0.0-20250313160903-790751417220
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250313160903-790751417220
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250318180415-0f3e7c4087af
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/proxy v0.0.0-20250313160903-790751417220
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/xray v0.0.0-20250313160903-790751417220
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-20250313160903-790751417220

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cont
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/containerinsight v0.0.0-20250313160903-790751417220/go.mod h1:4HebVM9TmMpsxZAXLX5om998dTm1JUndjcpmhrnGkx4=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs v0.0.0-20250313160903-790751417220 h1:mxMnJHpqxpxRfZ/Ph/8RY9u7NhQftYWSkkSujLMRU3s=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs v0.0.0-20250313160903-790751417220/go.mod h1:sCx+2x6y1jjWGcXbgyP97Q+Himx84LlPZ9yWLgcV4vo=
-github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250313160903-790751417220 h1:InKUp04/CXtZ4QUeB1ec9fq0mYoqruncw669jnVtJDE=
-github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250313160903-790751417220/go.mod h1:kxuPS8JKnLVWie4PnL8iCoFx/mr89yR4VYFvJhlQfpY=
+github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250318180415-0f3e7c4087af h1:w4PiBzq24qzG26jk5hvWvw78xAapfvNSkZSUml8sVk8=
+github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250318180415-0f3e7c4087af/go.mod h1:kxuPS8JKnLVWie4PnL8iCoFx/mr89yR4VYFvJhlQfpY=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/proxy v0.0.0-20250313160903-790751417220 h1:epYN+kmQQ5h7W+qc/iMUv4PT1swMgzrj9NUIUMifMIc=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/proxy v0.0.0-20250313160903-790751417220/go.mod h1:jNjrbc2MpIBzlaEnOVdlxniDzIUgzD80fm6wkBs0flw=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/xray v0.0.0-20250313160903-790751417220 h1:9qmR+GqEiKd9s4eqQLYE6f/4GszLx8LRb+qw+41gjNU=


### PR DESCRIPTION
# Description of changes
This change updates `go.mod` to point to an updated version of the contrib with the endpoint slices change. 

Related PR: https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/289

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

# Tests
Integration test run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/13933467063

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh` ✅ 
2. Run `make lint` ✅ 




