### PR TITLE
Temporarily disable Dotnet EC2 Windows Test

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -190,13 +190,14 @@ jobs:
       caller-workflow-name: 'main-build'
       dotnet-version: '8.0'
 
-  dotnet-ec2-windows-e2e-test:
-    needs: [ CheckBuildTestArtifacts ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-ec2-windows-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      caller-workflow-name: 'main-build'
+# Temporarily disable Dotnet EC2 Windows Test
+#  dotnet-ec2-windows-e2e-test:
+#    needs: [ CheckBuildTestArtifacts ]
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/dotnet-ec2-windows-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      caller-workflow-name: 'main-build'
 
   dotnet-eks-e2e-test:
     needs: [ CheckBuildTestArtifacts, node-eks-e2e-test ]


### PR DESCRIPTION
# Description of the issue
There is an issue in dotnet windows application signal E2E and it's hard to debug due to lake of logs, temporarily disable it to try to found the root cause of the issue

# Description of changes
Temporarily disable Dotnet EC2 Windows Test

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




