### PR TITLE
Gets podIp from connection context in entity processor to extract the pod metadata in map

### DIFF
--- a/internal/clientutil/client.go
+++ b/internal/clientutil/client.go
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package clientutil
+
+import (
+	"net"
+	"strings"
+
+	"go.opentelemetry.io/collector/client"
+)
+
+// Address returns the address of the client connecting to the collector.
+func Address(client client.Info) string {
+	if client.Addr == nil {
+		return ""
+	}
+	switch addr := client.Addr.(type) {
+	case *net.UDPAddr:
+		return addr.IP.String()
+	case *net.TCPAddr:
+		return addr.IP.String()
+	case *net.IPAddr:
+		return addr.IP.String()
+	}
+
+	// If this is not a known address type, check for known "untyped" formats.
+	// 1.1.1.1:<port>
+
+	lastColonIndex := strings.LastIndex(client.Addr.String(), ":")
+	if lastColonIndex != -1 {
+		ipString := client.Addr.String()[:lastColonIndex]
+		ip := net.ParseIP(ipString)
+		if ip != nil {
+			return ip.String()
+		}
+	}
+
+	return client.Addr.String()
+}

--- a/internal/clientutil/client_test.go
+++ b/internal/clientutil/client_test.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package clientutil
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/client"
+)
+
+type fakeAddr string
+
+func (s fakeAddr) String() string {
+	return string(s)
+}
+
+func (fakeAddr) Network() string {
+	return "tcp"
+}
+
+func TestAddress(t *testing.T) {
+	tests := []struct {
+		name   string
+		client client.Info
+		want   string
+	}{
+		{
+			name: "UDPAddr",
+			client: client.Info{
+				Addr: &net.UDPAddr{
+					IP:   net.IPv4(192, 0, 2, 1),
+					Port: 1234,
+				},
+			},
+			want: "192.0.2.1",
+		},
+		{
+			name: "TCPAddr",
+			client: client.Info{
+				Addr: &net.TCPAddr{
+					IP:   net.IPv4(192, 0, 2, 2),
+					Port: 1234,
+				},
+			},
+			want: "192.0.2.2",
+		},
+		{
+			name: "IPAddr",
+			client: client.Info{
+				Addr: &net.IPAddr{
+					IP: net.IPv4(192, 0, 2, 3),
+				},
+			},
+			want: "192.0.2.3",
+		},
+		{
+			name: "fake_addr_with_port",
+			client: client.Info{
+				Addr: fakeAddr("1.1.1.1:3200"),
+			},
+			want: "1.1.1.1",
+		},
+		{
+			name: "fake_addr_without_port",
+			client: client.Info{
+				Addr: fakeAddr("1.1.1.1"),
+			},
+			want: "1.1.1.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Address(tt.client))
+		})
+	}
+}

--- a/plugins/processors/awsentity/processor_test.go
+++ b/plugins/processors/awsentity/processor_test.go
@@ -83,8 +83,8 @@ func newMockSetAutoScalingGroup(es *mockEntityStore) func(string) {
 	}
 }
 
