### PR TITLE
[EKS Performance Testing] Implement github action for scaling up and down eks performance cluster

### DIFF
--- a/.github/workflows/eks-performance-cluster-scaling.yml
+++ b/.github/workflows/eks-performance-cluster-scaling.yml
@@ -23,10 +23,15 @@ on:
         required: true
         type: number
         default: 500
+      node_group_count:
+        description: 'Count of node groups'
+        type: number
+        default: 10
 
 env:
   AWS_REGION: ${{ inputs.region || 'us-west-2' }}
   CLUSTER_NAME: ${{ inputs.cluster_name || 'eks-performance' }}
+  NODE_GROUP_COUNT: ${{ inputs.node_group_count || 10 }}
   DESIRED_CAPACITY_PER_NODEGROUP: ${{ inputs.desired_capacity_per_nodegroup || 500 }}
   TERRAFORM_AWS_ASSUME_ROLE: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
   TERRAFORM_AWS_ASSUME_ROLE_DURATION: 3600  # 1 hour duration
@@ -68,7 +73,7 @@ jobs:
         run: |
           echo "Starting scale UP operation with desired capacity: 500"
           
-          for i in {1..10}; do
+          for i in $(seq 1 $NODE_GROUP_COUNT); do
             echo "Scaling node group: eks-performance-node-${i} to 500"
             aws eks update-nodegroup-config \
               --cluster-name eks-performance \
@@ -85,7 +90,7 @@ jobs:
         run: |
           echo "Starting scale DOWN operation with desired capacity: 0"
           
-          for i in {1..10}; do
+          for i in $(seq 1 $NODE_GROUP_COUNT); do
             echo "Scaling node group: eks-performance-node-${i} to 0"
             aws eks update-nodegroup-config \
               --cluster-name eks-performance \
@@ -102,7 +107,7 @@ jobs:
         run: |
           echo "Starting manual scaling operation with desired capacity: ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}"
           
-          for i in {1..10}; do
+          for i in $(seq 1 $NODE_GROUP_COUNT); do
             echo "Scaling node group: eks-performance-node-${i} to ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}"
             aws eks update-nodegroup-config \
               --cluster-name eks-performance \
@@ -122,9 +127,9 @@ jobs:
           
           # Determine expected count based on trigger type
           if [ "${{ github.event.schedule }}" = "0 21 * * 1" ]; then
-            EXPECTED_NODE_COUNT=$((10 * 0))
+            EXPECTED_NODE_COUNT=$((${{ env.NODE_GROUP_COUNT }} * 0))
           else
-            EXPECTED_NODE_COUNT=$((10 * ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}))
+            EXPECTED_NODE_COUNT=$((${{ env.NODE_GROUP_COUNT }} * ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}))
           fi
           
           echo "Expected total nodes: ${EXPECTED_NODE_COUNT}"

--- a/.github/workflows/eks-performance-cluster-scaling.yml
+++ b/.github/workflows/eks-performance-cluster-scaling.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
         default: 'eks-performance'
-      desired_capacity:
+      desired_capacity_per_nodegroup:
         description: 'Desired capacity for each node group'
         required: true
         type: number
@@ -27,7 +27,7 @@ on:
 env:
   AWS_REGION: ${{ inputs.region || 'us-west-2' }}
   CLUSTER_NAME: ${{ inputs.cluster_name || 'eks-performance' }}
-  DESIRED_CAPACITY: ${{ inputs.desired_capacity || 500 }}
+  DESIRED_CAPACITY_PER_NODEGROUP: ${{ inputs.desired_capacity_per_nodegroup || 500 }}
   TERRAFORM_AWS_ASSUME_ROLE: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
   TERRAFORM_AWS_ASSUME_ROLE_DURATION: 3600  # 1 hour duration
   CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
@@ -100,15 +100,15 @@ jobs:
       - name: Scale node groups (Manual)
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "Starting manual scaling operation with desired capacity: ${{ env.DESIRED_CAPACITY }}"
+          echo "Starting manual scaling operation with desired capacity: ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}"
           
           for i in {1..10}; do
