### PR TITLE
Append customer prometheus scrape configs

### DIFF
--- a/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.conf
+++ b/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.conf
@@ -1,0 +1,27 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[outputs]
+
+  [[outputs.cloudwatch]]
+
+  [[outputs.cloudwatchlogs]]
+    endpoint_override = "https://fake_endpoint"
+    force_flush_interval = "5s"
+    log_stream_name = "i-UNKNOWN"
+    mode = "EC2"
+    region = "us-west-2"
+    region_type = "ACJ"

--- a/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.json
+++ b/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.json
@@ -1,0 +1,52 @@
+{
+  "agent": {
+    "region": "us-west-2"
+  },
+  "metrics": {
+    "metrics_destinations": {
+      "cloudwatch": {},
+      "amp": {
+        "workspace_id": "ws-12345"
+      }
+    },
+    "metrics_collected": {
+      "prometheus": {
+        "prometheus_config_path": "{prometheusFileName}"
+      }
+    }
+  },
+  "logs": {
+    "metrics_collected": {
+      "prometheus": {
+        "prometheus_config_path": "{prometheusFileName}",
+        "ecs_service_discovery": {
+          "sd_result_file": "/tmp/cwagent_ecs_auto_sd.yaml",
+          "docker_label": {},
+          "task_definition_list": [
+            {
+              "sd_task_definition_arn_pattern": ".*:task-definition/nginx.*:[0-9]+",
+              "metrics_path": "/metrics",
+              "metrics_ports": "9113"
+            }
+          ]
+        },
+        "emf_processor": {
+          "metric_declaration_dedup": true,
+          "metric_namespace": "ECS/ContainerInsights/Prometheus",
+          "metric_unit": {},
+          "metric_declaration": [
+            {
+              "source_labels": ["Service"],
+              "label_matcher": "nginx.*",
+              "dimensions": [["Service"]],
+              "metric_selectors": ["^nginx_request_count$"]
+            }
+          ]
+        },
+        "log_group_name": "/aws/ecs/containerinsights/TestCluster/prometheus"
+      }
+    },
+    "force_flush_interval": 5,
+    "endpoint_override": "https://fake_endpoint"
+  }
+}

