### PR TITLE
Ecs Observer config

### DIFF
--- a/plugins/processors/prometheusadapter/processor.go
+++ b/plugins/processors/prometheusadapter/processor.go
@@ -8,13 +8,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
-	"github.com/prometheus/common/model"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/util/collections"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/prometheusadapter/internal"

--- a/translator/translate/otel/extension/ecsobserver/translator.go
+++ b/translator/translate/otel/extension/ecsobserver/translator.go
@@ -21,7 +21,7 @@ const (
 	defaultMetricsPath      = "/metrics"
 	defaultPortLabel        = "ECS_PROMETHEUS_EXPORTER_PORT"
 	defaultMetricsPathLabel = "ECS_PROMETHEUS_METRICS_PATH"
-	defaultJobNameLabel     = ""
+	defaultJobNameLabel     = "job"
 )
 
 var ecsSDKey = common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.PrometheusKey, common.ECSServiceDiscovery)
@@ -92,7 +92,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		dockerConfig := ecsobserver.DockerLabelConfig{
 			MetricsPathLabel: getStringWithDefault(dockerLabel, "sd_metrics_path_label", defaultMetricsPathLabel),
 			PortLabel:        getStringWithDefault(dockerLabel, "sd_port_label", defaultPortLabel),
-			JobNameLabel:     getString(dockerLabel, "sd_job_name_label"),
+			JobNameLabel:     getStringWithDefault(dockerLabel, "sd_job_name_label", defaultJobNameLabel),
 		}
 		cfg.DockerLabels = []ecsobserver.DockerLabelConfig{dockerConfig} // Initialize as slice with single element
 	}

