### PR TITLE
Fixing prometheus env configuration expansion problem

### DIFF
--- a/translator/tocwconfig/sampleConfig/prometheus_expansion.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_expansion.yaml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 5s
+  scrape_timeout: 5s
+scrape_configs:
+  - job_name: 'prometheus_test_job'
+    static_configs:
+      - targets: ['localhost:8101']
+    metric_relabel_configs:
+      - source_labels: ['__name__']
+        target_label: 'my_name'
+        action: replace
+        regex: '(.*)'
+        replacement: $1

--- a/translator/tocwconfig/sampleConfig/prometheus_expansion_config.conf
+++ b/translator/tocwconfig/sampleConfig/prometheus_expansion_config.conf
@@ -1,0 +1,25 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = "host_name_from_env"
+  interval = "60s"
+  logfile = ""
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    endpoint_override = "https://fake_endpoint"
+    force_flush_interval = "30s"
+    log_stream_name = "host_name_from_env"
+    mode = "EC2"
+    region = "us-east-1"
+    region_type = "ACJ"

--- a/translator/tocwconfig/sampleConfig/prometheus_expansion_config.json
+++ b/translator/tocwconfig/sampleConfig/prometheus_expansion_config.json
@@ -1,0 +1,89 @@
+{
+  "agent": {
+    "region": "us-east-1"
+  },
+  "logs": {
+    "metrics_collected": {
+      "prometheus": {
+        "cluster_name": "TestCluster",
+        "log_group_name": "/aws/ecs/containerinsights/TestCluster/prometheus",
+        "prometheus_config_path": "{prometheusFileName}",
+        "ecs_service_discovery": {
+          "docker_label": {
+            "sd_job_name_label": "ECS_PROMETHEUS_JOB_NAME_1",
+            "sd_metrics_path_label": "ECS_PROMETHEUS_METRICS_PATH",
+            "sd_port_label": "ECS_PROMETHEUS_EXPORTER_PORT_SUBSET"
+          },
+          "task_definition_list": [
+            {
+              "sd_job_name": "task_def_1",
+              "sd_metrics_path": "/stats/metrics",
+              "sd_metrics_ports": "9901",
+              "sd_task_definition_arn_pattern": ".*task_def_1:[0-9]+"
+            },
+            {
+              "sd_container_name_pattern": "^envoy$",
+              "sd_metrics_ports": "9902",
+              "sd_task_definition_arn_pattern": "task_def_2"
+            }
+          ],
+          "service_name_list_for_tasks": [
+            {
+              "sd_job_name": "service_name_1",
+              "sd_metrics_path": "/metrics",
+              "sd_metrics_ports": "9113",
+              "sd_service_name_pattern": ".*-application-stack",
+              "sd_container_name_pattern": "nginx-prometheus-exporter"
+            },
+            {
+              "sd_metrics_path":"/stats/metrics",
+              "sd_metrics_ports": "9114",
+              "sd_service_name_pattern": "run-application-stack"
+            }
+          ],
+          "sd_cluster_region": "us-west-1",
+          "sd_frequency": "1m",
+          "sd_result_file": "{ecsSdFileName}",
+          "sd_target_cluster": "ecs-cluster-a"
+        },
+        "emf_processor": {
+          "metric_declaration_dedup": true,
+          "metric_namespace": "CustomizedNamespace",
+          "metric_unit": {
+            "nginx_request_count": "Count"
+          },
+          "metric_declaration": [
+            {
+              "dimensions": [["Service"]],
+              "label_matcher": "nginx.*",
+              "label_separator": ";",
+              "metric_selectors": ["^nginx_request_count$"],
+              "source_labels": ["Service"]
+            },
+            {
+              "label_matcher": "default",
+              "metric_selectors": [".*"],
+              "source_labels": ["Namespace"]
+            },
+            {
+              "source_labels":["name"],
+              "dimensions":[
+                ["name"]
+              ],
+              "metric_selectors": ["^.*$"]
+            },
+            {
+              "source_labels":["name"],
+              "dimensions":[
+                ["name"]
+              ],
+              "metric_selectors": ["^node_cpu_guest_seconds_total$"]
+            }
+          ]
+        }
+      }
+    },
+    "force_flush_interval": 30,
+    "endpoint_override":"https://fake_endpoint"
+  }
+}

