### PR TITLE
Add check for prometheus cluster name

### DIFF
--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -486,9 +486,14 @@ func KueueContainerInsightsEnabled(conf *confmap.Conf) bool {
 }
 
 func GetClusterName(conf *confmap.Conf) string {
-	val, ok := GetString(conf, ConfigKey(LogsKey, MetricsCollectedKey, KubernetesKey, "cluster_name"))
-	if ok && val != "" {
-		return val
+	val1, ok1 := GetString(conf, ConfigKey(LogsKey, MetricsCollectedKey, KubernetesKey, "cluster_name"))
+	if ok1 && val1 != "" {
+		return val1
+	}
+
+	val2, ok2 := GetString(conf, ConfigKey(LogsKey, MetricsCollectedKey, PrometheusKey, "cluster_name"))
+	if ok2 && val2 != "" {
+		return val2
 	}
 
 	envVarClusterName := os.Getenv("K8S_CLUSTER_NAME")

--- a/translator/translate/otel/processor/awsentity/translator_test.go
+++ b/translator/translate/otel/processor/awsentity/translator_test.go
@@ -96,6 +96,9 @@ func TestTranslate(t *testing.T) {
 						"kubernetes": map[string]interface{}{
 							"cluster_name": "ci-logs",
 						},
+						"prometheus": map[string]interface{}{
+							"cluster_name": "ci-prometheus",
+						},
 					},
 				},
 			},
@@ -104,6 +107,43 @@ func TestTranslate(t *testing.T) {
 			envClusterName: "env-cluster",
 			want: &awsentity.Config{
 				ClusterName:    "ci-logs",
+				KubernetesMode: config.ModeEKS,
+				Platform:       config.ModeEC2,
+			},
+		},
+		"PrometheusUnderLogs": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"prometheus": map[string]interface{}{
+							"cluster_name": "ci-prometheus",
+						},
+					},
+				},
+			},
+			mode:           config.ModeEC2,
+			kubernetesMode: config.ModeEKS,
+			want: &awsentity.Config{
+				ClusterName:    "ci-prometheus",
+				KubernetesMode: config.ModeEKS,
+				Platform:       config.ModeEC2,
+			},
+		},
+		"PrometheusPrecedence": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"prometheus": map[string]interface{}{
+							"cluster_name": "ci-prometheus",
+						},
+					},
+				},
+			},
+			mode:           config.ModeEC2,
+			kubernetesMode: config.ModeEKS,
+			envClusterName: "env-cluster",
+			want: &awsentity.Config{
+				ClusterName:    "ci-prometheus",
 				KubernetesMode: config.ModeEKS,
 				Platform:       config.ModeEC2,
 			},


### PR DESCRIPTION
# Description of the issue
The cluster name can also be present under the `prometheus` section for the CloudWatch Agent configuration. If that's present, then we should use that cluster name.

# Description of changes
- Add check for prometheus cluster name.
- Add unit tests.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit testing.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