--- a/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
@@ -1,0 +1,526 @@
+exporters:
+    awscloudwatch:
+        force_flush_interval: 1m0s
+        max_datums_per_call: 1000
+        max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        namespace: CWAgent
+        region: us-west-2
+        resource_to_telemetry_conversion:
+            enabled: true
+    awsemf/prometheus:
+        add_entity: false
+        certificate_file_path: ""
+        detailed_metrics: true
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: false
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: false
+        external_id: ""
+        imds_retries: 1
+        local_mode: false
+        log_group_name: /aws/ecs/containerinsights/TestCluster/prometheus
+        log_retention: 0
+        log_stream_name: '{JobName}'
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - Service
+              label_matchers:
+                - label_names:
+                    - Service
+                  regex: nginx.*
+                  separator: ;
+              metric_name_selectors:
+                - ^nginx_request_count$
+        middleware: agenthealth/logs
+        namespace: ECS/ContainerInsights/Prometheus
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        profile: ""
+        proxy_address: ""
+        region: us-west-2
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: true
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        version: "0"
+    prometheusremotewrite/amp:
+        add_metric_suffixes: true
+        auth:
+            authenticator: sigv4auth
+        endpoint: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345/api/v1/remote_write
+        idle_conn_timeout: 1m30s
+        max_batch_size_bytes: 3000000
+        max_idle_conns: 100
+        namespace: ""
+        remote_write_queue:
+            enabled: true
+            num_consumers: 5
+            queue_size: 10000
+        resource_to_telemetry_conversion:
+            clear_after_copy: true
+            enabled: true
+        retry_on_failure:
+            enabled: true
+            initial_interval: 50ms
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        send_metadata: false
+        target_info:
+            enabled: true
+        timeout: 5s
+        write_buffer_size: 524288
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    agenthealth/statuscode:
+        is_status_code_enabled: true
+        is_usage_data_enabled: true
+        stats:
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    ecs_observer:
+        cluster_name: myTestCluster
+        cluster_region: us-west-2
+        docker_labels:
+            - job_name: ""
+              job_name_label: job
+              metrics_path: ""
+              metrics_path_label: ECS_PROMETHEUS_METRICS_PATH
+              port_label: ECS_PROMETHEUS_EXPORTER_PORT
+        job_label_name: ""
+        refresh_interval: 1m0s
+        result_file: /tmp/cwagent_ecs_auto_sd.yaml
+        task_definitions:
+            - arn_pattern: .*:task-definition/nginx.*:[0-9]+
+              container_name_pattern: ""
+              job_name: ""
+              metrics_path: /metrics
+              metrics_ports: []
+    sigv4auth:
+        assume_role:
+            sts_region: us-west-2
+        region: us-west-2
+processors:
+    batch/prometheus/amp:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 1m0s
+    batch/prometheus/cloudwatch:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 1m0s
+    batch/prometheus/cloudwatchlogs:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 5s
+    cumulativetodelta/prometheus/cloudwatch:
+        exclude:
+            match_type: ""
+        include:
+            match_type: ""
+        initial_value: 2
+        max_staleness: 0s
+    deltatocumulative/prometheus/amp:
+        max_stale: 336h0m0s
+        max_streams: 9223372036854775807
+    prometheusadapter/prometheus/cloudwatch: {}
+    prometheusadapter/prometheus/cloudwatchlogs: {}
+receivers:
+    prometheus:
+        config:
+            global:
+                evaluation_interval: 1m
+                scrape_interval: 1m
+                scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                scrape_timeout: 10s
+            scrape_configs:
+                - enable_compression: true
+                  enable_http2: true
+                  fallback_scrape_protocol: PrometheusText0.0.4
+                  file_sd_configs:
+                    - files:
+                        - /tmp/cwagent_ecs_auto_sd.yaml
+                      refresh_interval: 5m
+                  follow_redirects: true
+                  honor_timestamps: true
+                  job_name: test
+                  metrics_path: /metrics
+                  relabel_configs:
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_cluster_name
+                      target_label: ClusterName
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_cluster_name
+                      target_label: TaskClusterName
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_container_name
+                      target_label: container_name
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_launch_type
+                      target_label: LaunchType
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_started_by
+                      target_label: StartedBy
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_group
+                      target_label: TaskGroup
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_definition_family
+                      target_label: TaskDefinitionFamily
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_definition_revision
+                      target_label: TaskRevision
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_instance_type
+                      target_label: InstanceType
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_subnet_id
+                      target_label: SubnetId
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_vpc_id
+                      target_label: VpcId
+                    - action: replace
+                      regex: ^arn:aws:ecs:.*:.*:task.*\/(.*)$
+                      source_labels:
+                        - __meta_ecs_source
+                      target_label: TaskId
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                          - __meta_ecs_container_labels_app_x
+                      target_label: app_x
+                    - action: replace
+                      replacement: $1
+                      separator: ;
+                      source_labels:
+                        - StartedBy
+                      target_label: CustomStartedBy
+                  scheme: http
+                  scrape_interval: 1m
+                  scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                  scrape_timeout: 10s
+                  track_timestamps_staleness: false
+        report_extra_scrape_metrics: false
+        start_time_metric_regex: ""
+        trim_metric_suffixes: false
+        use_start_time_metric: false
+    prometheus/prometheus/cloudwatch:
+        config:
+            global:
+                evaluation_interval: 1m
+                scrape_interval: 1m
+                scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                scrape_timeout: 10s
+            scrape_configs:
+                - enable_compression: true
+                  enable_http2: true
+                  fallback_scrape_protocol: PrometheusText0.0.4
+                  file_sd_configs:
+                    - files:
+                        - /tmp/cwagent_ecs_auto_sd.yaml
+                      refresh_interval: 5m
+                  follow_redirects: true
+                  honor_timestamps: true
+                  job_name: test
+                  metrics_path: /metrics
+                  relabel_configs:
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_cluster_name
+                      target_label: ClusterName
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_cluster_name
+                      target_label: TaskClusterName
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_container_name
+                      target_label: container_name
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_launch_type
+                      target_label: LaunchType
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_started_by
+                      target_label: StartedBy
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_group
+                      target_label: TaskGroup
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_definition_family
+                      target_label: TaskDefinitionFamily
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_definition_revision
+                      target_label: TaskRevision
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_instance_type
+                      target_label: InstanceType
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_subnet_id
+                      target_label: SubnetId
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_vpc_id
+                      target_label: VpcId
+                    - action: replace
+                      regex: ^arn:aws:ecs:.*:.*:task.*\/(.*)$
+                      source_labels:
+                        - __meta_ecs_source
+                      target_label: TaskId
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_container_labels_app_x
+                      target_label: app_x
+                    - action: replace
+                      replacement: $1
+                      separator: ;
+                      source_labels:
+                        - StartedBy
+                      target_label: CustomStartedBy
+                  scheme: http
+                  scrape_interval: 1m
+                  scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                  scrape_timeout: 10s
+                  track_timestamps_staleness: false
+        report_extra_scrape_metrics: false
+        start_time_metric_regex: ""
+        trim_metric_suffixes: false
+        use_start_time_metric: false
+    prometheus/prometheus/cloudwatchlogs:
+        config:
+            global:
+                evaluation_interval: 1m
+                scrape_interval: 1m
+                scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                scrape_timeout: 10s
+            scrape_configs:
+                - enable_compression: true
+                  enable_http2: true
+                  fallback_scrape_protocol: PrometheusText0.0.4
+                  file_sd_configs:
+                    - files:
+                        - /tmp/cwagent_ecs_auto_sd.yaml
+                      refresh_interval: 5m
+                  follow_redirects: true
+                  honor_timestamps: true
+                  job_name: test
+                  metrics_path: /metrics
+                  relabel_configs:
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_cluster_name
+                      target_label: ClusterName
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_cluster_name
+                      target_label: TaskClusterName
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_container_name
+                      target_label: container_name
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_launch_type
+                      target_label: LaunchType
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_started_by
+                      target_label: StartedBy
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_group
+                      target_label: TaskGroup
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_definition_family
+                      target_label: TaskDefinitionFamily
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_task_definition_revision
+                      target_label: TaskRevision
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_instance_type
+                      target_label: InstanceType
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_subnet_id
+                      target_label: SubnetId
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_ec2_vpc_id
+                      target_label: VpcId
+                    - action: replace
+                      regex: ^arn:aws:ecs:.*:.*:task.*\/(.*)$
+                      source_labels:
+                        - __meta_ecs_source
+                      target_label: TaskId
+                    - action: replace
+                      regex: (.*)
+                      source_labels:
+                        - __meta_ecs_container_labels_app_x
+                      target_label: app_x
+                    - action: replace
+                      replacement: $1
+                      separator: ;
+                      source_labels:
+                        - StartedBy
+                      target_label: CustomStartedBy
+                  scheme: http
+                  scrape_interval: 1m
+                  scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                  scrape_timeout: 10s
+                  track_timestamps_staleness: false
+        report_extra_scrape_metrics: false
+        start_time_metric_regex: ""
+        trim_metric_suffixes: false
+        use_start_time_metric: false
+service:
+    extensions:
+        - agenthealth/metrics
+        - agenthealth/statuscode
+        - sigv4auth
+        - agenthealth/logs
+        - ecs_observer
+    pipelines:
+        metrics/prometheus/amp:
+            exporters:
+                - prometheusremotewrite/amp
+            processors:
+                - batch/prometheus/amp
+                - deltatocumulative/prometheus/amp
+            receivers:
+                - prometheus
+        metrics/prometheus/cloudwatch:
+            exporters:
+                - awscloudwatch
+            processors:
+                - prometheusadapter/prometheus/cloudwatch
+                - batch/prometheus/cloudwatch
+                - cumulativetodelta/prometheus/cloudwatch
+            receivers:
+                - prometheus/prometheus/cloudwatch
+        metrics/prometheus/cloudwatchlogs:
+            exporters:
+                - awsemf/prometheus
+            processors:
+                - prometheusadapter/prometheus/cloudwatchlogs
+                - batch/prometheus/cloudwatchlogs
+            receivers:
+                - prometheus/prometheus/cloudwatchlogs
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/testdata/prometheus_customer_relabel.yaml
+++ b/translator/tocwconfig/testdata/prometheus_customer_relabel.yaml
@@ -1,0 +1,8 @@
+scrape_configs:
+  - job_name: test
+    file_sd_configs:
+      - files: ['/tmp/cwagent_ecs_auto_sd.yaml']
+    relabel_configs:
+      - action: replace
+        source_labels: [StartedBy]
+        target_label: CustomStartedBy

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -1034,7 +1034,7 @@ func TestPrometheusCustomerRelabelConfigs(t *testing.T) {
 	tokenReplacements := map[string]string{
 		prometheusFileNameToken: strings.ReplaceAll(prometheusConfigFileName, "\\", "\\\\"),
 	}
-	
+
 	testPrometheusConfig := `global:
   scrape_interval: 1m
   scrape_timeout: 10s
@@ -1046,10 +1046,10 @@ scrape_configs:
       - action: replace
         source_labels: [StartedBy]
         target_label: CustomStartedBy`
-	
+
 	err := os.WriteFile(prometheusConfigFileName, []byte(testPrometheusConfig), os.ModePerm)
 	require.NoError(t, err)
-	
+
 	checkTranslation(t, "prometheus_customer_relabel_config_linux", "linux", expectedEnvVars, "", tokenReplacements)
 }
 

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -1002,7 +1002,6 @@ func verifyToYamlTranslation(t *testing.T, input interface{}, expectedYamlFilePa
 		require.NoError(t, err)
 		yamlStr := toyamlconfig.ToYamlConfig(yamlConfig)
 		require.NoError(t, yaml.Unmarshal([]byte(yamlStr), &actual))
-		// assert.NoError(t, os.WriteFile(expectedYamlFilePath, []byte(yamlStr), 0644)) // useful for regenerating YAML
 		opt := cmpopts.SortSlices(func(x, y interface{}) bool {
 			return pretty.Sprint(x) < pretty.Sprint(y)
 		})
@@ -1020,6 +1019,38 @@ func replaceTokens(base []byte, tokenReplacements ...map[string]string) string {
 		}
 	}
 	return content
