### PR TITLE
fix concurrent map write crash in getDests

### DIFF
--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -76,7 +76,7 @@ type CloudWatchLogs struct {
 
 	pusherStopChan  chan struct{}
 	pusherWaitGroup sync.WaitGroup
-	cwDests         map[pusher.Target]*cwDest
+	cwDests         sync.Map
 	workerPool      pusher.WorkerPool
 	targetManager   pusher.TargetManager
 	once            sync.Once
@@ -91,9 +91,13 @@ func (c *CloudWatchLogs) Close() error {
 	close(c.pusherStopChan)
 	c.pusherWaitGroup.Wait()
 
-	for _, d := range c.cwDests {
-		d.Stop()
-	}
+	c.cwDests.Range(func(key, value interface{}) bool {
+		if d, ok := value.(*cwDest); ok {
+			d.Stop()
+		}
+		return true
+	})
+
 	if c.workerPool != nil {
 		c.workerPool.Stop()
 	}
@@ -129,8 +133,8 @@ func (c *CloudWatchLogs) CreateDest(group, stream string, retention int, logGrou
 }
 
 func (c *CloudWatchLogs) getDest(t pusher.Target, logSrc logs.LogSrc) *cwDest {
-	if cwd, ok := c.cwDests[t]; ok {
-		return cwd
+	if cwd, ok := c.cwDests.Load(t); ok {
+		return cwd.(*cwDest)
 	}
 
 	logThrottleRetryer := retryer.NewLogThrottleRetryer(c.Log)
@@ -148,7 +152,7 @@ func (c *CloudWatchLogs) getDest(t pusher.Target, logSrc logs.LogSrc) *cwDest {
 	})
 	p := pusher.NewPusher(c.Log, t, client, c.targetManager, logSrc, c.workerPool, c.ForceFlushInterval.Duration, maxRetryTimeout, c.pusherStopChan, &c.pusherWaitGroup)
 	cwd := &cwDest{pusher: p, retryer: logThrottleRetryer}
-	c.cwDests[t] = cwd
+	c.cwDests.Store(t, cwd)
 	return cwd
 }
 
@@ -400,7 +404,7 @@ func init() {
 		return &CloudWatchLogs{
 			ForceFlushInterval: internal.Duration{Duration: defaultFlushTimeout},
 			pusherStopChan:     make(chan struct{}),
-			cwDests:            make(map[pusher.Target]*cwDest),
+			cwDests:            sync.Map{},
 			middleware: agenthealth.NewAgentHealth(
 				zap.NewNop(),
 				&agenthealth.Config{


### PR DESCRIPTION
# Description of the issue
There is a concurrent map write here
```
fatal error: concurrent map writes
goroutine 80 [running]:
github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs.(*CloudWatchLogs).getDest(0xc0006bc580, {{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, 0x0}, {0x0, 0x0})
	github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go:151 +0x410
github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs.(*CloudWatchLogs).writeMetricAsStructuredLog(0xc0006bc580, {0x5d02670, 0xc000892fc0})
	github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go:190 +0x177
github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs.(*CloudWatchLogs).Write(0xc0006bc580, {0xc000630be0?, 0x80f966?, 0xc00084b100?})
	github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go:106 +0x33
github.com/influxdata/telegraf/models.(*RunningOutput).write(0xc00075a480, {0xc000630be0, 0xa, 0xa})
	github.com/influxdata/telegraf@v0.0.0-00010101000000-000000000000/models/running_output.go:244 +0x109
github.com/influxdata/telegraf/models.(*RunningOutput).Write(0xc00075a480)
	github.com/influxdata/telegraf@v0.0.0-00010101000000-000000000000/models/running_output.go:201 +0x187
github.com/influxdata/telegraf/agent.(*Agent).flushOnce.func1()
	github.com/influxdata/telegraf@v0.0.0-00010101000000-000000000000/agent/agent.go:847 +0x23
created by github.com/influxdata/telegraf/agent.(*Agent).flushOnce in goroutine 54
	github.com/influxdata/telegraf@v0.0.0-00010101000000-000000000000/agent/agent.go:846 +0xa6
goroutine 1 [semacquire]:
```

# Description of changes
Move to sync.Map

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




