### PR TITLE
Centralize log state management into shared package

### DIFF
--- a/internal/state/offset.go
+++ b/internal/state/offset.go
@@ -1,0 +1,211 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package state
+
+import (
+	"bytes"
+	"encoding"
+	"errors"
+	"log"
+	"math"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	// defaultSaveInterval is the default duration between state file saves
+	defaultSaveInterval = 100 * time.Millisecond
+	// defaultQueueSize is the default capacity of the offset queue
+	defaultQueueSize = 2000
+)
+
+// FileOffset represents a position within a file. It handles truncation detection through
+// sequence numbers.
+type FileOffset struct {
+	// seq handles file truncation, when file is truncated, we increase the seq
+	seq    uint64
+	offset uint64
+}
+
+var _ encoding.TextMarshaler = (*FileOffset)(nil)
+var _ encoding.TextUnmarshaler = (*FileOffset)(nil)
+var _ Comparator[FileOffset] = (*FileOffset)(nil)
+
+// NewFileOffset creates a new FileOffset with the specified value.
+func NewFileOffset(v uint64) FileOffset {
+	return FileOffset{offset: v}
+}
+
+// Set updates the offset. Increments the sequence number when a smaller offset is given to indicate possible
+// file truncation.
+func (o *FileOffset) Set(v uint64) {
+	if v < o.offset {
+		o.seq++
+	}
+	o.offset = v
+}
+
+// SetInt64 updates the offset. Ignores negative values.
+func (o *FileOffset) SetInt64(v int64) {
+	if v >= 0 {
+		o.Set(uint64(v))
+	}
+}
+
+// Get returns the offset.
+func (o FileOffset) Get() uint64 {
+	return o.offset
+}
+
+// GetInt64 returns the offset. Returns 0 if offset exceeds MaxInt64.
+func (o FileOffset) GetInt64() int64 {
+	if o.offset > math.MaxInt64 {
+		return 0
+	}
+	return int64(o.offset)
+}
+
+// MarshalText converts the offset to a string.
+func (o FileOffset) MarshalText() ([]byte, error) {
+	return []byte(strconv.FormatUint(o.offset, 10)), nil
+}
+
+// UnmarshalText parses the first line into the offset.
+func (o *FileOffset) UnmarshalText(text []byte) error {
+	firstLine := text
+	index := bytes.IndexByte(text, '\n')
+	if index != -1 {
+		firstLine = text[:index]
+	}
+	offset, err := strconv.ParseUint(string(firstLine), 10, 64)
+	if err != nil {
+		return err
+	}
+	o.offset = offset
+	return nil
+}
+
+// Compare two FileOffset based on sequence number and then offset value.
+func (o FileOffset) Compare(other FileOffset) int {
+	if o.seq != other.seq {
+		if o.seq < other.seq {
+			return -1
+		}
+		return 1
+	}
+	if o.offset < other.offset {
+		return -1
+	}
+	if o.offset > other.offset {
+		return 1
+	}
+	return 0
+}
+
+type fileOffsetManager struct {
+	name          string
+	stateFilePath string
+	offsetCh      chan FileOffset
+	saveInterval  time.Duration
+}
+
+// FileOffsetManager is a state manager that handles the FileOffset.
+type FileOffsetManager Manager[FileOffset]
+
+var _ FileOffsetManager = (*fileOffsetManager)(nil)
+
+func NewFileOffsetManager(cfg ManagerConfig) FileOffsetManager {
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = defaultQueueSize
+	}
+	if cfg.SaveInterval <= 0 {
+		cfg.SaveInterval = defaultSaveInterval
+	}
+	return &fileOffsetManager{
+		name:          cfg.Name,
+		stateFilePath: cfg.StateFilePath(),
+		offsetCh:      make(chan FileOffset, cfg.QueueSize),
+		saveInterval:  cfg.SaveInterval,
+	}
+}
+
+// Enqueue the offset. Will drop the oldest in the queue if full.
+func (m *fileOffsetManager) Enqueue(offset FileOffset) {
+	select {
+	case m.offsetCh <- offset:
+	default:
+		<-m.offsetCh
+		m.offsetCh <- offset
+	}
+}
+
+// Restore the offset of the file if the state file exists.
+func (m *fileOffsetManager) Restore() (FileOffset, error) {
+	var offset FileOffset
+	content, err := os.ReadFile(m.stateFilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("D! No state file exists for %s", m.name)
+		} else {
+			log.Printf("W! Failed to read state file for %s: %v", m.name, err)
+		}
+		return offset, err
+	}
+	if err = offset.UnmarshalText(content); err != nil {
+		log.Printf("W! Invalid state file content: %v", err)
+		return offset, err
+	}
+	log.Printf("I! Reading from offset %v in %s", offset.Get(), m.name)
+	return offset, nil
+}
+
+// Save the offset in the state file.
+func (m *fileOffsetManager) Save(offset FileOffset) error {
+	if m.stateFilePath == "" {
+		return nil
+	}
+	data, err := offset.MarshalText()
+	if err != nil {
+		return err
+	}
+	data = append(data, []byte("\n"+m.name)...)
+	return os.WriteFile(m.stateFilePath, data, FileMode)
+}
+
+// Run starts the update/save loop.
+func (m *fileOffsetManager) Run(notification Notification) {
+	t := time.NewTicker(m.saveInterval)
+	defer t.Stop()
+
+	var offset, lastSavedOffset FileOffset
+	for {
+		select {
+		case o := <-m.offsetCh:
+			if o.Compare(offset) > 0 {
+				offset = o
+			}
+		case <-t.C:
+			if offset.Compare(lastSavedOffset) == 0 {
+				continue
+			}
+			if err := m.Save(offset); err != nil {
+				log.Printf("E! Error happened when saving state file (%s): %v", m.stateFilePath, err)
+				continue
+			}
+			lastSavedOffset = offset
+		case <-notification.Delete:
+			log.Printf("W! Deleting state file (%s)", m.stateFilePath)
+			if err := os.Remove(m.stateFilePath); err != nil {
+				log.Printf("W! Error happened while deleting state file (%s) on cleanup: %v", m.stateFilePath, err)
+			}
+			return
+		case <-notification.Done:
+			if err := m.Save(offset); err != nil {
+				log.Printf("E! Error happened during final state file (%s) save, duplicate log maybe sent at next start: %v", m.stateFilePath, err)
+			}
+			return
+		}
+	}
+}

