### PR TITLE
Add Instance id entity attribute only if the application node is same as agent node

### DIFF
--- a/plugins/processors/awsentity/processor.go
+++ b/plugins/processors/awsentity/processor.go
@@ -5,6 +5,7 @@ package awsentity
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
@@ -251,7 +252,10 @@ func (p *awsEntityProcessor) processMetrics(ctx context.Context, md pmetric.Metr
 					resourceAttrs.PutStr(entityattributes.AttributeEntityNamespace, eksAttributes.Namespace)
 					resourceAttrs.PutStr(entityattributes.AttributeEntityWorkload, eksAttributes.Workload)
 					resourceAttrs.PutStr(entityattributes.AttributeEntityNode, eksAttributes.Node)
-					AddAttributeIfNonEmpty(resourceAttrs, entityattributes.AttributeEntityInstanceID, ec2Info.GetInstanceID())
+					//Add Instance id attribute only if the application node is same as agent node
+					if eksAttributes.Node == os.Getenv("K8S_NODE_NAME") {
+						AddAttributeIfNonEmpty(resourceAttrs, entityattributes.AttributeEntityInstanceID, eksAttributes.InstanceId)
+					}
 					AddAttributeIfNonEmpty(resourceAttrs, entityattributes.AttributeEntityAwsAccountId, ec2Info.GetAccountID())
 					AddAttributeIfNonEmpty(resourceAttrs, entityattributes.AttributeEntityServiceNameSource, entityServiceNameSource)
 				}


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._
Agent can be now deployed as deployment and statefulset along with daemonset. In the entity attributes retrieval logic for K8s env, Agent can only get its own instance Id. This Agent instance id will be the same as Application instance id in case of daemon set. But in deployment and statefulset, its not the case.

# Description of changes
_How does this change address the problem?_
Agent Entity processor will not attach instance Id to the attributes if the node name of agent is different from node name of application metrics.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
Unit Tests
Manual Test
1. Created an EKS cluster and deployed the Amazon CloudWatch Observability EKS add-on.
2. Set up sample application by following https://aws-otel.github.io/docs/getting-started/adot-eks-add-on/sample-app.
  - Removed resource attributes.
  - Changed `OTEL_EXPORTER_OTLP_ENDPOINT` to `http://cloudwatch-agent.amazon-cloudwatch:4317`.
3. Built the agent image by running `make docker-build-amd64` and changed the image in the AmazonCloudWatchAgent custom resource from `podIp-ctx` branch.
  - Added debug exporter to OTLP pipeline for testing.

Agent Config:
```
    {
      "agent": {
       "debug": true,
      },
      "logs": {
        "metrics_collected": {
          "otlp": {
            "grpc_endpoint": "0.0.0.0:4317",
            "http_endpoint": "0.0.0.0:4318"
          },
        }
      },
    }
```
** Agent deployed as daemonset - Instance Id attached as the node name matches**
```
2025-03-26T13:53:12Z I! {"caller":"awsentity/processor.go:255","msg":"Application node name:","kind":"processor","name":"awsentity/service/otlp","pipeline":"metrics/hostOtlpMetrics/cloudwatchlogs","appNode":"ip-192-168-21-167.ec2.internal"}  │
│ 2025-03-26T13:53:12Z I! {"caller":"awsentity/processor.go:256","msg":"K8S_NODE_NAME:","kind":"processor","name":"awsentity/service/otlp","pipeline":"metrics/hostOtlpMetrics/cloudwatchlogs","K8S_NODE_NAME":"ip-192-168-21-167.ec2.internal"}    │
│ 2025-03-26T13:53:15Z D! {"caller":"awsemfexporter@v0.115.0/emf_exporter.go:105","msg":"Start processing resource metrics","kind":"exporter","data_type":"metrics","name":"awsemf","labels":{"cloud.account.id":"957688854012","cloud.availability │
│ _zone":"us-east-1d","cloud.platform":"aws_ec2","cloud.provider":"aws","cloud.region":"us-east-1","com.amazonaws.cloudwatch.entity.internal.aws.account.id":"957688854012","com.amazonaws.cloudwatch.entity.internal.deployment.environment":"eks: │
│ compass-ga2/default","com.amazonaws.cloudwatch.entity.internal.instance.id":"i-08af5d4aa36035459","com.amazonaws.cloudwatch.entity.internal.k8s.cluster.name":"compass-ga2","com.amazonaws.cloudwatch.entity.internal.k8s.namespace.name":"defaul │
│ t","com.amazonaws.cloudwatch.entity.internal.k8s.node.name":"ip-192-168-21-167.ec2.internal","com.amazonaws.cloudwatch.entity.internal.k8s.workload.name":"sample-app","com.amazonaws.cloudwatch.entity.internal.platform.type":"AWS::EKS","com.a │
│ mazonaws.cloudwatch.entity.internal.service.name":"test-service","com.amazonaws.cloudwatch.entity.internal.service.name.source":"Instrumentation","com.amazonaws.cloudwatch.entity.internal.type":"Service","container.id":"404f4e7f4d8dbe0186d84 │
│ 4af64eb1d640968dcd951758fd5ecb9f8d6c6764cc4","host.arch":"amd64","host.id":"i-08af5d4aa36035459","host.image.id":"ami-038080a1d7b840a46","host.name":"ip-192-168-21-167.ec2.internal","host.type":"m5.large","os.description":"Linux 5.10.234-225 │
│ .895.amzn2.x86_64","os.type":"linux","process.command_line":"/usr/lib/jvm/java-17-openjdk-amd64:bin:java -javaagent:/aws-observability/classpath/aws-opentelemetry-agent-1.17.0.jar","process.executable.path":"/usr/lib/jvm/java-17-openjdk-amd6 │
│ 4:bin:java","process.pid":"","process.runtime.description":"Debian OpenJDK 64-Bit Server VM 17.0.4+8-Debian-1deb11u1","process.runtime.name":"OpenJDK Runtime Environment","process.runtime.version":"17.0.4+8-Debian-1deb11u1","service.name":"t │
│ est-service","telemetry.auto.version":"1.17.0-aws","telemetry.sdk.language":"java","telemetry.sdk.name":"opentelemetry","telemetry.sdk.version":"1.17.0"}} 
```
** Agent deployed as deployment- instance id not attached as node name is different **

