### PR TITLE
fix panic under concurrency in application signals processor

### DIFF
--- a/plugins/processors/awsapplicationsignals/processor.go
+++ b/plugins/processors/awsapplicationsignals/processor.go
@@ -28,8 +28,6 @@ const (
 	failedToProcessAttributeWithLimiter = "failed to process attributes with limiter, keep the data"
 )
 
-var metricCaser = cases.Title(language.English)
-
 // this is used to Process some attributes (like IP addresses) to a generic form to reduce high cardinality
 type attributesMutator interface {
 	Process(attributes, resourceAttributes pcommon.Map, isTrace bool) error
@@ -143,7 +141,7 @@ func (ap *awsapplicationsignalsprocessor) processMetrics(ctx context.Context, md
 				m := metrics.At(k)
 				// Check if the first letter of the metric name is not capitalized
 				if len(m.Name()) > 0 && !unicode.IsUpper(rune(m.Name()[0])) {
-					m.SetName(metricCaser.String(m.Name())) // Ensure metric name is in sentence case
+					m.SetName(cases.Title(language.English).String(m.Name())) // Ensure metric name is in sentence case
 				}
 				ap.processMetricAttributes(ctx, m, resourceAttributes)
 				ap.aggregationMutator.ProcessMetrics(ctx, m, resourceAttributes)


### PR DESCRIPTION
# Description of the issue
This PR fixes a panic issue described in https://github.com/aws/amazon-cloudwatch-agent/pull/1702.

# Description of changes
`golang.org/x/text/cases.Caser.String` is not goroutine safe. In this PR, we initialize a new Caser when a metric processed by Application Signals is found with camel case naming.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added a unit test.

Before the change:
The unit test returned with 
```
goroutine 7 [running]:
golang.org/x/text/cases.(*context).copyXOR(0xc000016280)
golang.org/x/text/cases.title(0xc000016280)
golang.org/x/text/cases.(*titleCaser).Transform(0xc000016280, {0xc0004bc000, 0x80, 0x80}, {0xc0004bc080, 0x5, 0x80}, 0x1)
golang.org/x/text/transform.String({0x130064088, 0xc000016280}, {0x104daa452, 0x5})
golang.org/x/text/cases.Caser.String(...)
github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals.(*awsapplicationsignalsprocessor).processMetrics(0xc0003aa6c0, {0x105778598, 0x107953100}, {0xc000580030?, 0xc00029402c?})
github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals.TestProcessMetricsWithConcurrency.func1()
created by github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals.TestProcessMetricsWithConcurrency in goroutine 5
panic: runtime error: slice bounds out of range [6:5]
```

After the change, the test passed.

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