--- a/translator/tocwconfig/sampleConfig/prometheus_expansion_config.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_expansion_config.yaml
@@ -1,0 +1,208 @@
+exporters:
+    awsemf/prometheus:
+        add_entity: false
+        certificate_file_path: ""
+        detailed_metrics: true
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: false
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: false
+        external_id: ""
+        imds_retries: 1
+        local_mode: false
+        log_group_name: /aws/ecs/containerinsights/TestCluster/prometheus
+        log_retention: 0
+        log_stream_name: '{JobName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - Service
+              label_matchers:
+                - label_names:
+                    - Service
+                  regex: nginx.*
+                  separator: ;
+              metric_name_selectors:
+                - ^nginx_request_count$
+            - dimensions: []
+              label_matchers:
+                - label_names:
+                    - Namespace
+                  regex: default
+                  separator: ;
+              metric_name_selectors:
+                - .*
+            - dimensions:
+                - - name
+              label_matchers:
+                - label_names:
+                    - name
+                  regex: .*
+                  separator: ;
+              metric_name_selectors:
+                - ^.*$
+            - dimensions:
+                - - name
+              label_matchers:
+                - label_names:
+                    - name
+                  regex: .*
+                  separator: ;
+              metric_name_selectors:
+                - ^node_cpu_guest_seconds_total$
+        metric_descriptors:
+            - metric_name: nginx_request_count
+              overwrite: false
+              unit: Count
+        middleware: agenthealth/logs
+        namespace: CustomizedNamespace
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        profile: ""
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        version: "0"
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    agenthealth/statuscode:
+        is_status_code_enabled: true
+        is_usage_data_enabled: true
+        stats:
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    ecs_observer:
+        cluster_name: ecs-cluster-a
+        cluster_region: us-west-1
+        docker_labels:
+            - job_name: ""
+              job_name_label: ECS_PROMETHEUS_JOB_NAME_1
+              metrics_path: ""
+              metrics_path_label: ECS_PROMETHEUS_METRICS_PATH
+              port_label: ECS_PROMETHEUS_EXPORTER_PORT_SUBSET
+        job_label_name: ""
+        refresh_interval: 1m0s
+        result_file: '{ecsSdFileName}'
+        services:
+            - container_name_pattern: nginx-prometheus-exporter
+              job_name: service_name_1
+              metrics_path: /metrics
+              metrics_ports:
+                - 9113
+              name_pattern: .*-application-stack
+            - container_name_pattern: ""
+              job_name: ""
+              metrics_path: /stats/metrics
+              metrics_ports:
+                - 9114
+              name_pattern: run-application-stack
+        task_definitions:
+            - arn_pattern: .*task_def_1:[0-9]+
+              container_name_pattern: ""
+              job_name: task_def_1
+              metrics_path: /stats/metrics
+              metrics_ports:
+                - 9901
+            - arn_pattern: task_def_2
+              container_name_pattern: ^envoy$
+              job_name: ""
+              metrics_path: /metrics
+              metrics_ports:
+                - 9902
+    entitystore:
+        mode: ec2
+        region: us-east-1
+processors:
+    batch/prometheus/cloudwatchlogs:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 30s
+    prometheusadapter/prometheus/cloudwatchlogs: {}
+receivers:
+    prometheus/prometheus/cloudwatchlogs:
+        config:
+            global:
+                evaluation_interval: 1m
+                scrape_interval: 5s
+                scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                scrape_timeout: 5s
+            scrape_configs:
+                - enable_compression: true
+                  enable_http2: true
+                  fallback_scrape_protocol: PrometheusText0.0.4
+                  follow_redirects: true
+                  honor_timestamps: true
+                  job_name: prometheus_test_job
+                  metric_relabel_configs:
+                    - action: replace
+                      regex: (.*)
+                      replacement: $$$$1
+                      separator: ;
+                      source_labels:
+                        - __name__
+                      target_label: my_name
+                  metrics_path: /metrics
+                  scheme: http
+                  scrape_interval: 5s
+                  scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                  scrape_timeout: 5s
+                  static_configs:
+                    - targets:
+                        - localhost:8101
+                  track_timestamps_staleness: false
+        report_extra_scrape_metrics: false
+        start_time_metric_regex: ""
+        trim_metric_suffixes: false
+        use_start_time_metric: false
+service:
+    extensions:
+        - agenthealth/logs
+        - agenthealth/statuscode
+        - ecs_observer
+        - entitystore
+    pipelines:
+        metrics/prometheus/cloudwatchlogs:
+            exporters:
+                - awsemf/prometheus
+            processors:
+                - prometheusadapter/prometheus/cloudwatchlogs
+                - batch/prometheus/cloudwatchlogs
+            receivers:
+                - prometheus/prometheus/cloudwatchlogs
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -54,6 +54,9 @@ var prometheusConfig string
 //go:embed sampleConfig/prometheus_cwa_config.yaml
 var prometheusPMDConfig string
 