-func newMockPodMeta(workload, namespace, node string) func() k8sclient.PodMetadata {
-	return func() k8sclient.PodMetadata {
+func newMockPodMeta(workload, namespace, node string) func(ctx context.Context) k8sclient.PodMetadata {
+	return func(ctx context.Context) k8sclient.PodMetadata {
 		return k8sclient.PodMetadata{
 			Workload:  workload,
 			Namespace: namespace,
@@ -936,7 +936,7 @@ func TestAwsEntityProcessor_AddsEntityFieldsFromPodMeta_WithMock(t *testing.T) {
 	tests := []struct {
 		name           string
 		metrics        pmetric.Metrics
-		mockGetPodMeta func() k8sclient.PodMetadata
+		mockGetPodMeta func(ctx context.Context) k8sclient.PodMetadata
 		want           map[string]any
 	}{
 		{


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._
To support the [Explore related](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ExploreRelated.html) feature in CloudWatch, the CloudWatch Agent sends an "Entity", which includes relevant metadata to correlate metrics or logs between resources (e.g., an EKS cluster) and services (e.g., a Java application). For OTLP Custom metrics , Agent need to extract the workload, namespace and node name to build entity. 
https://github.com/aws/amazon-cloudwatch-agent/pull/1583 implements the changes to build the podIP to podMetadata mapping using endpointSliceWatcher. Agent need to have a mechanism to extract the IP address to get the podMetadata from the mapping. 

# Description of changes
_How does this change address the problem?_
This change gets the podIP from connection context in entity processor and uses it retrieve the podMetadata

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
Unit Tests
Manual tests
1. Created an EKS cluster and deployed the Amazon CloudWatch Observability EKS add-on.
2. Set up sample application by following https://aws-otel.github.io/docs/getting-started/adot-eks-add-on/sample-app.
  - Removed resource attributes.
  - Changed `OTEL_EXPORTER_OTLP_ENDPOINT` to `http://cloudwatch-agent.amazon-cloudwatch:4317`.
3. Built the agent image by running `make docker-build-amd64` and changed the image in the AmazonCloudWatchAgent custom resource from `podIp-ctx` branch.
  - Added debug exporter to OTLP pipeline for testing.

Agent Config:
```
    {
      "agent": {
       "debug": true,
      },
      "logs": {
        "metrics_collected": {
          "otlp": {
            "grpc_endpoint": "0.0.0.0:4317",
            "http_endpoint": "0.0.0.0:4318"
          },
        }
      },
    }
```
Agent Logs
```
2025-03-20T15:42:12Z I! {"caller":"k8smetadata/extension.go:98","msg":"GetPodMetadata: found metadata","kind":"extension","name":"k8smetadata",**"ip":"192.168.25.151",**"workload":"sample-app","namespace":"default","node":"ip-192-168-21-167.ec2.internal"} 
```
the sample app has the below IP address
```
 sample-app-6b456fc5cf-zv7ps                                             ●         1/1          Running                                0 **192.168.25.151**```

Entity is sent as expected

```
 2025-03-20T15:44:13Z D! {"caller":"awsemfexporter@v0.115.0/emf_exporter.go:105","msg":"Start processing resource metrics","kind":"exporter","data_type":"metrics","name":"awsemf","labels":{"cloud.account.id":"9576888xxxxx","cloud.availabili │
│ ty_zone":"us-east-1d","cloud.platform":"aws_ec2","cloud.provider":"aws","cloud.region":"us-east-1","com.amazonaws.cloudwatch.entity.internal.aws.account.id":"9576888xxxxx,"com.amazonaws.cloudwatch.entity.internal.deployment.environment":" │
│ eks:compass-ga2/default","com.amazonaws.cloudwatch.entity.internal.instance.id":"i-08af5d4aa360xxxxx","com.amazonaws.cloudwatch.entity.internal.k8s.cluster.name":"compass-ga2","com.amazonaws.cloudwatch.entity.internal.k8s.namespace.name":" │
│ default","com.amazonaws.cloudwatch.entity.internal.k8s.node.name":"ip-192-168-21-xxx.ec2.internal","com.amazonaws.cloudwatch.entity.internal.k8s.workload.name":"sample-app","com.amazonaws.cloudwatch.entity.internal.platform.type":"AWS::EKS │
│ ","com.amazonaws.cloudwatch.entity.internal.service.name":"test-service","com.amazonaws.cloudwatch.entity.internal.service.name.source":"Instrumentation","com.amazonaws.cloudwatch.entity.internal.type":"Service","container.id":"404f4e7f4d8 │
│ dbe0186d844af64eb1d640968dcd951758fd5ecb9f8d6c67xxxx","host.arch":"amd64","host.id":"i-08af5d4aa360xxxxx","host.image.id":"ami-038080a1d7b8xxxxx","host.name":"ip-192-168-21-xxx.ec2.internal","host.type":"m5.large","os.description":"Linux  │
│ 5.10.234-225.895.amzn2.x86_64","os.type":"linux","process.command_line":"/usr/lib/jvm/java-17-openjdk-amd64:bin:java -javaagent:/aws-observability/classpath/aws-opentelemetry-agent-1.17.0.jar","process.executable.path":"/usr/lib/jvm/java-1 │
│ 7-openjdk-amd64:bin:java","process.pid":"","process.runtime.description":"Debian OpenJDK 64-Bit Server VM 17.0.4+8-Debian-1deb11u1","process.runtime.name":"OpenJDK Runtime Environment","process.runtime.version":"17.0.4+8-Debian-1deb11u1"," │
│ service.name":"test-service","telemetry.auto.version":"1.17.0-aws","telemetry.sdk.language":"java","telemetry.sdk.name":"opentelemetry","telemetry.sdk.version":"1.17.0"}}
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




