### PR TITLE
Add eks addon e2e tests and update original helm charts e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,7 +8,7 @@ env:
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "tjstark/e2e-eks-addon-tests"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
   TERRAFORM_AWS_ASSUME_ROLE_ITAR: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_ITAR }}
   TERRAFORM_AWS_ASSUME_ROLE_CN: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}
   OPERATOR_GITHUB_REPO_NAME: "aws/amazon-cloudwatch-agent-operator"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,7 +8,7 @@ env:
   ECR_INTEGRATION_TEST_REPO: "cwagent-integration-test"
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
   CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
-  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+  CWA_GITHUB_TEST_REPO_BRANCH: "tjstark/e2e-eks-addon-tests"
   TERRAFORM_AWS_ASSUME_ROLE_ITAR: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_ITAR }}
   TERRAFORM_AWS_ASSUME_ROLE_CN: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}
   OPERATOR_GITHUB_REPO_NAME: "aws/amazon-cloudwatch-agent-operator"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -152,13 +152,13 @@ jobs:
         run: |
           echo "eks_e2e_jmx_matrix: ${{ steps.set-matrix.outputs.eks_e2e_jmx_matrix }}"
 
-  EKSE2EJVMTomcatTest:
+  EKSE2EJVMTomcatTestHelm:
     needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
-    name: 'EKSE2EJVMTomcatTest'
+    name: 'EKSE2EJVMTomcatTestHelm'
     uses: ./.github/workflows/eks-e2e-test.yml
     with:
       terraform_dir: terraform/eks/e2e
-      job_id: eks-e2e-jvm-tomcat-test
+      job_id: eks-e2e-jvm-tomcat-test-helm
       test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_jmx_matrix }}
       test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
       test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
@@ -170,17 +170,18 @@ jobs:
       region: ${{ inputs.region || 'us-west-2' }}
       helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
       terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      agent_config: resources/cwagent_configs/jvm_tomcat.json
+      agent_config: resources/cwagent_configs_helm_chart/jvm_tomcat.json
       sample_app: resources/sample_apps/tomcat.yaml
+      eks_installation_type: "HELM_CHART"
     secrets: inherit
 
-  EKSE2EKafkaTest:
+  EKSE2EJVMTomcatTestAddon:
     needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
-    name: 'EKSE2EKafkaTest'
+    name: 'EKSE2EJVMTomcatTestAddon'
     uses: ./.github/workflows/eks-e2e-test.yml
     with:
       terraform_dir: terraform/eks/e2e
-      job_id: eks-e2e-kafka-test
+      job_id: eks-e2e-jvm-tomcat-test-addon
       test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_jmx_matrix }}
       test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
       test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
@@ -192,17 +193,41 @@ jobs:
       region: ${{ inputs.region || 'us-west-2' }}
       helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
       terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      agent_config: resources/cwagent_configs/kafka.json
+      agent_config: resources/cwagent_configs_eks_addon/jvm_tomcat.json
+      sample_app: resources/sample_apps/tomcat.yaml
+      eks_installation_type: "EKS_ADDON"
+    secrets: inherit
+
+  EKSE2EKafkaTestHelm:
+    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
+    name: 'EKSE2EKafkaTestHelm'
+    uses: ./.github/workflows/eks-e2e-test.yml
+    with:
+      terraform_dir: terraform/eks/e2e
+      job_id: eks-e2e-kafka-test-helm
+      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_jmx_matrix }}
+      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
+      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
+      cloudwatch_agent_tag: ${{ github.sha }}
+      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
+      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
+      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+      agent_config: resources/cwagent_configs_helm_chart/kafka.json
       sample_app: resources/sample_apps/kafka.yaml
+      eks_installation_type: "HELM_CHART"
     secrets: inherit
 
-  EKSE2EJMXContainerInsightsTest:
+  EKSE2EKafkaTestAddon:
     needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
-    name: 'EKSE2EJMXContainerInsightsTest'
+    name: 'EKSE2EKafkaTestAddon'
     uses: ./.github/workflows/eks-e2e-test.yml
     with:
       terraform_dir: terraform/eks/e2e
