### PR TITLE
Add step to check for `ready for testing` label before running integration tests

### DIFF
--- a/.github/workflows/PR-test.yml
+++ b/.github/workflows/PR-test.yml
@@ -23,13 +23,30 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
+      - unlabeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+  CheckLabel:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.has_label }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ready for testing') }}" == "true" ]]; then
+            echo "has_label=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_label=false" >> $GITHUB_OUTPUT
+          fi
+
   BuildAndUpload:
+    needs: [ CheckLabel ]
+    if: needs.CheckLabel.outputs.should_run == 'true'
     uses: ./.github/workflows/test-build.yml
     secrets: inherit
     permissions:
@@ -43,6 +60,8 @@ jobs:
 
   OutputEnvVariables:
     name: 'OutputEnvVariables'
+    needs: [ CheckLabel ]
+    if: needs.CheckLabel.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     outputs:
       CWA_GITHUB_TEST_REPO_NAME: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_NAME }}
@@ -77,7 +96,8 @@ jobs:
 
   StartLocalStack:
     name: 'StartLocalStack'
-    needs: [OutputEnvVariables]
+    needs: [ CheckLabel, OutputEnvVariables ]
+    if: needs.CheckLabel.outputs.should_run == 'true'
     uses: ./.github/workflows/start-localstack.yml
     secrets: inherit
     permissions:
@@ -93,8 +113,9 @@ jobs:
       s3_integration_bucket: ${{ vars.S3_INTEGRATION_BUCKET }}
 
   GenerateTestMatrix:
-    needs: [OutputEnvVariables]
     name: 'GenerateTestMatrix'
+    needs: [ CheckLabel, OutputEnvVariables ]
+    if: needs.CheckLabel.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     outputs:
       ec2_linux_matrix: ${{ steps.set-matrix.outputs.ec2_linux_matrix }}
@@ -136,8 +157,9 @@ jobs:
 
 
   EC2LinuxIntegrationTest:
-    needs: [ GenerateTestMatrix, OutputEnvVariables, StartLocalStack, BuildAndUpload ]
     name: 'EC2LinuxTests'
+    needs: [ CheckLabel, GenerateTestMatrix, OutputEnvVariables, StartLocalStack, BuildAndUpload ]
+    if: needs.CheckLabel.outputs.should_run == 'true'
     uses:  ./.github/workflows/ec2-integration-test.yml
     with:
       build_id: ${{ github.sha }}
@@ -155,8 +177,9 @@ jobs:
     secrets: inherit
 
   EC2SELinuxIntegrationTest:
-    needs: [ GenerateTestMatrix, OutputEnvVariables, StartLocalStack ]
     name: 'EC2SELinuxTests'
+    needs: [ CheckLabel, GenerateTestMatrix, OutputEnvVariables, StartLocalStack ]
+    if: needs.CheckLabel.outputs.should_run == 'true'
     uses:  ./.github/workflows/ec2-integration-test.yml
     with:
       build_id: ${{ github.sha }}
@@ -175,8 +198,8 @@ jobs:
 
   StopLocalStack:
     name: 'StopLocalStack'
-    if: ${{ always() && needs.StartLocalStack.result == 'success' }}
-    needs: [ StartLocalStack, EC2LinuxIntegrationTest, OutputEnvVariables ]
+    needs: [ CheckLabel, StartLocalStack, EC2LinuxIntegrationTest, OutputEnvVariables ]
+    if: ${{ always() && needs.StartLocalStack.result == 'success' && needs.CheckLabel.outputs.should_run == 'true'}}
     uses: ./.github/workflows/stop-localstack.yml
     secrets: inherit
     permissions:


### PR DESCRIPTION
# Description of the issue
Reduce unnecessary integration test runs triggered each commit that is pushed to a PR

# Description of changes
Adds a step to check for the `ready for testing` label on a PR before running the PR-test workflow.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tests **skipped** when label is not present on PR
![](https://github.com/user-attachments/assets/c1b3ee07-25fc-4c1d-971b-2aecb6019800)

Tests **ran** when label is present on PR
![](https://github.com/user-attachments/assets/d981cab2-3505-4653-b02a-d74f1b16d713)


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




