### PR TITLE
The build process fails on tests if run as root

### DIFF
--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -127,6 +127,8 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 
 	if !ua.isRoot {
 		ua.inputs.Add(flagRunAsUser)
+	} else if len(ua.inputs) == 0 {
+		ua.inputs.Add(flagRunAsUser)
 	}
 
 	ua.inputsStr.Store(componentsStr(typeInputs, ua.inputs))

--- a/extension/agenthealth/handler/useragent/useragent_test.go
+++ b/extension/agenthealth/handler/useragent/useragent_test.go
@@ -129,7 +129,7 @@ func TestEmf(t *testing.T) {
 	}
 	ua := newUserAgent()
 	if len(ua.inputs) == 0 {
-    	ua.isRoot = false
+		ua.isRoot = false
 	}
 	ua.SetComponents(otelCfg, &telegraf.Config{})
 	assert.Len(t, ua.inputs, 2)

--- a/extension/agenthealth/handler/useragent/useragent_test.go
+++ b/extension/agenthealth/handler/useragent/useragent_test.go
@@ -128,6 +128,9 @@ func TestEmf(t *testing.T) {
 		},
 	}
 	ua := newUserAgent()
+	if len(ua.inputs) == 0 {
+    	ua.isRoot = false
+	}
 	ua.SetComponents(otelCfg, &telegraf.Config{})
 	assert.Len(t, ua.inputs, 2)
 	assert.Len(t, ua.processors, 0)
@@ -154,6 +157,9 @@ func TestMissingEmfExporterConfig(t *testing.T) {
 		},
 	}
 	ua := newUserAgent()
+	if len(ua.inputs) == 0 {
+		ua.isRoot = false
+	}
 	ua.SetComponents(otelCfg, &telegraf.Config{})
 	assert.Len(t, ua.inputs, 2)
 	assert.Len(t, ua.processors, 0)
@@ -198,6 +204,9 @@ func TestJmx(t *testing.T) {
 		},
 	}
 	ua := newUserAgent()
+	if len(ua.inputs) == 0 {
+		ua.isRoot = false
+    }
 	ua.SetComponents(otelCfg, &telegraf.Config{})
 	assert.Len(t, ua.inputs, 5)
 	assert.Len(t, ua.processors, 0)


### PR DESCRIPTION
# Description of the issue
The build process fails on tests if run as root. The non-root build works correctly.

Platform: Debian 12

Steps to reproduce:
1) Login as root (or any other user with id=0). Clone code
2) Run: make clean test check_secrets amazon-cloudwatch-agent-linux package-deb

It fail with following errors:

```
    useragent_test.go:132: 
        	Error Trace:	/build/src/amazon-cloudwatch-agent/amazon-cloudwatch-agent/extension/agenthealth/handler/useragent/useragent_test.go:132
        	Error:      	"map[nop:{}]" should have 2 item(s), but has 1
        	Test:       	TestEmf
    useragent_test.go:136: 
        	Error Trace:	/build/src/amazon-cloudwatch-agent/amazon-cloudwatch-agent/extension/agenthealth/handler/useragent/useragent_test.go:136
        	Error:      	Not equal: 
        	            	expected: "inputs:(nop run_as_user)"
        	            	actual  : "inputs:(nop)"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-inputs:(nop run_as_user)
        	            	+inputs:(nop)
        	Test:       	TestEmf
```



```
--- FAIL: TestSetComponentsEmpty (0.00s)
    useragent_test.go:82: 
        	Error Trace:	/build/src/amazon-cloudwatch-agent/amazon-cloudwatch-agent/extension/agenthealth/handler/useragent/useragent_test.go:82
        	Error:      	"map[]" should have 1 item(s), but has 0
        	Test:       	TestSetComponentsEmpty
    useragent_test.go:86: 
        	Error Trace:	/build/src/amazon-cloudwatch-agent/amazon-cloudwatch-agent/extension/agenthealth/handler/useragent/useragent_test.go:86
        	Error:      	Not equal: 
        	            	expected: "inputs:(run_as_user)"
        	            	actual  : ""
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-inputs:(run_as_user)
        	            	+
        	Test:       	TestSetComponentsEmpty

```
# Description of changes
It checks whether 'ua.input' is empty.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Test finished successfully. 

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



