### PR TITLE
Add new Neuroncore capacity metrics

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
@@ -157,6 +157,10 @@ exporters:
                 - pod_gpu_limit
                 - pod_gpu_usage_total
                 - pod_gpu_reserved_capacity
+                - pod_neuroncore_request
+                - pod_neuroncore_limit
+                - pod_neuroncore_usage_total
+                - pod_neuroncore_reserved_capacity
             - dimensions:
                 - - ClusterName
                   - InstanceId
@@ -185,6 +189,11 @@ exporters:
                 - node_gpu_limit
                 - node_gpu_usage_total
                 - node_gpu_reserved_capacity
+                - node_neuroncore_limit
+                - node_neuroncore_usage_total
+                - node_neuroncore_reserved_capacity
+                - node_neuroncore_unreserved_capacity
+                - node_neuroncore_available_capacity
             - dimensions:
                 - - ClusterName
                   - InstanceId

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -108,6 +108,7 @@ func getPodMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 		}...)
 		if awscontainerinsight.AcceleratedComputeMetricsEnabled(conf) {
 			selectors = append(selectors, "pod_gpu_request", "pod_gpu_limit", "pod_gpu_usage_total", "pod_gpu_reserved_capacity")
+			selectors = append(selectors, "pod_neuroncore_request", "pod_neuroncore_limit", "pod_neuroncore_usage_total", "pod_neuroncore_reserved_capacity")
 		}
 	}
 
@@ -155,6 +156,7 @@ func getNodeMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDecla
 	}
 	if awscontainerinsight.AcceleratedComputeMetricsEnabled(conf) {
 		nodeMetrics = append(nodeMetrics, "node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity")
+		nodeMetrics = append(nodeMetrics, "node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity", "node_neuroncore_available_capacity")
 	}
 	if enhancedContainerInsightsEnabled {
 		return []*awsemfexporter.MetricDeclaration{

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -311,6 +311,7 @@ func TestTranslator(t *testing.T) {
 							"pod_container_status_waiting_reason_image_pull_error", "pod_container_status_waiting_reason_start_error", "pod_container_status_waiting_reason_create_container_error",
 							"pod_container_status_waiting_reason_create_container_config_error", "pod_container_status_terminated_reason_oom_killed",
 							"pod_gpu_request", "pod_gpu_limit", "pod_gpu_usage_total", "pod_gpu_reserved_capacity",
+							"pod_neuroncore_request", "pod_neuroncore_limit", "pod_neuroncore_usage_total", "pod_neuroncore_reserved_capacity",
 						},
 					},
 					{
@@ -320,7 +321,9 @@ func TestTranslator(t *testing.T) {
 							"node_cpu_usage_total", "node_cpu_limit", "node_memory_working_set", "node_memory_limit",
 							"node_status_condition_ready", "node_status_condition_disk_pressure", "node_status_condition_memory_pressure",
 							"node_status_condition_pid_pressure", "node_status_condition_network_unavailable", "node_status_condition_unknown",
-							"node_status_capacity_pods", "node_status_allocatable_pods", "node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity"},
+							"node_status_capacity_pods", "node_status_allocatable_pods", "node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity",
+							"node_neuroncore_request", "node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity",
+							"node_neuroncore_unreserved_capacity"},
 					},
 					{
 						Dimensions: [][]string{

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -322,8 +322,7 @@ func TestTranslator(t *testing.T) {
 							"node_status_condition_ready", "node_status_condition_disk_pressure", "node_status_condition_memory_pressure",
 							"node_status_condition_pid_pressure", "node_status_condition_network_unavailable", "node_status_condition_unknown",
 							"node_status_capacity_pods", "node_status_allocatable_pods", "node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity",
-							"node_neuroncore_request", "node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity",
-							"node_neuroncore_unreserved_capacity"},
+							"node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity", "node_neuroncore_available_capacity"},
 					},
 					{
 						Dimensions: [][]string{


### PR DESCRIPTION
# Description of the issue

Followup to Contrib PR: https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/345

To add new neuroncore resource allocation metrics: `neuroncore_limit`, `neuroncore_usage_total`, `neuroncore_reserved_capacity`, `neuroncore_unreserved_capacity`, `neuroncore_available_capacity`