+}
+
+func TestPrometheusCustomerRelabelConfigs(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	ecsutil.GetECSUtilSingleton().Region = "us-west-2"
+	ecsutil.GetECSUtilSingleton().Cluster = "myTestCluster"
+	testutil.SetPrometheusRemoteWriteTestingEnv(t)
+	t.Setenv(config.HOST_NAME, "host_name_from_env")
+	temp := t.TempDir()
+	prometheusConfigFileName := filepath.Join(temp, "prometheus.yaml")
+	expectedEnvVars := map[string]string{}
+	tokenReplacements := map[string]string{
+		prometheusFileNameToken: strings.ReplaceAll(prometheusConfigFileName, "\\", "\\\\"),
+	}
+	
+	testPrometheusConfig := `global:
+  scrape_interval: 1m
+  scrape_timeout: 10s
+scrape_configs:
+  - job_name: test
+    file_sd_configs:
+      - files: ['/tmp/cwagent_ecs_auto_sd.yaml']
+    relabel_configs:
+      - action: replace
+        source_labels: [StartedBy]
+        target_label: CustomStartedBy`
+	
+	err := os.WriteFile(prometheusConfigFileName, []byte(testPrometheusConfig), os.ModePerm)
+	require.NoError(t, err)
+	
+	checkTranslation(t, "prometheus_customer_relabel_config_linux", "linux", expectedEnvVars, "", tokenReplacements)
 }
 
 func checkIfEnvTranslateSucceed(t *testing.T, jsonStr string, targetOs string, expectedEnvVars map[string]string) {

--- a/translator/translate/otel/receiver/prometheus/translator_test.go
+++ b/translator/translate/otel/receiver/prometheus/translator_test.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/util/testutil"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
@@ -321,6 +321,10 @@ func TestAddDefaultECSRelabelConfigs_Success(t *testing.T) {
 					Files: []string{defaultECSSDfileName},
 				},
 			},
