### PR TITLE
Import /internal/aws/metrics from aws otel contrib

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -2,11 +2,11 @@
 Amazon CloudWatch Agent 1.300058.0 (2025-07-17)
 ========================================================================
 Enhancements:
-[ContainerInsights] Added ability to set CollectionRole via environment variable
-[ContainerInsights] Increased data cache TTL and cleanup interval to support metric collection intervals greater than 300s
-[Logs] Set default concurrency for multi-threaded log processing
-[Logs] Improved log state file handling for Windows event logs
-[Logs] Increased maximum log event size to 1MB and improved handling of large log lines
+* [ContainerInsights] Added ability to set CollectionRole via environment variable
+* [ContainerInsights] Increased data cache TTL and cleanup interval to support metric collection intervals greater than 300s
+* [Logs] Set default concurrency for multi-threaded log processing
+* [Logs] Improved log state file handling for Windows event logs
+* [Logs] Increased maximum log event size to 1MB and improved handling of large log lines
 
 ========================================================================
 Amazon CloudWatch Agent 1.300057.0 (2025-06-16)

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/containerinsight v0.0.0-20250717174233-f514045fc484
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs v0.0.0-20250717174233-f514045fc484
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250717174233-f514045fc484
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/metrics v0.0.0-20250717174233-f514045fc484
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/proxy v0.0.0-20250717174233-f514045fc484
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/xray v0.0.0-20250717174233-f514045fc484
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-20250717174233-f514045fc484

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlo
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs v0.0.0-20250717174233-f514045fc484/go.mod h1:XK8ww4E/9UaVR0wz3mS1HRr+qFEfA/FBZoSRZjVnJRs=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250717174233-f514045fc484 h1:36mpJBt/c/mZYE7R2+z2anERw0vmc7tf22SJ9FkRJf8=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20250717174233-f514045fc484/go.mod h1:xfyU9SHUkrBm12LyvF/Er2tuu05e38EiGHcm7MESH5Q=
+github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/metrics v0.0.0-20250717174233-f514045fc484 h1:f2HIJ5BXMHZyxW1HEO8XJYJvrcfYemL3/YGNgNH+zzA=
+github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/metrics v0.0.0-20250717174233-f514045fc484/go.mod h1:+LUB5b3GWrryX5hhlf+7BjSFD+16Q8gIYfiTzeWMSiM=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/proxy v0.0.0-20250717174233-f514045fc484 h1:vT1HWTJO20L1Rq/kUD2h7u9PUHzHxDpyCatD8aLbh4Q=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/proxy v0.0.0-20250717174233-f514045fc484/go.mod h1:eklUjguJnJHw1JzuOSk6fUdcBsQwzHP6kss8f3exHgw=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/xray v0.0.0-20250717174233-f514045fc484 h1:Cz7fayukEfW+34WvS+3Jh3w3kYKDSQxTv/z4BRCypME=
@@ -1228,8 +1230,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/file
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.124.1/go.mod h1:BTHYA2guZgstbEQiIjx72OCVWzzI5WBFzuakZxcwjeY=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.124.1 h1:IXiiog4CkQWu/wSfiyYHpKGVgOa9BPlt9lD5YeYJTJg=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.124.1/go.mod h1:Hj+DbabX9lrGYwcdp6eXFCe/s7neivgPOr4PrWWUUow=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics v0.124.1 h1:Oy9Ov9bPm7vRIPjI1si9Ycz+Bxl18J+ijUi/CXrL7Ts=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics v0.124.1/go.mod h1:+LUB5b3GWrryX5hhlf+7BjSFD+16Q8gIYfiTzeWMSiM=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.124.1 h1:cFu3VtuWdwvD1ftvTXH3v4Rm+be3BBhCz1OwiKoUQN0=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.124.1/go.mod h1:LtzoVivtOUNmNS+4xQjvuh7m6gbLJdmsyL/C+3/wtV4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.124.0 h1:gJ2gWuy+1kybCTQMLAxKTbcsIKKr3R8UDZhIagAey0k=


### PR DESCRIPTION
# Description of the issue
Due to [this PR's](https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/333) changes, we need to use the amazon-contributing otel fork's `internal/aws/metrics`


# Description of changes
- Updates go.mod and go.sum to replace internal/aws/metrics
- Updated release notes formatting

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
built agent and tested in EKS

Testing in [Main PR](https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/333)

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.