### PR TITLE
Explicitly use windows-2022 for building Win22 docker image

### DIFF
--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -187,7 +187,7 @@ jobs:
 
   BuildMSI-2022:
     name: 'BuildMSI-2022'
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [ MakeMSIZip ]
     permissions:
       id-token: write


### PR DESCRIPTION
# Description of the issue
The windows-latest label will migrate from Windows Server 2022 to Windows Server 2025 beginning September 2, 2025. For more information see https://github.com/actions/runner-images/issues/12677

# Description of changes
When building our Windows 2022 docker image, explicitly use the `windows-2022` runner instead of `windows-latest`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
<check build>

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