+			RelabelConfigs: []*relabel.Config{
+				{SourceLabels: model.LabelNames{"__address__"}, Action: relabel.Replace, TargetLabel: "custom_label", Regex: relabel.MustNewRegexp("(.*)")},
+				{SourceLabels: model.LabelNames{"__name__"}, Action: relabel.Drop, Regex: relabel.MustNewRegexp("unwanted_.*")},
+			},
 		},
 	}
 
@@ -340,18 +344,18 @@ func TestAddDefaultECSRelabelConfigs_Success(t *testing.T) {
 	})
 
 	configKey := "logs.metrics_collected.prometheus"
+
 	addDefaultECSRelabelConfigs(scrapeConfigs, conf, configKey)
 
 	// Should add configs because ecs_service_discovery is explicitly configured
 	assert.Len(t, scrapeConfigs[0].RelabelConfigs, 13, "Should add relabel configs when ecs_service_discovery is explicitly configured")
 	validateRelabelFields(t, scrapeConfigs[0])
 	assert.Empty(t, scrapeConfigs[1].RelabelConfigs, "Other job should not have relabel configs")
-	assert.Len(t, scrapeConfigs[2].RelabelConfigs, 13, "Should add relabel configs when ecs_service_discovery is explicitly configured")
+	assert.Len(t, scrapeConfigs[2].RelabelConfigs, 15, "Should prepend relabel configs when customer provides relabel configs ")
 	validateRelabelFields(t, scrapeConfigs[2])
