### PR TITLE
Revert "[AppSignal E2E Testing] Validate E2E Tests Are Accounted For"

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -214,21 +214,3 @@ jobs:
     with:
       aws-region: us-east-1
       caller-workflow-name: 'main-build'
-
-  # This validation is to ensure that all test workflows relevant to this repo are actually
-  # being used in this repo, which is referring to all the other jobs in this file.
-  #
-  # If this starts failing, then it most likely means that new e2e test workflow was
-  # added to `aws-observability/aws-application-signals-test-framework`, but was not
-  # added to this file. It could also mean that a test in this file has been removed.
-  #
-  # If a particular test file is intended to not be tested in this repo and should not
-  # be failing this particular validation, then choose one of the following options:
-  # - Add the test file to the exclusions input (CSV format) to the workflow
-  #   (see: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/validate-e2e-tests-are-accounted-for.yml#L1)
-  # - Update the `validate-e2e-tests-are-accounted-for` job to change which "workflow files are expected to be used by this repo"
-  #   (see: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/validate-e2e-tests-are-accounted-for.yml)
-  validate-all-tests-are-accounted-for:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
-    with:
-      exclusions: dotnet-ec2-nuget-test.yml,dotnet-ec2-asg-test.yml,dotnet-eks-windows-test.yml,java-ec2-ubuntu-test.yml


### PR DESCRIPTION
Reverts aws/amazon-cloudwatch-agent#1806

Workflow is failing after above change, which added one workflow that exceeded the workflow limit:
- https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16998813970

> Invalid workflow file: .github/workflows/application-signals-e2e-test.yml#L1
too many workflows are referenced, total: 21, limit: 20

Also checking with whoever manages `aws` GH org to see if we can get this limit increased [like was done in this GitHub issue comment](https://github.com/orgs/community/discussions/32192#discussioncomment-13720562), in which I can cancel this PR.