--- a/translator/translate/otel/extension/ecsobserver/translator.go
+++ b/translator/translate/otel/extension/ecsobserver/translator.go
@@ -5,7 +5,6 @@ package ecsobserver
 
 import (
 	"fmt"
-	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
 
 const (

--- a/translator/translate/otel/extension/ecsobserver/translator.go
+++ b/translator/translate/otel/extension/ecsobserver/translator.go
@@ -95,7 +95,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	// Docker label based service discovery
 	if dockerLabel, ok := ecsSD["docker_label"].(map[string]interface{}); ok {
 		dockerConfig := ecsobserver.DockerLabelConfig{
-			MetricsPathLabel: getStringWithDefault(dockerLabel, "sd_metrics_path_label", defaultMetricsPath),
+			MetricsPathLabel: getStringWithDefault(dockerLabel, "sd_metrics_path_label", defaultMetricsPathLabel),
 			PortLabel:        getStringWithDefault(dockerLabel, "sd_port_label", defaultPortLabel),
 			JobNameLabel:     getString(dockerLabel, "sd_job_name_label"),
 		}

--- a/translator/translate/otel/extension/ecsobserver/translator_test.go
+++ b/translator/translate/otel/extension/ecsobserver/translator_test.go
@@ -371,6 +371,23 @@ func TestTranslator_Translate(t *testing.T) {
 			},
 		},
 		{
+			name: "missing sd_target_cluster uses ECS util",
+			config: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"prometheus": map[string]interface{}{
+							"ecs_service_discovery": map[string]interface{}{
+								"sd_frequency":      "1m",
+								"sd_cluster_region": "us-west-2",
+								"sd_result_file":    "/tmp/test.yaml",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true, // ECS util returns empty in test environment
+		},
+		{
 			name: "missing required fields",
 			config: map[string]interface{}{
 				"logs": map[string]interface{}{

--- a/translator/translate/otel/extension/ecsobserver/translator_test.go
+++ b/translator/translate/otel/extension/ecsobserver/translator_test.go
@@ -34,14 +34,14 @@ func TestTranslator_Translate(t *testing.T) {
 						"prometheus": map[string]interface{}{
 							"prometheus_config_path": "{prometheusFileName}",
 							"ecs_service_discovery": map[string]interface{}{
-								"sd_frequency":      "2m",
+								"sd_frequency":      "1m",
 								"sd_target_cluster": "my-ecs-cluster",
 								"sd_cluster_region": "us-west-2",
 								"sd_result_file":    "{ecsSdFileName}",
 								"docker_label": map[string]interface{}{
-									"sd_port_label":         "ECS_PROMETHEUS_EXPORTER_PORT_CUSTOM",
-									"sd_metrics_path_label": "ECS_PROMETHEUS_METRICS_PATH_CUSTOM",
-									"sd_job_name_label":     "ECS_PROMETHEUS_JOB_NAME_CUSTOM",
+									"sd_port_label":         "ECS_PROMETHEUS_EXPORTER_PORT",
+									"sd_metrics_path_label": "ECS_PROMETHEUS_METRICS_PATH",
+									"sd_job_name_label":     "ECS_PROMETHEUS_JOB_NAME",
 								},
 								"task_definition_list": []interface{}{
 									map[string]interface{}{
@@ -84,15 +84,15 @@ func TestTranslator_Translate(t *testing.T) {
 				},
 			},
 			expected: &ecsobserver.Config{
-				RefreshInterval: (2 * time.Minute),
+				RefreshInterval: time.Minute,
 				ClusterName:     "my-ecs-cluster",
 				ClusterRegion:   "us-west-2",
 				ResultFile:      "{ecsSdFileName}",
 				DockerLabels: []ecsobserver.DockerLabelConfig{
 					{
-						PortLabel:        "ECS_PROMETHEUS_EXPORTER_PORT_CUSTOM",
-						JobNameLabel:     "ECS_PROMETHEUS_JOB_NAME_CUSTOM",
-						MetricsPathLabel: "ECS_PROMETHEUS_METRICS_PATH_CUSTOM",
+						PortLabel:        "ECS_PROMETHEUS_EXPORTER_PORT",
+						JobNameLabel:     "ECS_PROMETHEUS_JOB_NAME",
+						MetricsPathLabel: "ECS_PROMETHEUS_METRICS_PATH",
 					},
 				},
 				TaskDefinitions: []ecsobserver.TaskDefinitionConfig{
@@ -176,11 +176,11 @@ func TestTranslator_Translate(t *testing.T) {
 								"sd_frequency":      "15s",
 								"sd_target_cluster": "my-ecs-cluster",
 								"sd_cluster_region": "us-west-2",
-								"sd_result_file":    "/tmp/cwagent_ecs_auto_sd.yaml",
+								"sd_result_file":    "/custom/result/file.yaml",
 								"docker_label": map[string]interface{}{
 									"sd_port_label":         "ECS_PROMETHEUS_EXPORTER_PORT_SUBSET_A",
-									"sd_metrics_path_label": "MY_METRICS_PATH",
-									"sd_job_name_label":     "ECS_PROMETHEUS_JOB_NAME",
+									"sd_metrics_path_label": "ECS_PROMETHEUS_METRICS_PATH_CUSTOM",
+									"sd_job_name_label":     "ECS_PROMETHEUS_JOB_NAME_CUSTOM",
 								},
 							},
 						},
@@ -191,11 +191,11 @@ func TestTranslator_Translate(t *testing.T) {
 				RefreshInterval: 15 * time.Second,
 				ClusterName:     "my-ecs-cluster",
 				ClusterRegion:   "us-west-2",
-				ResultFile:      "/tmp/cwagent_ecs_auto_sd.yaml",
+				ResultFile:      "/custom/result/file.yaml",
 				DockerLabels: []ecsobserver.DockerLabelConfig{
 					{
-						JobNameLabel:     "ECS_PROMETHEUS_JOB_NAME",
-						MetricsPathLabel: "MY_METRICS_PATH",
+						JobNameLabel:     "ECS_PROMETHEUS_JOB_NAME_CUSTOM",
+						MetricsPathLabel: "ECS_PROMETHEUS_METRICS_PATH_CUSTOM",
 						PortLabel:        "ECS_PROMETHEUS_EXPORTER_PORT_SUBSET_A",
 					},
 				},
@@ -384,21 +384,6 @@ func TestTranslator_Translate(t *testing.T) {
 				},
 			},
 			wantErr: true, // ECS util returns empty in test environment
-		},
-		{
-			name: "missing required fields",
-			config: map[string]interface{}{
-				"logs": map[string]interface{}{
-					"metrics_collected": map[string]interface{}{
-						"prometheus": map[string]interface{}{
-							"ecs_service_discovery": map[string]interface{}{
-								"sd_frequency": "1m",
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
 		},
 		{
 			name:    "nil config",

--- a/translator/translate/otel/extension/ecsobserver/translator_test.go
+++ b/translator/translate/otel/extension/ecsobserver/translator_test.go
@@ -14,9 +14,13 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
 
 func TestTranslator_Translate(t *testing.T) {
+	ecsutil.GetECSUtilSingleton().Cluster = "my-ecs-cluster"
+	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
+
 	tests := []struct {
 		name     string
 		config   map[string]interface{}
@@ -144,9 +148,7 @@ func TestTranslator_Translate(t *testing.T) {
 					"metrics_collected": map[string]interface{}{
 						"prometheus": map[string]interface{}{
 							"ecs_service_discovery": map[string]interface{}{
-								"sd_target_cluster": "my-ecs-cluster",
-								"sd_cluster_region": "us-west-2",
-								"docker_label":      map[string]interface{}{},
+								"docker_label": map[string]interface{}{},
 							},
 						},
 					},
@@ -155,7 +157,7 @@ func TestTranslator_Translate(t *testing.T) {
 			expected: &ecsobserver.Config{
 				RefreshInterval: time.Minute,
 				ClusterName:     "my-ecs-cluster",
-				ClusterRegion:   "us-west-2",
+				ClusterRegion:   "us-east-1",
 				ResultFile:      "/tmp/cwagent_ecs_auto_sd.yaml",
 				DockerLabels: []ecsobserver.DockerLabelConfig{
 					{
@@ -367,28 +369,6 @@ func TestTranslator_Translate(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "missing sd_target_cluster uses ECS util",
-			config: map[string]interface{}{
-				"logs": map[string]interface{}{
-					"metrics_collected": map[string]interface{}{
-						"prometheus": map[string]interface{}{
-							"ecs_service_discovery": map[string]interface{}{
-								"sd_frequency":      "1m",
-								"sd_cluster_region": "us-west-2",
-								"sd_result_file":    "/tmp/test.yaml",
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name:    "nil config",
-			config:  nil,
-			wantErr: true,
 		},
 	}
 

--- a/translator/translate/otel/extension/ecsobserver/translator_test.go
+++ b/translator/translate/otel/extension/ecsobserver/translator_test.go
@@ -34,14 +34,14 @@ func TestTranslator_Translate(t *testing.T) {
 						"prometheus": map[string]interface{}{
 							"prometheus_config_path": "{prometheusFileName}",
 							"ecs_service_discovery": map[string]interface{}{
-								"sd_frequency":      "1m",
+								"sd_frequency":      "2m",
 								"sd_target_cluster": "my-ecs-cluster",
 								"sd_cluster_region": "us-west-2",
 								"sd_result_file":    "{ecsSdFileName}",
 								"docker_label": map[string]interface{}{
-									"sd_port_label":         "ECS_PROMETHEUS_EXPORTER_PORT",
+									"sd_port_label":         "ECS_PROMETHEUS_EXPORTER_PORT_CUSTOM",
 									"sd_metrics_path_label": "ECS_PROMETHEUS_METRICS_PATH_CUSTOM",
-									"sd_job_name_label":     "ECS_PROMETHEUS_JOB_NAME",
+									"sd_job_name_label":     "ECS_PROMETHEUS_JOB_NAME_CUSTOM",
 								},
 								"task_definition_list": []interface{}{
 									map[string]interface{}{
@@ -84,14 +84,14 @@ func TestTranslator_Translate(t *testing.T) {
 				},
 			},
 			expected: &ecsobserver.Config{
-				RefreshInterval: time.Minute,
+				RefreshInterval: (2 * time.Minute),
 				ClusterName:     "my-ecs-cluster",
 				ClusterRegion:   "us-west-2",
 				ResultFile:      "{ecsSdFileName}",
 				DockerLabels: []ecsobserver.DockerLabelConfig{
 					{
-						PortLabel:        "ECS_PROMETHEUS_EXPORTER_PORT",
-						JobNameLabel:     "ECS_PROMETHEUS_JOB_NAME",
+						PortLabel:        "ECS_PROMETHEUS_EXPORTER_PORT_CUSTOM",
+						JobNameLabel:     "ECS_PROMETHEUS_JOB_NAME_CUSTOM",
 						MetricsPathLabel: "ECS_PROMETHEUS_METRICS_PATH_CUSTOM",
 					},
 				},
@@ -144,10 +144,8 @@ func TestTranslator_Translate(t *testing.T) {
 					"metrics_collected": map[string]interface{}{
 						"prometheus": map[string]interface{}{
 							"ecs_service_discovery": map[string]interface{}{
-								"sd_frequency":      "1m",
 								"sd_target_cluster": "my-ecs-cluster",
 								"sd_cluster_region": "us-west-2",
-								"sd_result_file":    "/tmp/cwagent_ecs_auto_sd.yaml",
 								"docker_label":      map[string]interface{}{},
 							},
 						},

--- a/translator/translate/otel/extension/ecsobserver/translator_test.go
+++ b/translator/translate/otel/extension/ecsobserver/translator_test.go
@@ -383,7 +383,7 @@ func TestTranslator_Translate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true, // ECS util returns empty in test environment
+			wantErr: true,
 		},
 		{
 			name:    "nil config",

--- a/translator/translate/otel/extension/ecsobserver/translator_test.go
+++ b/translator/translate/otel/extension/ecsobserver/translator_test.go
@@ -40,7 +40,7 @@ func TestTranslator_Translate(t *testing.T) {
 								"sd_result_file":    "{ecsSdFileName}",
 								"docker_label": map[string]interface{}{
 									"sd_port_label":         "ECS_PROMETHEUS_EXPORTER_PORT",
-									"sd_metrics_path_label": "ECS_PROMETHEUS_METRICS_PATH",
+									"sd_metrics_path_label": "ECS_PROMETHEUS_METRICS_PATH_CUSTOM",
 									"sd_job_name_label":     "ECS_PROMETHEUS_JOB_NAME",
 								},
 								"task_definition_list": []interface{}{
@@ -92,7 +92,7 @@ func TestTranslator_Translate(t *testing.T) {
 					{
 						PortLabel:        "ECS_PROMETHEUS_EXPORTER_PORT",
 						JobNameLabel:     "ECS_PROMETHEUS_JOB_NAME",
-						MetricsPathLabel: "ECS_PROMETHEUS_METRICS_PATH",
+						MetricsPathLabel: "ECS_PROMETHEUS_METRICS_PATH_CUSTOM",
 					},
 				},
 				TaskDefinitions: []ecsobserver.TaskDefinitionConfig{
@@ -162,7 +162,7 @@ func TestTranslator_Translate(t *testing.T) {
 				DockerLabels: []ecsobserver.DockerLabelConfig{
 					{
 						JobNameLabel:     defaultJobNameLabel,
-						MetricsPathLabel: defaultMetricsPath,
+						MetricsPathLabel: defaultMetricsPathLabel,
 						PortLabel:        defaultPortLabel,
 					},
 				},

--- a/translator/translate/otel/receiver/prometheus/translator_test.go
+++ b/translator/translate/otel/receiver/prometheus/translator_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/targetallocator"
 	promcommon "github.com/prometheus/common/config"
@@ -23,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
+	"gopkg.in/yaml.v3"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/util/testutil"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"


### PR DESCRIPTION
# Description of the issue
Updates ECS Observer Config Translator for parity with existing Ecs Service Discovery defaults

# Description of changes
List of modifications
* Dynamically retrieve default value for clusterName and clusterRegion when not provided (make them optional)
* Update refreshDuration default to `1m`
* Update ResultFile default to `/tmp/cwagent_ecs_auto_sd.yaml`
* Update JobNameLabel default to `job`
* Update MetricPathLabel default to `ECS_PROMETHEUS_METRICS_PATH`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests & all tests pass
```
make test
make fmt
make fmt-sh
make lint
```

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