-
 }
 
-func TestAddDefaultRelabelConfigs_notECS(t *testing.T) {
+func TestDontAddDefaultRelabelConfigs_notECS(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = ""
 
 	scrapeConfigWithFileSD := &config.ScrapeConfig{
@@ -387,7 +391,7 @@ func TestAddDefaultRelabelConfigs_notECS(t *testing.T) {
 	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 0, "ScrapeConfig should have no relabel configs when not in ECS")
 }
 
-func TestAddDefaultRelabelConfigs_noEcsSdConfig(t *testing.T) {
+func TestDontAddDefaultRelabelConfigs_noEcsSdConfig(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
 
 	scrapeConfigWithFileSD := &config.ScrapeConfig{
@@ -420,7 +424,7 @@ func TestAddDefaultRelabelConfigs_noEcsSdConfig(t *testing.T) {
 	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 0, "ScrapeConfig should have no relabel configs when ecs_service_discovery is not configured")
 }
 
-func TestAddDefaultRelabelConfigs_mismatchEcsSdResultFile(t *testing.T) {
+func TestDontAddDefaultRelabelConfigs_mismatchEcsSdResultFile(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
 
 	scrapeConfigWithFileSD := &config.ScrapeConfig{
@@ -457,7 +461,7 @@ func TestAddDefaultRelabelConfigs_mismatchEcsSdResultFile(t *testing.T) {
 	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 0, "ScrapeConfig should have no relabel configs when sd_result_file doesn't match")
 }
 
-func TestAddDefaultRelabelConfigs_emptyScrapeConfigs(t *testing.T) {
+func TestDontAddDefaultRelabelConfigs_emptyScrapeConfigs(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
 
 	scrapeConfigs := []*config.ScrapeConfig{}
@@ -482,6 +486,67 @@ func TestAddDefaultRelabelConfigs_emptyScrapeConfigs(t *testing.T) {
 
 	// Should not panic with empty scrape configs
 	assert.Len(t, scrapeConfigs, 0, "Should remain empty")
+}
+
+func TestAppendCustomerRelabelConfigs(t *testing.T) {
+	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
+
+	customerRelabelConfig := &relabel.Config{
+		Action:       relabel.Replace,
+		SourceLabels: model.LabelNames{"StartedBy"},
+		TargetLabel:  "CustomStartedBy",
+		Regex:        relabel.MustNewRegexp("(.*)"),
+	}
+
+	scrapeConfigWithFileSD := &config.ScrapeConfig{
+		JobName: "test-job",
+		ServiceDiscoveryConfigs: []discovery.Config{
+			&file.SDConfig{
+				Files: []string{defaultECSSDfileName},
+			},
+		},
+		RelabelConfigs: []*relabel.Config{customerRelabelConfig},
+	}
+
+	scrapeConfigs := []*config.ScrapeConfig{scrapeConfigWithFileSD}
+
+	conf := confmap.NewFromStringMap(map[string]interface{}{
+		"logs": map[string]interface{}{
+			"metrics_collected": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"ecs_service_discovery": map[string]interface{}{
+						"sd_result_file": defaultECSSDfileName,
+					},
+				},
+			},
+		},
+	})
+	configKey := "logs.metrics_collected.prometheus"
+
+	addDefaultECSRelabelConfigs(scrapeConfigs, conf, configKey)
+
+	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 14, "Should have 13 default + 1 customer relabel config")
+	validateRelabelFields(t, scrapeConfigWithFileSD)
+
+	customerProvidedConfig := scrapeConfigWithFileSD.RelabelConfigs[13]
+	assert.Equal(t, "CustomStartedBy", customerProvidedConfig.TargetLabel)
+	assert.Equal(t, model.LabelNames{"StartedBy"}, customerProvidedConfig.SourceLabels)
+}
+
+func validateRelabelFields(t *testing.T, scrapeConfigWithFileSD *config.ScrapeConfig) {
+	assert.Equal(t, "ClusterName", scrapeConfigWithFileSD.RelabelConfigs[0].TargetLabel)
+	assert.Equal(t, "TaskClusterName", scrapeConfigWithFileSD.RelabelConfigs[1].TargetLabel)
+	assert.Equal(t, "container_name", scrapeConfigWithFileSD.RelabelConfigs[2].TargetLabel)
+	assert.Equal(t, "LaunchType", scrapeConfigWithFileSD.RelabelConfigs[3].TargetLabel)
+	assert.Equal(t, "StartedBy", scrapeConfigWithFileSD.RelabelConfigs[4].TargetLabel)
+	assert.Equal(t, "TaskGroup", scrapeConfigWithFileSD.RelabelConfigs[5].TargetLabel)
+	assert.Equal(t, "TaskDefinitionFamily", scrapeConfigWithFileSD.RelabelConfigs[6].TargetLabel)
+	assert.Equal(t, "TaskRevision", scrapeConfigWithFileSD.RelabelConfigs[7].TargetLabel)
+	assert.Equal(t, "InstanceType", scrapeConfigWithFileSD.RelabelConfigs[8].TargetLabel)
+	assert.Equal(t, "SubnetId", scrapeConfigWithFileSD.RelabelConfigs[9].TargetLabel)
+	assert.Equal(t, "VpcId", scrapeConfigWithFileSD.RelabelConfigs[10].TargetLabel)
+	assert.Equal(t, "TaskId", scrapeConfigWithFileSD.RelabelConfigs[11].TargetLabel)
+	assert.Equal(t, "app_x", scrapeConfigWithFileSD.RelabelConfigs[12].TargetLabel)
 }
 
 func TestEscapeStrings(t *testing.T) {
@@ -516,68 +581,4 @@ func normalizeYAML(s string) string {
 		}
 	}
 	return buf.String()
-}
-
-func TestAppendCustomerRelabelConfigs(t *testing.T) {
-	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
-
-	customerRelabelConfig := &relabel.Config{
-		Action:       relabel.Replace,
-		SourceLabels: model.LabelNames{"StartedBy"},
-		TargetLabel:  "CustomStartedBy",
-		Regex:        relabel.MustNewRegexp("(.*)"),
-	}
-
-	scrapeConfigWithFileSD := &config.ScrapeConfig{
-		JobName: "test-job",
-		ServiceDiscoveryConfigs: []discovery.Config{
-			&file.SDConfig{
-				Files: []string{defaultECSSDfileName},
-			},
-		},
-		RelabelConfigs: []*relabel.Config{customerRelabelConfig},
-	}
-
-	scrapeConfigs := []*config.ScrapeConfig{scrapeConfigWithFileSD}
-
-	customerConfigs := extractCustomerRelabelConfigs(scrapeConfigs)
-
-	conf := confmap.NewFromStringMap(map[string]interface{}{
-		"logs": map[string]interface{}{
-			"metrics_collected": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"ecs_service_discovery": map[string]interface{}{
-						"sd_result_file": defaultECSSDfileName,
-					},
-				},
-			},
-		},
-	})
-	configKey := "logs.metrics_collected.prometheus"
-
-	addDefaultECSRelabelConfigs(scrapeConfigs, conf, configKey)
-	appendCustomerRelabelConfigs(scrapeConfigs, customerConfigs, conf)
-
-	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 14, "Should have 13 default + 1 customer relabel config")
-	validateRelabelFields(t, scrapeConfigWithFileSD)
-
-	customerProvidedConfig := scrapeConfigWithFileSD.RelabelConfigs[13]
-	assert.Equal(t, "CustomStartedBy", customerProvidedConfig.TargetLabel)
-	assert.Equal(t, model.LabelNames{"StartedBy"}, customerProvidedConfig.SourceLabels)
-}
-
-func validateRelabelFields(t *testing.T, scrapeConfigWithFileSD *config.ScrapeConfig) {
-	assert.Equal(t, "ClusterName", scrapeConfigWithFileSD.RelabelConfigs[0].TargetLabel)
-	assert.Equal(t, "TaskClusterName", scrapeConfigWithFileSD.RelabelConfigs[1].TargetLabel)
-	assert.Equal(t, "container_name", scrapeConfigWithFileSD.RelabelConfigs[2].TargetLabel)
-	assert.Equal(t, "LaunchType", scrapeConfigWithFileSD.RelabelConfigs[3].TargetLabel)
-	assert.Equal(t, "StartedBy", scrapeConfigWithFileSD.RelabelConfigs[4].TargetLabel)
-	assert.Equal(t, "TaskGroup", scrapeConfigWithFileSD.RelabelConfigs[5].TargetLabel)
-	assert.Equal(t, "TaskDefinitionFamily", scrapeConfigWithFileSD.RelabelConfigs[6].TargetLabel)
-	assert.Equal(t, "TaskRevision", scrapeConfigWithFileSD.RelabelConfigs[7].TargetLabel)
-	assert.Equal(t, "InstanceType", scrapeConfigWithFileSD.RelabelConfigs[8].TargetLabel)
-	assert.Equal(t, "SubnetId", scrapeConfigWithFileSD.RelabelConfigs[9].TargetLabel)
-	assert.Equal(t, "VpcId", scrapeConfigWithFileSD.RelabelConfigs[10].TargetLabel)
-	assert.Equal(t, "TaskId", scrapeConfigWithFileSD.RelabelConfigs[11].TargetLabel)
-	assert.Equal(t, "app_x", scrapeConfigWithFileSD.RelabelConfigs[12].TargetLabel)
 }


### PR DESCRIPTION
# Description of the issue
When a customer provides prometheus scrape config relabel configs, we should not overwrite them. Additionally, the customer provided config must be processed last, after the default relabel config. This is to retain backwards compatibility given the new labels generated by the OTEL plugin for prometheus file-based service discovery (ECS Observer).

# Description of changes
This change detects customer provided relabel configs and appends them to the dynamically configured relabel configs so that they can be processed after

ex: 
Customer provides
```		Action:       relabel.Replace,
		SourceLabels: model.LabelNames{"StartedBy"},
		TargetLabel:  "CustomStartedBy",
		Regex:        relabel.MustNewRegexp("(.*)"),

```

then the generated relabelConfig must look like this so that the Customer's action on `StartedBy` does not fail
```		
...
Action:       relabel.Replace,
SourceLabels: model.LabelNames{"__meta_ecs_task_started_by"},
TargetLabel:  "StartedBy",
Regex:        relabel.MustNewRegexp("(.*)"),
...
Action:       relabel.Replace,
SourceLabels: model.LabelNames{"StartedBy"},
TargetLabel:  "CustomStartedBy",
Regex:        relabel.MustNewRegexp("(.*)"),

```


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests to verify customer scrape configs & all unit tests are passing

```
make test
make fmt
make fmt-sh
make lint
```


# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