-            echo "Scaling node group: eks-performance-node-${i} to ${{ env.DESIRED_CAPACITY }}"
+            echo "Scaling node group: eks-performance-node-${i} to ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}"
             aws eks update-nodegroup-config \
               --cluster-name eks-performance \
               --nodegroup-name eks-performance-node-${i} \
               --region us-west-2 \
-              --scaling-config desiredSize=${{ env.DESIRED_CAPACITY }}
+              --scaling-config desiredSize=${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}
           
           done
 
@@ -121,12 +121,10 @@ jobs:
           ACTUAL_NODE_COUNT=$(kubectl get nodes --no-headers | wc -l)
           
           # Determine expected count based on trigger type
-          if [ "${{ github.event.schedule }}" = "0 9 * * 0" ]; then
-            EXPECTED_NODE_COUNT=$((10 * 500))
-          elif [ "${{ github.event.schedule }}" = "0 21 * * 1" ]; then
+          if [ "${{ github.event.schedule }}" = "0 21 * * 1" ]; then
             EXPECTED_NODE_COUNT=$((10 * 0))
           else
-            EXPECTED_NODE_COUNT=$((10 * ${{ env.DESIRED_CAPACITY }}))
+            EXPECTED_NODE_COUNT=$((10 * ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}))
           fi
           
           echo "Expected total nodes: ${EXPECTED_NODE_COUNT}"

--- a/.github/workflows/eks-performance-cluster-scaling.yml
+++ b/.github/workflows/eks-performance-cluster-scaling.yml
@@ -66,7 +66,6 @@ jobs:
       - name: Update kubeconfig for EKS cluster
         run: |
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
-          kubectl get nodes -o wide
 
       - name: Scale up node groups (Sunday)
         if: github.event.schedule == '0 9 * * 0'

--- a/.github/workflows/eks-performance-cluster-scaling.yml
+++ b/.github/workflows/eks-performance-cluster-scaling.yml
@@ -65,20 +65,20 @@ jobs:
 
       - name: Update kubeconfig for EKS cluster
         run: |
-          aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+          aws eks update-kubeconfig --name $CLUSTER_NAME --region $AWS_REGION
 
       - name: Scale up node groups (Sunday)
         if: github.event.schedule == '0 9 * * 0'
         run: |
-          echo "Starting scale UP operation with desired capacity: 500"
+          echo "Starting scale UP operation with desired capacity: $DESIRED_CAPACITY_PER_NODEGROUP"
           
           for i in $(seq 1 $NODE_GROUP_COUNT); do
-            echo "Scaling node group: eks-performance-node-${i} to 500"
+            echo "Scaling node group: $CLUSTER_NAME-node-${i} to $DESIRED_CAPACITY_PER_NODEGROUP"
             aws eks update-nodegroup-config \
-              --cluster-name eks-performance \
-              --nodegroup-name eks-performance-node-${i} \
-              --region us-west-2 \
-              --scaling-config desiredSize=500
+              --cluster-name $CLUSTER_NAME \
+              --nodegroup-name $CLUSTER_NAME-node-${i} \
+              --region $AWS_REGION \
+              --scaling-config desiredSize=$DESIRED_CAPACITY_PER_NODEGROUP
           
             echo "Waiting 1 minute before scaling next node group..."
             sleep 60
@@ -90,11 +90,11 @@ jobs:
           echo "Starting scale DOWN operation with desired capacity: 0"
           
           for i in $(seq 1 $NODE_GROUP_COUNT); do
-            echo "Scaling node group: eks-performance-node-${i} to 0"
+            echo "Scaling node group: $CLUSTER_NAME-node-${i} to 0"
             aws eks update-nodegroup-config \
-              --cluster-name eks-performance \
-              --nodegroup-name eks-performance-node-${i} \
-              --region us-west-2 \
+              --cluster-name $CLUSTER_NAME \
+              --nodegroup-name $CLUSTER_NAME-node-${i} \
+              --region $AWS_REGION \
               --scaling-config desiredSize=0
           
             echo "Waiting 1 minute before scaling next node group..."
