### PR TITLE
Add aws.remote.resource.account.* attributes to Application Signals EMF logs

### DIFF
--- a/plugins/processors/awsapplicationsignals/common/types.go
+++ b/plugins/processors/awsapplicationsignals/common/types.go
@@ -47,6 +47,9 @@ const (
 const (
 	MetricAttributeRemoteDbUser                       = "RemoteDbUser"
 	MetricAttributeRemoteResourceCfnPrimaryIdentifier = "RemoteResourceCfnPrimaryIdentifier"
+	MetricAttributeRemoteResourceAccountID            = "RemoteResourceAccountId"
+	MetricAttributeRemoteResourceAccountAccessKey     = "RemoteResourceAccountAccessKey"
+	MetricAttributeRemoteResourceRegion               = "RemoteResourceRegion"
 )
 
 const (

--- a/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
+++ b/plugins/processors/awsapplicationsignals/internal/attributes/attributes.go
@@ -15,9 +15,12 @@ const (
 	AWSRemoteTarget                       = "aws.remote.target"
 	AWSRemoteResourceIdentifier           = "aws.remote.resource.identifier"
 	AWSRemoteResourceType                 = "aws.remote.resource.type"
+	AWSRemoteResourceCfnPrimaryIdentifier = "aws.remote.resource.cfn.primary.identifier"
+	AWSRemoteResourceAccountID            = "aws.remote.resource.account.id"
+	AWSRemoteResourceAccountAccessKey     = "aws.remote.resource.account.access_key"
+	AWSRemoteResourceRegion               = "aws.remote.resource.region"
 	AWSHostedInEnvironment                = "aws.hostedin.environment"
 	AWSRemoteDbUser                       = "aws.remote.db.user"
-	AWSRemoteResourceCfnPrimaryIdentifier = "aws.remote.resource.cfn.primary.identifier"
 
 	AWSECSClusterName = "aws.ecs.cluster.name"
 	AWSECSTaskID      = "aws.ecs.task.id"

--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer.go
@@ -43,6 +43,9 @@ var attributesRenamingForMetric = map[string]string{
 	attr.AWSRemoteResourceType:                 common.CWMetricAttributeRemoteResourceType,
 	attr.AWSRemoteDbUser:                       common.MetricAttributeRemoteDbUser,
 	attr.AWSRemoteResourceCfnPrimaryIdentifier: common.MetricAttributeRemoteResourceCfnPrimaryIdentifier,
+	attr.AWSRemoteResourceAccountID:            common.MetricAttributeRemoteResourceAccountID,
+	attr.AWSRemoteResourceAccountAccessKey:     common.MetricAttributeRemoteResourceAccountAccessKey,
+	attr.AWSRemoteResourceRegion:               common.MetricAttributeRemoteResourceRegion,
 	attr.AWSECSClusterName:                     common.MetricAttributeECSCluster,
 	attr.AWSECSTaskID:                          common.MetricAttributeECSTaskId,
 }

--- a/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
+++ b/plugins/processors/awsapplicationsignals/internal/normalizer/attributesnormalizer_test.go
@@ -78,7 +78,7 @@ func TestRenameAttributes_for_trace(t *testing.T) {
 }
 
 func TestNormalizedResourceAttributeKeys(t *testing.T) {
-	assert.Equal(t, 31, len(normalizedResourceAttributeKeys))
+	assert.Equal(t, 34, len(normalizedResourceAttributeKeys))
 	for key := range attributesRenamingForMetric {
 		assert.Contains(t, normalizedResourceAttributeKeys, key)
 	}


### PR DESCRIPTION
# Description of the issue
_Describe the problem or feature in addition to a link to the issues._

# Description of changes
In this PR, we populate `aws.remote.resource.account.*` to identify the owner account ID of the remote resource.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



