### PR TITLE
Fix typo in repackaging for Mac AMD64

### DIFF
--- a/.github/workflows/repackage-release-artifacts.yml
+++ b/.github/workflows/repackage-release-artifacts.yml
@@ -78,7 +78,7 @@ jobs:
 
           pushd darwin/amd64
           unzip AmazonCloudWatchAgent.zip
-          aws s3 cp --no-progress ./amazon-cloudwatch-agent.pkg s3://${{ env.S3_INTEGRATION_BUCKET }}/integration-test/packaging/${{ inputs.build_id }}/arm64/amazon-cloudwatch-agent.pkg
+          aws s3 cp --no-progress ./amazon-cloudwatch-agent.pkg s3://${{ env.S3_INTEGRATION_BUCKET }}/integration-test/packaging/${{ inputs.build_id }}/amd64/amazon-cloudwatch-agent.pkg
           popd
 
           pushd darwin/arm64


### PR DESCRIPTION
# Description of the issue
Integration tests for release candidate artifacts are failing because it is unable to find the AMD64 version of the .pkg files. 

# Description of changes
There is a typo in the repackaging workflow that uploads the AMD64 version of the files to the ARM64 path, which then gets overwritten by the real ARM64 artifacts.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the updated commands manually, re-executed integration tests, AMD64 Mac tests are successful.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




