### PR TITLE
Add workflow step that is named after the build_id input

### DIFF
--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -44,6 +44,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  id:
+    name: Workflow ID Provider
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{ github.event.inputs.build_id }}
+        run: echo run identifier ${{ inputs.build_id }}
   OutputEnvVariables:
     name: 'OutputEnvVariables'
     runs-on: ubuntu-latest
@@ -332,7 +338,7 @@ jobs:
             else
               cd terraform/ec2/win
             fi
-            
+
             terraform init
             if terraform apply --auto-approve \
               -var="ssh_key_value=${PRIVATE_KEY}" \
@@ -502,7 +508,7 @@ jobs:
             else
               cd terraform/ec2/win
             fi
-            
+
             terraform init
             if terraform apply --auto-approve \
               -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
@@ -579,7 +585,7 @@ jobs:
             else
               cd terraform/ec2/mac
             fi
-            
+
             terraform init
             if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}" \
@@ -708,7 +714,7 @@ jobs:
             else
               cd terraform/ecs_ec2/daemon
             fi
-            
+
             terraform init
             if terraform apply --auto-approve\
               -var="test_dir=${{ matrix.arrays.test_dir }}"\
@@ -784,7 +790,7 @@ jobs:
             else
               cd terraform/ecs_fargate/linux
             fi
-            
+
             terraform init
             if terraform apply --auto-approve\
               -var="test_dir=${{ matrix.arrays.test_dir }}"\
@@ -856,7 +862,7 @@ jobs:
             else
               cd terraform/eks/daemon
             fi
-            
+
             terraform init
             if terraform apply --auto-approve \
               -var="test_dir=${{ matrix.arrays.test_dir }}"\
@@ -931,7 +937,7 @@ jobs:
             else
               cd terraform/eks/deployment
             fi
-            
+
             terraform init
             if terraform apply --auto-approve \
               -var="test_dir=${{ matrix.arrays.test_dir }}"\


### PR DESCRIPTION
This will be used to programmatically search for the workflow kicked off programmatically since the GitHub API doesn't return the workflow ID

# Description of the issue
We want to build a system that will automatically start the integration tests on candidate release artifacts. Right now, the system can kick off integration tests using the GitHub REST API by essentially running the following:
```
% curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <TOKEN>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/aws/amazon-cloudwatch-agent/actions/workflows/test-artifacts.yml/dispatches \
  -d '{"ref":"main","inputs":{"build_id":"1.300053.0b1047"}}'
```
  
Unfortunately, this API call does not return the created workflow ID ([see docs](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)), so the system will have to find the workflow ID another way.

# Description of changes
This adds one new job which has a single step whose name is the `build_id`. This will allow the system to find the correct workflow by looking through the recently created worfklows and finding the workflow that has a step with the correct name.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Dispatched a Test Artifacts workflow, parsed through the results to find the right workflow. Here are the abbreviated calls/responses:

Find recent workflow ([see API docs](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository)):
```
% curl -L \
-X GET \
https://api.github.com/repos/aws/amazon-cloudwatch-agent/actions/runs\?created\=\>2025-03-21T02:00:00
{
  "total_count": 2,
  "workflow_runs": [
    {
      "id": 13983135894,
      "name": "Test Artifacts",
      "node_id": "WFR_kwLODyYK1M8AAAADQXW4lg",
      "head_branch": "dricross/workflow-id-provider",
      "head_sha": "c5f8a2e1311caa794d9c5d45a3ba8fcc361ab0ad",
      "path": ".github/workflows/test-artifacts.yml",
      "display_title": "Test Artifacts",
      "run_number": 23,
      "event": "workflow_dispatch",
      "status": "in_progress",
      "conclusion": null,
      "workflow_id": 143250592,
      ....
      "jobs_url": "https://api.github.com/repos/aws/amazon-cloudwatch-agent/actions/runs/13983135894/jobs",
      ...
    },
    {
      "id": 13983093565,
      "name": "Build Test Artifacts",
      "node_id": "WFR_kwLODyYK1M8AAAADQXUTPQ",
      "head_branch": "dricross/workflow-id-provider",
      "head_sha": "c5f8a2e1311caa794d9c5d45a3ba8fcc361ab0ad",
      "path": ".github/workflows/build-test-artifacts.yml",
      "display_title": "Build Test Artifacts",
      "run_number": 745,
      "event": "workflow_dispatch",
      "status": "in_progress",
      "conclusion": null,
      "workflow_id": 110664820,
      ...
      "jobs_url": "https://api.github.com/repos/aws/amazon-cloudwatch-agent/actions/runs/13983093565/jobs",
      ...
    }
  ]
}
```

Use `jobs_url` from `Test Artifacts` workflow to get job details ([see API docs](https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2022-11-28#list-jobs-for-a-workflow-run)):
```
% curl -L \
> -X GET \
> https://api.github.com/repos/aws/amazon-cloudwatch-agent/actions/runs/13983135894/jobs
{
  "total_count": 326,
  "jobs": [
    {
      "id": 39152052210,
      "run_id": 13983135894,
      "workflow_name": "Test Artifacts",
      "head_branch": "dricross/workflow-id-provider",
      "run_url": "https://api.github.com/repos/aws/amazon-cloudwatch-agent/actions/runs/13983135894",
      ...
      "name": "OutputEnvVariables",
      ...
    },
    {
      "id": 39152052353,
      "run_id": 13983135894,
      "workflow_name": "Test Artifacts",
      "head_branch": "dricross/workflow-id-provider",
      ....
      "name": "Workflow ID Provider",
      "steps": [
        {
          "name": "Set up job",
          "status": "completed",
          "conclusion": "success",
          "number": 1,
          "started_at": "2025-03-21T02:08:06Z",
          "completed_at": "2025-03-21T02:08:06Z"
        },
        {
          "name": "1.300053.0b1047",
          "status": "completed",
          "conclusion": "success",
          "number": 2,
          "started_at": "2025-03-21T02:08:06Z",
          "completed_at": "2025-03-21T02:08:06Z"
        },
        {
          "name": "Complete job",
          "status": "completed",
          "conclusion": "success",
          "number": 3,
          "started_at": "2025-03-21T02:08:06Z",
          "completed_at": "2025-03-21T02:08:06Z"
        }
      ],
     ...
    },
    {
      "id": 39152059112,
      "run_id": 13983135894,
      "workflow_name": "Test Artifacts",
      "head_branch": "dricross/workflow-id-provider",
      ...
      "name": "GenerateTestMatrix",
      "steps": [
      ]
    },
    <very long.... omitted>
  ]
}
```

Find the entry in jobs whose name is "Workflow ID Provider" and then look at the second step's name: 1.300053.0b1047. workflow_id 143250592 is the right workflow to look at. So we'd check the status/conclusion on the workflow ([see API docs](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#get-a-workflow)):
```
% curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <TOKEN>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/aws/amazon-cloudwatch-agent/actions/workflows/143250592
{
  "id": 143250592,
  "node_id": "W_kwDODyYK1M4IidSg",
  "name": "Test Artifacts",
  "path": ".github/workflows/test-artifacts.yml",
  "state": "active",
  "created_at": "2025-02-10T12:41:27.000-05:00",
  "updated_at": "2025-03-20T22:07:58.000-04:00",
  "url": "https://api.github.com/repos/aws/amazon-cloudwatch-agent/actions/workflows/143250592",
  "html_url": "https://github.com/aws/amazon-cloudwatch-agent/blob/main/.github/workflows/test-artifacts.yml",
  "badge_url": "https://github.com/aws/amazon-cloudwatch-agent/workflows/Test%20Artifacts/badge.svg"
}
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