-      job_id: eks-e2e-jmx-containerinsights-test
+      job_id: eks-e2e-kafka-test-addon
       test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_jmx_matrix }}
       test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
       test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
@@ -214,6 +239,54 @@ jobs:
       region: ${{ inputs.region || 'us-west-2' }}
       helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
       terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      agent_config: resources/cwagent_configs/containerinsights.json
-      sample_app: resources/sample_apps/tomcat.yaml
+      agent_config: resources/cwagent_configs_eks_addon/kafka.json
+      sample_app: resources/sample_apps/kafka.yaml
+      eks_installation_type: "EKS_ADDON"
     secrets: inherit
+
+  EKSE2EJMXContainerInsightsTestHelm:
+    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
+    name: 'EKSE2EJMXContainerInsightsTestHelm'
+    uses: ./.github/workflows/eks-e2e-test.yml
+    with:
+      terraform_dir: terraform/eks/e2e
+      job_id: eks-e2e-jmx-containerinsights-test-helm
+      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_jmx_matrix }}
+      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
+      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
+      cloudwatch_agent_tag: ${{ github.sha }}
+      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
+      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
+      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+      agent_config: resources/cwagent_configs_helm_chart/containerinsights.json
+      sample_app: resources/sample_apps/tomcat.yaml
+      eks_installation_type: "HELM_CHART"
+    secrets: inherit
+
+  EKSE2EJMXContainerInsightsTestAddon:
+    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
+    name: 'EKSE2EJMXContainerInsightsTestAddon'
+    uses: ./.github/workflows/eks-e2e-test.yml
+    with:
+      terraform_dir: terraform/eks/e2e
+      job_id: eks-e2e-jmx-containerinsights-test-addon
+      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_jmx_matrix }}
+      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
+      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
+      cloudwatch_agent_tag: ${{ github.sha }}
+      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
+      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
+      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+      agent_config: resources/cwagent_configs_eks_addon/containerinsights.json
+      sample_app: resources/sample_apps/tomcat.yaml
+      eks_installation_type: "EKS_ADDON"
+    secrets: inherit
+

--- a/.github/workflows/eks-e2e-test.yml
+++ b/.github/workflows/eks-e2e-test.yml
@@ -65,6 +65,9 @@ on:
       sample_app:
         required: true
         type: string
+      eks_installation_type:
+        required: true
+        type: string
 
 jobs:
   EKSE2ETest:
@@ -132,7 +135,8 @@ jobs:
               -var="agent_config=${{ inputs.agent_config }}" \
               -var="prometheus_config=${{ inputs.prometheus_config }}" \
               -var="otel_config=${{ inputs.otel_config }}" \
-              -var="sample_app=${{ inputs.sample_app }}"; then
+              -var="sample_app=${{ inputs.sample_app }}" \
+              -var="eks_installation_type=${{ inputs.eks_installation_type }}"; then
               terraform destroy --auto-approve
             else
               terraform destroy --auto-approve && exit 1


### PR DESCRIPTION
# Description of the issue
This PR adds parallel test paths for both Helm and Addon deployment methods in the EKS E2E test workflow. The changes include:

# Description of changes
1. Renamed existing e2e tests jobs to include "Helm" suffix:
   - EKSE2EJVMTomcatTest → EKSE2EJVMTomcatTestHelm
   - EKSE2EKafkaTest → EKSE2EKafkaTestHelm
   - EKSE2EJMXContainerInsightsTest → EKSE2EJMXContainerInsightsTestHelm

2. Added new corresponding test jobs for EKS Add-on:
   - EKSE2EJVMTomcatTestAddon
   - EKSE2EKafkaTestAddon
   - EKSE2EJMXContainerInsightsTestAddon

3. Added `eks_installation_type` flag to indicate Helm Charts of EKS Add-on installation

These changes will allow us to validate both deployment methods in parallel, ensuring compatibility and functionality across different installation approaches.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Passing E2E test runs (ran twice)
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14391860200
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14388827097

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




