### PR TITLE
Add deltatocumulativeprocessor for AMP destinations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -211,6 +211,7 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.6
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.115.0
 	go.opentelemetry.io/collector/component/componenttest v0.115.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.115.0
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.113.0
@@ -442,7 +443,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.115.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.115.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opencontainers/runc v1.1.14 // indirect

--- a/go.mod
+++ b/go.mod
@@ -425,6 +425,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.115.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.115.0 // indirect
@@ -441,6 +442,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.115.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.115.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.115.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opencontainers/runc v1.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1205,6 +1205,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics v
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics v0.115.0/go.mod h1:G56rS4nL0VypkD7a94UaQmIjO5t0kffVcjbhpvSogww=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.115.0 h1:vRQQFD4YpasQFUAdF030UWtaflSYFXK542bfWMGhOK0=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.115.0/go.mod h1:BZ7DT+0VkKR7P3I9PGEDfVa0GdB0ty41eEcejIUXF9A=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.115.0 h1:tFUm48xxdtuk3AgY5AY90DJ6UnxRW5k/HBpA24blCAo=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.115.0/go.mod h1:EI5GXHQVRNLx78DSyqSU8ZzIxQayUN7KlaeVChk5rJc=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.115.0 h1:h6zEsBtuZalQu7lKYf6ZCcj8fTocT+zxdmuOou9515Q=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.115.0/go.mod h1:6QU/K0dGCGYorkOvJmhbDFCspy4RPxRkFjf9I64y6I0=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8stest v0.115.0 h1:vXDJE8YHfAoYIAlPRtODchlqb6lWnGhJxPaT2ljvN7I=
@@ -1239,6 +1241,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributespr
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.115.0/go.mod h1:z8XdvlhXSYVboxS3TPGembE9kfxLAYH2PxPLMvf8wTk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.115.0 h1:t3BGnPpmeuxW51vISSu51PrAs49ACBCa1Yl1NfZGE5Y=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.115.0/go.mod h1:jQLYyroEYEV1kWJApmGBgVuGUd73v+Q6EUJ6Wy7N508=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.115.0 h1:a0LC50FmNTyWI/vIhKWSyDRw8GLlq2XFIY7GezlK3/w=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.115.0/go.mod h1:hNQwpth9RZ+nS9oCDDKRo56XwNc2TGhZGcAKc4CF1AI=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.115.0 h1:X6rEs7IxDpcDDBOCmkA3xHmc373UxHchH7BykK3Ao+o=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.115.0/go.mod h1:fmLLh7jL0uK/t8op9TieOz7pwxItl4hdFo2fX7U0Etg=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.115.0 h1:ficXJmB6l6kfiu+R6CmggtnlQWMHUNzu2csDYA4CFSs=

