### PR TITLE
[translator/awsentity] Allow service and environment configuration for OTLP in EC2

### DIFF
--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1352,6 +1352,18 @@
         },
         "tls": {
           "$ref": "#/definitions/tlsDefinitions"
+        },
+        "service.name": {
+          "description": "The name of the service to associate with the telemetry produced by the agent.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "deployment.environment": {
+          "description": "The name of the environment to associate with the telemetry produced by the agent.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 259
         }
       },
       "additionalProperties": false

--- a/translator/tocwconfig/sampleConfig/compass_linux_config.json
+++ b/translator/tocwconfig/sampleConfig/compass_linux_config.json
@@ -17,6 +17,8 @@
   "logs": {
     "metrics_collected": {
       "otlp": {
+        "service.name": "otlp-level-service",
+        "deployment.environment": "otlp-level-environment",
         "grpc_endpoint": "127.0.0.1:4317",
         "http_endpoint": "127.0.0.1:4318"
       }

--- a/translator/tocwconfig/sampleConfig/compass_linux_config.json
+++ b/translator/tocwconfig/sampleConfig/compass_linux_config.json
@@ -15,6 +15,12 @@
     "deployment.environment": "agent-level-environment"
   },
   "logs": {
+    "metrics_collected": {
+      "otlp": {
+        "grpc_endpoint": "127.0.0.1:4317",
+        "http_endpoint": "127.0.0.1:4318"
+      }
+    },
     "logs_collected": {
       "files": {
         "collect_list": [
@@ -48,6 +54,10 @@
   },
   "metrics": {
     "metrics_collected": {
+      "otlp": {
+        "grpc_endpoint": "127.0.0.1:4317",
+        "http_endpoint": "127.0.0.1:4318"
+      },
       "collectd": {
         "service_address": "udp://127.0.0.1:25826",
         "name_prefix": "collectd_",

--- a/translator/tocwconfig/sampleConfig/compass_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/compass_linux_config.yaml
@@ -19,7 +19,45 @@ exporters:
               - InstanceType
             - - d1
             - []
+    awsemf:
+        add_entity: true
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: false
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://logs-fips.us-west-2.amazonaws.com
+        enhanced_container_insights: false
+        imds_retries: 1
+        local_mode: false
+        log_group_name: /aws/cwagent
+        log_retention: 0
+        log_stream_name: ""
+        max_retries: 2
+        middleware: agenthealth/logs
+        namespace: CWAgent
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        profile: ""
+        proxy_address: ""
+        region: us-west-2
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: log_role_arn_value_test
+        version: "0"
 extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
     agenthealth/metrics:
         is_usage_data_enabled: true
         stats:
@@ -43,6 +81,49 @@ processors:
         entity_type: Service
         platform: ec2
         scrape_datapoint_attribute: true
+    awsentity/service/otlp/cloudwatch:
+        entity_type: Service
+        platform: ec2
+        transform_entity:
+            key_attributes:
+                - key: Name
+                  value: agent-level-service
+                - key: Environment
+                  value: agent-level-environment
+            attributes:
+                - key: AWS.ServiceNameSource
+                  value: UserConfiguration
+    awsentity/service/otlp/cloudwatchlogs:
+        entity_type: Service
+        platform: ec2
+        transform_entity:
+            key_attributes:
+                - key: Name
+                  value: agent-level-service
+                - key: Environment
+                  value: agent-level-environment
+            attributes:
+                - key: AWS.ServiceNameSource
+                  value: UserConfiguration
+    batch/hostOtlpMetrics/cloudwatchlogs:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 1m0s
+    cumulativetodelta/hostOtlpMetrics:
+        exclude:
+            match_type: ""
+        include:
+            match_type: ""
+        initial_value: 2
+        max_staleness: 0s
+    cumulativetodelta/hostOtlpMetrics/cloudwatchlogs:
+        exclude:
+            match_type: ""
+        include:
+            match_type: ""
+        initial_value: 2
+        max_staleness: 0s
     ec2tagger:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
@@ -55,6 +136,29 @@ processors:
         refresh_tags_interval: 0s
         refresh_volumes_interval: 0s
 receivers:
+    otlp/metrics:
+        protocols:
+            grpc:
+                dialer:
+                    timeout: 0s
+                endpoint: 127.0.0.1:4317
+                include_metadata: false
+                max_concurrent_streams: 0
+                max_recv_msg_size_mib: 0
+                read_buffer_size: 524288
+                transport: tcp
+                write_buffer_size: 0
+            http:
+                endpoint: 127.0.0.1:4318
+                idle_timeout: 0s
+                include_metadata: false
+                logs_url_path: /v1/logs
+                max_request_body_size: 0
+                metrics_url_path: /v1/metrics
+                read_header_timeout: 0s
+                read_timeout: 0s
+                traces_url_path: /v1/traces
+                write_timeout: 0s
     telegraf_socket_listener:
         collection_interval: 10s
         initial_delay: 1s
@@ -67,6 +171,7 @@ service:
     extensions:
         - agenthealth/metrics
         - agenthealth/statuscode
+        - agenthealth/logs
         - entitystore
     pipelines:
         metrics/hostCustomMetrics:
@@ -78,6 +183,24 @@ service:
             receivers:
                 - telegraf_statsd
                 - telegraf_socket_listener
+        metrics/hostOtlpMetrics:
+            exporters:
+                - awscloudwatch
+            processors:
+                - awsentity/service/otlp/cloudwatch
+                - cumulativetodelta/hostOtlpMetrics
+                - ec2tagger
+            receivers:
+                - otlp/metrics
+        metrics/hostOtlpMetrics/cloudwatchlogs:
+            exporters:
+                - awsemf
+            processors:
+                - awsentity/service/otlp/cloudwatchlogs
+                - batch/hostOtlpMetrics/cloudwatchlogs
+                - cumulativetodelta/hostOtlpMetrics/cloudwatchlogs
+            receivers:
+                - otlp/metrics
     telemetry:
         logs:
             development: false

--- a/translator/tocwconfig/sampleConfig/compass_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/compass_linux_config.yaml
@@ -99,9 +99,9 @@ processors:
         transform_entity:
             key_attributes:
                 - key: Name
-                  value: agent-level-service
+                  value: otlp-level-service
                 - key: Environment
-                  value: agent-level-environment
+                  value: otlp-level-environment
             attributes:
                 - key: AWS.ServiceNameSource
                   value: UserConfiguration

--- a/translator/translate/otel/pipeline/host/translator.go
+++ b/translator/translate/otel/pipeline/host/translator.go
@@ -12,13 +12,9 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/pipeline"
-	semconv "go.opentelemetry.io/collector/semconv/v1.22.0"
 
-	"github.com/aws/amazon-cloudwatch-agent/internal/entity"
-	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsentity/entityattributes"
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
-	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awscloudwatch"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awsemf"
@@ -33,6 +29,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/ec2taggerprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/metricsdecorator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/rollupprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
 
@@ -117,9 +114,9 @@ func (t translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators,
 		} else if currentContext.Mode() == config.ModeEC2 {
 			switch t.Destination() {
 			case common.DefaultDestination, common.CloudWatchKey:
-				entityProcessor = createEntityProcessorFromConfig(common.OtlpKey+"/"+common.CloudWatchKey, common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey), conf)
+				entityProcessor = util.CreateEntityProcessorFromConfig(common.OtlpKey+"/"+common.CloudWatchKey, common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey), conf)
 			case common.CloudWatchLogsKey:
-				entityProcessor = createEntityProcessorFromConfig(common.OtlpKey+"/"+common.CloudWatchLogsKey, common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.OtlpKey), conf)
+				entityProcessor = util.CreateEntityProcessorFromConfig(common.OtlpKey+"/"+common.CloudWatchLogsKey, common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.OtlpKey), conf)
 			}
 		}
 	case common.PipelineNameHostCustomMetrics:
@@ -178,44 +175,4 @@ func determinePipeline(name string) string {
 		return common.PipelineNameHost
 	}
 	return ""
-}
-
-func createEntityProcessorFromConfig(name string, configSection string, conf *confmap.Conf) common.ComponentTranslator {
-	serviceName, _ := common.GetString(conf, common.ConfigKey(configSection, semconv.AttributeServiceName))
-	environment, _ := common.GetString(conf, common.ConfigKey(configSection, semconv.AttributeDeploymentEnvironment))
-	if serviceName == "" {
-		serviceName = agent.Global_Config.ServiceName
-	}
-	if environment == "" {
-		environment = agent.Global_Config.DeploymentEnvironment
-	}
-	// Only create transform if at least one attribute is present
-	if serviceName != "" || environment != "" {
-		transform := &entity.Transform{
-			KeyAttributes: make([]entity.KeyPair, 0),
-			Attributes:    make([]entity.KeyPair, 0),
-		}
-
-		if serviceName != "" {
-			transform.KeyAttributes = append(transform.KeyAttributes, entity.KeyPair{
-				Key:   entityattributes.ServiceName,
-				Value: serviceName,
-			})
-			transform.Attributes = append(transform.Attributes, entity.KeyPair{
-				Key:   entityattributes.ServiceNameSource,
-				Value: entityattributes.AttributeServiceNameSourceUserConfig,
-			})
-		}
-
-		if environment != "" {
-			transform.KeyAttributes = append(transform.KeyAttributes, entity.KeyPair{
-				Key:   entityattributes.DeploymentEnvironment,
-				Value: environment,
-			})
-		}
-
-		return awsentity.NewTranslatorWithEntityTypeAndTransform(awsentity.Service, name, false, transform)
-	}
-
-	return awsentity.NewTranslatorWithEntityType(awsentity.Service, common.OtlpKey, false)
 }

--- a/translator/translate/otel/pipeline/host/translator_test.go
+++ b/translator/translate/otel/pipeline/host/translator_test.go
@@ -327,6 +327,47 @@ func TestTranslator(t *testing.T) {
 				extensions: []string{"sigv4auth"},
 			},
 		},
+		"WithOtlpMetricsEC2AndServiceName": {
+			input: map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"otlp": map[string]interface{}{
+							"service.name": "test-service",
+						},
+					},
+				},
+			},
+			pipelineName: common.PipelineNameHostOtlpMetrics,
+			mode:         config.ModeEC2,
+			want: &want{
+				pipelineID: "metrics/hostOtlpMetrics",
+				receivers:  []string{"nop", "other"},
+				processors: []string{"cumulativetodelta/hostOtlpMetrics", "awsentity/service/otlp/cloudwatch"},
+				exporters:  []string{"awscloudwatch"},
+				extensions: []string{"agenthealth/metrics", "agenthealth/statuscode"},
+			},
+		},
+		"WithOtlpMetricsEC2CloudWatchLogsAndServiceName": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"otlp": map[string]interface{}{
+							"service.name": "test-service",
+						},
+					},
+				},
+			},
+			pipelineName: common.PipelineNameHostOtlpMetrics,
+			destination:  common.CloudWatchLogsKey,
+			mode:         config.ModeEC2,
+			want: &want{
+				pipelineID: "metrics/hostOtlpMetrics/cloudwatchlogs",
+				receivers:  []string{"nop", "other"},
+				processors: []string{"cumulativetodelta/hostOtlpMetrics/cloudwatchlogs", "awsentity/service/otlp/cloudwatchlogs", "batch/hostOtlpMetrics/cloudwatchlogs"},
+				exporters:  []string{"awsemf"},
+				extensions: []string{"agenthealth/logs", "agenthealth/statuscode"},
+			},
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/translator/translate/otel/processor/awsentity/translator.go
+++ b/translator/translate/otel/processor/awsentity/translator.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/entity"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsentity"
-	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
@@ -96,6 +95,10 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	// in EC2 or Non-EC2
 	cfg.Platform = ctx.Mode()
 