@@ -104,15 +104,15 @@ jobs:
       - name: Scale node groups (Manual)
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "Starting manual scaling operation with desired capacity: ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}"
+          echo "Starting manual scaling operation with desired capacity: $DESIRED_CAPACITY_PER_NODEGROUP"
           
           for i in $(seq 1 $NODE_GROUP_COUNT); do
-            echo "Scaling node group: eks-performance-node-${i} to ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}"
+            echo "Scaling node group: $CLUSTER_NAME-node-${i} to $DESIRED_CAPACITY_PER_NODEGROUP"
             aws eks update-nodegroup-config \
-              --cluster-name eks-performance \
-              --nodegroup-name eks-performance-node-${i} \
-              --region us-west-2 \
-              --scaling-config desiredSize=${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}
+              --cluster-name $CLUSTER_NAME \
+              --nodegroup-name $CLUSTER_NAME-node-${i} \
+              --region $AWS_REGION \
+              --scaling-config desiredSize=$DESIRED_CAPACITY_PER_NODEGROUP
           
           done
 
@@ -126,17 +126,17 @@ jobs:
           
           # Determine expected count based on trigger type
           if [ "${{ github.event.schedule }}" = "0 21 * * 1" ]; then
-            EXPECTED_NODE_COUNT=$((${{ env.NODE_GROUP_COUNT }} * 0))
+            EXPECTED_NODE_COUNT=$(($NODE_GROUP_COUNT * 0))
           else
-            EXPECTED_NODE_COUNT=$((${{ env.NODE_GROUP_COUNT }} * ${{ env.DESIRED_CAPACITY_PER_NODEGROUP }}))
+            EXPECTED_NODE_COUNT=$(($NODE_GROUP_COUNT * $DESIRED_CAPACITY_PER_NODEGROUP))
           fi
           
-          echo "Expected total nodes: ${EXPECTED_NODE_COUNT}"
-          echo "Actual total nodes: ${ACTUAL_NODE_COUNT}"
+          echo "Expected total nodes: $EXPECTED_NODE_COUNT"
+          echo "Actual total nodes: $ACTUAL_NODE_COUNT"
           
           if [ "$ACTUAL_NODE_COUNT" -eq "$EXPECTED_NODE_COUNT" ]; then
             echo "Validation successful! Node count matches expected value."
           else
-            echo "Validation failed. Expected ${EXPECTED_NODE_COUNT} nodes but found ${ACTUAL_NODE_COUNT} nodes."
+            echo "Validation failed. Expected $EXPECTED_NODE_COUNT nodes but found $ACTUAL_NODE_COUNT nodes."
             exit 1
           fi

