### PR TITLE
Implement workflow to install addon/helm on performance cluster

### DIFF
--- a/.github/workflows/eks-performance-cluster-addon-install.yml
+++ b/.github/workflows/eks-performance-cluster-addon-install.yml
@@ -1,0 +1,246 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+name: "Install/Remove Helm Charts After Scaling"
+on:
+  # Use workflow_run to trigger this workflow after the scaling workflow completes
+  workflow_run:
+    workflows: ["EKS Cluster Scaling"]
+    types:
+      - completed
+  #    branches:
+  #      - main  # Adjust this if your default branch is different
+
+  # Keep the manual trigger option
+  workflow_dispatch:
+    inputs:
+      # Required Core Settings
+      cluster_name:
+        description: 'EKS Cluster Name'
+        required: true
+        type: string
+        default: 'eks-performance'
+      region:
+        description: 'AWS Region'
+        required: true
+        type: string
+        default: 'us-west-2'
+
+      # Optional Settings
+      cloudwatch_agent_repository:
+        description: 'CloudWatch Agent Repository'
+        type: string
+      cloudwatch_agent_tag:
+        description: 'CloudWatch Agent Tag'
+        type: string
+      cloudwatch_agent_operator_repository:
+        description: 'CloudWatch Agent Operator Repository'
+        type: string
+      cloudwatch_agent_operator_tag:
+        description: 'CloudWatch Agent Operator Tag'
+        type: string
+      helm-charts-branch:
+        description: 'Branch of the helm charts to test'
+        type: string
+        default: 'main'
+      operator-branch:
+        description: 'Branch of the operator to test'
+        type: string
+        default: 'main'
+      terraform_assume_role:
+        description: 'AWS IAM Role to assume'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Cluster environment variables
+  AWS_REGION: ${{ inputs.region || 'us-west-2' }}
+  CLUSTER_NAME: ${{ inputs.cluster_name || 'eks-performance' }}
+  TERRAFORM_AWS_ASSUME_ROLE: ${{ inputs.terraform_assume_role || vars.TERRAFORM_AWS_ASSUME_ROLE }}
+  TERRAFORM_AWS_ASSUME_ROLE_DURATION: 3600  # 1 hour duration
+
+  # ECR repository environment variables
+  AGENT_ECR_TEST_REPO: "cwagent-integration-test"
+  OPERATOR_ECR_TEST_REPO: "cwagent-operator-pre-release"
+
+  # Github repository environment variables
+  OPERATOR_GITHUB_REPO_NAME: "aws/amazon-cloudwatch-agent-operator"
+
+jobs:
+  # Check if this workflow should run
+  check-trigger:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'schedule') }}
+    steps:
+      - name: Check trigger type
+        id: check-trigger
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            echo "Triggered by workflow_run from a scheduled event"
+          else
+            echo "Triggered manually via workflow_dispatch"
+          fi
+    outputs:
+      should_continue: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'schedule') }}
+
+  # Get latest operator commit from github repo
+  GetLatestOperatorCommitSHA:
+    needs: check-trigger
+    if: ${{ needs.check-trigger.outputs.should_continue == 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      operator_commit_sha: ${{steps.get_latest_sha.outputs.operator_sha}}
+      operator_repo_name: ${{env.OPERATOR_GITHUB_REPO_NAME}}
+    steps:
+      - name: Checkout the target repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{env.OPERATOR_GITHUB_REPO_NAME}}
+          ref: ${{ inputs.operator-branch || 'main' }}
+          path: operator-repo
+
+      - name: Get latest commit SHA
+        id: get_latest_sha
+        run: |
+          cd operator-repo
+          latest_sha=$(git rev-parse HEAD)
+          echo "operator_sha=$latest_sha" >> "$GITHUB_OUTPUT"
+
+  # Build and upload agent image to ECR repo
+  BuildAgent:
+    needs: check-trigger
+    if: ${{ needs.check-trigger.outputs.should_continue == 'true' }}
+    uses: ./.github/workflows/build-test-artifacts.yml
+    concurrency:
+      group: "Build-Test-Artifacts-${{github.ref_name}}"
+      cancel-in-progress: true
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      test-image-before-upload: false
+
+  # Build and upload operator image to ECR repo
+  BuildOperator:
+    needs: [ check-trigger, GetLatestOperatorCommitSHA ]
+    if: ${{ needs.check-trigger.outputs.should_continue == 'true' }}
+    uses: aws/amazon-cloudwatch-agent-operator/.github/workflows/build-and-upload.yml@main
+    concurrency:
+      group: ${{ github.workflow }}-operator-${{ inputs.operator-branch || 'main' }}
+      cancel-in-progress: true
+    secrets: inherit
+    with:
+      tag: ${{needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha}}
+      target-sha: ${{needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha}}
+      repository: ${{needs.GetLatestOperatorCommitSHA.outputs.operator_repo_name}}
+      test-image-before-upload: false
+
+  install-helm:
+    needs: [ check-trigger, BuildAgent, BuildOperator, GetLatestOperatorCommitSHA ]
+    if: ${{ needs.check-trigger.outputs.should_continue == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE}}
+          aws-region: ${{ env.AWS_REGION}}
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
+
+      - name: Login ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'latest'
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+
+      - name: Update kubeconfig
+        run: |
+          aws eks update-kubeconfig --name $CLUSTER_NAME --region $AWS_REGION
+
+      - name: Clone Helm Charts Repository
+        run: |
+          rm -rf ./helm-charts
+          git clone -b ${{ inputs.helm-charts-branch || 'main' }} https://github.com/aws-observability/helm-charts.git ./helm-charts
+
+      - name: Check node count and manage Helm chart
+        run: |
+          NODE_COUNT=$(kubectl get nodes --no-headers | wc -l)
+
+          if [ "$NODE_COUNT" -eq 0 ]; then
+            echo "Node count is 0, removing Helm chart"
+            helm uninstall amazon-cloudwatch-observability -n amazon-cloudwatch || echo "Chart not found or already removed"
+          else
+            echo "Node count is $NODE_COUNT, installing/updating Helm chart"
+          
+            # Echo all variables being passed to helm
+            echo "CLUSTER_NAME: ${{ inputs.cluster_name ||env.CLUSTER_NAME }}"
+            echo "REGION: ${{ inputs.region || env.AWS_REGION }}"
+            echo "AGENT_REPOSITORY: ${{ inputs.cloudwatch_agent_repository || env.AGENT_ECR_TEST_REPO }}"
+            echo "AGENT_TAG: ${{ inputs.cloudwatch_agent_tag || github.sha }}"
+            echo "AGENT_REPOSITORY_DOMAIN: ${{ steps.login-ecr.outputs.registry }}"
+            echo "MANAGER_REPOSITORY: ${{ inputs.cloudwatch_agent_operator_repository || env.OPERATOR_ECR_TEST_REPO }}"
+            echo "MANAGER_TAG: ${{ inputs.cloudwatch_agent_operator_tag || needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}"
+            echo "MANAGER_REPOSITORY_DOMAIN: ${{ steps.login-ecr.outputs.registry }}"
+          
+            helm upgrade --install amazon-cloudwatch-observability \
+              ./helm-charts/charts/amazon-cloudwatch-observability \
+              --namespace amazon-cloudwatch \
+              --create-namespace \
+              --set clusterName=${{ inputs.cluster_name ||env.CLUSTER_NAME }} \
+              --set region=${{ inputs.region || env.AWS_REGION }} \
+              --set agent.image.repository=${{ inputs.cloudwatch_agent_repository || env.AGENT_ECR_TEST_REPO }} \
+              --set agent.image.tag=${{ inputs.cloudwatch_agent_tag || github.sha }} \
+              --set agent.image.repositoryDomainMap.public=${{ steps.login-ecr.outputs.registry }} \
+              --set manager.image.repository=${{ inputs.cloudwatch_agent_operator_repository || env.OPERATOR_ECR_TEST_REPO }} \
+              --set manager.image.tag=${{ inputs.cloudwatch_agent_operator_tag || needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }} \
+              --set manager.image.repositoryDomainMap.public=${{ steps.login-ecr.outputs.registry }}
+          fi
+
+  cleanup-on-failure:
+    if: ${{ failure() || cancelled() }}
+    runs-on: ubuntu-latest
+    needs: [ install-helm ]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE}}
+          aws-region: ${{ env.AWS_REGION}}
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'latest'
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+
+      - name: Update kubeconfig
+        run: |
+          aws eks update-kubeconfig --name $CLUSTER_NAME --region $AWS_REGION
+
+      - name: Uninstall Helm chart
+        run: |
+          echo "Test was cancelled or failed. Cleaning up resources..."
+          helm uninstall amazon-cloudwatch-observability -n amazon-cloudwatch || echo "Chart not found or already removed"
+          echo "Cleanup completed"

--- a/.github/workflows/eks-performance-cluster-addon-install.yml
+++ b/.github/workflows/eks-performance-cluster-addon-install.yml
@@ -7,8 +7,8 @@ on:
     workflows: ["EKS Cluster Scaling"]
     types:
       - completed
-  #    branches:
-  #      - main  # Adjust this if your default branch is different
+    branches:
+      - main
 
   # Keep the manual trigger option
   workflow_dispatch:


### PR DESCRIPTION
# Description of the issue
To enable performance testing on the large scale testing EKS cluster created [here](https://github.com/aws/amazon-cloudwatch-agent/pull/1776), we need to ensure that the AWS Observability addon gets installed upon cluster sclaing action. This task implements a github action that will do this via helm.

# Description of changes
- Created GitHub action for installing addon with helm
- Builds the latest versions of the operator and agent and uplaods it to ECR
- Installs it using helm command
- Triggers upon completion of the `EKS Cluster Scaling` workflow
- Can also be ran manually with workflow_dispatch
- Cleans/removes helm chart on 2 conditions: If the task fails/is canceled or node count is 0 which means a scale down was completed


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16380906842

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



