### PR TITLE
Add support for deployment.environment.name

### DIFF
--- a/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
+++ b/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
@@ -27,6 +27,10 @@ const (
 	ResourceDetectionHostName = "host.name"
 	ResourceDetectionASG      = "ec2.tag.aws:autoscaling:groupName"
 
+	// deployment resource attributes
+	AttributeDeploymentEnvironment = "deployment.environment"
+	AttributeDeploymentEnvironmentName = "deployment.environment.name"
+
 	// ApplicationSignals behaviour-changing attributes
 	AWSApplicationSignalsMetricResourceKeys = "aws.application_signals.metric_resource_keys"
 )

--- a/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
+++ b/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
@@ -28,7 +28,7 @@ const (
 	ResourceDetectionASG      = "ec2.tag.aws:autoscaling:groupName"
 
 	// deployment resource attributes
-	AttributeDeploymentEnvironment = "deployment.environment"
+	AttributeDeploymentEnvironment     = "deployment.environment"
 	AttributeDeploymentEnvironmentName = "deployment.environment.name"
 
 	// ApplicationSignals behaviour-changing attributes

--- a/plugins/processors/awsapplicationsignals/internal/resolver/attributesresolver.go
+++ b/plugins/processors/awsapplicationsignals/internal/resolver/attributesresolver.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/collector/semconv/v1.22.0"
 	"go.uber.org/zap"
 
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals/common"
@@ -28,16 +27,18 @@ const (
 )
 
 var GenericInheritedAttributes = map[string]string{
-	semconv.AttributeDeploymentEnvironment: attr.AWSLocalEnvironment,
-	attr.ResourceDetectionHostName:         common.AttributeHost,
+	attr.AttributeDeploymentEnvironment:     attr.AWSLocalEnvironment,
+	attr.AttributeDeploymentEnvironmentName: attr.AWSLocalEnvironment,
+	attr.ResourceDetectionHostName:          common.AttributeHost,
 }
 
 // DefaultInheritedAttributes is an allow-list that also renames attributes from the resource detection processor
 var DefaultInheritedAttributes = map[string]string{
-	semconv.AttributeDeploymentEnvironment: attr.AWSLocalEnvironment,
-	attr.ResourceDetectionASG:              common.AttributeEC2AutoScalingGroup,
-	attr.ResourceDetectionHostId:           common.AttributeEC2InstanceId,
-	attr.ResourceDetectionHostName:         common.AttributeHost,
+	attr.AttributeDeploymentEnvironment:     attr.AWSLocalEnvironment,
+	attr.AttributeDeploymentEnvironmentName: attr.AWSLocalEnvironment,
+	attr.ResourceDetectionASG:               common.AttributeEC2AutoScalingGroup,
+	attr.ResourceDetectionHostId:            common.AttributeEC2InstanceId,
+	attr.ResourceDetectionHostName:          common.AttributeHost,
 }
 
 type subResolver interface {


### PR DESCRIPTION
# Description of the issue
ApplicationSignalsProcessor relies on the resource attribute `deployment.environment` as a customer-provided override for ApplicationSignals `Environment`. However, `deployment.environment` has been deprecated and replaced with `deployment.environment.name` in the upstream.

# Description of changes
In this PR, we are adding support for the new attribute, while maintaining support for the old attribute, since customers may still specify `deployment.environment`, for example, if they are running on older OTEL versions.

Callout: We are no longer getting these attribute names from semconv as:
1. We were relying on go.opentelemetry.io/collector/semconv/v1.22.0, which does not have `deployment.environment.name`
2. https://pkg.go.dev/go.opentelemetry.io/collector/semconv has been deprecated
3. It's replacement, https://pkg.go.dev/go.opentelemetry.io/otel/semconv does not include `deployment.environment.name`: https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-go+deployment.environment.name&type=code
4. Nor does it include `deployment.environment` in the latest releases (1.3x): https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-go+deployment.environment&type=code

So we hardcode these attributes within the processor logic.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Unit tests pass
* E2E testing:  done on EC2 with a simple Java application and latest ADOT SDK.
   * Scenario 1: `export OTEL_RESOURCE_ATTRIBUTES="service.name=2122Test1"` - Success, `Environment` metric dimension set to `ec2:default`.
   * Scenario 2: `export OTEL_RESOURCE_ATTRIBUTES="service.name=2122Test1,deployment.environment=test1"` - Success, `Environment` metric dimension set to `test1`.
   * Scenario 3: `export OTEL_RESOURCE_ATTRIBUTES="service.name=2122Test1,deployment.environment.name=test2"` - Success, `Environment` metric dimension set to `test2`.
   * Scenario 4: `export OTEL_RESOURCE_ATTRIBUTES="service.name=2122Test1,deployment.environment=test3,deployment.environment.name=test4"` - Success, `Environment` metric dimension set to `test4`. // Not a realistic test, just edge testing.
   * Scenario 5: `export OTEL_RESOURCE_ATTRIBUTES="service.name=2122Test1,deployment.environment.name=test5,deployment.environment=test6"` - Success, `Environment` metric dimension set to `test5`. // Not a realistic test, just edge testing.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

Done

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