+	if t.transform != nil {
+		cfg.TransformEntity = t.transform
+	}
+
 	if cfg.KubernetesMode != "" {
 		clusterName, clusterNameConfigured := common.GetHostedIn(conf)
 
@@ -104,10 +107,6 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		}
 
 		cfg.ClusterName = clusterName
-	} else if cfg.Platform == config.ModeEC2 {
-		if t.transform != nil {
-			cfg.TransformEntity = t.transform
-		}
 	}
 
 	return cfg, nil

--- a/translator/translate/otel/processor/awsentity/translator_test.go
+++ b/translator/translate/otel/processor/awsentity/translator_test.go
@@ -151,6 +151,52 @@ func TestTranslate(t *testing.T) {
 				},
 			},
 		},
+		"KubernetesWithTransform": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"kubernetes": map[string]interface{}{
+							"cluster_name": "k8s-cluster",
+						},
+					},
+				},
+			},
+			mode:           config.ModeEC2,
+			kubernetesMode: config.ModeEKS,
+			inputTransform: &entity.Transform{
+				KeyAttributes: []entity.KeyPair{
+					{
+						Key:   "Name",
+						Value: "k8s-service",
+					},
+				},
+				Attributes: []entity.KeyPair{
+					{
+						Key:   "AWS.ServiceNameSource",
+						Value: "UserConfiguration",
+					},
+				},
+			},
+			want: &awsentity.Config{
+				ClusterName:    "k8s-cluster",
+				KubernetesMode: config.ModeEKS,
+				Platform:       config.ModeEC2,
+				TransformEntity: &entity.Transform{
+					KeyAttributes: []entity.KeyPair{
+						{
+							Key:   "Name",
+							Value: "k8s-service",
+						},
+					},
+					Attributes: []entity.KeyPair{
+						{
+							Key:   "AWS.ServiceNameSource",
+							Value: "UserConfiguration",
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/translator/translate/util/entityutil.go
+++ b/translator/translate/util/entityutil.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"go.opentelemetry.io/collector/confmap"
+	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/entity"
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsentity/entityattributes"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/awsentity"
+)
+
+// For unit testing
+var NewTranslatorWithEntityType = awsentity.NewTranslatorWithEntityType
+var NewTranslatorWithEntityTypeAndTransform = awsentity.NewTranslatorWithEntityTypeAndTransform
+
+func CreateEntityProcessorFromConfig(name string, configSection string, conf *confmap.Conf) common.ComponentTranslator {
+	// Prioritize agent global config first
+	serviceName := agent.Global_Config.ServiceName
+	environment := agent.Global_Config.DeploymentEnvironment
+
+	if val, _ := common.GetString(conf, common.ConfigKey(configSection, semconv.AttributeServiceName)); val != "" {
+		serviceName = val
+	}
+	if val, _ := common.GetString(conf, common.ConfigKey(configSection, semconv.AttributeDeploymentEnvironment)); val != "" {
+		environment = val
+	}
+
+	// Only create transform if at least one attribute is present
+	if serviceName != "" || environment != "" {
+		transform := &entity.Transform{
+			KeyAttributes: make([]entity.KeyPair, 0),
+			Attributes:    make([]entity.KeyPair, 0),
+		}
+
+		if serviceName != "" {
+			transform.KeyAttributes = append(transform.KeyAttributes, entity.KeyPair{
+				Key:   entityattributes.ServiceName,
+				Value: serviceName,
+			})
+			transform.Attributes = append(transform.Attributes, entity.KeyPair{
+				Key:   entityattributes.ServiceNameSource,
+				Value: entityattributes.AttributeServiceNameSourceUserConfig,
+			})
+		}
+
+		if environment != "" {
+			transform.KeyAttributes = append(transform.KeyAttributes, entity.KeyPair{
+				Key:   entityattributes.DeploymentEnvironment,
+				Value: environment,
+			})
+		}
+
+		return NewTranslatorWithEntityTypeAndTransform(awsentity.Service, name, false, transform)
+	}
+
+	return NewTranslatorWithEntityType(awsentity.Service, common.OtlpKey, false)
+}

--- a/translator/translate/util/entityutil_test.go
+++ b/translator/translate/util/entityutil_test.go
@@ -1,0 +1,219 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/confmap"
+	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/entity"
+	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsentity/entityattributes"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/awsentity"
+)
+
+func TestCreateEntityProcessorFromConfig(t *testing.T) {
+	originalServiceName := agent.Global_Config.ServiceName
+	originalEnvironment := agent.Global_Config.DeploymentEnvironment
+	originalNewTranslatorWithEntityType := NewTranslatorWithEntityType
+	originalNewTranslatorWithEntityTypeAndTransform := NewTranslatorWithEntityTypeAndTransform
+
+	defer func() {
+		agent.Global_Config.ServiceName = originalServiceName
+		agent.Global_Config.DeploymentEnvironment = originalEnvironment
+		NewTranslatorWithEntityType = originalNewTranslatorWithEntityType
+		NewTranslatorWithEntityTypeAndTransform = originalNewTranslatorWithEntityTypeAndTransform
+	}()
+
+	testCases := []struct {
+		name              string
+		globalServiceName string
+		globalEnvironment string
+		configServiceName string
+		configEnvironment string
+		expectedName      string
+		expectedTransform *entity.Transform
+	}{
+		{
+			name:              "Empty config and global values",
+			globalServiceName: "",
+			globalEnvironment: "",
+			configServiceName: "",
+			configEnvironment: "",
+			expectedName:      common.OtlpKey,
+			expectedTransform: nil,
+		},
+		{
+			name:              "Only global service name",
+			globalServiceName: "global-service",
+			globalEnvironment: "",
+			configServiceName: "",
+			configEnvironment: "",
+			expectedName:      "test-name",
+			expectedTransform: &entity.Transform{
+				KeyAttributes: []entity.KeyPair{
+					{
+						Key:   entityattributes.ServiceName,
+						Value: "global-service",
+					},
+				},
+				Attributes: []entity.KeyPair{
+					{
+						Key:   entityattributes.ServiceNameSource,
+						Value: entityattributes.AttributeServiceNameSourceUserConfig,
+					},
+				},
+			},
+		},
+		{
+			name:              "Only global environment",
+			globalServiceName: "",
+			globalEnvironment: "global-env",
+			configServiceName: "",
+			configEnvironment: "",
+			expectedName:      "test-name",
+			expectedTransform: &entity.Transform{
+				KeyAttributes: []entity.KeyPair{
+					{
+						Key:   entityattributes.DeploymentEnvironment,
+						Value: "global-env",
+					},
+				},
+				Attributes: []entity.KeyPair{},
+			},
+		},
+		{
+			name:              "Global values with config overrides",
+			globalServiceName: "global-service",
+			globalEnvironment: "global-env",
+			configServiceName: "config-service",
+			configEnvironment: "config-env",
+			expectedName:      "test-name",
+			expectedTransform: &entity.Transform{
+				KeyAttributes: []entity.KeyPair{
+					{
+						Key:   entityattributes.ServiceName,
+						Value: "config-service",
+					},
+					{
+						Key:   entityattributes.DeploymentEnvironment,
+						Value: "config-env",
+					},
+				},
+				Attributes: []entity.KeyPair{
+					{
+						Key:   entityattributes.ServiceNameSource,
+						Value: entityattributes.AttributeServiceNameSourceUserConfig,
+					},
+				},
+			},
+		},
+		{
+			name:              "Config service name only",
+			globalServiceName: "",
+			globalEnvironment: "",
+			configServiceName: "config-service",
+			configEnvironment: "",
+			expectedName:      "test-name",
+			expectedTransform: &entity.Transform{
+				KeyAttributes: []entity.KeyPair{
+					{
+						Key:   entityattributes.ServiceName,
+						Value: "config-service",
+					},
+				},
+				Attributes: []entity.KeyPair{
+					{
+						Key:   entityattributes.ServiceNameSource,
+						Value: entityattributes.AttributeServiceNameSourceUserConfig,
+					},
+				},
+			},
+		},
+		{
+			name:              "Config environment only",
+			globalServiceName: "",
+			globalEnvironment: "",
+			configServiceName: "",
+			configEnvironment: "config-env",
+			expectedName:      "test-name",
+			expectedTransform: &entity.Transform{
+				KeyAttributes: []entity.KeyPair{
+					{
+						Key:   entityattributes.DeploymentEnvironment,
+						Value: "config-env",
+					},
+				},
+				Attributes: []entity.KeyPair{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent.Global_Config.ServiceName = tc.globalServiceName
+			agent.Global_Config.DeploymentEnvironment = tc.globalEnvironment
+
+			configMap := make(map[string]interface{})
+			const configSection = "metrics"
+			if tc.configServiceName != "" {
+				configMap[common.ConfigKey(configSection, semconv.AttributeServiceName)] = tc.configServiceName
+			}
+			if tc.configEnvironment != "" {
+				configMap[common.ConfigKey(configSection, semconv.AttributeDeploymentEnvironment)] = tc.configEnvironment
+			}
+			conf := confmap.NewFromStringMap(configMap)
+
+			var capturedEntityType string
+			var capturedName string
+			var capturedTransform *entity.Transform
+			NewTranslatorWithEntityType = func(entityType string, name string, scrapeDatapointAttribute bool) common.ComponentTranslator {
+				capturedEntityType = entityType
+				capturedName = name
+				return originalNewTranslatorWithEntityType(entityType, name, scrapeDatapointAttribute)
+			}
+			NewTranslatorWithEntityTypeAndTransform = func(entityType string, name string, scrapeDatapointAttribute bool, transform *entity.Transform) common.ComponentTranslator {
+				capturedEntityType = entityType
+				capturedName = name
+				capturedTransform = transform
+				return originalNewTranslatorWithEntityTypeAndTransform(entityType, name, scrapeDatapointAttribute, transform)
+			}
+
+			CreateEntityProcessorFromConfig("test-name", configSection, conf)
+
+			assert.Equal(t, awsentity.Service, capturedEntityType, "Entity type should match")
+			assert.Equal(t, tc.expectedName, capturedName, "Name should match")
+
+			if tc.expectedTransform == nil {
+				assert.Nil(t, capturedTransform, "Transform should be nil")
+			} else {
+				assert.NotNil(t, capturedTransform, "Transform should not be nil")
+
+				// Verify key attributes
+				assert.Equal(t, len(tc.expectedTransform.KeyAttributes), len(capturedTransform.KeyAttributes),
+					"Number of key attributes should match")
+				for i, expectedKeyAttr := range tc.expectedTransform.KeyAttributes {
+					assert.Equal(t, expectedKeyAttr.Key, capturedTransform.KeyAttributes[i].Key,
+						"Key attribute key should match")
+					assert.Equal(t, expectedKeyAttr.Value, capturedTransform.KeyAttributes[i].Value,
+						"Key attribute value should match")
+				}
+
+				// Verify attributes
+				assert.Equal(t, len(tc.expectedTransform.Attributes), len(capturedTransform.Attributes),
+					"Number of attributes should match")
+				for i, expectedAttr := range tc.expectedTransform.Attributes {
+					assert.Equal(t, expectedAttr.Key, capturedTransform.Attributes[i].Key,
+						"Attribute key should match")
+					assert.Equal(t, expectedAttr.Value, capturedTransform.Attributes[i].Value,
+						"Attribute value should match")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description of the issue
For existing plugins supported as Service entity for Explore Related integrations, customers have the option to configure the service name and environment name. We need to do the same for OTLP metrics.


# Description of changes
1. Add translation for detecting configuration value for `service.name` and `deployment.environment`.
2. Sets `AWS.ServiceNameSource` as `UserConfiguration` when the configuration is detected.
3. Configuration allowed for both CloudWatch And EMF exporter. Example:
### CloudWatch Metric Configuration
```
{
  "metrics": {
    "metrics_collected": {
      "otlp": {
        "service.name": "config-service-name",
        "deployment.environment": "config-environment-name"
      }
    }
  }
}
```
### EMF Configuration
```
"logs": {
    "metrics_collected": {
      "otlp": {
        "service.name": "otlp-level-service",
        "deployment.environment": "otlp-level-environment",
        "grpc_endpoint": "127.0.0.1:4317",
        "http_endpoint": "127.0.0.1:4318"
      }
    }
}
```
4. Deeper level configuration takes priority, meaning `otlp` section > `logs` section or `metrics` section > `agent` section
# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit test

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
5. Run `make lint`