```
2025-03-26T13:50:12Z I! {"caller":"awsentity/processor.go:255","msg":"Application node name:","kind":"processor","name":"awsentity/service/otlp","pipeline":"metrics/hostOtlpMetrics/cloudwatchlogs","appNode":"ip-192-168-21-167.ec2.internal"}  │
│ 2025-03-26T13:50:12Z I! {"caller":"awsentity/processor.go:256","msg":"K8S_NODE_NAME:","kind":"processor","name":"awsentity/service/otlp","pipeline":"metrics/hostOtlpMetrics/cloudwatchlogs","K8S_NODE_NAME":"ip-192-168-34-189.ec2.internal"}    │
│ 2025-03-26T13:50:14Z D! {"caller":"awsemfexporter@v0.115.0/emf_exporter.go:105","msg":"Start processing resource metrics","kind":"exporter","data_type":"metrics","name":"awsemf","labels":{"cloud.account.id":"957688854012","cloud.availability │
│ _zone":"us-east-1d","cloud.platform":"aws_ec2","cloud.provider":"aws","cloud.region":"us-east-1","com.amazonaws.cloudwatch.entity.internal.aws.account.id":"957688854012","com.amazonaws.cloudwatch.entity.internal.deployment.environment":"eks: │
│ compass-ga2/default","com.amazonaws.cloudwatch.entity.internal.k8s.cluster.name":"compass-ga2","com.amazonaws.cloudwatch.entity.internal.k8s.namespace.name":"default","com.amazonaws.cloudwatch.entity.internal.k8s.node.name":"ip-192-168-21-16 │
│ 7.ec2.internal","com.amazonaws.cloudwatch.entity.internal.k8s.workload.name":"sample-app","com.amazonaws.cloudwatch.entity.internal.platform.type":"AWS::EKS","com.amazonaws.cloudwatch.entity.internal.service.name":"test-service","com.amazona │
│ ws.cloudwatch.entity.internal.service.name.source":"Instrumentation","com.amazonaws.cloudwatch.entity.internal.type":"Service","container.id":"404f4e7f4d8dbe0186d844af64eb1d640968dcd951758fd5ecb9f8d6c6764cc4","host.arch":"amd64","host.id":"i │
│ -08af5d4aa36035459","host.image.id":"ami-038080a1d7b840a46","host.name":"ip-192-168-21-167.ec2.internal","host.type":"m5.large","os.description":"Linux 5.10.234-225.895.amzn2.x86_64","os.type":"linux","process.command_line":"/usr/lib/jvm/jav │
│ a-17-openjdk-amd64:bin:java -javaagent:/aws-observability/classpath/aws-opentelemetry-agent-1.17.0.jar","process.executable.path":"/usr/lib/jvm/java-17-openjdk-amd64:bin:java","process.pid":"","process.runtime.description":"Debian OpenJDK 64 │
│ -Bit Server VM 17.0.4+8-Debian-1deb11u1","process.runtime.name":"OpenJDK Runtime Environment","process.runtime.version":"17.0.4+8-Debian-1deb11u1","service.name":"test-service","telemetry.auto.version":"1.17.0-aws","telemetry.sdk.language":" │
│ java","telemetry.sdk.name":"opentelemetry","telemetry.sdk.version":"1.17.0"}}
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




