### PR TITLE
Fixing CWA error_mode bug in addon v4.2.0 

### DIFF
--- a/translator/tocwconfig/sampleConfig/container_insights_jmx.yaml
+++ b/translator/tocwconfig/sampleConfig/container_insights_jmx.yaml
@@ -478,11 +478,11 @@ processors:
         log_statements: []
         metric_statements:
             - context: resource
-              error_mode: ""
+              error_mode: propagate
               statements:
                 - keep_keys(attributes, ["ClusterName", "Namespace", "NodeName"])
             - context: metric
-              error_mode: ""
+              error_mode: propagate
               statements:
                 - set(unit, "Bytes") where name == "jvm.memory.heap.used"
                 - set(unit, "Bytes") where name == "jvm.memory.nonheap.used"

--- a/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/jmx_eks_config_linux.yaml
@@ -188,7 +188,7 @@ processors:
         log_statements: []
         metric_statements:
             - context: resource
-              error_mode: ""
+              error_mode: propagate
               statements:
                 - delete_matching_keys(attributes, "^cloud.*")
                 - delete_matching_keys(attributes, "^host.*")

--- a/translator/translate/otel/processor/transformprocessor/transform_jmx_config.yaml
+++ b/translator/translate/otel/processor/transformprocessor/transform_jmx_config.yaml
@@ -1,8 +1,10 @@
 metric_statements:
   - context: resource
+    error_mode: propagate
     statements:
       - keep_keys(attributes, ["ClusterName", "Namespace", "NodeName"])
   - context: metric
+    error_mode: propagate
     statements:
       - set(unit, "Bytes") where name == "jvm.memory.heap.used"
       - set(unit, "Bytes") where name == "jvm.memory.nonheap.used"

--- a/translator/translate/otel/processor/transformprocessor/transform_jmx_drop_config.yaml
+++ b/translator/translate/otel/processor/transformprocessor/transform_jmx_drop_config.yaml
@@ -1,5 +1,6 @@
 metric_statements:
   - context: resource
+    error_mode: propagate
     statements:
       - delete_matching_keys(attributes, "^cloud.*")
       - delete_matching_keys(attributes, "^host.*")

--- a/translator/translate/otel/processor/transformprocessor/translator_test.go
+++ b/translator/translate/otel/processor/transformprocessor/translator_test.go
@@ -52,4 +52,5 @@ func TestJmxTranslate(t *testing.T) {
 	assert.Len(t, actualCfg.MetricStatements, 1)
 	sort.Strings(expectedCfg.MetricStatements[0].Statements)
 	sort.Strings(actualCfg.MetricStatements[0].Statements)
+	assert.Equal(t, string(actualCfg.ErrorMode), "propagate")
 }


### PR DESCRIPTION
# Description of the issue
Currently for CWA addon version v4.2.0 when jmx is configured we never set the error_mode for context in the transform processor as we never updated the default yamls. This causes the CWA to generate error_mode: "" in its generated yaml which leads to an error as error_mode can't be an empty string. A similar issue also occurred during the Otel Bump to v0.124.1 and the fix was to initialize error_mode to the default which is "propagate". This is the contrib pr that added error_mode to the context statement: https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/9280ca1c515d86a10da6378154a27404472ac56c. 


# Description of changes
Adding "propagate" as default error_mode value for transform processor's default agent yaml to fix empty string initialization for the CWA. 

# Tests
Ran the addon version v4.2.0 with this configuration:

```
    {
      "agent": {
        "metrics_collection_interval": 10,
        "region": "us-west-2"
      },
      "metrics": {
        "metrics_collected": {
          "jmx": {
            "endpoint": "localhost:12345",
            "jvm": {
              "measurement": [
                "jvm.threads.count",
                "jvm.memory.heap.used"
              ]
            }
          }
        }
      }
    }
```
### We received this error below:

<img width="1303" height="168" alt="Screenshot 2025-08-26 at 1 46 41 PM" src="https://github.com/user-attachments/assets/be4fa0d1-deba-4c05-a2cc-7b14a15589f7" />

----------------
### After implementing fix with the updated agent, the agent was able to run successfully: 
<img width="951" height="546" alt="Screenshot 2025-08-22 at 3 39 13 PM" src="https://github.com/user-attachments/assets/37709f91-a472-43f0-a957-7035019587fa" />