--- a/.github/workflows/eks-performance-cluster-scaling.yml
+++ b/.github/workflows/eks-performance-cluster-scaling.yml
@@ -1,0 +1,140 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+name: EKS Cluster Scaling
+
+on:
+  schedule:
+    - cron: '0 9 * * 0'  # Scale up: Runs every Sunday at 9:00 AM
+    - cron: '0 21 * * 1'  # Scale down: Runs every Monday at 9:00 PM
+  workflow_dispatch:
+    inputs:
+      region:
+        description: 'AWS Region'
+        required: true
+        type: string
+        default: 'us-west-2'
+      cluster_name:
+        description: 'EKS Cluster Name'
+        required: true
+        type: string
+        default: 'eks-performance'
+      desired_capacity:
+        description: 'Desired capacity for each node group'
+        required: true
+        type: number
+        default: 500
+
+env:
+  AWS_REGION: ${{ inputs.region || 'us-west-2' }}
+  CLUSTER_NAME: ${{ inputs.cluster_name || 'eks-performance' }}
+  DESIRED_CAPACITY: ${{ inputs.desired_capacity || 500 }}
+  TERRAFORM_AWS_ASSUME_ROLE: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+  TERRAFORM_AWS_ASSUME_ROLE_DURATION: 3600  # 1 hour duration
+  CWA_GITHUB_TEST_REPO_NAME: "aws/amazon-cloudwatch-agent-test"
+  CWA_GITHUB_TEST_REPO_URL: "https://github.com/aws/amazon-cloudwatch-agent-test.git"
+  CWA_GITHUB_TEST_REPO_BRANCH: "main"
+
+jobs:
+  scale-eks-cluster:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ env.CWA_GITHUB_TEST_REPO_NAME }}
+          ref: ${{ env.CWA_GITHUB_TEST_REPO_BRANCH }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE}}
+          aws-region: ${{ inputs.region || 'us-west-2' }}
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'latest'
+
+      - name: Update kubeconfig for EKS cluster
+        run: |
+          aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+          kubectl get nodes -o wide
+
+      - name: Scale up node groups (Sunday)
+        if: github.event.schedule == '0 9 * * 0'
+        run: |
+          echo "Starting scale UP operation with desired capacity: 500"
+          
+          for i in {1..10}; do
+            echo "Scaling node group: eks-performance-node-${i} to 500"
+            aws eks update-nodegroup-config \
+              --cluster-name eks-performance \
+              --nodegroup-name eks-performance-node-${i} \
+              --region us-west-2 \
+              --scaling-config desiredSize=500
+          
+            echo "Waiting 1 minute before scaling next node group..."
+            sleep 60
+          done
+
+      - name: Scale down node groups (Monday)
+        if: github.event.schedule == '0 21 * * 1'
+        run: |
+          echo "Starting scale DOWN operation with desired capacity: 0"
+          
+          for i in {1..10}; do
+            echo "Scaling node group: eks-performance-node-${i} to 0"
+            aws eks update-nodegroup-config \
+              --cluster-name eks-performance \
+              --nodegroup-name eks-performance-node-${i} \
+              --region us-west-2 \
+              --scaling-config desiredSize=0
+          
+            echo "Waiting 1 minute before scaling next node group..."
+            sleep 60
+          done
+
+      - name: Scale node groups (Manual)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Starting manual scaling operation with desired capacity: ${{ env.DESIRED_CAPACITY }}"
+          
+          for i in {1..10}; do
+            echo "Scaling node group: eks-performance-node-${i} to ${{ env.DESIRED_CAPACITY }}"
+            aws eks update-nodegroup-config \
+              --cluster-name eks-performance \
+              --nodegroup-name eks-performance-node-${i} \
+              --region us-west-2 \
+              --scaling-config desiredSize=${{ env.DESIRED_CAPACITY }}
+          
+          done
+
+      - name: Validate total node count
+        run: |
+          echo "Waiting 20 minutes for scaling operations to complete..."
+          sleep 1200
+          
+          echo "Validating total number of nodes in the cluster..."
+          ACTUAL_NODE_COUNT=$(kubectl get nodes --no-headers | wc -l)
+          
+          # Determine expected count based on trigger type
+          if [ "${{ github.event.schedule }}" = "0 9 * * 0" ]; then
+            EXPECTED_NODE_COUNT=$((10 * 500))
+          elif [ "${{ github.event.schedule }}" = "0 21 * * 1" ]; then
+            EXPECTED_NODE_COUNT=$((10 * 0))
+          else
+            EXPECTED_NODE_COUNT=$((10 * ${{ env.DESIRED_CAPACITY }}))
+          fi
+          
+          echo "Expected total nodes: ${EXPECTED_NODE_COUNT}"
+          echo "Actual total nodes: ${ACTUAL_NODE_COUNT}"
+          
+          if [ "$ACTUAL_NODE_COUNT" -eq "$EXPECTED_NODE_COUNT" ]; then
+            echo "Validation successful! Node count matches expected value."
+          else
+            echo "Validation failed. Expected ${EXPECTED_NODE_COUNT} nodes but found ${ACTUAL_NODE_COUNT} nodes."
+            exit 1
+          fi


### PR DESCRIPTION
# Description of the issue
We are working towards implementing EKS performance testing on a large scale EKS cluster. The cluster is already created and static.

# Description of changes
Implemented a github workflow that does the following:
1. Connects to EKS cluster
2. Uses aws eks cli to scale the nodegroups up and down. 


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Success Case: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16332007802/job/46136527659
Failure Case: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16331406386/job/46134643323

Defaults and variables work for both.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
4. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