--- a/internal/state/offset_test.go
+++ b/internal/state/offset_test.go
@@ -1,0 +1,266 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package state
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileOffset(t *testing.T) {
+	t.Run("NewOffset", func(t *testing.T) {
+		t.Parallel()
+		offset := NewFileOffset(0)
+		assert.Zero(t, offset.Get())
+	})
+	t.Run("GetSet", func(t *testing.T) {
+		t.Parallel()
+		offset := NewFileOffset(math.MaxUint64)
+		assert.Equal(t, uint64(math.MaxUint64), offset.Get())
+		assert.Zero(t, offset.GetInt64())
+		assert.EqualValues(t, 0, offset.seq)
+		offset.SetInt64(50)
+		assert.EqualValues(t, 50, offset.Get())
+		assert.EqualValues(t, 50, offset.GetInt64())
+		assert.EqualValues(t, 1, offset.seq)
+		offset.SetInt64(-10)
+		assert.EqualValues(t, 50, offset.Get())
+		assert.EqualValues(t, 50, offset.GetInt64())
+		assert.EqualValues(t, 1, offset.seq)
+	})
+	t.Run("Unmarshal/Loop", func(t *testing.T) {
+		t.Parallel()
+		offset := NewFileOffset(100)
+
+		data, err := offset.MarshalText()
+		assert.NoError(t, err)
+
+		var restored FileOffset
+		assert.NoError(t, restored.UnmarshalText(data))
+		assert.EqualValues(t, offset.Get(), restored.Get())
+	})
+	t.Run("Unmarshal/Invalid", func(t *testing.T) {
+		t.Parallel()
+		var offset FileOffset
+		assert.Error(t, offset.UnmarshalText([]byte("test")))
+		assert.Zero(t, offset.Get())
+	})
+	t.Run("Compare", func(t *testing.T) {
+		t.Parallel()
+		testCases := map[string]struct {
+			a, b FileOffset
+			want int
+		}{
+			"Equal": {
+				a:    FileOffset{seq: 1, offset: 100},
+				b:    FileOffset{seq: 1, offset: 100},
+				want: 0,
+			},
+			"Offset/Greater": {
+				a:    FileOffset{seq: 1, offset: 200},
+				b:    FileOffset{seq: 1, offset: 100},
+				want: 1,
+			},
+			"Offset/Lesser": {
+				a:    FileOffset{seq: 1, offset: 100},
+				b:    FileOffset{seq: 1, offset: 200},
+				want: -1,
+			},
+			"Sequence/Greater": {
+				a:    FileOffset{seq: 2, offset: 100},
+				b:    FileOffset{seq: 1, offset: 200},
+				want: 1,
+			},
+			"Sequence/Lesser": {
+				a:    FileOffset{seq: 1, offset: 200},
+				b:    FileOffset{seq: 2, offset: 100},
+				want: -1,
+			},
+		}
+		for name, testCase := range testCases {
+			t.Run(name, func(t *testing.T) {
+				assert.Equal(t, testCase.want, testCase.a.Compare(testCase.b))
+			})
+		}
+	})
+}
+
+func TestFileOffsetManager(t *testing.T) {
+	t.Run("New", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		testCases := map[string]struct {
+			cfg              ManagerConfig
+			wantFilePath     string
+			wantQueueSize    int
+			wantSaveInterval time.Duration
+		}{
+			"ValidConfig": {
+				cfg: ManagerConfig{
+					StateFileDir:    tmpDir,
+					StateFilePrefix: "test_prefix_",
+					Name:            "valid.log",
+					QueueSize:       10,
+					SaveInterval:    time.Millisecond,
+				},
+				wantFilePath:     filepath.Join(tmpDir, "test_prefix_valid.log"),
+				wantQueueSize:    10,
+				wantSaveInterval: time.Millisecond,
+			},
+			"InvalidConfig": {
+				cfg: ManagerConfig{
+					StateFileDir:    "",
+					StateFilePrefix: "test_prefix_",
+					Name:            "valid.log",
+					QueueSize:       -1,
+					SaveInterval:    0,
+				},
+				wantFilePath:     "",
+				wantQueueSize:    defaultQueueSize,
+				wantSaveInterval: defaultSaveInterval,
+			},
+		}
+		for name, testCase := range testCases {
+			t.Run(name, func(t *testing.T) {
+				got := NewFileOffsetManager(testCase.cfg).(*fileOffsetManager)
+				assert.Equal(t, testCase.cfg.Name, got.name)
+				assert.Equal(t, testCase.wantFilePath, got.stateFilePath)
+				assert.Equal(t, testCase.wantQueueSize, cap(got.offsetCh))
+				assert.Equal(t, testCase.wantSaveInterval, got.saveInterval)
+			})
+		}
+	})
+	t.Run("Restore/Missing", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		manager := NewFileOffsetManager(ManagerConfig{StateFileDir: tmpDir, Name: "missing.log"})
+		_, err := manager.Restore()
+		assert.Error(t, err)
+	})
+	t.Run("Enqueue/Multiple", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		manager := NewFileOffsetManager(ManagerConfig{StateFileDir: tmpDir, Name: "overwrite.log"})
+
+		notification := Notification{
+			Delete: make(chan struct{}),
+			Done:   make(chan struct{}),
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.Run(notification)
+		}()
+
+		offset1 := NewFileOffset(100)
+		manager.Enqueue(offset1)
+
+		offset2 := NewFileOffset(200)
+		manager.Enqueue(offset2)
+
+		time.Sleep(2 * defaultSaveInterval)
+
+		restored, err := manager.Restore()
+		assert.NoError(t, err)
+		assert.Equal(t, offset2.Get(), restored.Get())
+
+		close(notification.Done)
+	})
+	t.Run("Run/Notification/Delete", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		cfg := ManagerConfig{StateFileDir: tmpDir, Name: "delete.log"}
+		manager := NewFileOffsetManager(cfg)
+
+		err := manager.Save(NewFileOffset(100))
+		assert.NoError(t, err)
+
+		notification := Notification{
+			Delete: make(chan struct{}),
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.Run(notification)
+		}()
+		close(notification.Delete)
+		wg.Wait()
+
+		_, err = os.Stat(cfg.StateFilePath())
+		assert.True(t, os.IsNotExist(err))
+	})
+	t.Run("Run/Notification/Done", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		manager := NewFileOffsetManager(ManagerConfig{StateFileDir: tmpDir, Name: "test.log"})
+		manager.(*fileOffsetManager).saveInterval = time.Hour
+
+		notification := Notification{
+			Done: make(chan struct{}),
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.Run(notification)
+		}()
+
+		initial := NewFileOffset(100)
+		manager.Enqueue(initial)
+
+		time.Sleep(time.Millisecond)
+
+		close(notification.Done)
+		wg.Wait()
+
+		restored, err := manager.Restore()
+		assert.NoError(t, err)
+		assert.Equal(t, initial.Get(), restored.Get())
+	})
+	t.Run("Enqueue/QueueOverflow", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		manager := NewFileOffsetManager(ManagerConfig{
+			StateFileDir: tmpDir,
+			Name:         "overflow.log",
+			QueueSize:    10,
+		})
+
+		notification := Notification{
+			Done: make(chan struct{}),
+		}
+
+		for i := 0; i <= 20; i++ {
+			offset := FileOffset{}
+			offset.SetInt64(int64(i))
+			manager.Enqueue(offset)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.Run(notification)
+		}()
+
+		time.Sleep(2 * defaultSaveInterval)
+		close(notification.Done)
+		wg.Wait()
+
+		restored, err := manager.Restore()
+		assert.NoError(t, err)
+		assert.EqualValues(t, 20, restored.Get())
+	})
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package state
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// FileMode is the file permissions used for the state file.
+	FileMode = 0644
+)
+
+// Comparator compares the itself with another of the same type.
+type Comparator[T any] interface {
+	Compare(other T) int
+}
+
+// Manager handles persistence of state.
+type Manager[T any] interface {
+	// Enqueue the current state in memory.
+	Enqueue(state T)
+	// Restore loads the previous state.
+	Restore() (T, error)
+	// Save persists the current state.
+	Save(state T) error
+	// Run starts the update/save loop.
+	Run(ch Notification)
+}
+
+// Notification contains channels used to stop the Manager run loop.
+type Notification struct {
+	Delete chan struct{}
+	Done   chan struct{}
+}
+
+// ManagerConfig provides all options available to configure a Manager.
+type ManagerConfig struct {
+	Name            string
+	StateFileDir    string
+	StateFilePrefix string
+	QueueSize       int
+	SaveInterval    time.Duration
+}
+
+func (c ManagerConfig) StateFilePath() string {
+	return FilePath(c.StateFileDir, c.StateFilePrefix+c.Name)
+}
+
+// FilePath combines the directory and escaped name.
+func FilePath(dir, name string) string {
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, escapeFilePath(name))
+}
+
+func escapeFilePath(filePath string) string {
+	escapedFilePath := filepath.ToSlash(filePath)
+	escapedFilePath = strings.ReplaceAll(escapedFilePath, "/", "_")
+	escapedFilePath = strings.ReplaceAll(escapedFilePath, " ", "_")
+	escapedFilePath = strings.ReplaceAll(escapedFilePath, ":", "_")
+	return escapedFilePath
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package state
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilePath(t *testing.T) {
+	testDir := filepath.Join("tmp", "state")
+	testCases := map[string]struct {
+		dir  string
+		name string
+		want string
+	}{
+		"WithoutDirectory": {
+			dir:  "",
+			name: "test",
+			want: "",
+		},
+		"WithFilePath": {
+			dir:  testDir,
+			name: "/var/log/file.log",
+			want: filepath.Join(testDir, "_var_log_file.log"),
+		},
+		"WithSpaces": {
+			dir:  testDir,
+			name: "replace spaces with underscores",
+			want: filepath.Join(testDir, "replace_spaces_with_underscores"),
+		},
+		"WithColons": {
+			dir:  testDir,
+			name: "replace:colons:with:underscores",
+			want: filepath.Join(testDir, "replace_colons_with_underscores"),
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := FilePath(testCase.dir, testCase.name)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+func TestManagerConfig(t *testing.T) {
+	testDir := filepath.Join("tmp", "state")
+	cfg := ManagerConfig{
+		StateFileDir: testDir,
+		Name:         "no_prefix.log",
+	}
+	assert.Equal(t, filepath.Join(testDir, "no_prefix.log"), cfg.StateFilePath())
+	cfg = ManagerConfig{
+		StateFileDir:    testDir,
+		StateFilePrefix: "dormant volca",
+		Name:            "no_prefix.log",
+	}
+	assert.Equal(t, filepath.Join(testDir, "dormant_volcano_prefix.log"), cfg.StateFilePath())
+}

--- a/plugins/inputs/logfile/tail/tail.go
+++ b/plugins/inputs/logfile/tail/tail.go
@@ -87,7 +87,7 @@ type Tail struct {
 
 	lk sync.Mutex
 
-	FileDeletedCh chan bool
+	FileDeletedCh chan struct{}
 }
 
 // TailFile begins tailing the file. Output stream is made available
@@ -103,7 +103,7 @@ func TailFile(filename string, config Config) (*Tail, error) {
 		Filename:      filename,
 		Lines:         make(chan *Line),
 		Config:        config,
-		FileDeletedCh: make(chan bool),
+		FileDeletedCh: make(chan struct{}),
 	}
 
 	// when Logger was not specified in config, create new one

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"log"
 	"os"
-	"strconv"
 	"sync"
 	"time"
 
@@ -15,13 +14,13 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/extension/entitystore"
 	"github.com/aws/amazon-cloudwatch-agent/internal/logscommon"
+	"github.com/aws/amazon-cloudwatch-agent/internal/state"
 	"github.com/aws/amazon-cloudwatch-agent/logs"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail"
 	"github.com/aws/amazon-cloudwatch-agent/sdk/service/cloudwatchlogs"
 )
 
 const (
-	stateFileMode      = 0644
 	tailCloseThreshold = 3 * time.Second
 )
 
@@ -30,21 +29,10 @@ var (
 	defaultBufferSize   = 1
 )
 
-type fileOffset struct {
-	seq, offset int64 // Seq handles file trucation, when file is trucated, we increase the offset seq
-}
-
-func (fo *fileOffset) SetOffset(o int64) {
-	if o < fo.offset { // Increment the sequence number when a smaller offset is given (truncated)
-		fo.seq++
-	}
-	fo.offset = o
-}
-
 type LogEvent struct {
 	msg    string
 	t      time.Time
-	offset fileOffset
+	offset state.FileOffset
 	src    *tailerSrc
 }
 
@@ -66,7 +54,7 @@ type tailerSrc struct {
 	class           string
 	fileGlobPath    string
 	destination     string
-	stateFilePath   string
+	stateManager    state.FileOffsetManager
 	tailer          *tail.Tail
 	autoRemoval     bool
 	timestampFn     func(string) (time.Time, string)
@@ -78,7 +66,6 @@ type tailerSrc struct {
 	outputFn           func(logs.LogEvent)
 	isMLStart          func(string) bool
 	filters            []*LogFilter
-	offsetCh           chan fileOffset
 	done               chan struct{}
 	startTailerOnce    sync.Once
 	cleanUpFns         []func()
@@ -91,7 +78,9 @@ type tailerSrc struct {
 var _ logs.LogSrc = (*tailerSrc)(nil)
 
 func NewTailerSrc(
-	group, stream, destination, stateFilePath, logClass, fileGlobPath string,
+	group, stream, destination string,
+	stateManager state.FileOffsetManager,
+	logClass, fileGlobPath string,
 	tailer *tail.Tail,
 	autoRemoval bool,
 	isMultilineStartFn func(string) bool,
@@ -107,7 +96,7 @@ func NewTailerSrc(
 		group:              group,
 		stream:             stream,
 		destination:        destination,
-		stateFilePath:      stateFilePath,
+		stateManager:       stateManager,
 		class:              logClass,
 		fileGlobPath:       fileGlobPath,
 		tailer:             tailer,
@@ -120,15 +109,16 @@ func NewTailerSrc(
 		truncateSuffix:     truncateSuffix,
 		retentionInDays:    retentionInDays,
 		backpressureFdDrop: !autoRemoval && backpressureMode == logscommon.LogBackpressureModeFDRelease,
-
-		offsetCh: make(chan fileOffset, 2000),
-		done:     make(chan struct{}),
+		done:               make(chan struct{}),
 	}
 
 	if ts.backpressureFdDrop {
 		ts.buffer = make(chan *LogEvent, defaultBufferSize)
 	}
-	go ts.runSaveState()
+	go ts.stateManager.Run(state.Notification{
+		Delete: ts.tailer.FileDeletedCh,
+		Done:   ts.done,
+	})
 	return ts
 }
 
@@ -168,14 +158,8 @@ func (ts *tailerSrc) Retention() int {
 func (ts *tailerSrc) Class() string {
 	return ts.class
 }
-func (ts *tailerSrc) Done(offset fileOffset) {
-	// ts.offsetCh will only be blocked when the runSaveState func has exited,
-	// which only happens when the original file has been removed, thus making
-	// Keeping its offset useless
-	select {
-	case ts.offsetCh <- offset:
-	default:
-	}
+func (ts *tailerSrc) Done(offset state.FileOffset) {
+	ts.stateManager.Enqueue(offset)
 }
 
 func (ts *tailerSrc) Stop() {
@@ -206,7 +190,8 @@ func (ts *tailerSrc) runTail() {
 	var init string
 	var msgBuf bytes.Buffer
 	var cnt int
-	fo := &fileOffset{}
+	//fo := &fileOffset{}
+	fo := state.FileOffset{}
 	ignoreUntilNextEvent := false
 
 	for {
@@ -235,14 +220,14 @@ func (ts *tailerSrc) runTail() {
 			if ts.isMLStart == nil {
 				msgBuf.Reset()
 				msgBuf.WriteString(text)
-				fo.SetOffset(line.Offset)
+				fo.SetInt64(line.Offset)
 				init = ""
 			} else if ts.isMLStart(text) || (!ignoreUntilNextEvent && msgBuf.Len() == 0) {
 				init = text
 				ignoreUntilNextEvent = false
 			} else if ignoreUntilNextEvent || msgBuf.Len() >= ts.maxEventSize {
 				ignoreUntilNextEvent = true
-				fo.SetOffset(line.Offset)
+				fo.SetInt64(line.Offset)
 				continue
 			} else {
 				msgBuf.WriteString("\n")
@@ -251,14 +236,14 @@ func (ts *tailerSrc) runTail() {
 					msgBuf.Truncate(ts.maxEventSize - len(ts.truncateSuffix))
 					msgBuf.WriteString(ts.truncateSuffix)
 				}
-				fo.SetOffset(line.Offset)
+				fo.SetInt64(line.Offset)
 				continue
 			}
 
 			ts.publishEvent(msgBuf, fo)
 			msgBuf.Reset()
 			msgBuf.WriteString(init)
-			fo.SetOffset(line.Offset)
+			fo.SetInt64(line.Offset)
 			cnt = 0
 		case <-t.C:
 			if msgBuf.Len() > 0 {
@@ -276,7 +261,7 @@ func (ts *tailerSrc) runTail() {
 	}
 }
 
-func (ts *tailerSrc) publishEvent(msgBuf bytes.Buffer, fo *fileOffset) {
+func (ts *tailerSrc) publishEvent(msgBuf bytes.Buffer, fo state.FileOffset) {
 	// helper to handle event publishing
 	if msgBuf.Len() == 0 {
 		return
@@ -286,7 +271,7 @@ func (ts *tailerSrc) publishEvent(msgBuf bytes.Buffer, fo *fileOffset) {
 	e := &LogEvent{
 		msg:    modifiedMsg,
 		t:      timestamp,
-		offset: *fo,
+		offset: fo,
 		src:    ts,
 	}
 	if ShouldPublish(ts.group, ts.stream, ts.filters, e) {
@@ -367,51 +352,4 @@ func (ts *tailerSrc) cleanUp() {
 	if ts.outputFn != nil {
 		ts.outputFn(nil) // inform logs agent the tailer src's exit, to stop runSrcToDest
 	}
-}
-
-func (ts *tailerSrc) runSaveState() {
-	t := time.NewTicker(100 * time.Millisecond)
-	defer t.Stop()
-
-	var offset, lastSavedOffset fileOffset
-	for {
-		select {
-		case o := <-ts.offsetCh:
-			if o.seq > offset.seq || (o.seq == offset.seq && o.offset > offset.offset) {
-				offset = o
-			}
-		case <-t.C:
-			if offset == lastSavedOffset {
-				continue
-			}
-			err := ts.saveState(offset.offset)
-			if err != nil {
-				log.Printf("E! [logfile] Error happened when saving file state %s to file state folder %s: %v", ts.tailer.Filename, ts.stateFilePath, err)
-				continue
-			}
-			lastSavedOffset = offset
-		case <-ts.tailer.FileDeletedCh:
-			log.Printf("W! [logfile] deleting state file %s", ts.stateFilePath)
-			err := os.Remove(ts.stateFilePath)
-			if err != nil {
-				log.Printf("W! [logfile] Error happened while deleting state file %s on cleanup: %v", ts.stateFilePath, err)
-			}
-			return
-		case <-ts.done:
-			err := ts.saveState(offset.offset)
-			if err != nil {
-				log.Printf("E! [logfile] Error happened during final file state saving of logfile %s to file state folder %s, duplicate log maybe sent at next start: %v", ts.tailer.Filename, ts.stateFilePath, err)
-			}
-			return
-		}
-	}
-}
-
-func (ts *tailerSrc) saveState(offset int64) error {
-	if ts.stateFilePath == "" || offset == 0 {
-		return nil
-	}
-
-	content := []byte(strconv.FormatInt(offset, 10) + "\n" + ts.tailer.Filename)
-	return os.WriteFile(ts.stateFilePath, content, stateFileMode)
 }

--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/logscommon"
+	"github.com/aws/amazon-cloudwatch-agent/internal/state"
 	"github.com/aws/amazon-cloudwatch-agent/logs"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail"
 	"github.com/aws/amazon-cloudwatch-agent/profiler"
@@ -61,9 +63,16 @@ func TestTailerSrc(t *testing.T) {
 
 	require.NoError(t, err, fmt.Sprintf("Failed to create tailer src for file %v with error: %v", file, err))
 	require.Equal(t, beforeCount+1, tail.OpenFileCount.Load())
+
+	stateFilePath := statefile.Name()
+	m := state.NewFileOffsetManager(state.ManagerConfig{
+		StateFileDir: filepath.Dir(stateFilePath),
+		Name:         filepath.Base(stateFilePath),
+	})
+
 	ts := NewTailerSrc(
 		"groupName", "streamName",
-		"destination", statefile.Name(),
+		"destination", m,
 		util.InfrequentAccessLogGroupClass,
 		"tailsrctest-*.log",
 		tailer,
@@ -173,10 +182,16 @@ func TestOffsetDoneCallBack(t *testing.T) {
 
 	require.NoError(t, err, fmt.Sprintf("Failed to create tailer src for file %v with error: %v", file, err))
 
+	stateFilePath := statefile.Name()
+	m := state.NewFileOffsetManager(state.ManagerConfig{
+		StateFileDir: filepath.Dir(stateFilePath),
+		Name:         filepath.Base(stateFilePath),
+	})
+
 	ts := NewTailerSrc(
 		"groupName", "streamName",
 		"destination",
-		statefile.Name(),
+		m,
 		util.InfrequentAccessLogGroupClass,
 		"tailsrctest-*.log",
 		tailer,
@@ -394,13 +409,20 @@ func setupTailer(t *testing.T, multiLineFn func(string) bool, maxEventSize int, 
 	}
 	err = config.init()
 	assert.NoError(t, err)
+
+	stateFilePath := statefile.Name()
+	m := state.NewFileOffsetManager(state.ManagerConfig{
+		StateFileDir: filepath.Dir(stateFilePath),
+		Name:         filepath.Base(stateFilePath),
+	})
+
 	ts := NewTailerSrc(
 		t.Name(),
 		t.Name(),
 		"destination",
+		m,
 		util.InfrequentAccessLogGroupClass,
 		"tailsrctest-*.log",
-		statefile.Name(),
 		tailer,
 		autoRemoval,
 		multiLineFn,

--- a/plugins/inputs/windows_event_log/windows_event_log.go
+++ b/plugins/inputs/windows_event_log/windows_event_log.go
@@ -9,8 +9,6 @@ package windows_event_log
 import (
 	"errors"
 	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -18,12 +16,14 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/logscommon"
+	"github.com/aws/amazon-cloudwatch-agent/internal/state"
 	"github.com/aws/amazon-cloudwatch-agent/logs"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/windows_event_log/wineventlog"
 )
 
 const (
 	forcePullInterval = 250 * time.Millisecond
+	stateQueueSize    = 100
 )
 
 var startOnlyOnce sync.Once
@@ -93,10 +93,11 @@ func (s *Plugin) Start(acc telegraf.Accumulator) error {
 	for _, eventConfig := range s.Events {
 		// Assume no 2 EventConfigs have the same combination of:
 		// LogGroupName, LogStreamName, Name.
-		stateFilePath, err := getStateFilePath(s, &eventConfig)
+		stateManagerCfg, err := getStateManagerConfig(s, &eventConfig)
 		if err != nil {
 			return err
 		}
+		stateManager := state.NewFileOffsetManager(stateManagerCfg)
 		destination := eventConfig.Destination
 		if destination == "" {
 			destination = s.Destination
@@ -108,7 +109,7 @@ func (s *Plugin) Start(acc telegraf.Accumulator) error {
 			eventConfig.LogStreamName,
 			eventConfig.RenderFormat,
 			destination,
-			stateFilePath,
+			stateManager,
 			eventConfig.BatchReadSize,
 			eventConfig.Retention,
 			eventConfig.LogGroupClass,
@@ -124,27 +125,23 @@ func (s *Plugin) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
-// getStateFilePath returns a unique file pathname for a given EventConfig.
-func getStateFilePath(plugin *Plugin, ec *EventConfig) (string, error) {
+// getStateManagerConfig returns a state.ManagerConfig with a unique name for a given EventConfig and windows event
+// log specific prefix.
+func getStateManagerConfig(plugin *Plugin, ec *EventConfig) (state.ManagerConfig, error) {
+	var cfg state.ManagerConfig
 	if plugin.FileStateFolder == "" {
-		return "", errors.New("empty FileStateFolder")
+		return cfg, errors.New("empty FileStateFolder")
 	}
 	err := os.MkdirAll(plugin.FileStateFolder, 0755)
 	if err != nil {
-		return "", err
+		return cfg, err
 	}
-	stateFileName := logscommon.WindowsEventLogPrefix +
-		escapeFileName(ec.LogGroupName+"_"+ec.LogStreamName+"_"+ec.Name)
-	return filepath.Join(plugin.FileStateFolder, stateFileName), nil
-}
-
-// escapeFileName returns a valid filename string.
-func escapeFileName(filePath string) string {
-	escapedFilePath := filepath.ToSlash(filePath)
-	escapedFilePath = strings.Replace(escapedFilePath, "/", "_", -1)
-	escapedFilePath = strings.Replace(escapedFilePath, " ", "_", -1)
-	escapedFilePath = strings.Replace(escapedFilePath, ":", "_", -1)
-	return escapedFilePath
+	return state.ManagerConfig{
+		StateFileDir:    plugin.FileStateFolder,
+		StateFilePrefix: logscommon.WindowsEventLogPrefix,
+		Name:            ec.LogGroupName + "_" + ec.LogStreamName + "_" + ec.Name,
+		QueueSize:       stateQueueSize,
+	}, nil
 }
 
 func (s *Plugin) Stop() {

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -10,15 +10,14 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"golang.org/x/sys/windows"
 
+	"github.com/aws/amazon-cloudwatch-agent/internal/state"
 	"github.com/aws/amazon-cloudwatch-agent/logs"
 	"github.com/aws/amazon-cloudwatch-agent/sdk/service/cloudwatchlogs"
 )
@@ -56,19 +55,18 @@ type windowsEventLog struct {
 	renderFormat  string
 	maxToRead     int // Maximum number returned in one read.
 	destination   string
-	stateFilePath string
+	stateManager  state.FileOffsetManager
 
 	eventHandle   EvtHandle
 	eventOffset   uint64
 	retention     int
 	outputFn      func(logs.LogEvent)
-	offsetCh      chan uint64
 	done          chan struct{}
 	startOnce     sync.Once
 	resubscribeCh chan struct{}
 }
 
-func NewEventLog(name string, levels []string, logGroupName, logStreamName, renderFormat, destination, stateFilePath string, maximumToRead int, retention int, logGroupClass string) *windowsEventLog {
+func NewEventLog(name string, levels []string, logGroupName, logStreamName, renderFormat, destination, string, stateManager state.FileOffsetManager, maximumToRead int, retention int, logGroupClass string) *windowsEventLog {
 	eventLog := &windowsEventLog{
 		name:          name,
 		levels:        levels,
@@ -78,10 +76,9 @@ func NewEventLog(name string, levels []string, logGroupName, logStreamName, rend
 		renderFormat:  renderFormat,
 		maxToRead:     maximumToRead,
 		destination:   destination,
-		stateFilePath: stateFilePath,
+		stateManager:  stateManager,
 		retention:     retention,
 
-		offsetCh:      make(chan uint64, 100),
 		done:          make(chan struct{}),
 		resubscribeCh: make(chan struct{}),
 	}
@@ -89,8 +86,9 @@ func NewEventLog(name string, levels []string, logGroupName, logStreamName, rend
 }
 
 func (w *windowsEventLog) Init() error {
-	go w.runSaveState()
-	w.eventOffset = w.loadState()
+	go w.stateManager.Run(state.Notification{Done: w.done})
+	offset, _ := w.stateManager.Restore()
+	w.eventOffset = offset.Get()
 	return w.Open()
 }
 
@@ -254,50 +252,11 @@ func (w *windowsEventLog) SetEventOffset(eventOffset uint64) {
 }
 
 func (w *windowsEventLog) Done(offset uint64) {
-	w.offsetCh <- offset
+	w.stateManager.Enqueue(state.NewFileOffset(offset))
 }
 
 func (w *windowsEventLog) ResubscribeCh() chan struct{} {
 	return w.resubscribeCh
-}
-
-func (w *windowsEventLog) runSaveState() {
-	t := time.NewTicker(saveStateInterval)
-	defer w.Stop()
-
-	var offset, lastSavedOffset uint64
-	for {
-		select {
-		case o := <-w.offsetCh:
-			if o > offset {
-				offset = o
-			}
-		case <-t.C:
-			if offset == lastSavedOffset {
-				continue
-			}
-			err := w.saveState(offset)
-			if err != nil {
-				log.Printf("E! [wineventlog] Error happened when saving file state %s to file state folder %s: %v", w.logGroupName, w.stateFilePath, err)
-				continue
-			}
-			lastSavedOffset = offset
-		case <-w.done:
-			err := w.saveState(offset)
-			if err != nil {
-				log.Printf("E! [wineventlog] Error happened during final file state saving of logfile %s to file state folder %s, duplicate log maybe sent at next start: %v", w.logGroupName, w.stateFilePath, err)
-			}
-			break
-		}
-	}
-}
-
-func (w *windowsEventLog) saveState(offset uint64) error {
-	if w.stateFilePath == "" || offset == 0 {
-		return nil
-	}
-	content := []byte(strconv.FormatUint(offset, 10) + "\n" + w.logGroupName)
-	return os.WriteFile(w.stateFilePath, content, 0644)
 }
 
 func (w *windowsEventLog) read() []*windowsEventLogRecord {
@@ -425,23 +384,4 @@ func (w *windowsEventLog) getRecord(evtHandle EvtHandle) (*windowsEventLogRecord
 		return nil, fmt.Errorf("renderFormat is not recognized, %s", w.renderFormat)
 	}
 	return newRecord, nil
-}
-
-func (w *windowsEventLog) loadState() uint64 {
-	if _, err := os.Stat(w.stateFilePath); err != nil {
-		log.Printf("I! [wineventlog] The state file for %s does not exist: %v", w.stateFilePath, err)
-		return 0
-	}
-	byteArray, err := os.ReadFile(w.stateFilePath)
-	if err != nil {
-		log.Printf("W! [wineventlog] Issue encountered when reading offset from file %s: %v", w.stateFilePath, err)
-		return 0
-	}
-	offset, err := strconv.ParseUint(strings.Split(string(byteArray), "\n")[0], 10, 64)
-	if err != nil {
-		log.Printf("W! [wineventlog] Issue encountered when parsing offset value %v: %v", byteArray, err)
-		return 0
-	}
-	log.Printf("D! [wineventlog] Reading from offset %v in %s", offset, w.stateFilePath)
-	return offset
 }

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
@@ -14,6 +14,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows/svc/eventlog"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/logscommon"
+	"github.com/aws/amazon-cloudwatch-agent/internal/state"
 )
 
 var (
@@ -33,8 +36,7 @@ var (
 
 // TestNewEventLog verifies constructor's default values.
 func TestNewEventLog(t *testing.T) {
-	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
-		STATE_FILE_PATH, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
+	elog := newTestEventLog(t, NAME, LEVELS)
 	assert.Equal(t, NAME, elog.name)
 	assert.Equal(t, uint64(0), elog.eventOffset)
 	assert.Zero(t, elog.eventHandle)
@@ -44,27 +46,23 @@ func TestNewEventLog(t *testing.T) {
 // And fails with invalid inputs.
 func TestOpen(t *testing.T) {
 	// Happy path.
-	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
-		STATE_FILE_PATH, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
+	elog := newTestEventLog(t, NAME, LEVELS)
 	assert.NoError(t, elog.Open())
 	assert.NotZero(t, elog.eventHandle)
 	assert.NoError(t, elog.Close())
 	// Bad event log source name does not cause Open() to fail.
 	// But eventHandle will be 0 and Close() will fail because of it.
-	elog = NewEventLog("FakeBadElogName", LEVELS, GROUP_NAME, STREAM_NAME,
-		RENDER_FMT, DEST, STATE_FILE_PATH, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
+	elog = newTestEventLog(t, "FakeBadElogName", LEVELS)
 	assert.NoError(t, elog.Open())
 	assert.Zero(t, elog.eventHandle)
 	assert.Error(t, elog.Close())
 	// bad LEVELS does not cause Open() to fail.
-	elog = NewEventLog(NAME, []string{"498"}, GROUP_NAME, STREAM_NAME,
-		RENDER_FMT, DEST, STATE_FILE_PATH, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
+	elog = newTestEventLog(t, NAME, []string{"498"})
 	assert.NoError(t, elog.Open())
 	assert.NotZero(t, elog.eventHandle)
 	assert.NoError(t, elog.Close())
 	// bad wlog.eventOffset does not cause Open() to fail.
-	elog = NewEventLog(NAME, []string{"498"}, GROUP_NAME, STREAM_NAME,
-		RENDER_FMT, DEST, STATE_FILE_PATH, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
+	elog = newTestEventLog(t, NAME, []string{"498"})
 	elog.eventOffset = 9987
 	assert.NoError(t, elog.Open())
 	assert.NotZero(t, elog.eventHandle)
@@ -74,8 +72,7 @@ func TestOpen(t *testing.T) {
 // TestReadGoodSource will verify we can read events written by a registered
 // event log source.
 func TestReadGoodSource(t *testing.T) {
-	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
-		STATE_FILE_PATH, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
+	elog := newTestEventLog(t, NAME, LEVELS)
 	assert.NoError(t, elog.Open())
 	seekToEnd(t, elog)
 	writeEvents(t, 10, true, "CWA_UnitTest111", 777)
@@ -87,8 +84,7 @@ func TestReadGoodSource(t *testing.T) {
 // TestReadBadSource will verify that we cannot read events written by an
 // unregistered event log source.
 func TestReadBadSource(t *testing.T) {
-	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
-		STATE_FILE_PATH, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
+	elog := newTestEventLog(t, NAME, LEVELS)
 	assert.NoError(t, elog.Open())
 	seekToEnd(t, elog)
 	writeEvents(t, 10, false, "CWA_UnitTest222", 888)
@@ -101,8 +97,7 @@ func TestReadBadSource(t *testing.T) {
 // registered event log source, even if the batch contains events from an
 // unregistered source too.
 func TestReadWithBothSources(t *testing.T) {
-	elog := NewEventLog(NAME, LEVELS, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
-		STATE_FILE_PATH, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
+	elog := newTestEventLog(t, NAME, LEVELS)
 	assert.NoError(t, elog.Open())
 	seekToEnd(t, elog)
 	writeEvents(t, 10, true, "CWA_UnitTest111", 777)
@@ -174,4 +169,15 @@ func checkEvents(t *testing.T, records []*windowsEventLogRecord, substring strin
 		}
 	}
 	assert.Equal(t, count, found, "expected %v, %v, actual %v", substring, count, found)
+}
+
+func newTestEventLog(t *testing.T, name string, levels []string) *windowsEventLog {
+	t.Helper()
+	manager := state.NewFileOffsetManager(state.ManagerConfig{
+		StateFileDir:    t.TempDir(),
+		StateFilePrefix: logscommon.WindowsEventLogPrefix,
+		Name:            GROUP_NAME + "_" + STREAM_NAME + "_" + name,
+	})
+	return NewEventLog(name, levels, GROUP_NAME, STREAM_NAME, RENDER_FMT, DEST,
+		manager, BATCH_SIZE, RETENTION, LOG_GROUP_CLASS)
 }


### PR DESCRIPTION
# Description of the issue
Both the log tailing input plugin ([logfile](https://github.com/aws/amazon-cloudwatch-agent/blob/93ae77359bc5cfce19a1869de33f31e1cd56ae48/plugins/inputs/logfile/README.md)) and the windows log events input plugin ([windows_event_log](https://github.com/aws/amazon-cloudwatch-agent/tree/93ae77359bc5cfce19a1869de33f31e1cd56ae48/plugins/inputs/windows_event_log)) maintain state files. The plugins create one state file for each tailed log file and each subscribed windows event respectively. The state files serve as a way to keep track of progress (byte offset) and a recovery mechanism to restart from the last known position if the agent restarts. This helps to maintain log integrity and prevent duplicate processing of already sent logs.

Since these are maintained in two separate packages, there is overlap in how the behavior is defined and makes it more difficult to maintain or make changes to.

# Description of changes
Centralizes log state management into a single shared package `state` which has a `FileOffsetManager` that manages the update/save loop for the state file.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests and update existing unit tests to use state manager package.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




