### PR TITLE
Remove Attestation from Linux image manifests in ECR for Nightly Build

### DIFF
--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -388,12 +388,8 @@ jobs:
           docker manifest create $REGISTRY/$REPOSITORYWindows --amend $REGISTRY/$REPO2022 --amend $REGISTRY/$REPO2019
           docker manifest push $REGISTRY/$REPOSITORYWindows
 
-          docker buildx imagetools inspect --raw $REGISTRY/$REPOLinuxAmd > linux-amd.json
-          docker buildx imagetools inspect --raw $REGISTRY/$REPOLinuxArm > linux-arm.json
-          docker buildx imagetools inspect --raw $REGISTRY/$REPOSITORYWindows | jq '.manifests[0]' > 2019.json
-          docker buildx imagetools inspect --raw $REGISTRY/$REPOSITORYWindows | jq '.manifests[1]' > 2022.json
-
-          docker buildx imagetools create -f linux-amd.json -f linux-arm.json -f 2019.json -f 2022.json --tag $REGISTRY/$OrigREPOSITORY
+          docker manifest create $REGISTRY/$OrigREPOSITORY --amend $REGISTRY/$REPO2022 --amend $REGISTRY/$REPO2019 --amend $REGISTRY/$REPOLinuxAmd --amend $REGISTRY/$REPOLinuxArm
+          docker manifest push $REGISTRY/$OrigREPOSITORY
 
   #GH actions set up gpg only works on ubuntu as of this commit date
   GPGSignWindowsPackage:

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -112,6 +112,7 @@ jobs:
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64
           platforms: linux/amd64
+          provenance: false
 
       - name: Build Cloudwatch Agent Image arm64
         uses: docker/build-push-action@v6
@@ -123,6 +124,7 @@ jobs:
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64
           platforms: linux/arm64
+          provenance: false
 
   MakeMSIZip:
     name: 'MakeMSIZip'
@@ -386,8 +388,8 @@ jobs:
           docker manifest create $REGISTRY/$REPOSITORYWindows --amend $REGISTRY/$REPO2022 --amend $REGISTRY/$REPO2019
           docker manifest push $REGISTRY/$REPOSITORYWindows
 
-          docker buildx imagetools inspect --raw $REGISTRY/$REPOLinuxAmd | jq '.manifests[0]' > linux-amd.json
-          docker buildx imagetools inspect --raw $REGISTRY/$REPOLinuxArm | jq '.manifests[0]' > linux-arm.json
+          docker buildx imagetools inspect --raw $REGISTRY/$REPOLinuxAmd > linux-amd.json
+          docker buildx imagetools inspect --raw $REGISTRY/$REPOLinuxArm > linux-arm.json
           docker buildx imagetools inspect --raw $REGISTRY/$REPOSITORYWindows | jq '.manifests[0]' > 2019.json
           docker buildx imagetools inspect --raw $REGISTRY/$REPOSITORYWindows | jq '.manifests[1]' > 2022.json
 


### PR DESCRIPTION
# Description of the issue
Before this change, the linux images published to ECR are layered with an Attestation created by default by the docker build-push-action. As a result, a top level image index is created with the expected amd64/arm64 tag. Lack of tag on the nested linux images prevents automated identification of the linux image manifests (ex: for filtering CVE scan results)

# Description of changes

This change sets the docker build-push-action flag for `providence` to false to stop creating the Attestation and top level image index. This now allows the actual CWA image to be published to ECR with the expected tags `linux-amd64` and `linux-arm64`

Additionally, builds the multi-architecture manifest list using `docker create manifest` since the above change removes the linux image index. We can now point directly to the CWA linux arm64 and amd64 images using their tags.

ECR for the Nightly Build repository before change:

![Screenshot 2025-04-23 at 12 12 32 PM](https://github.com/user-attachments/assets/01b46177-3f2e-494c-8abd-6ecd12731d74)


ECR for the Nightly Build repository after change:

![Screenshot 2025-04-23 at 7 42 58 PM](https://github.com/user-attachments/assets/4cdfd6e2-43cc-4400-b73d-43b29ab61da4)


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Validations performed on forked repo against developer account to confirm tagging is successful

See sample successful run of Nightly Build with dev branch:
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14629808785

Integration tests pass: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14631292291


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




