### PR TITLE
Update RELEASE_NOTES 1.300054.0 release

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,5 @@
 ========================================================================
-Amazon CloudWatch Agent 1.300054.0 (2023-06-15)
+Amazon CloudWatch Agent 1.300054.0 (2025-03-20)
 ========================================================================
 Features:
 * [EFA] Added Elastic Network Interface (ENI) ID as a dimension to EFA (Elastic Fabric Adapter) metrics

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,22 @@
 ========================================================================
+Amazon CloudWatch Agent 1.300054.0 (2023-06-15)
+========================================================================
+Features:
+* [EFA] Added Elastic Network Interface (ENI) ID as a dimension to EFA (Elastic Fabric Adapter) metrics
+* [Kubernetes] Added support for using Kubernetes secret file for bearer token when accessing apiserver Prometheus endpoint
+
+Enhancements:
+* [ContainerInsights] Switched to using EndpointSlices instead of Endpoints for improved performance in large EKS clusters
+* [Logs] Added option to trim timestamp from log messages if enabled by customer
+* [EC2Tagger] Set separate refresh intervals for tags (default 0) and volumes (default 5 minutes if VolumeId configured)
+
+Bug Fixes:
+* [CloudWatch Exporter] Fixed issue with nil metric values by dropping metrics with nil values
+* [Logs] Implemented fixed-size buffer to handle file descriptors in log tailer, controlled by a feature flag
+* [Logs] Added 'backpressure_drop' feature flag for granular control of log handling during file rotation
+* [Kubernetes] Implemented dynamic CA certificate handling for kubelet connections
+
+========================================================================
 Amazon CloudWatch Agent 1.300053.0 (2025-02-26)
 ========================================================================
 Bug Fixes:


### PR DESCRIPTION
This pr is to update release notes for 1.300054.0 release. Below are the changes for this pr: Features:

- Added Elastic Network Interface (ENI) ID as a dimension to EFA (Elastic Fabric Adapter) metrics
- Added support for using Kubernetes secret file for bearer token when accessing apiserver Prometheus endpoint

Enhancements:

- [ContainerInsights]: Switched to using EndpointSlices instead of Endpoints for improved performance in large EKS clusters
- [Logs]: Added option to trim timestamp from log messages if enabled by customer
- [EC2Tagger]: Set separate refresh intervals for tags (default 0) and volumes (default 5 minutes if VolumeId configured)

Bug Fixes:

- [CloudWatch Exporter]: Fixed issue with nil metric values by dropping metrics with nil values
- [Logs]: Implemented fixed-size buffer to handle file descriptors in log tailer, controlled by a feature flag
- [Logs]: Added 'backpressure_drop' feature flag for granular control of log handling during file rotation
- Implemented dynamic CA certificate handling for kubelet connections



