### PR TITLE
Add Neuron Core and EFA capacity metrics

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
@@ -157,6 +157,14 @@ exporters:
                 - pod_gpu_limit
                 - pod_gpu_usage_total
                 - pod_gpu_reserved_capacity
+                - pod_neuroncore_request
+                - pod_neuroncore_limit
+                - pod_neuroncore_usage_total
+                - pod_neuroncore_reserved_capacity
+                - pod_efa_request
+                - pod_efa_limit
+                - pod_efa_usage_total
+                - pod_efa_reserved_capacity
             - dimensions:
                 - - ClusterName
                   - InstanceId
@@ -187,6 +195,16 @@ exporters:
                 - node_gpu_reserved_capacity
                 - node_gpu_unreserved_capacity
                 - node_gpu_available_capacity
+                - node_neuroncore_limit
+                - node_neuroncore_usage_total
+                - node_neuroncore_reserved_capacity
+                - node_neuroncore_unreserved_capacity
+                - node_neuroncore_available_capacity
+                - node_efa_limit
+                - node_efa_usage_total
+                - node_efa_reserved_capacity
+                - node_efa_unreserved_capacity
+                - node_efa_available_capacity
             - dimensions:
                 - - ClusterName
                   - InstanceId

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -108,6 +108,8 @@ func getPodMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDeclar
 		}...)
 		if awscontainerinsight.AcceleratedComputeMetricsEnabled(conf) {
 			selectors = append(selectors, "pod_gpu_request", "pod_gpu_limit", "pod_gpu_usage_total", "pod_gpu_reserved_capacity")
+			selectors = append(selectors, "pod_neuroncore_request", "pod_neuroncore_limit", "pod_neuroncore_usage_total", "pod_neuroncore_reserved_capacity")
+			selectors = append(selectors, "pod_efa_request", "pod_efa_limit", "pod_efa_usage_total", "pod_efa_reserved_capacity")
 		}
 	}
 
@@ -155,6 +157,8 @@ func getNodeMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDecla
 	}
 	if awscontainerinsight.AcceleratedComputeMetricsEnabled(conf) {
 		nodeMetrics = append(nodeMetrics, "node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity", "node_gpu_unreserved_capacity", "node_gpu_available_capacity")
+		nodeMetrics = append(nodeMetrics, "node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity", "node_neuroncore_available_capacity")
+		nodeMetrics = append(nodeMetrics, "node_efa_limit", "node_efa_usage_total", "node_efa_reserved_capacity", "node_efa_unreserved_capacity", "node_efa_available_capacity")
 	}
 	if enhancedContainerInsightsEnabled {
 		return []*awsemfexporter.MetricDeclaration{

--- a/translator/translate/otel/exporter/awsemf/translator_test.go
+++ b/translator/translate/otel/exporter/awsemf/translator_test.go
@@ -311,6 +311,8 @@ func TestTranslator(t *testing.T) {
 							"pod_container_status_waiting_reason_image_pull_error", "pod_container_status_waiting_reason_start_error", "pod_container_status_waiting_reason_create_container_error",
 							"pod_container_status_waiting_reason_create_container_config_error", "pod_container_status_terminated_reason_oom_killed",
 							"pod_gpu_request", "pod_gpu_limit", "pod_gpu_usage_total", "pod_gpu_reserved_capacity",
+							"pod_neuroncore_request", "pod_neuroncore_limit", "pod_neuroncore_usage_total", "pod_neuroncore_reserved_capacity",
+							"pod_efa_request", "pod_efa_limit", "pod_efa_usage_total", "pod_efa_reserved_capacity",
 						},
 					},
 					{
@@ -319,8 +321,10 @@ func TestTranslator(t *testing.T) {
 							"node_memory_reserved_capacity", "node_number_of_running_pods", "node_number_of_running_containers",
 							"node_cpu_usage_total", "node_cpu_limit", "node_memory_working_set", "node_memory_limit",
 							"node_status_condition_ready", "node_status_condition_disk_pressure", "node_status_condition_memory_pressure",
-							"node_status_condition_pid_pressure", "node_status_condition_network_unavailable", "node_status_condition_unknown",
-							"node_status_capacity_pods", "node_status_allocatable_pods", "node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity", "node_gpu_unreserved_capacity", "node_gpu_available_capacity"},
+							"node_status_condition_pid_pressure", "node_status_condition_network_unavailable", "node_status_condition_unknown", "node_status_capacity_pods", "node_status_allocatable_pods",
+							"node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity", "node_gpu_unreserved_capacity", "node_gpu_available_capacity",
+							"node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity", "node_neuroncore_available_capacity",
+							"node_efa_limit", "node_efa_usage_total", "node_efa_reserved_capacity", "node_efa_unreserved_capacity", "node_efa_available_capacity"},
 					},
 					{
 						Dimensions: [][]string{


### PR DESCRIPTION
# Description of changes
Adding new Neuron Core and EFA capacity metrics. Same as:
* https://github.com/aws/amazon-cloudwatch-agent/pull/1815
* https://github.com/aws/amazon-cloudwatch-agent/pull/1816

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
See PRs above.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



