### PR TITLE
Bumping eks retries integ test

### DIFF
--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -847,7 +847,7 @@ jobs:
       - name: Terraform apply
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 2
+          max_attempts: 4
           timeout_minutes: 90 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
           retry_wait_seconds: 5
           command: |


### PR DESCRIPTION
# Description of the issue
Test fails in some occasions where it should not, test might be flaky so increasing number of retries will allow for more accurate test. (only increases time duration of test by ~10 minutes-15 if all tests fail).



# Description of changes
_How does this change address the problem?_

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




