### PR TITLE
Add log concurrency flag

### DIFF
--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -33,6 +33,7 @@ const (
 	flagEnhancedContainerInsights = "enhanced_container_insights"
 	flagSELinux                   = "selinux"
 	flagROSA                      = "rosa"
+	flagLogConcurrency            = "log_concurrency"
 	separator                     = " "
 
 	typeInputs     = "inputs"
@@ -48,6 +49,7 @@ var (
 type UserAgent interface {
 	SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegraf.Config)
 	SetContainerInsightsFlag()
+	SetLogConcurrencyFlag()
 	Header(isUsageDataEnabled bool) string
 	Listen(listener func())
 }
@@ -136,10 +138,18 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 }
 
 func (ua *userAgent) SetContainerInsightsFlag() {
+	ua.setFlag(flagContainerInsights)
+}
+
+func (ua *userAgent) SetLogConcurrencyFlag() {
+	ua.setFlag(flagLogConcurrency)
+}
+
+func (ua *userAgent) setFlag(flag string) {
 	ua.dataLock.Lock()
 	defer ua.dataLock.Unlock()
-	if !ua.outputs.Contains(flagContainerInsights) {
-		ua.outputs.Add(flagContainerInsights)
+	if !ua.outputs.Contains(flag) {
+		ua.outputs.Add(flag)
 		ua.outputsStr.Store(componentsStr(typeOutputs, ua.outputs))
 		ua.notify()
 	}

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -147,6 +147,7 @@ func (c *CloudWatchLogs) getDest(t pusher.Target, logSrc logs.LogSrc) *cwDest {
 	c.once.Do(func() {
 		if c.Concurrency > 1 {
 			c.workerPool = pusher.NewWorkerPool(c.Concurrency)
+			useragent.Get().SetLogConcurrencyFlag()
 		}
 		c.targetManager = pusher.NewTargetManager(c.Log, client)
 	})


### PR DESCRIPTION
# Description of changes
Adds a flag to the user agent when multi-threading is enabled.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



