### PR TITLE
Improve batching for range state

### DIFF
--- a/internal/state/range.go
+++ b/internal/state/range.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding"
 	"fmt"
+	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -30,6 +31,10 @@ type Range struct {
 
 var _ encoding.TextMarshaler = (*Range)(nil)
 var _ encoding.TextUnmarshaler = (*Range)(nil)
+
+func NewRange(start, end uint64) Range {
+	return Range{start: start, end: end}
+}
 
 // Set updates the start and end offsets of the range. If the new start is before the current start, it indicates
 // file truncation and increments the sequence number.
@@ -203,7 +208,7 @@ func newRangeTracker(name string, capacity int) RangeTracker {
 	if capacity == 1 {
 		return newSingleRangeTracker(name)
 	}
-	return newMultiRangeTrackerWithCap(name, capacity)
+	return newMultiRangeTracker(name, capacity)
 }
 
 // singleRangeTracker only keeps track of the maximum offset. It stores a single range starting at 0 and ending at the
@@ -306,14 +311,9 @@ type multiRangeTracker struct {
 
 var _ RangeTracker = (*multiRangeTracker)(nil)
 
-// newMultiRangeTracker creates an unbounded multiRangeTracker.
-func newMultiRangeTracker(name string) RangeTracker {
-	return newMultiRangeTrackerWithCap(name, -1)
-}
-
-// newMultiRangeTrackerWithCap creates a bounded multiRangeTracker based on the capacity. When capacity is exceeded, the oldest ranges
-// are merged/collapsed.
-func newMultiRangeTrackerWithCap(name string, capacity int) RangeTracker {
+// newMultiRangeTrackerWithCap creates a bounded multiRangeTracker based on the capacity. When capacity is exceeded,
+// the oldest ranges are merged/collapsed.
+func newMultiRangeTracker(name string, capacity int) RangeTracker {
 	return &multiRangeTracker{
 		name: name,
 		cap:  capacity,
@@ -399,6 +399,7 @@ func (t *multiRangeTracker) collapseOldest() {
 	t.tree.Delete(*first)
 	t.tree.Delete(*second)
 
+	log.Printf("D! Tracked ranges for %s exceeds max. Collapsing %s and %s", t.name, *first, *second)
 	merged := mergeRanges(*first, *second)
 	t.tree.ReplaceOrInsert(merged)
 }

--- a/internal/state/range_test.go
+++ b/internal/state/range_test.go
@@ -63,7 +63,7 @@ func TestRange(t *testing.T) {
 		assert.True(t, r1.Contains(r1))
 	})
 	t.Run("Unmarshal", func(t *testing.T) {
-		r := Range{start: 5, end: 10}
+		r := NewRange(5, 10)
 		got, err := r.MarshalText()
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("5-10"), got)
@@ -73,7 +73,7 @@ func TestRange(t *testing.T) {
 		assert.Equal(t, r, r2)
 	})
 	t.Run("Unmarshal/Unbounded", func(t *testing.T) {
-		r := Range{start: 5, end: unboundedEnd}
+		r := NewRange(5, unboundedEnd)
 		got, err := r.MarshalText()
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("5-"), got)
@@ -248,7 +248,7 @@ func TestSingleRangeTracker_Unmarshal(t *testing.T) {
 func TestMultiRangeTracker_Insert(t *testing.T) {
 	t.Run("NonOverlapping", func(t *testing.T) {
 		t.Parallel()
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.True(t, tracker.Insert(Range{start: 0, end: 5}))
 		assert.True(t, tracker.Insert(Range{start: 20, end: 30}))
 		assert.Equal(t, 2, tracker.Len())
@@ -259,7 +259,7 @@ func TestMultiRangeTracker_Insert(t *testing.T) {
 	})
 	t.Run("Merge/Adjacent", func(t *testing.T) {
 		t.Parallel()
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.True(t, tracker.Insert(Range{start: 0, end: 5}))
 		assert.True(t, tracker.Insert(Range{start: 20, end: 30}))
 		assert.True(t, tracker.Insert(Range{start: 5, end: 10}))
@@ -271,7 +271,7 @@ func TestMultiRangeTracker_Insert(t *testing.T) {
 	})
 	t.Run("Merge/Overlap/Single", func(t *testing.T) {
 		t.Parallel()
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.True(t, tracker.Insert(Range{start: 0, end: 5}))
 		assert.True(t, tracker.Insert(Range{start: 20, end: 30}))
 		assert.True(t, tracker.Insert(Range{start: 15, end: 25}))
@@ -283,7 +283,7 @@ func TestMultiRangeTracker_Insert(t *testing.T) {
 	})
 	t.Run("Merge/Overlap/Multiple", func(t *testing.T) {
 		t.Parallel()
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.True(t, tracker.Insert(Range{start: 0, end: 5}))
 		assert.True(t, tracker.Insert(Range{start: 20, end: 30}))
 		assert.True(t, tracker.Insert(Range{start: 10, end: 15}))
@@ -295,7 +295,7 @@ func TestMultiRangeTracker_Insert(t *testing.T) {
 	})
 	t.Run("AlreadyContained", func(t *testing.T) {
 		t.Parallel()
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.True(t, tracker.Insert(Range{start: 0, end: 20}))
 		assert.False(t, tracker.Insert(Range{start: 10, end: 15}))
 		assert.False(t, tracker.Insert(Range{start: 0, end: 20}))
@@ -303,7 +303,7 @@ func TestMultiRangeTracker_Insert(t *testing.T) {
 	})
 	t.Run("Invalid", func(t *testing.T) {
 		t.Parallel()
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		r := Range{start: 0, end: 0}
 		assert.False(t, r.IsValid())
 		assert.False(t, tracker.Insert(r))
@@ -312,7 +312,7 @@ func TestMultiRangeTracker_Insert(t *testing.T) {
 	})
 	t.Run("CollapseWhenOverCapacity", func(t *testing.T) {
 		t.Parallel()
-		tracker := newMultiRangeTrackerWithCap("test", 2)
+		tracker := newMultiRangeTracker("test", 2)
 		assert.True(t, tracker.Insert(Range{start: 0, end: 5}))
 		assert.True(t, tracker.Insert(Range{start: 10, end: 15}))
 		assert.True(t, tracker.Insert(Range{start: 20, end: 25}))
@@ -328,7 +328,7 @@ func TestMultiRangeTracker_Unmarshal(t *testing.T) {
 			{start: 20, end: 30},
 			{start: 45, end: 50},
 		}
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.NoError(t, tracker.UnmarshalText([]byte("50\ntest\n0-5,20-30,45-50")))
 		assert.Equal(t, 3, tracker.Len())
 		assert.Equal(t, want, tracker.Ranges())
@@ -346,46 +346,46 @@ func TestMultiRangeTracker_Unmarshal(t *testing.T) {
 		assert.Equal(t, "0\ntest", string(got))
 	})
 	t.Run("Empty", func(t *testing.T) {
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.NoError(t, tracker.UnmarshalText([]byte("")))
 		assert.Equal(t, 0, tracker.Len())
 	})
 	t.Run("Invalid/SingleLine", func(t *testing.T) {
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.Error(t, tracker.UnmarshalText([]byte("test")))
 		assert.Equal(t, 0, tracker.Len())
 	})
 	t.Run("Invalid/MultiLine", func(t *testing.T) {
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.Error(t, tracker.UnmarshalText([]byte("test\ntest\ntest")))
 		assert.Equal(t, 0, tracker.Len())
 	})
 	t.Run("Invalid/MissingMaxOffset", func(t *testing.T) {
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.Error(t, tracker.UnmarshalText([]byte("0-15,20-30\ntest")))
 		assert.Equal(t, 0, tracker.Len())
 	})
 	t.Run("Invalid/Range", func(t *testing.T) {
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.NoError(t, tracker.UnmarshalText([]byte("50\ntest-test\ntest")))
 		assert.Equal(t, RangeList{
 			{start: 0, end: 50},
 		}, tracker.Ranges())
 	})
 	t.Run("Invalid/OutOfOrder", func(t *testing.T) {
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.NoError(t, tracker.UnmarshalText([]byte("50\n10-20,30-50\ntest")))
 		assert.Equal(t, RangeList{
 			{start: 0, end: 50},
 		}, tracker.Ranges())
 	})
 	t.Run("BackwardsCompatible/Invalid", func(t *testing.T) {
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.Error(t, tracker.UnmarshalText([]byte("-1\ntest")))
 		assert.Equal(t, 0, tracker.Len())
 	})
 	t.Run("BackwardsCompatible/Valid", func(t *testing.T) {
-		tracker := newMultiRangeTracker("test")
+		tracker := newMultiRangeTracker("test", -1)
 		assert.NoError(t, tracker.UnmarshalText([]byte("20")))
 		assert.Equal(t, RangeList{
 			{start: 0, end: 20},
@@ -398,7 +398,7 @@ func TestMultiRangeTracker_Unmarshal(t *testing.T) {
 }
 
 func TestMultiRangeTracker_Ranges(t *testing.T) {
-	tracker := newMultiRangeTracker("test")
+	tracker := newMultiRangeTracker("test", -1)
 	got := tracker.Ranges()
 	assert.NotNil(t, got)
 	assert.Empty(t, got)
@@ -410,7 +410,7 @@ func TestMultiRangeTracker_Ranges(t *testing.T) {
 }
 
 func TestInvertRanges(t *testing.T) {
-	tracker := newMultiRangeTracker("test")
+	tracker := newMultiRangeTracker("test", -1)
 	assert.True(t, tracker.Insert(Range{start: 5, end: 10}))
 	assert.True(t, tracker.Insert(Range{start: 20, end: 25}))
 	ranges := tracker.Ranges()
@@ -430,7 +430,7 @@ func TestInvertRanges(t *testing.T) {
 
 func BenchmarkMultiRangeTracker(b *testing.B) {
 	b.Run("Insert", func(b *testing.B) {
-		tracker := newMultiRangeTrackerWithCap("test", 50)
+		tracker := newMultiRangeTracker("test", 50)
 		r := rand.New(rand.NewSource(64))
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -441,7 +441,7 @@ func BenchmarkMultiRangeTracker(b *testing.B) {
 		}
 	})
 	b.Run("Insert/NonOverlapping", func(b *testing.B) {
-		tracker := newMultiRangeTrackerWithCap("test", 50)
+		tracker := newMultiRangeTracker("test", 50)
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -449,7 +449,7 @@ func BenchmarkMultiRangeTracker(b *testing.B) {
 		}
 	})
 	b.Run("Invert", func(b *testing.B) {
-		tracker := newMultiRangeTrackerWithCap("test", 50)
+		tracker := newMultiRangeTracker("test", 50)
 		for i := 0; i < b.N; i++ {
 			tracker.Insert(Range{start: uint64(i * 10), end: uint64(i*10 + 5)})
 		}
@@ -461,7 +461,7 @@ func BenchmarkMultiRangeTracker(b *testing.B) {
 		}
 	})
 	b.Run("Ranges", func(b *testing.B) {
-		tracker := newMultiRangeTrackerWithCap("test", 1000)
+		tracker := newMultiRangeTracker("test", 1000)
 		for i := 0; i < b.N; i++ {
 			tracker.Insert(Range{start: uint64(i * 10), end: uint64(i*10 + 5)})
 		}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -14,10 +14,16 @@ const (
 	FileMode = 0644
 )
 
+// Queue handles queued state changes.
+type Queue[T any] interface {
+	ID() string
+	// Enqueue the current state in memory.
+	Enqueue(state T)
+}
+
 // Manager handles persistence of state.
 type Manager[I, O any] interface {
-	// Enqueue the current state in memory.
-	Enqueue(state I)
+	Queue[I]
 	// Restore loads the previous state.
 	Restore() (O, error)
 	// Run starts the update/save loop.

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 
+	"github.com/aws/amazon-cloudwatch-agent/internal/state"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/inputs/logfile/tail"
 	"github.com/aws/amazon-cloudwatch-agent/sdk/service/cloudwatchlogs"
 )
@@ -28,6 +29,12 @@ type LogEvent interface {
 	Message() string
 	Time() time.Time
 	Done()
+}
+
+type StatefulLogEvent interface {
+	LogEvent
+	Range() state.Range
+	RangeQueue() state.FileRangeQueue
 }
 
 type LogEntityProvider interface {

--- a/plugins/inputs/logfile/tailersrc.go
+++ b/plugins/inputs/logfile/tailersrc.go
@@ -36,6 +36,8 @@ type LogEvent struct {
 	src    *tailerSrc
 }
 
+var _ logs.StatefulLogEvent = (*LogEvent)(nil)
+
 func (le LogEvent) Message() string {
 	return le.msg
 }
@@ -45,7 +47,14 @@ func (le LogEvent) Time() time.Time {
 }
 
 func (le LogEvent) Done() {
-	le.src.Done(le.offset)
+}
+
+func (le LogEvent) Range() state.Range {
+	return le.offset
+}
+
+func (le LogEvent) RangeQueue() state.FileRangeQueue {
+	return le.src.stateManager
 }
 
 type tailerSrc struct {
@@ -157,9 +166,6 @@ func (ts *tailerSrc) Retention() int {
 
 func (ts *tailerSrc) Class() string {
 	return ts.class
-}
-func (ts *tailerSrc) Done(offset state.Range) {
-	ts.stateManager.Enqueue(offset)
 }
 
 func (ts *tailerSrc) Stop() {

--- a/plugins/inputs/logfile/tailersrc_test.go
+++ b/plugins/inputs/logfile/tailersrc_test.go
@@ -156,7 +156,7 @@ func TestTailerSrc(t *testing.T) {
 	assert.Eventually(t, func() bool { return tail.OpenFileCount.Load() <= beforeCount }, 3*time.Second, time.Second)
 }
 
-func TestOffsetDoneCallBack(t *testing.T) {
+func TestStatefulLogEvent(t *testing.T) {
 	original := multilineWaitPeriod
 	defer resetState(original)
 
@@ -215,13 +215,15 @@ func TestOffsetDoneCallBack(t *testing.T) {
 			close(done)
 			return
 		}
-		evt.Done()
+		sle, ok := evt.(logs.StatefulLogEvent)
+		assert.True(t, ok)
+		sle.RangeQueue().Enqueue(sle.Range())
 		i++
 		switch i {
 		case 10:
 			// Test before first truncate
 			time.Sleep(1 * time.Second)
-			b, err := os.ReadFile(statefile.Name())
+			b, err := os.ReadFile(stateFilePath)
 			require.NoError(t, err, fmt.Sprintf("Failed to read state file: %v", err))
 			offset, err := strconv.Atoi(string(bytes.Split(b, []byte("\n"))[0]))
 			require.NoError(t, err, fmt.Sprintf("Failed to parse offset: %v, from '%s'", err, b))
@@ -229,8 +231,8 @@ func TestOffsetDoneCallBack(t *testing.T) {
 		case 15:
 			// Test after first truncate, saved offset should decrease
 			time.Sleep(1 * time.Second)
-			log.Println(statefile.Name())
-			b, err := os.ReadFile(statefile.Name())
+			log.Println(stateFilePath)
+			b, err := os.ReadFile(stateFilePath)
 			require.NoError(t, err, fmt.Sprintf("Failed to read state file: %v", err))
 			file_parts := bytes.Split(b, []byte("\n"))
 			log.Println("file_parts: ", file_parts)
@@ -241,7 +243,7 @@ func TestOffsetDoneCallBack(t *testing.T) {
 			require.Equal(t, offset, 505, fmt.Sprintf("Wrong offset %v is written to state file, after truncate and write shorter logs expecting 505", offset))
 		case 35:
 			time.Sleep(1 * time.Second)
-			b, err := os.ReadFile(statefile.Name())
+			b, err := os.ReadFile(stateFilePath)
 			require.NoError(t, err, fmt.Sprintf("Failed to read state file: %v", err))
 			offset, err := strconv.Atoi(string(bytes.Split(b, []byte("\n"))[0]))
 			require.NoError(t, err, fmt.Sprintf("Failed to parse offset: %v, from '%s'", err, b))

--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog.go
@@ -302,6 +302,8 @@ type LogEvent struct {
 	src    *windowsEventLog
 }
 
+var _ logs.StatefulLogEvent = (*LogEvent)(nil)
+
 func (le LogEvent) Message() string {
 	return le.msg
 }
@@ -311,7 +313,14 @@ func (le LogEvent) Time() time.Time {
 }
 
 func (le LogEvent) Done() {
-	le.src.Done(le.offset)
+}
+
+func (le LogEvent) Range() state.Range {
+	return le.offset
+}
+
+func (le LogEvent) RangeQueue() state.FileRangeQueue {
+	return le.src.stateManager
 }
 
 // getRecords attempts to render and format each of the given EvtHandles.

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/convert.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/convert.go
@@ -69,5 +69,12 @@ func (c *converter) convert(e logs.LogEvent) *logEvent {
 		c.lastUpdateTime = now
 		c.lastWarnMessage = time.Time{}
 	}
-	return newLogEvent(t, message, e.Done)
+	var state *logEventState
+	if sle, ok := e.(logs.StatefulLogEvent); ok {
+		state = &logEventState{
+			r:     sle.Range(),
+			queue: sle.RangeQueue(),
+		}
+	}
+	return newStatefulLogEvent(t, message, e.Done, state)
 }


### PR DESCRIPTION
# Description of the issue
With the range state management added as part of https://github.com/aws/amazon-cloudwatch-agent/pull/1718, if multi-threading is enabled, the agent tries to keep track of distinct, non-overlapping ranges. The multi-range tracker will merge any overlapping ranges on insert. It was built with capacity limits and when capacity is exceeded, it will collapse the lowest ranges.

The current logic on successful send of a log event batch is to call all the `Done` callbacks for each individual log event in the batch. This enqueues each of the ranges onto the tracker for insertion/merging. With a maximum limit of 10000 events in a batch, this quickly becomes too much unnecessary work.

# Description of changes
Instead of sending each individual range, pre-merge the ranges in the batch and send them as a single range. The log tailing logic is still sequential/single-threaded, so the log events in a batch will be continuous and can be naively merged. This reduces the amount of work the tracker needs to do and helps to keep the number of tracked ranges below the the capacity threshold.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests. Ran the changes manually with some additional logging in the `RangeQueueBatcher`.
```
	log.Printf("D! Done in RangeQueueBatcher: %s became %s", b.rs, b.r)
```

```
D! Done in RangeQueueBatcher: [19204063-19204117,19204117-19204183,19204183-19204237,19204237-19204254,19204254-19204290,19204290-19204597,19204597-19204619,19204619-19204925,19204925-19204949,19204949-19204991,19204991-19205043,19205043-19205073,19205073-19206413,19206413-19206455,19206480-19206481,19206481-19206535,19206535-19206602,19206602-19206656,19206656-19206673,19206673-19206693,19206693-19206735,19206735-19206772,19206830-19206831,19206831-19206885,19206885-19207737,19207737-19207930,19207930-19207984,19207984-19208038,19208038-19208092,19208092-19208146,19208146-19208200,19208200-19208254,19208254-19208308,19208308-19208362,19208362-19208416,19208416-19208470,19208470-19208524,19208524-19208578,19208578-19208632,19208632-19208686] became 19204063-19208686
```

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



