### PR TITLE
[ApplicationSignals] Support copying resource attributes to metric attributes for EMF export

### DIFF
--- a/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
+++ b/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
@@ -28,5 +28,5 @@ const (
 	ResourceDetectionASG      = "ec2.tag.aws:autoscaling:groupName"
 
 	// ApplicationSignals behaviour-changing attributes
-	AwsApplicationSignalsMetricResourceKeys = "aws.application_signals.metric_resource_keys"
+	AWSApplicationSignalsMetricResourceKeys = "aws.application_signals.metric_resource_keys"
 )

--- a/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
+++ b/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
@@ -26,4 +26,7 @@ const (
 	ResourceDetectionHostId   = "host.id"
 	ResourceDetectionHostName = "host.name"
 	ResourceDetectionASG      = "ec2.tag.aws:autoscaling:groupName"
+
+	// ApplicationSignals behaviour-changing attributes
+	AwsApplicationSignalsMetricResourceKeys = "aws.application_signals.metric_resource_keys"
 )

--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
@@ -120,7 +120,7 @@ func TestCopyResourceAttributesToAttributes_NoCopyDuplicateResourceAttributes(t 
 	for resourceAttrKey := range normalizedResourceAttributeKeys {
 		resourceAttributes.PutStr(resourceAttrKey, resourceAttrKey+"-value")
 	}
-	resourceAttributes.PutStr(attr.AwsApplicationSignalsMetricResourceKeys, "all_attributes")
+	resourceAttributes.PutStr(attr.AWSApplicationSignalsMetricResourceKeys, "all_attributes")
 	attributes := GenerateCopiedMetricAttributes(resourceAttributes)
 
 	for resourceAttrKey := range normalizedResourceAttributeKeys {
@@ -134,14 +134,14 @@ func TestCopyResourceAttributesToAttributes_CopyAllResourceAttributes(t *testing
 	for i := 1; i <= 10; i++ {
 		resourceAttributes.PutStr(strconv.Itoa(i), strconv.Itoa(i))
 	}
-	resourceAttributes.PutStr(attr.AwsApplicationSignalsMetricResourceKeys, "all_attributes")
+	resourceAttributes.PutStr(attr.AWSApplicationSignalsMetricResourceKeys, "all_attributes")
 	attributes := GenerateCopiedMetricAttributes(resourceAttributes)
 
 	assert.Equal(t, attributes.Len(), 11)
 	for i := 1; i <= 10; i++ {
 		assertStringAttributeEqual(t, attributes, "otel.resource."+strconv.Itoa(i), strconv.Itoa(i))
 	}
-	assertStringAttributeEqual(t, attributes, "otel.resource."+attr.AwsApplicationSignalsMetricResourceKeys, "all_attributes")
+	assertStringAttributeEqual(t, attributes, "otel.resource."+attr.AWSApplicationSignalsMetricResourceKeys, "all_attributes")
 }
 
 func TestCopyResourceAttributesToAttributes_CopySpecificResourceAttributes(t *testing.T) {
@@ -149,7 +149,7 @@ func TestCopyResourceAttributesToAttributes_CopySpecificResourceAttributes(t *te
 	for i := 1; i <= 10; i++ {
 		resourceAttributes.PutStr(strconv.Itoa(i), strconv.Itoa(i))
 	}
-	resourceAttributes.PutStr(attr.AwsApplicationSignalsMetricResourceKeys, "1&3&20&9")
+	resourceAttributes.PutStr(attr.AWSApplicationSignalsMetricResourceKeys, "1&3&20&9")
 	attributes := GenerateCopiedMetricAttributes(resourceAttributes)
 
 	assert.Equal(t, attributes.Len(), 3)

--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
@@ -4,6 +4,7 @@
 package normalizer
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,10 +77,26 @@ func TestRenameAttributes_for_trace(t *testing.T) {
 	}
 }
 
-func TestCopyResourceAttributesToAttributes(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
-	normalizer := NewAttributesNormalizer(logger)
+func TestNormalizedResourceAttributeKeys(t *testing.T) {
+	assert.Equal(t, 31, len(normalizedResourceAttributeKeys))
+	for key := range attributesRenamingForMetric {
+		assert.Contains(t, normalizedResourceAttributeKeys, key)
+	}
+	for key := range resourceToMetricAttributes {
+		assert.Contains(t, normalizedResourceAttributeKeys, key)
+	}
+	assert.Contains(t, normalizedResourceAttributeKeys, attr.AWSHostedInEnvironment)
+	assert.Contains(t, normalizedResourceAttributeKeys, attr.ResourceDetectionHostId)
+	assert.Contains(t, normalizedResourceAttributeKeys, deprecatedsemconv.AttributeTelemetryAutoVersion)
+	assert.Contains(t, normalizedResourceAttributeKeys, semconv.AttributeServiceName)
+	assert.Contains(t, normalizedResourceAttributeKeys, semconv.AttributeTelemetryDistroName)
+	assert.Contains(t, normalizedResourceAttributeKeys, semconv.AttributeTelemetryDistroVersion)
+	assert.Contains(t, normalizedResourceAttributeKeys, semconv.AttributeTelemetrySDKLanguage)
+	assert.Contains(t, normalizedResourceAttributeKeys, semconv.AttributeTelemetrySDKName)
+	assert.Contains(t, normalizedResourceAttributeKeys, semconv.AttributeTelemetrySDKVersion)
+}
 
+func TestCopyResourceAttributesToAttributes_ResourceToMetricAttributesAndLocalServiceCopied(t *testing.T) {
 	// Create a pcommon.Map for resourceAttributes with some attributes
 	resourceAttributes := pcommon.NewMap()
 	for resourceAttrKey, attrKey := range resourceToMetricAttributes {
@@ -87,12 +104,7 @@ func TestCopyResourceAttributesToAttributes(t *testing.T) {
 	}
 	resourceAttributes.PutStr("host.id", "i-01ef7d37f42caa168")
 	resourceAttributes.PutStr("aws.local.service", "test-app")
-
-	// Create a pcommon.Map for attributes
-	attributes := pcommon.NewMap()
-
-	// Call the process method
-	normalizer.copyResourceAttributesToAttributes(attributes, resourceAttributes, false)
+	attributes := GenerateCopiedMetricAttributes(resourceAttributes)
 
 	// Check that the attribute has been copied correctly
 	for _, attrKey := range resourceToMetricAttributes {
@@ -101,6 +113,49 @@ func TestCopyResourceAttributesToAttributes(t *testing.T) {
 
 	assertStringAttributeEqual(t, attributes, "K8s.Node", "i-01ef7d37f42caa168")
 	assertStringAttributeEqual(t, attributes, "aws.local.service", "test-app")
+}
+
+func TestCopyResourceAttributesToAttributes_NoCopyDuplicateResourceAttributes(t *testing.T) {
+	resourceAttributes := pcommon.NewMap()
+	for resourceAttrKey := range normalizedResourceAttributeKeys {
+		resourceAttributes.PutStr(resourceAttrKey, resourceAttrKey+"-value")
+	}
+	resourceAttributes.PutStr(attr.AwsApplicationSignalsMetricResourceKeys, "all_attributes")
+	attributes := GenerateCopiedMetricAttributes(resourceAttributes)
+
+	for resourceAttrKey := range normalizedResourceAttributeKeys {
+		_, exists := attributes.Get("otel.resource." + resourceAttrKey)
+		assert.False(t, exists, "%v unexpectedly found in attributes", "otel.resource."+resourceAttrKey)
+	}
+}
+
+func TestCopyResourceAttributesToAttributes_CopyAllResourceAttributes(t *testing.T) {
+	resourceAttributes := pcommon.NewMap()
+	for i := 1; i <= 10; i++ {
+		resourceAttributes.PutStr(strconv.Itoa(i), strconv.Itoa(i))
+	}
+	resourceAttributes.PutStr(attr.AwsApplicationSignalsMetricResourceKeys, "all_attributes")
+	attributes := GenerateCopiedMetricAttributes(resourceAttributes)
+
+	assert.Equal(t, attributes.Len(), 11)
+	for i := 1; i <= 10; i++ {
+		assertStringAttributeEqual(t, attributes, "otel.resource."+strconv.Itoa(i), strconv.Itoa(i))
+	}
+	assertStringAttributeEqual(t, attributes, "otel.resource."+attr.AwsApplicationSignalsMetricResourceKeys, "all_attributes")
+}
+
+func TestCopyResourceAttributesToAttributes_CopySpecificResourceAttributes(t *testing.T) {
+	resourceAttributes := pcommon.NewMap()
+	for i := 1; i <= 10; i++ {
+		resourceAttributes.PutStr(strconv.Itoa(i), strconv.Itoa(i))
+	}
+	resourceAttributes.PutStr(attr.AwsApplicationSignalsMetricResourceKeys, "1&3&20&9")
+	attributes := GenerateCopiedMetricAttributes(resourceAttributes)
+
+	assert.Equal(t, attributes.Len(), 3)
+	for _, i := range []int{1, 3, 9} {
+		assertStringAttributeEqual(t, attributes, "otel.resource."+strconv.Itoa(i), strconv.Itoa(i))
+	}
 }
 
 func TestTruncateAttributes(t *testing.T) {
@@ -261,4 +316,14 @@ func assertStringAttributeEqual(t *testing.T, attributes pcommon.Map, attrKey, a
 	} else {
 		t.Errorf("Attribute %s is not found", attrKey)
 	}
+}
+
+func GenerateCopiedMetricAttributes(resourceAttributes pcommon.Map) pcommon.Map {
+	logger, _ := zap.NewDevelopment()
+	normalizer := NewAttributesNormalizer(logger)
+	// Create a pcommon.Map for attributes
+	attributes := pcommon.NewMap()
+	// Call the process method
+	normalizer.copyResourceAttributesToAttributes(attributes, resourceAttributes, false)
+	return attributes
 }


### PR DESCRIPTION
*Callout*: Original PR: https://github.com/aws/amazon-cloudwatch-agent/pull/1673

# Description of the issue
In this change, we are supporting new attribute copying behaviour for ApplicationSignals. This will allow customers to specify which/all attributes they want to be present in their EMF records. 

# Description of changes
If the following key is present in the resource attributes: `aws.application_signals.metric_resource_keys`, we will copy attributes specified in the value (or all attributes if `all_attributes`) from resource to metric. Note that we do not copy attributes that are already copied/normalized by exisiting ApplicationSignals processor logic, to avoid data duplication. Also note that we prefix all copied attribute keys with `otel.resource` to avoid collisions with existing metric attributes.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Unit tests - DONE
* E2E tests - DONE:

## E2E
* Testing done on EC2 with a simple Java application and latest ADOT SDK.
* Scenario 1: `export OTEL_RESOURCE_ATTRIBUTES="service.name=test_1"`
```
{
    "EC2.InstanceId": "i-08a60809b167727a9",
    "Environment": "ec2:default",
    "Host": "ip-172-31-86-6.ec2.internal",
    "Operation": "InternalOperation",
    "PlatformType": "AWS::EC2",
    "Service": "test_1",
    "Telemetry.Agent": "CWAgent/",
    "Telemetry.SDK": "opentelemetry-java-instrumentation,2.10.0-aws,java,Auto",
    "Telemetry.Source": "LocalRootSpan",
    "Version": "1",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "ApplicationSignals",
                "Dimensions": [...],
                "Metrics": [...]
            }
        ],
        "Timestamp": 1746569096772
    },
    "http.response.status_code": "400",
    "Error": {...},
    "Fault": {...},
    "Latency": {...}
}
```
* Scenario 2: `export OTEL_RESOURCE_ATTRIBUTES="service.name=test_2,aws.application_signals.metric_resource_keys=all_attributes"`
```
{
    "EC2.InstanceId": "i-08a60809b167727a9",
    "Environment": "ec2:default",
    "Host": "ip-172-31-86-6.ec2.internal",
    "Operation": "InternalOperation",
    "PlatformType": "AWS::EC2",
    "Service": "test_2",
    "Telemetry.Agent": "CWAgent/",
    "Telemetry.SDK": "opentelemetry-java-instrumentation,2.10.0-aws,java,Auto",
    "Telemetry.Source": "LocalRootSpan",
    "Version": "1",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "ApplicationSignals",
                "Dimensions": [...]
                ],
                "Metrics": [... ]
            }
        ],
        "Timestamp": 1746569287138
    },
    "otel.resource.aws.application_signals.metric_resource_keys": "all_attributes",
    "otel.resource.cloud.account.id": "<redacted>",
    "otel.resource.cloud.availability_zone": "us-east-1a",
    "otel.resource.cloud.platform": "aws_ec2",
    "otel.resource.cloud.provider": "aws",
    "otel.resource.cloud.region": "us-east-1",
    "otel.resource.host.arch": "amd64",
    "otel.resource.host.image.id": "ami-0f88e80871fd81e91",
    "otel.resource.host.name": "ip-172-31-86-6.ec2.internal",
    "otel.resource.host.type": "t2.micro",
    "otel.resource.os.description": "Linux 6.1.134-150.224.amzn2023.x86_64",
    "otel.resource.os.type": "linux",
    "otel.resource.process.command_args": "[\"/usr/lib/jvm/java-24-amazon-corretto.x86_64/bin/java\",\"-cp\",\"sample.jar\",\"org.example.App\"]",
    "otel.resource.process.executable.path": "/usr/lib/jvm/java-24-amazon-corretto.x86_64/bin/java",
    "otel.resource.process.pid": "28811",
    "otel.resource.process.runtime.description": "Amazon.com Inc. OpenJDK 64-Bit Server VM 24.0.1+9-FR",
    "otel.resource.process.runtime.name": "OpenJDK Runtime Environment",
    "otel.resource.process.runtime.version": "24.0.1+9-FR",
    "otel.resource.service.instance.id": "e17754f4-0e91-4fc1-b357-f3c5ba02e432",
    "Error": {...},
    "Fault": {...},
    "Latency": {...}
}
```
* Scenario 3: `export OTEL_RESOURCE_ATTRIBUTES="service.name=test_3,Internal_Org=Financial,Business Unit=Payments,Region=us-east-1,Stage=Prod,aws.application_signals.metric_resource_keys=Business Unit&Region&Stage&Organization" `
```
{
    "EC2.InstanceId": "i-08a60809b167727a9",
    "Environment": "ec2:default",
    "Host": "ip-172-31-86-6.ec2.internal",
    "Operation": "InternalOperation",
    "PlatformType": "AWS::EC2",
    "Service": "test_3",
    "Telemetry.Agent": "CWAgent/",
    "Telemetry.SDK": "opentelemetry-java-instrumentation,2.10.0-aws,java,Auto",
    "Telemetry.Source": "LocalRootSpan",
    "Version": "1",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "ApplicationSignals",
                "Dimensions": [...],
                "Metrics": [...]
            }
        ],
        "Timestamp": 1746569476199
    },
    "otel.resource.Business Unit": "Payments",
    "otel.resource.Region": "us-east-1",
    "otel.resource.Stage": "Prod",
    "Error": {...},
    "Fault": {...},
    "Latency": {...}
}
```
# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
   1. Done - no diff
2. Run `make lint`
   1. Done - no diff