+//go:embed sampleConfig/prometheus_expansion.yaml
+var prometheusExpansionConfig string
+
 type testCase struct {
 	filename        string
 	targetPlatform  string
@@ -431,7 +434,6 @@ func TestPrometheusConfig(t *testing.T) {
 	checkTranslation(t, "prometheus_config_windows", "windows", nil, "", tokenReplacements)
 }
 
-
 func TestPrometheusPMDConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(true)
@@ -449,6 +451,25 @@ func TestPrometheusPMDConfig(t *testing.T) {
 
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "prometheus_pmd_config", "linux", expectedEnvVars, "", tokenReplacements)
+}
+
+func TestPrometheusExpansionConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetRunInContainer(true)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	t.Setenv(config.HOST_NAME, "host_name_from_env")
+
+	temp := t.TempDir()
+	prometheusConfigFileName := filepath.Join(temp, "prometheus.yaml")
+	err := os.WriteFile(prometheusConfigFileName, []byte(prometheusExpansionConfig), 0600)
+	require.NoError(t, err)
+
+	tokenReplacements := map[string]string{
+		prometheusFileNameToken: strings.ReplaceAll(prometheusConfigFileName, "\\", "\\\\"),
+	}
+
+	expectedEnvVars := map[string]string{}
+	checkTranslation(t, "prometheus_expansion_config", "linux", expectedEnvVars, "", tokenReplacements)
 }
 
 func TestPrometheusConfigwithTargetAllocator(t *testing.T) {
@@ -913,7 +934,7 @@ func verifyToTomlTranslation(t *testing.T, input interface{}, desiredTomlPath st
 	_, decodeError2 := toml.Decode(tomlStr, &actual)
 	assert.NoError(t, decodeError2)
 
-	// assert.NoError(t, os.WriteFile(desiredTomlPath, []byte(tomlStr), 0644)) // useful for regenerating TOML
+	//assert.NoError(t, os.WriteFile(desiredTomlPath, []byte(tomlStr), 0644)) // useful for regenerating TOML
 
 	// This less function sort the content of string slice in alphabetical order so the
 	// cmp.Equal method will compare the two struct with slices in them, regardless the elements within the slices
@@ -946,7 +967,7 @@ func verifyToYamlTranslation(t *testing.T, input interface{}, expectedYamlFilePa
 		yamlStr := toyamlconfig.ToYamlConfig(yamlConfig)
 		require.NoError(t, yaml.Unmarshal([]byte(yamlStr), &actual))
 
-		// assert.NoError(t, os.WriteFile(expectedYamlFilePath, []byte(yamlStr), 0644)) // useful for regenerating YAML
+		//assert.NoError(t, os.WriteFile(expectedYamlFilePath, []byte(yamlStr), 0644)) // useful for regenerating YAML
 
 		opt := cmpopts.SortSlices(func(x, y interface{}) bool {
 			return pretty.Sprint(x) < pretty.Sprint(y)


### PR DESCRIPTION
## Description:

OpenTelemetry Prometheus receiver's regex replacement syntax ($1, ${1}, etc.) conflicts with the CloudWatch Agent's environment variable expansion, causing startup errors when processing Prometheus configurations with metric relabeling rules.

## Description of change
Modified the Prometheus translator to escape $ characters (replacing $ with $$$$) in the configuration before parsing. This double escaping handles the two-step variable expansion process in the agent while preserving the functionality of both regex capture groups and environment variables.
