### PR TITLE
[Bug Fix] Drop metric if it has nil value in cloudwatch exporter

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -441,6 +441,11 @@ func (c *CloudWatch) BuildMetricDatum(metric *aggregationDatum) (cloudwatch.Enti
 			continue
 		}
 		if len(distList) == 0 {
+			if metric.Value == nil {
+				log.Printf("E! metric (%s) has nil value, dropping it", *metric.MetricName)
+				continue
+			}
+
 			if !distribution.IsSupportedValue(*metric.Value, distribution.MinValue, distribution.MaxValue) {
 				log.Printf("E! metric (%s) has an unsupported value: %v, dropping it", *metric.MetricName, *metric.Value)
 				continue

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -442,7 +442,7 @@ func (c *CloudWatch) BuildMetricDatum(metric *aggregationDatum) (cloudwatch.Enti
 		}
 		if len(distList) == 0 {
 			if metric.Value == nil {
-				log.Printf("E! metric (%s) has nil value, dropping it", *metric.MetricName)
+				log.Printf("D! metric (%s) has nil value, dropping it", *metric.MetricName)
 				continue
 			}
 

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -195,6 +195,15 @@ func TestProcessRollup(t *testing.T) {
 func TestBuildMetricDatumDropUnsupported(t *testing.T) {
 	svc := new(mockCloudWatchClient)
 	cw := newCloudWatchClient(svc, time.Second)
+
+	_, datums := cw.BuildMetricDatum(&aggregationDatum{
+		MetricDatum: cloudwatch.MetricDatum{
+			MetricName: aws.String("test_nil_value"),
+			Value:      nil,
+		},
+	})
+	assert.Empty(t, datums)
+
 	testCases := []float64{
 		math.NaN(),
 		math.Inf(1),


### PR DESCRIPTION
# Description of the issue
When collecting OTLP custom metrics, if a sample application isn't configured properly, it can sometimes send faulty non-distribution metrics that don't include a value.
```
│   ],                                                                                                                                                                                                                                                                                                                                   │
│   MetricName: "http.server.duration",                                                                                                                                                                                                                                                                                                  │
│   StorageResolution: 60,                                                                                                                                                                                                                                                                                                               │
│   Timestamp: 2025-03-19 05:49:04.06746721 +0000 UTC,                                                                                                                                                                                                                                                                                   │
│   Unit: "Milliseconds"                                                                                                                                                                                                                                                                                                                 │
│   (we expect to see Value populated here)
│ }.       
```

The CloudWatch Agent has logic in the `cloudwatch` output plugin, which panics when it receives a non-distribution metric with a nil value since it tries to de-reference it in order to check if if the value is in a valid range:
```
if !distribution.IsSupportedValue(*metric.Value, distribution.MinValue, distribution.MaxValue) {
	log.Printf("E! metric (%s) has an unsupported value: %v, dropping it", *metric.MetricName, *metric.Value)
	continue
}
``` 

A nil check should be added prior to prevent this from happening.

# Description of changes
- Add a condition to drop metrics with a nil value.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
## Before
<img width="418" alt="Screenshot 2025-03-19 at 2 00 07 AM" src="https://github.com/user-attachments/assets/947dbad7-e874-475c-9485-368a4af3c12b" />

## After
> No longer panics.
<img width="501" alt="Screenshot 2025-03-19 at 2 08 15 AM" src="https://github.com/user-attachments/assets/452169f0-530f-49f9-afe1-0897aef85115" />


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`