### PR TITLE
Fix flaky wineventlog gap test

### DIFF
--- a/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
+++ b/plugins/inputs/windows_event_log/wineventlog/wineventlog_test.go
@@ -343,6 +343,7 @@ func marshalRangeList(rl state.RangeList) string {
 }
 
 func assertStateFileRange(t *testing.T, fileName string, rl state.RangeList) {
+	time.Sleep(200 * time.Millisecond)
 	content, _ := os.ReadFile(fileName)
 	assert.Contains(t, string(content), marshalRangeList(rl))
 }


### PR DESCRIPTION
# Description of the issue
The wineventlog gap tests would sometimes fail due to the state file not being written in time for the test to read the content.

# Description of changes
Add a sleep before reading the contents of the state file.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. Unit test
  a. I ran the test repetitively, before the change, the test would fail after about the fifth try. After this change, I was not able to get it to fail.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
3. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.
**I don't think this is necessary**


