### PR TITLE
Fix service ip to workload mapping in an edge case

### DIFF
--- a/extension/k8smetadata/extension.go
+++ b/extension/k8smetadata/extension.go
@@ -68,7 +68,7 @@ func (e *KubernetesMetadata) Start(_ context.Context, _ component.Host) error {
 			//
 			// Scenario:
 			//   When a deployment associated with service X has only one pod, the following events occur:
-			//     a. A pod terminates (one endpoint terminating). For this event, we add the service -> workload mapping immediately
+			//     a. A pod terminates (one endpoint terminating). For this event, we keep the service -> workload mapping (which is added before)
 			//     b. The endpoints become empty (null endpoints). For this event, we remove the service -> workload mapping in a delay way
 			//     c. A new pod starts (one endpoint starting). For this event, we add the same service -> workload mapping immediately
 			//

--- a/extension/k8smetadata/extension.go
+++ b/extension/k8smetadata/extension.go
@@ -56,18 +56,43 @@ func (e *KubernetesMetadata) Start(_ context.Context, _ component.Host) error {
 	// jitter calls to the kubernetes api (a precaution to prevent overloading api server)
 	jitterSleep(jitterKubernetesAPISeconds)
 
-	timedDeleter := &k8sclient.TimedDeleter{Delay: deletionDelay}
 	sharedInformerFactory := informers.NewSharedInformerFactory(clientset, 0)
 	e.safeStopCh = &k8sclient.SafeChannel{Ch: make(chan struct{}), Closed: false}
 
 	for _, obj := range e.config.Objects {
 		switch obj {
 		case "endpointslices":
+			// For the endpoint slice watcher, we maintain two mappings:
+			//   1. ip -> workflow
+			//   2. service -> workflow
+			//
+			// Scenario:
+			//   When a deployment associated with service X has only one pod, the following events occur:
+			//     a. A pod terminates (one endpoint terminating).
+			//     b. The endpoints become empty (null endpoints).
+			//     c. A new pod starts (one endpoint starting).
+			//
+			// Problem:
+			//   In step (b), a deletion delay (e.g., 2 minutes) is initiated for the mapping with service key X.
+			//   Then, in step (c), the mapping for service key X is re-added. Since the new mapping is inserted
+			//   before the delay expires, the scheduled deletion from step (b) may erroneously remove the mapping
+			//   added in step (c).
+			//
+			// Root Cause and Resolution:
+			//   The issue is caused by deleting the mapping using only the key, without verifying the value.
+			//   To fix this, we need to compare both the key and the value before deletion.
+			//   That is exactly the purpose of TimedDeleterWithIDCheck.
+			timedDeleter := &k8sclient.TimedDeleterWithIDCheck{Delay: deletionDelay}
 			e.endpointSliceWatcher = k8sclient.NewEndpointSliceWatcher(e.logger, sharedInformerFactory, timedDeleter)
 			e.endpointSliceWatcher.Run(e.safeStopCh.Ch)
 			e.endpointSliceWatcher.WaitForCacheSync(e.safeStopCh.Ch)
 			e.logger.Debug("EndpointSlice cache synced")
 		case "services":
+			// for service watcher, we are doing the mapping from IP to service name, it's very rare for an ip to be reused
+			// by two services. So we don't face the issue of service -> workflow mapping in endpointSliceWatcher.
+			// Technically, we can use TimedDeleterWithIDCheck as well but it will involve changing podwatcher with a lot of code changes.
+			// I don't think it's worthwhile to do it now. We might conside to do it when podwatcher is no longer in use.
+			timedDeleter := &k8sclient.TimedDeleter{Delay: deletionDelay}
 			e.serviceWatcher = k8sclient.NewServiceWatcher(e.logger, sharedInformerFactory, timedDeleter)
 			e.serviceWatcher.Run(e.safeStopCh.Ch)
 			e.serviceWatcher.WaitForCacheSync(e.safeStopCh.Ch)

--- a/extension/k8smetadata/extension.go
+++ b/extension/k8smetadata/extension.go
@@ -63,14 +63,14 @@ func (e *KubernetesMetadata) Start(_ context.Context, _ component.Host) error {
 		switch obj {
 		case "endpointslices":
 			// For the endpoint slice watcher, we maintain two mappings:
-			//   1. ip -> workflow
-			//   2. service -> workflow
+			//   1. ip -> workload
+			//   2. service -> workload
 			//
 			// Scenario:
 			//   When a deployment associated with service X has only one pod, the following events occur:
-			//     a. A pod terminates (one endpoint terminating).
-			//     b. The endpoints become empty (null endpoints).
-			//     c. A new pod starts (one endpoint starting).
+			//     a. A pod terminates (one endpoint terminating). For this event, we add the service -> workload mapping immediately
+			//     b. The endpoints become empty (null endpoints). For this event, we remove the service -> workload mapping in a delay way
+			//     c. A new pod starts (one endpoint starting). For this event, we add the same service -> workload mapping immediately
 			//
 			// Problem:
 			//   In step (b), a deletion delay (e.g., 2 minutes) is initiated for the mapping with service key X.
@@ -89,7 +89,7 @@ func (e *KubernetesMetadata) Start(_ context.Context, _ component.Host) error {
 			e.logger.Debug("EndpointSlice cache synced")
 		case "services":
 			// for service watcher, we are doing the mapping from IP to service name, it's very rare for an ip to be reused
-			// by two services. So we don't face the issue of service -> workflow mapping in endpointSliceWatcher.
+			// by two services. So we don't face the issue of service -> workload mapping in endpointSliceWatcher.
 			// Technically, we can use TimedDeleterWithIDCheck as well but it will involve changing podwatcher with a lot of code changes.
 			// I don't think it's worthwhile to do it now. We might conside to do it when podwatcher is no longer in use.
 			timedDeleter := &k8sclient.TimedDeleter{Delay: deletionDelay}

--- a/internal/k8sCommon/k8sclient/endpointslicewatcher.go
+++ b/internal/k8sCommon/k8sclient/endpointslicewatcher.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 	discv1 "k8s.io/api/discovery/v1"
 	"k8s.io/client-go/informers"
@@ -32,6 +33,22 @@ type PodMetadata struct {
 	Workload  string
 	Namespace string
 	Node      string
+	uuid      string // unexported field to store the unique identifier
+}
+
+// NewPodMetadata constructs a new PodMetadata instance with a unique uuid.
+func NewPodMetadata(workload, namespace, node string) PodMetadata {
+	return PodMetadata{
+		Workload:  workload,
+		Namespace: namespace,
+		Node:      node,
+		uuid:      uuid.NewString(),
+	}
+}
+
+// UUID returns the unique identifier (uuid) for the PodMetadata.
+func (pm PodMetadata) UUID() string {
+	return pm.uuid
 }
 
 // kvPair holds one mapping from key -> value. The isService flag
@@ -127,11 +144,7 @@ func (w *EndpointSliceWatcher) extractEndpointSliceKeyValuePairs(slice *discv1.E
 				continue
 			}
 
-			fullWl := PodMetadata{
-				Workload:  derivedWorkload,
-				Namespace: ns,
-				Node:      nodeName,
-			}
+			fullWl := NewPodMetadata(derivedWorkload, ns, nodeName)
 
 			// Build IP and IP:port pairs
 			for _, addr := range endpoint.Addresses {

--- a/internal/k8sCommon/k8sclient/kubernetes_utils.go
+++ b/internal/k8sCommon/k8sclient/kubernetes_utils.go
@@ -229,3 +229,48 @@ func (td *TimedDeleter) DeleteWithDelay(m *sync.Map, key interface{}) {
 		m.Delete(key)
 	}()
 }
+
+type UUIDValue interface {
+	UUID() string
+}
+
+// TimedDeleterWithIDCheck deletes a key from a sync.Map after a specified delay,
+// but only if the value associated with the key has not been updated (i.e. its UUID is unchanged).
+// Please note TimedDeleterWithIDCheck only work with UUIDValue as value type
+type TimedDeleterWithIDCheck struct {
+	Delay time.Duration
+}
+
+// DeleteWithDelay schedules the deletion of key from map m after the delay.
+// It only deletes the key if the value's UUID remains the same.
+func (td *TimedDeleterWithIDCheck) DeleteWithDelay(m *sync.Map, key interface{}) {
+	// Attempt to load the value for the key.
+	deleteVal, ok := m.Load(key)
+	if !ok {
+		return
+	}
+
+	// The stored value must be of type UUIDValue.
+	initialVal, ok := deleteVal.(UUIDValue)
+	if !ok {
+		return
+	}
+
+	go func() {
+		time.Sleep(td.Delay)
+		// Check if the key still exists.
+		currentValRaw, ok := m.Load(key)
+		if !ok {
+			return
+		}
+		currentVal, ok := currentValRaw.(UUIDValue)
+		if !ok {
+			return
+		}
+
+		// Compare the UUIDs of the initial value and the current value.
+		if currentVal.UUID() == initialVal.UUID() {
+			m.Delete(key)
+		}
+	}()
+}

--- a/internal/k8sCommon/k8sclient/kubernetes_utils.go
+++ b/internal/k8sCommon/k8sclient/kubernetes_utils.go
@@ -153,9 +153,9 @@ func InferWorkloadName(podName, fallbackServiceName string) string {
 	return podName
 }
 
-const IP_PORT_PATTERN = `^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d+)$`
+const IPPortPattern = `^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d+)$`
 
-var ipPortRegex = regexp.MustCompile(IP_PORT_PATTERN)
+var ipPortRegex = regexp.MustCompile(IPPortPattern)
 
 func ExtractIPPort(ipPort string) (string, string, bool) {
 	match := ipPortRegex.MatchString(ipPort)

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
@@ -183,7 +183,7 @@ func getKubernetesResolver(platformCode, clusterName string, logger *zap.Logger)
 		//
 		// Scenario:
 		//   When a deployment associated with service X has only one pod, the following events occur:
-		//     a. A pod terminates (one endpoint terminating). For this event, we add the service -> workload mapping immediately
+		//     a. A pod terminates (one endpoint terminating). For this event, we keep the service -> workload mapping (which is added before)
 		//     b. The endpoints become empty (null endpoints). For this event, we remove the service -> workload mapping in a delay way
 		//     c. A new pod starts (one endpoint starting). For this event, we add the same service -> workload mapping immediately
 		//

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
@@ -178,14 +178,14 @@ func getKubernetesResolver(platformCode, clusterName string, logger *zap.Logger)
 		sharedInformerFactory := informers.NewSharedInformerFactory(clientset, 0)
 
 		// For the endpoint slice watcher, we maintain two mappings:
-		//   1. ip -> workflow
-		//   2. service -> workflow
+		//   1. ip -> workload
+		//   2. service -> workload
 		//
 		// Scenario:
 		//   When a deployment associated with service X has only one pod, the following events occur:
-		//     a. A pod terminates (one endpoint terminating). For this event, we add the service -> workflow mapping immediately
-		//     b. The endpoints become empty (null endpoints). For this event, we remove the service -> workflow mapping in a delay way
-		//     c. A new pod starts (one endpoint starting). For this event, we add the same service -> workflow mapping immediately
+		//     a. A pod terminates (one endpoint terminating). For this event, we add the service -> workload mapping immediately
+		//     b. The endpoints become empty (null endpoints). For this event, we remove the service -> workload mapping in a delay way
+		//     c. A new pod starts (one endpoint starting). For this event, we add the same service -> workload mapping immediately
 		//
 		// Problem:
 		//   In step (b), a deletion delay (e.g., 2 minutes) is initiated for the mapping with service key X.
@@ -201,7 +201,7 @@ func getKubernetesResolver(platformCode, clusterName string, logger *zap.Logger)
 		endptSliceWatcher := k8sclient.NewEndpointSliceWatcher(logger, sharedInformerFactory, TimedDeleterWithIDCheck)
 
 		// for service watcher, we are doing the mapping from IP to service name, it's very rare for an ip to be reused
-		// by two services. So we don't face the issue of service -> workflow mapping in endpointSliceWatcher.
+		// by two services. So we don't face the issue of service -> workload mapping in endpointSliceWatcher.
 		// Technically, we can use TimedDeleterWithIDCheck as well but it will involve changing podwatcher with a log of code changes.
 		// I don't think it's worthwhile to do it now. We might conside to do it when podwatcher is no longer in use.
 		timedDeleter := &k8sclient.TimedDeleter{Delay: deletionDelay}

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes.go
@@ -176,10 +176,36 @@ func getKubernetesResolver(platformCode, clusterName string, logger *zap.Logger)
 		jitterSleep(jitterKubernetesAPISeconds)
 
 		sharedInformerFactory := informers.NewSharedInformerFactory(clientset, 0)
-		timedDeleter := &k8sclient.TimedDeleter{Delay: deletionDelay}
 
+		// For the endpoint slice watcher, we maintain two mappings:
+		//   1. ip -> workflow
+		//   2. service -> workflow
+		//
+		// Scenario:
+		//   When a deployment associated with service X has only one pod, the following events occur:
+		//     a. A pod terminates (one endpoint terminating). For this event, we add the service -> workflow mapping immediately
+		//     b. The endpoints become empty (null endpoints). For this event, we remove the service -> workflow mapping in a delay way
+		//     c. A new pod starts (one endpoint starting). For this event, we add the same service -> workflow mapping immediately
+		//
+		// Problem:
+		//   In step (b), a deletion delay (e.g., 2 minutes) is initiated for the mapping with service key X.
+		//   Then, in step (c), the mapping for service key X is re-added. Since the new mapping is inserted
+		//   before the delay expires, the scheduled deletion from step (b) may erroneously remove the mapping
+		//   added in step (c).
+		//
+		// Root Cause and Resolution:
+		//   The issue is caused by deleting the mapping using only the key, without verifying the value.
+		//   To fix this, we need to compare both the key and the value before deletion.
+		//   That is exactly the purpose of TimedDeleterWithIDCheck.
+		TimedDeleterWithIDCheck := &k8sclient.TimedDeleterWithIDCheck{Delay: deletionDelay}
+		endptSliceWatcher := k8sclient.NewEndpointSliceWatcher(logger, sharedInformerFactory, TimedDeleterWithIDCheck)
+
+		// for service watcher, we are doing the mapping from IP to service name, it's very rare for an ip to be reused
+		// by two services. So we don't face the issue of service -> workflow mapping in endpointSliceWatcher.
+		// Technically, we can use TimedDeleterWithIDCheck as well but it will involve changing podwatcher with a log of code changes.
+		// I don't think it's worthwhile to do it now. We might conside to do it when podwatcher is no longer in use.
+		timedDeleter := &k8sclient.TimedDeleter{Delay: deletionDelay}
 		svcWatcher := k8sclient.NewServiceWatcher(logger, sharedInformerFactory, timedDeleter)
-		endptSliceWatcher := k8sclient.NewEndpointSliceWatcher(logger, sharedInformerFactory, timedDeleter)
 
 		safeStopCh := &k8sclient.SafeChannel{Ch: make(chan struct{}), Closed: false}
 		// initialize the pod and service watchers for the cluster

--- a/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/kubernetes_test.go
@@ -215,7 +215,7 @@ func TestEksResolver(t *testing.T) {
 		attributes.PutStr(attr.AWSRemoteService, "192.168.1.2")
 		resourceAttributes = pcommon.NewMap()
 		resolver.ipToServiceAndNamespace.Store("192.168.1.2", "service1@test-namespace-3")
-		resolver.serviceToWorkload.Store("service1@test-namespace-3", "service1-deployment@test-namespace-3")
+		resolver.serviceToWorkload.Store("service1@test-namespace-3", k8sclient.NewPodMetadata("service1-deployment", "test-namespace-3", ""))
 		err = resolver.Process(attributes, resourceAttributes)
 		assert.NoError(t, err)
 		assert.Equal(t, "service1-deployment", getStrAttr(attributes, attr.AWSRemoteService, t))


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._

# Description of changes
_How does this change address the problem?_

When a kubernetes service is backed by a deployment with only one pod, we will observe the wrong service ip to workload mapping when the pod is killed. This is due to the following race:
  - Pod termination triggered a 2-min delayed deletion for the service ip to workload mapping.
  - A new pod started quickly and re-added the service ip to workload mapping.
  - The delayed deletion erroneously removed the new mapping because deletion was based solely on key.


This change introduces TimedDeleterWithIDCheck, which only deletes the mapping if the value’s UUID
remains unchanged. This ensures that if the mapping is updated (even with the same string content),
it won’t be deleted unintentionally.


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._
Manually reproduced the issue and then confirmed the fix is working. 

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




