### PR TITLE
Introduce shared receiver model for OTLP to avoid port conflicts

### DIFF
--- a/translator/translate/otel/pipeline/applicationsignals/translator.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translator.go
@@ -52,7 +52,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 	}
 
 	translators := &common.ComponentTranslators{
-		Receivers:  common.NewTranslatorMap(otlp.NewTranslator(common.WithName(common.AppSignals), otlp.WithSignal(t.signal))),
+		Receivers:  common.NewTranslatorMap(otlp.NewSharedTranslator(conf, common.WithName(common.AppSignals), otlp.WithSignal(t.signal))),
 		Processors: common.NewTranslatorMap[component.Config, component.ID](),
 		Exporters:  common.NewTranslatorMap[component.Config, component.ID](),
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](),

--- a/translator/translate/otel/pipeline/host/translators.go
+++ b/translator/translate/otel/pipeline/host/translators.go
@@ -54,14 +54,14 @@ func NewTranslators(conf *confmap.Conf, configSection, os string) (common.Transl
 	switch v := conf.Get(common.ConfigKey(configSection, common.OtlpKey)).(type) {
 	case []any:
 		for index := range v {
-			otlpReceivers.Set(otlpreceiver.NewTranslator(
+			otlpReceivers.Set(otlpreceiver.NewSharedTranslator(conf,
 				otlpreceiver.WithSignal(pipeline.SignalMetrics),
 				otlpreceiver.WithConfigKey(common.ConfigKey(configSection, common.OtlpKey)),
 				common.WithIndex(index),
 			))
 		}
 	case map[string]any:
-		otlpReceivers.Set(otlpreceiver.NewTranslator(
+		otlpReceivers.Set(otlpreceiver.NewSharedTranslator(conf,
 			otlpreceiver.WithSignal(pipeline.SignalMetrics),
 			otlpreceiver.WithConfigKey(common.ConfigKey(configSection, common.OtlpKey)),
 		))

--- a/translator/translate/otel/pipeline/xray/translator.go
+++ b/translator/translate/otel/pipeline/xray/translator.go
@@ -56,7 +56,7 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		translators.Receivers.Set(awsxrayreceiver.NewTranslator())
 	}
 	if conf.IsSet(otlpKey) {
-		translators.Receivers.Set(otlp.NewTranslator(
+		translators.Receivers.Set(otlp.NewSharedTranslator(conf,
 			otlp.WithSignal(pipeline.SignalTraces),
 			otlp.WithConfigKey(otlpKey)),
 		)

--- a/translator/translate/otel/receiver/otlp/translator.go
+++ b/translator/translate/otel/receiver/otlp/translator.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -73,6 +74,97 @@ func (t *translator) ID() component.ID {
 	return component.NewIDWithName(t.factory.Type(), t.Name())
 }
 
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[string]common.ComponentTranslator)
+	counter    int
+)
+
+func getEndpointKey(conf *confmap.Conf, configKey string, index int, signal pipeline.Signal) (string, error) {
+	grpcEndpoint := defaultGrpcEndpoint
+	httpEndpoint := defaultHttpEndpoint
+	tlsCert, tlsKey := "", ""
+
+	// Handle application signals defaults
+	if appSignalsConfigKeys, ok := common.AppSignalsConfigKeys[signal]; ok {
+		for _, appKey := range appSignalsConfigKeys {
+			if configKey == appKey {
+				grpcEndpoint = defaultAppSignalsGrpcEndpoint
+				httpEndpoint = defaultAppSignalsHttpEndpoint
+				break
+			}
+		}
+	}
+
+	if conf != nil && conf.IsSet(configKey) {
+		otlpMap := common.GetIndexedMap(conf, configKey, index)
+		if grpc, ok := otlpMap["grpc_endpoint"]; ok {
+			grpcEndpoint = grpc.(string)
+		}
+		if http, ok := otlpMap["http_endpoint"]; ok {
+			httpEndpoint = http.(string)
+		}
+		if tls, ok := otlpMap["tls"].(map[string]interface{}); ok {
+			if cert, ok := tls["cert_file"].(string); ok {
+				tlsCert = cert
+			}
+			if key, ok := tls["key_file"].(string); ok {
+				tlsKey = key
+			}
+		}
+	}
+
+	portKey := fmt.Sprintf("%s|%s", grpcEndpoint, httpEndpoint)
+	fullKey := fmt.Sprintf("%s|%s|%s", portKey, tlsCert, tlsKey)
+
+	// Check for port conflicts with different TLS configs
+	for existingKey := range registry {
+		if existingKey != fullKey && existingKey[:len(portKey)] == portKey && len(existingKey) > len(portKey) {
+			return "", fmt.Errorf("port conflict: endpoints %s already in use with different TLS configuration", portKey)
+		}
+	}
+
+	return fullKey, nil
+}
+
+func NewSharedTranslator(conf *confmap.Conf, opts ...common.TranslatorOption) common.ComponentTranslator {
+	t := &translator{factory: otlpreceiver.NewFactory()}
+	t.SetIndex(-1)
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	key, err := getEndpointKey(conf, t.configKey, t.Index(), t.signal)
+	if err != nil {
+		// Return error translator that will fail during Translate()
+		return &errorTranslator{err: err}
+	}
+
+	if existing, exists := registry[key]; exists {
+		return existing
+	}
+
+	counter++
+	t.SetName(fmt.Sprintf("otlp_shared_%d", counter))
+	registry[key] = t
+	return t
+}
+
+type errorTranslator struct {
+	err error
+}
+
+func (e *errorTranslator) ID() component.ID {
+	return component.NewID(component.MustNewType("otlp"))
+}
+
+func (e *errorTranslator) Translate(*confmap.Conf) (component.Config, error) {
+	return nil, e.err
+}
+
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*otlpreceiver.Config)
 
@@ -124,4 +216,12 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		cfg.HTTP.ServerConfig.Endpoint = httpEndpoint.(string)
 	}
 	return cfg, nil
+}
+
+// ResetRegistry clears the shared receiver registry for testing
+func ResetRegistry() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = make(map[string]common.ComponentTranslator)
+	counter = 0
 }

--- a/translator/translate/otel/receiver/otlp/translator_test.go
+++ b/translator/translate/otel/receiver/otlp/translator_test.go
@@ -424,3 +424,180 @@ func TestTranslateJMX(t *testing.T) {
 	assert.NotNil(t, gotCfg.HTTP)
 	assert.Equal(t, "0.0.0.0:4314", gotCfg.HTTP.ServerConfig.Endpoint)
 }
+
+func TestSharedTranslatorDeduplication(t *testing.T) {
+	ResetRegistry()
+
+	config := map[string]interface{}{
+		"metrics": map[string]interface{}{
+			"metrics_collected": map[string]interface{}{
+				"otlp": map[string]interface{}{
+					"grpc_endpoint": "127.0.0.1:4317",
+					"http_endpoint": "127.0.0.1:4318",
+				},
+			},
+		},
+		"traces": map[string]interface{}{
+			"traces_collected": map[string]interface{}{
+				"otlp": map[string]interface{}{
+					"grpc_endpoint": "127.0.0.1:4317",
+					"http_endpoint": "127.0.0.1:4318",
+				},
+			},
+		},
+	}
+
+	conf := confmap.NewFromStringMap(config)
+
+	metricsTranslator := NewSharedTranslator(conf,
+		WithSignal(pipeline.SignalMetrics),
+		WithConfigKey(common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey)),
+	)
+	tracesTranslator := NewSharedTranslator(conf,
+		WithSignal(pipeline.SignalTraces),
+		WithConfigKey(common.ConfigKey(common.TracesKey, common.TracesCollectedKey, common.OtlpKey)),
+	)
+
+	assert.Equal(t, metricsTranslator.ID(), tracesTranslator.ID(), "Same endpoints should share receiver")
+
+	_, err1 := metricsTranslator.Translate(conf)
+	_, err2 := tracesTranslator.Translate(conf)
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+}
+
+func TestArrayConfigDeduplication(t *testing.T) {
+	ResetRegistry()
+
+	config := map[string]interface{}{
+		"metrics": map[string]interface{}{
+			"metrics_collected": map[string]interface{}{
+				"otlp": []interface{}{
+					map[string]interface{}{
+						"grpc_endpoint": "127.0.0.1:4317",
+						"http_endpoint": "127.0.0.1:4318",
+					},
+					map[string]interface{}{
+						"grpc_endpoint": "127.0.0.1:4317",
+						"http_endpoint": "127.0.0.1:4318",
+					},
+					map[string]interface{}{
+						"grpc_endpoint": "127.0.0.1:5317",
+						"http_endpoint": "127.0.0.1:5318",
+					},
+				},
+			},
+		},
+	}
+
+	conf := confmap.NewFromStringMap(config)
+	configKey := common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey)
+
+	translator1 := NewSharedTranslator(conf, WithSignal(pipeline.SignalMetrics), WithConfigKey(configKey), common.WithIndex(0))
+	translator2 := NewSharedTranslator(conf, WithSignal(pipeline.SignalMetrics), WithConfigKey(configKey), common.WithIndex(1))
+	translator3 := NewSharedTranslator(conf, WithSignal(pipeline.SignalMetrics), WithConfigKey(configKey), common.WithIndex(2))
+
+	assert.Equal(t, translator1.ID(), translator2.ID(), "Same endpoints should share")
+	assert.NotEqual(t, translator1.ID(), translator3.ID(), "Different endpoints should not share")
+}
+
+func TestPortConflictDetection(t *testing.T) {
+	ResetRegistry()
+
+	config := map[string]interface{}{
+		"metrics": map[string]interface{}{
+			"metrics_collected": map[string]interface{}{
+				"otlp": map[string]interface{}{
+					"grpc_endpoint": "127.0.0.1:4317",
+					"http_endpoint": "127.0.0.1:4318",
+					"tls": map[string]interface{}{
+						"cert_file": "/path/to/cert1.pem",
+						"key_file":  "/path/to/key1.pem",
+					},
+				},
+			},
+		},
+		"traces": map[string]interface{}{
+			"traces_collected": map[string]interface{}{
+				"otlp": map[string]interface{}{
+					"grpc_endpoint": "127.0.0.1:4317", // Same ports
+					"http_endpoint": "127.0.0.1:4318", // Same ports
+					"tls": map[string]interface{}{
+						"cert_file": "/path/to/cert2.pem", // Different TLS
+						"key_file":  "/path/to/key2.pem",  // Different TLS
+					},
+				},
+			},
+		},
+	}
+
+	conf := confmap.NewFromStringMap(config)
+
+	// First translator should succeed
+	metricsTranslator := NewSharedTranslator(conf,
+		WithSignal(pipeline.SignalMetrics),
+		WithConfigKey(common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey)),
+	)
+	_, err1 := metricsTranslator.Translate(conf)
+	assert.NoError(t, err1, "First translator should succeed")
+
+	// Second translator should fail due to port conflict
+	tracesTranslator := NewSharedTranslator(conf,
+		WithSignal(pipeline.SignalTraces),
+		WithConfigKey(common.ConfigKey(common.TracesKey, common.TracesCollectedKey, common.OtlpKey)),
+	)
+	_, err2 := tracesTranslator.Translate(conf)
+	assert.Error(t, err2, "Second translator should fail due to port conflict")
+	assert.Contains(t, err2.Error(), "port conflict", "Error should mention port conflict")
+}
+
+func TestSamePortsSameTLS(t *testing.T) {
+	ResetRegistry()
+
+	config := map[string]interface{}{
+		"metrics": map[string]interface{}{
+			"metrics_collected": map[string]interface{}{
+				"otlp": map[string]interface{}{
+					"grpc_endpoint": "127.0.0.1:4317",
+					"http_endpoint": "127.0.0.1:4318",
+					"tls": map[string]interface{}{
+						"cert_file": "/path/to/cert.pem",
+						"key_file":  "/path/to/key.pem",
+					},
+				},
+			},
+		},
+		"traces": map[string]interface{}{
+			"traces_collected": map[string]interface{}{
+				"otlp": map[string]interface{}{
+					"grpc_endpoint": "127.0.0.1:4317", // Same ports
+					"http_endpoint": "127.0.0.1:4318", // Same ports
+					"tls": map[string]interface{}{
+						"cert_file": "/path/to/cert.pem", // Same TLS
+						"key_file":  "/path/to/key.pem",  // Same TLS
+					},
+				},
+			},
+		},
+	}
+
+	conf := confmap.NewFromStringMap(config)
+
+	metricsTranslator := NewSharedTranslator(conf,
+		WithSignal(pipeline.SignalMetrics),
+		WithConfigKey(common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.OtlpKey)),
+	)
+	tracesTranslator := NewSharedTranslator(conf,
+		WithSignal(pipeline.SignalTraces),
+		WithConfigKey(common.ConfigKey(common.TracesKey, common.TracesCollectedKey, common.OtlpKey)),
+	)
+
+	// Should share same receiver (same endpoints and TLS)
+	assert.Equal(t, metricsTranslator.ID(), tracesTranslator.ID(), "Same ports and TLS should share receiver")
+
+	// Both should translate successfully
+	_, err1 := metricsTranslator.Translate(conf)
+	_, err2 := tracesTranslator.Translate(conf)
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+}


### PR DESCRIPTION
# Description of the issue
With this changes ([PR #1361](https://github.com/aws/amazon-cloudwatch-agent/pull/1361), [PR #1375](https://github.com/aws/amazon-cloudwatch-agent/pull/1375)), if multiple use cases are configured on the same port, this can cause port binding errors and crash the agent.

# Description of changes
Introduce shared receiver model at config translation so that the same receiver can be used for different pipelines (traces, metrics and applicationSignals)

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
TBD

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