--- a/service/defaultcomponents/components.go
+++ b/service/defaultcomponents/components.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor"
@@ -96,6 +97,7 @@ func Factories() (otelcol.Factories, error) {
 		awsentity.NewFactory(),
 		batchprocessor.NewFactory(),
 		cumulativetodeltaprocessor.NewFactory(),
+		deltatocumulativeprocessor.NewFactory(),
 		deltatorateprocessor.NewFactory(),
 		ec2tagger.NewFactory(),
 		filterprocessor.NewFactory(),

--- a/service/defaultcomponents/components_test.go
+++ b/service/defaultcomponents/components_test.go
@@ -45,6 +45,7 @@ func TestComponents(t *testing.T) {
 		"attributes",
 		"batch",
 		"cumulativetodelta",
+		"deltatocumulative",
 		"deltatorate",
 		"ec2tagger",
 		"metricsgeneration",

--- a/translator/tocwconfig/sampleConfig/amp_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/amp_config_linux.yaml
@@ -99,6 +99,9 @@ processors:
         send_batch_max_size: 0
         send_batch_size: 8192
         timeout: 1m0s
+    deltatocumulative/host/amp:
+        max_stale: 5m0s
+        max_streams: 9223372036854775807
     ec2tagger:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
@@ -152,6 +155,7 @@ service:
                 - transform
                 - rollup
                 - batch/host/amp
+                - deltatocumulative/host/amp
             receivers:
                 - telegraf_cpu
         metrics/host/cloudwatch:

--- a/translator/tocwconfig/sampleConfig/amp_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/amp_config_linux.yaml
@@ -100,7 +100,7 @@ processors:
         send_batch_size: 8192
         timeout: 1m0s
     deltatocumulative/host/amp:
-        max_stale: 5m0s
+        max_stale: 336h0m0s
         max_streams: 9223372036854775807
     ec2tagger:
         ec2_instance_tag_keys:

--- a/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
@@ -105,6 +105,12 @@ processors:
             match_type: ""
         initial_value: 2
         max_staleness: 0s
+    deltatocumulative/host/amp:
+        max_stale: 5m0s
+        max_streams: 9223372036854775807
+    deltatocumulative/jmx/amp:
+        max_stale: 5m0s
+        max_streams: 9223372036854775807
     filter/jmx:
         error_mode: propagate
         logs: {}
@@ -187,6 +193,7 @@ service:
             processors:
                 - transform
                 - batch/host/amp
+                - deltatocumulative/host/amp
             receivers:
                 - telegraf_cpu
                 - telegraf_disk
@@ -207,6 +214,7 @@ service:
                 - resource/jmx
                 - transform/jmx
                 - batch/jmx/amp
+                - deltatocumulative/jmx/amp
             receivers:
                 - jmx
         metrics/jmx/cloudwatch:

--- a/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_config_linux.yaml
@@ -106,10 +106,10 @@ processors:
         initial_value: 2
         max_staleness: 0s
     deltatocumulative/host/amp:
-        max_stale: 5m0s
+        max_stale: 336h0m0s
         max_streams: 9223372036854775807
     deltatocumulative/jmx/amp:
-        max_stale: 5m0s
+        max_stale: 336h0m0s
         max_streams: 9223372036854775807
     filter/jmx:
         error_mode: propagate

--- a/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.yaml
@@ -93,10 +93,10 @@ processors:
         initial_value: 2
         max_staleness: 0s
     deltatocumulative/jmx/amp/0:
-        max_stale: 5m0s
+        max_stale: 336h0m0s
         max_streams: 9223372036854775807
     deltatocumulative/jmx/amp/1:
-        max_stale: 5m0s
+        max_stale: 336h0m0s
         max_streams: 9223372036854775807
     filter/jmx/0:
         error_mode: propagate

--- a/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.yaml
@@ -92,6 +92,12 @@ processors:
             match_type: ""
         initial_value: 2
         max_staleness: 0s
+    deltatocumulative/jmx/amp/0:
+        max_stale: 5m0s
+        max_streams: 9223372036854775807
+    deltatocumulative/jmx/amp/1:
+        max_stale: 5m0s
+        max_streams: 9223372036854775807
     filter/jmx/0:
         error_mode: propagate
         logs: {}
@@ -240,6 +246,7 @@ service:
                 - transform/jmx/drop
                 - transform/jmx/0
                 - batch/jmx/amp/0
+                - deltatocumulative/jmx/amp/0
             receivers:
                 - otlp/jmx
         metrics/jmx/amp/1:
@@ -252,6 +259,7 @@ service:
                 - transform/jmx/drop
                 - transform/jmx/1
                 - batch/jmx/amp/1
+                - deltatocumulative/jmx/amp/1
             receivers:
                 - otlp/jmx
         metrics/jmx/cloudwatch/0:

--- a/translator/tocwconfig/sampleConfig/prometheus_combined_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_combined_config_linux.yaml
@@ -152,7 +152,7 @@ processors:
         send_batch_size: 8192
         timeout: 30s
     deltatocumulative/prometheus/amp:
-        max_stale: 5m0s
+        max_stale: 336h0m0s
         max_streams: 9223372036854775807
 receivers:
     prometheus:

--- a/translator/tocwconfig/sampleConfig/prometheus_combined_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_combined_config_linux.yaml
@@ -151,6 +151,9 @@ processors:
         send_batch_max_size: 0
         send_batch_size: 8192
         timeout: 30s
+    deltatocumulative/prometheus/amp:
+        max_stale: 5m0s
+        max_streams: 9223372036854775807
 receivers:
     prometheus:
         config:
@@ -202,6 +205,7 @@ service:
                 - prometheusremotewrite/amp
             processors:
                 - batch/prometheus/amp
+                - deltatocumulative/prometheus/amp
             receivers:
                 - prometheus
         metrics/prometheus/cloudwatchlogs:

--- a/translator/tocwconfig/sampleConfig/prometheus_otel_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_otel_config_linux.yaml
@@ -62,6 +62,9 @@ processors:
         send_batch_max_size: 0
         send_batch_size: 8192
         timeout: 1m0s
+    deltatocumulative/prometheus/amp:
+        max_stale: 5m0s
+        max_streams: 9223372036854775807
 receivers:
     prometheus:
         config:
@@ -107,6 +110,7 @@ service:
                 - prometheusremotewrite/amp
             processors:
                 - batch/prometheus/amp
+                - deltatocumulative/prometheus/amp
             receivers:
                 - prometheus
     telemetry:

--- a/translator/tocwconfig/sampleConfig/prometheus_otel_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_otel_config_linux.yaml
@@ -63,7 +63,7 @@ processors:
         send_batch_size: 8192
         timeout: 1m0s
     deltatocumulative/prometheus/amp:
-        max_stale: 5m0s
+        max_stale: 336h0m0s
         max_streams: 9223372036854775807
 receivers:
     prometheus:

--- a/translator/translate/otel/pipeline/host/translator.go
+++ b/translator/translate/otel/pipeline/host/translator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/awsentity"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/cumulativetodeltaprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/deltatocumulativeprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/ec2taggerprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/metricsdecorator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/rollupprocessor"
@@ -136,6 +137,7 @@ func (t translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators,
 			translators.Processors.Set(rollupprocessor.NewTranslator())
 		}
 		translators.Processors.Set(batchprocessor.NewTranslatorWithNameAndSection(t.name, common.MetricsKey))
+		translators.Processors.Set(deltatocumulativeprocessor.NewTranslator(common.WithName(t.name)))
 		translators.Exporters.Set(prometheusremotewrite.NewTranslatorWithName(common.AMPKey))
 		translators.Extensions.Set(sigv4auth.NewTranslator())
 	case common.CloudWatchLogsKey:

--- a/translator/translate/otel/pipeline/host/translator.go
+++ b/translator/translate/otel/pipeline/host/translator.go
@@ -137,6 +137,7 @@ func (t translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators,
 			translators.Processors.Set(rollupprocessor.NewTranslator())
 		}
 		translators.Processors.Set(batchprocessor.NewTranslatorWithNameAndSection(t.name, common.MetricsKey))
+		// prometheusremotewrite doesn't support delta metrics so convert them to cumulative metrics
 		translators.Processors.Set(deltatocumulativeprocessor.NewTranslator(common.WithName(t.name)))
 		translators.Exporters.Set(prometheusremotewrite.NewTranslatorWithName(common.AMPKey))
 		translators.Extensions.Set(sigv4auth.NewTranslator())

--- a/translator/translate/otel/pipeline/host/translator_test.go
+++ b/translator/translate/otel/pipeline/host/translator_test.go
@@ -307,7 +307,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/host/amp",
 				receivers:  []string{"nop", "other"},
-				processors: []string{"rollup", "batch/host/amp"},
+				processors: []string{"rollup", "batch/host/amp", "deltatocumulative/host/amp"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},
@@ -322,7 +322,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/host/amp",
 				receivers:  []string{"nop", "other"},
-				processors: []string{"batch/host/amp"},
+				processors: []string{"batch/host/amp", "deltatocumulative/host/amp"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},

--- a/translator/translate/otel/pipeline/jmx/translator.go
+++ b/translator/translate/otel/pipeline/jmx/translator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/cumulativetodeltaprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/deltatocumulativeprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/ec2taggerprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/filterprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/metricsdecorator"
@@ -120,6 +121,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		if conf.IsSet(common.MetricsAggregationDimensionsKey) {
 			translators.Processors.Set(rollupprocessor.NewTranslator())
 		}
+		translators.Processors.Set(deltatocumulativeprocessor.NewTranslator(common.WithName(t.name)))
 		translators.Exporters.Set(prometheusremotewrite.NewTranslatorWithName(common.AMPKey))
 		translators.Extensions.Set(sigv4auth.NewTranslator())
 	default:

--- a/translator/translate/otel/pipeline/jmx/translator.go
+++ b/translator/translate/otel/pipeline/jmx/translator.go
@@ -121,6 +121,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		if conf.IsSet(common.MetricsAggregationDimensionsKey) {
 			translators.Processors.Set(rollupprocessor.NewTranslator())
 		}
+		// prometheusremotewrite doesn't support delta metrics so convert them to cumulative metrics
 		translators.Processors.Set(deltatocumulativeprocessor.NewTranslator(common.WithName(t.name)))
 		translators.Exporters.Set(prometheusremotewrite.NewTranslatorWithName(common.AMPKey))
 		translators.Extensions.Set(sigv4auth.NewTranslator())

--- a/translator/translate/otel/pipeline/jmx/translator_test.go
+++ b/translator/translate/otel/pipeline/jmx/translator_test.go
@@ -208,7 +208,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx/amp",
 				receivers:  []string{"jmx"},
-				processors: []string{"filter/jmx", "resource/jmx", "batch/jmx/amp"},
+				processors: []string{"filter/jmx", "resource/jmx", "batch/jmx/amp", "deltatocumulative/jmx/amp"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},
@@ -238,7 +238,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx/amp",
 				receivers:  []string{"otlp/jmx"},
-				processors: []string{"filter/jmx", "metricstransform/jmx", "transform/jmx/drop", "batch/jmx/amp"},
+				processors: []string{"filter/jmx", "metricstransform/jmx", "transform/jmx/drop", "batch/jmx/amp", "deltatocumulative/jmx/amp"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},
@@ -338,7 +338,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/jmx/amp/0",
 				receivers:  []string{"otlp/jmx"},
-				processors: []string{"filter/jmx/0", "metricstransform/jmx", "transform/jmx/drop", "transform/jmx/0", "batch/jmx/amp/0"},
+				processors: []string{"filter/jmx/0", "metricstransform/jmx", "transform/jmx/drop", "transform/jmx/0", "batch/jmx/amp/0", "deltatocumulative/jmx/amp/0"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},

--- a/translator/translate/otel/pipeline/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/prometheus/translator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/deltatocumulativeprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/rollupprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/adapter"
 	otelprom "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/prometheus"
@@ -80,7 +81,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		}
 		translators := &common.ComponentTranslators{
 			Receivers:  common.NewTranslatorMap(otelprom.NewTranslator()),
-			Processors: common.NewTranslatorMap(batchprocessor.NewTranslatorWithNameAndSection(t.name, common.MetricsKey)),
+			Processors: common.NewTranslatorMap(batchprocessor.NewTranslatorWithNameAndSection(t.name, common.MetricsKey), deltatocumulativeprocessor.NewTranslator(common.WithName(t.name))),
 			Exporters:  common.NewTranslatorMap(prometheusremotewrite.NewTranslatorWithName(common.AMPKey)),
 			Extensions: common.NewTranslatorMap(sigv4auth.NewTranslator()),
 		}

--- a/translator/translate/otel/pipeline/prometheus/translator_test.go
+++ b/translator/translate/otel/pipeline/prometheus/translator_test.go
@@ -107,7 +107,7 @@ func TestTranslator(t *testing.T) {
 			want: &want{
 				pipelineID: "metrics/prometheus/amp",
 				receivers:  []string{"prometheus"},
-				processors: []string{"batch/prometheus/amp"},
+				processors: []string{"batch/prometheus/amp", "deltatocumulative/prometheus/amp"},
 				exporters:  []string{"prometheusremotewrite/amp"},
 				extensions: []string{"sigv4auth"},
 			},

--- a/translator/translate/otel/processor/deltatocumulativeprocessor/translator.go
+++ b/translator/translate/otel/processor/deltatocumulativeprocessor/translator.go
@@ -4,6 +4,8 @@
 package deltatocumulativeprocessor
 
 import (
+	"time"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
@@ -37,5 +39,6 @@ func (t *translator) ID() component.ID {
 // Metrics section of the JSON config.
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*deltatocumulativeprocessor.Config)
+	cfg.MaxStale = 14 * 24 * time.Hour // two weeks
 	return cfg, nil
 }

--- a/translator/translate/otel/processor/deltatocumulativeprocessor/translator.go
+++ b/translator/translate/otel/processor/deltatocumulativeprocessor/translator.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package deltatocumulativeprocessor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+type translator struct {
+	factory processor.Factory
+	common.NameProvider
+	keys []string
+}
+
+var _ common.ComponentTranslator = (*translator)(nil)
+var _ common.NameSetter = (*translator)(nil)
+
+func NewTranslator(opts ...common.TranslatorOption) common.ComponentTranslator {
+	t := &translator{factory: deltatocumulativeprocessor.NewFactory()}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+func (t *translator) ID() component.ID {
+	return component.NewIDWithName(t.factory.Type(), t.Name())
+}
+
+// Translate creates a processor config based on the fields in the
+// Metrics section of the JSON config.
+func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
+	cfg := t.factory.CreateDefaultConfig().(*deltatocumulativeprocessor.Config)
+	return cfg, nil
+}

--- a/translator/translate/otel/processor/deltatocumulativeprocessor/translator_test.go
+++ b/translator/translate/otel/processor/deltatocumulativeprocessor/translator_test.go
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package deltatocumulativeprocessor
+
+// func TestTranslator(t *testing.T) {
+// 	cdpTranslator := NewTranslator(common.WithName("test"), WithDefaultKeys())
+// 	require.EqualValues(t, "cumulativetodelta/test", cdpTranslator.ID().String())
+// 	testCases := map[string]struct {
+// 		input   map[string]any
+// 		want    map[string]any
+// 		wantErr error
+// 	}{
+// 		"GenerateDeltaProcessorConfigWithCPU": {
+// 			input: map[string]any{
+// 				"metrics": map[string]any{
+// 					"metrics_collected": map[string]any{
+// 						"cpu": map[string]any{},
+// 					},
+// 				},
+// 			},
+// 			wantErr: &common.MissingKeyError{ID: cdpTranslator.ID(), JsonKey: fmt.Sprint(diskioKey, " or ", netKey, " or ", otlpKey, " or ", otlpEmfKey)},
+// 		},
+// 		"GenerateDeltaProcessorConfigWithNet": {
+// 			input: map[string]any{
+// 				"metrics": map[string]any{
+// 					"metrics_collected": map[string]any{
+// 						"net": map[string]any{},
+// 					},
+// 				},
+// 			},
+// 			want: map[string]any{
+// 				"initial_value": "drop",
+// 			},
+// 		},
+// 		"GenerateDeltaProcessorConfigWithDiskIO": {
+// 			input: map[string]any{
+// 				"metrics": map[string]any{
+// 					"metrics_collected": map[string]any{
+// 						"diskio": map[string]any{},
+// 					},
+// 				},
+// 			},
+// 			want: map[string]any{
+// 				"exclude": map[string]any{
+// 					"match_type": "strict",
+// 					"metrics":    []string{"iops_in_progress", "diskio_iops_in_progress"},
+// 				},
+// 				"initial_value": "drop",
+// 			},
+// 		},
+// 	}
+// 	factory := cumulativetodeltaprocessor.NewFactory()
+// 	for name, testCase := range testCases {
+// 		t.Run(name, func(t *testing.T) {
+// 			conf := confmap.NewFromStringMap(testCase.input)
+// 			got, err := cdpTranslator.Translate(conf)
+// 			require.Equal(t, testCase.wantErr, err)
+// 			if err == nil {
+// 				require.NotNil(t, got)
+// 				gotCfg, ok := got.(*cumulativetodeltaprocessor.Config)
+// 				require.True(t, ok)
+// 				wantCfg := factory.CreateDefaultConfig()
+// 				wantConf := confmap.NewFromStringMap(testCase.want)
+// 				require.NoError(t, wantConf.Unmarshal(&wantCfg))
+// 				assert.Equal(t, wantCfg, gotCfg)
+// 			}
+// 		})
+// 	}
+// }


### PR DESCRIPTION
# Description of the issue
Currently, the CloudWatch Agent uses the [prometheusremotewrite exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) to send metrics to Amazon Managed Prometheus. It does not support delta metrics so the metrics are dropped:

> Non-cumulative monotonic, histogram, and summary OTLP metrics are dropped by this exporter.

This issue was discovered while updating the AMP integration test: https://github.com/aws/amazon-cloudwatch-agent-test/pull/465#issue-2864562335

# Description of changes
To remediate, the agent will use [deltatocumulativeprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatocumulativeprocessor) in AMP destination pipelines to convert delta metrics to cumulative metrics before being processed by the exporter.

The processor has two settings:
* `max_stale`: how long until a series not receiving new samples is removed
* `max_streams`: upper limit of streams to track. new streams exceeding this limit will be dropped

The `max_stale` setting defaults to 5m which may not be ideal for all users. If users emit hourly delta metrics, for example, then the ingested datapoints will always start a new stream. The [`cumulativetodeltaprocessor`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/cumulativetodeltaprocessor/README.md) is very similar processor which has a similar setting. By default, the processor uses infinite staleness so metric streams will never be dropped. Ideally, we'd configure the deltatocumulativeprocessor in the same manner the be consistent, but infinite staleness is not an option for the deltatocumulativeprocessor. Instead, we'll follow AWS's [PutMetricData API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html) convention of supporting metrics up two weeks:

> You can specify time stamps that are as much as two weeks before the current date, and as much as 2 hours after the current day and time.

The `max_streams` setting defaults to 64-bit integer maximum (9223372036854775807) which is effectively infinite. This is consistent with the cumulativetodeltaprocessor which uses an unbounded map to keep track of metrics.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the AMP integration test with agent updates and then locate delta metrics in AMG:
![snap 250326182535 Z7tJrCzY](https://github.com/user-attachments/assets/dad49b8c-4d26-4818-8649-3e888abb2328)

Updated AMP integration test to check for delta counter and delta histogram metrics now that they are supported.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




