### PR TITLE
Cluster name relabel conditional

### DIFF
--- a/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
@@ -180,11 +180,6 @@ receivers:
                       regex: (.*)
                       source_labels:
                         - __meta_ecs_cluster_name
-                      target_label: ClusterName
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
                       target_label: TaskClusterName
                     - action: replace
                       regex: (.*)
@@ -247,6 +242,10 @@ receivers:
                       source_labels:
                         - StartedBy
                       target_label: CustomStartedBy
+                    - action: replace
+                      separator: ;
+                      replacement: custom-ecs-cluster-name
+                      target_label: ClusterName
                   scheme: http
                   scrape_interval: 1m
                   scrape_protocols:
@@ -288,11 +287,6 @@ receivers:
                       regex: (.*)
                       source_labels:
                         - __meta_ecs_cluster_name
-                      target_label: ClusterName
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
                       target_label: TaskClusterName
                     - action: replace
                       regex: (.*)
@@ -355,6 +349,10 @@ receivers:
                       source_labels:
                         - StartedBy
                       target_label: CustomStartedBy
+                    - action: replace
+                      separator: ;
+                      replacement: custom-ecs-cluster-name
+                      target_label: ClusterName
                   scheme: http
                   scrape_interval: 1m
                   scrape_protocols:
@@ -396,11 +394,6 @@ receivers:
                       regex: (.*)
                       source_labels:
                         - __meta_ecs_cluster_name
-                      target_label: ClusterName
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
                       target_label: TaskClusterName
                     - action: replace
                       regex: (.*)
@@ -463,6 +456,10 @@ receivers:
                       source_labels:
                         - StartedBy
                       target_label: CustomStartedBy
+                    - action: replace
+                      separator: ;
+                      replacement: custom-ecs-cluster-name
+                      target_label: ClusterName
                   scheme: http
                   scrape_interval: 1m
                   scrape_protocols:

--- a/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
@@ -227,9 +227,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex:
+                      replacement: test-ecs-cluster-0123456789
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)
@@ -330,9 +329,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex:
+                      replacement: test-ecs-cluster-0123456789
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)
@@ -433,9 +431,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex: 
+                      replacement: test-ecs-cluster-0123456789
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)

--- a/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
@@ -227,10 +227,6 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex:
-                      replacement: test-ecs-cluster-0123456789
-                      target_label: ClusterName
-                    - action: replace
                       regex: (.*)
                       source_labels:
                         - __meta_ecs_cluster_name
@@ -290,6 +286,10 @@ receivers:
                       source_labels:
                         - __meta_ecs_container_labels_app_x
                       target_label: app_x
+                    - action: replace
+                      regex:
+                      replacement: test-ecs-cluster-0123456789
+                      target_label: ClusterName
                   sample_limit: 10000
                   scheme: http
                   scrape_interval: 5m
@@ -329,10 +329,6 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex:
-                      replacement: test-ecs-cluster-0123456789
-                      target_label: ClusterName
-                    - action: replace
                       regex: (.*)
                       source_labels:
                         - __meta_ecs_cluster_name
@@ -392,6 +388,10 @@ receivers:
                       source_labels:
                         - __meta_ecs_container_labels_app_x
                       target_label: app_x
+                    - action: replace
+                      regex:
+                      replacement: test-ecs-cluster-0123456789
+                      target_label: ClusterName
                   sample_limit: 10000
                   scheme: http
                   scrape_interval: 5m
@@ -431,10 +431,6 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: 
-                      replacement: test-ecs-cluster-0123456789
-                      target_label: ClusterName
-                    - action: replace
                       regex: (.*)
                       source_labels:
                         - __meta_ecs_cluster_name
@@ -494,6 +490,10 @@ receivers:
                       source_labels:
                         - __meta_ecs_container_labels_app_x
                       target_label: app_x
+                    - action: replace
+                      regex:
+                      replacement: test-ecs-cluster-0123456789
+                      target_label: ClusterName
                   sample_limit: 10000
                   scheme: http
                   scrape_interval: 5m

--- a/translator/tocwconfig/testdata/prometheus_customer_relabel.yaml
+++ b/translator/tocwconfig/testdata/prometheus_customer_relabel.yaml
@@ -1,8 +1,0 @@
-scrape_configs:
-  - job_name: test
-    file_sd_configs:
-      - files: ['/tmp/cwagent_ecs_auto_sd.yaml']
-    relabel_configs:
-      - action: replace
-        source_labels: [StartedBy]
-        target_label: CustomStartedBy

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -1003,6 +1003,7 @@ func verifyToYamlTranslation(t *testing.T, input interface{}, expectedYamlFilePa
 		require.NoError(t, err)
 		yamlStr := toyamlconfig.ToYamlConfig(yamlConfig)
 		require.NoError(t, yaml.Unmarshal([]byte(yamlStr), &actual))
+		// assert.NoError(t, os.WriteFile(expectedYamlFilePath, []byte(yamlStr), 0644)) // useful for regenerating YAML
 		opt := cmpopts.SortSlices(func(x, y interface{}) bool {
 			return pretty.Sprint(x) < pretty.Sprint(y)
 		})

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -560,6 +560,7 @@ func TestPrometheusEcsSdConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetMode(config.ModeEC2)
 	ecsutil.GetECSUtilSingleton().Region = "us-west-2"
+	ecsutil.GetECSUtilSingleton().Cluster = "test-ecs-cluster-0123456789"
 	testutil.SetPrometheusRemoteWriteTestingEnv(t)
 	t.Setenv(config.HOST_NAME, "host_name_from_env")
 	temp := t.TempDir()

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -1046,7 +1046,10 @@ scrape_configs:
     relabel_configs:
       - action: replace
         source_labels: [StartedBy]
-        target_label: CustomStartedBy`
+        target_label: CustomStartedBy
+      - action: replace
+        replacement: custom-ecs-cluster-name
+        target_label: ClusterName`
 
 	err := os.WriteFile(prometheusConfigFileName, []byte(testPrometheusConfig), os.ModePerm)
 	require.NoError(t, err)

--- a/translator/translate/otel/receiver/prometheus/translator.go
+++ b/translator/translate/otel/receiver/prometheus/translator.go
@@ -202,6 +202,7 @@ func addDefaultECSRelabelConfigs(scrapeConfigs []*config.ScrapeConfig, conf *con
 
 	for _, scrapeConfig := range scrapeConfigs {
 		for _, sdConfig := range scrapeConfig.ServiceDiscoveryConfigs {
+
 			if fileSDConfig, ok := sdConfig.(*file.SDConfig); ok {
 				for _, filePath := range fileSDConfig.Files {
 					if filePath == ecsSDFileName {
@@ -211,12 +212,13 @@ func addDefaultECSRelabelConfigs(scrapeConfigs []*config.ScrapeConfig, conf *con
 					}
 				}
 			}
+
 		}
 	}
 }
 
 /*
-Adds ClusterName relabelConfig if not already set by customer.
+addClusterNameRelabelConfig Adds ClusterName relabelConfig if not already set by customer.
 Customer can specify the clusterName in the scraping job's relabel_config
 CWAgent won't overwrite in this case to support cross-cluster monitoring
 */

--- a/translator/translate/otel/receiver/prometheus/translator_test.go
+++ b/translator/translate/otel/receiver/prometheus/translator_test.go
@@ -590,6 +590,19 @@ func TestAppendCustomerRelabelConfigs(t *testing.T) {
 }
 
 func validateRelabelFields(t *testing.T, scrapeConfigWithFileSD *config.ScrapeConfig, clusterNameValue string) {
+	assert.Equal(t, "TaskClusterName", scrapeConfigWithFileSD.RelabelConfigs[0].TargetLabel)
+	assert.Equal(t, "container_name", scrapeConfigWithFileSD.RelabelConfigs[1].TargetLabel)
+	assert.Equal(t, "LaunchType", scrapeConfigWithFileSD.RelabelConfigs[2].TargetLabel)
+	assert.Equal(t, "StartedBy", scrapeConfigWithFileSD.RelabelConfigs[3].TargetLabel)
+	assert.Equal(t, "TaskGroup", scrapeConfigWithFileSD.RelabelConfigs[4].TargetLabel)
+	assert.Equal(t, "TaskDefinitionFamily", scrapeConfigWithFileSD.RelabelConfigs[5].TargetLabel)
+	assert.Equal(t, "TaskRevision", scrapeConfigWithFileSD.RelabelConfigs[6].TargetLabel)
+	assert.Equal(t, "InstanceType", scrapeConfigWithFileSD.RelabelConfigs[7].TargetLabel)
+	assert.Equal(t, "SubnetId", scrapeConfigWithFileSD.RelabelConfigs[8].TargetLabel)
+	assert.Equal(t, "VpcId", scrapeConfigWithFileSD.RelabelConfigs[9].TargetLabel)
+	assert.Equal(t, "TaskId", scrapeConfigWithFileSD.RelabelConfigs[10].TargetLabel)
+	assert.Equal(t, "app_x", scrapeConfigWithFileSD.RelabelConfigs[11].TargetLabel)
+
 	// Find ClusterName config instead of assuming position
 	var clusterNameConfig *relabel.Config
 	for _, config := range scrapeConfigWithFileSD.RelabelConfigs {

--- a/translator/translate/otel/receiver/prometheus/translator_test.go
+++ b/translator/translate/otel/receiver/prometheus/translator_test.go
@@ -295,7 +295,9 @@ func TestMetricsEmfTranslator(t *testing.T) {
 }
 
 func TestAddDefaultECSRelabelConfigs_Success(t *testing.T) {
+	testClusterName := "my-test-cluster"
 	ecsutil.GetECSUtilSingleton().Region = "us-test-2"
+	ecsutil.GetECSUtilSingleton().Cluster = testClusterName
 
 	scrapeConfigs := []*config.ScrapeConfig{
 		{
@@ -349,13 +351,65 @@ func TestAddDefaultECSRelabelConfigs_Success(t *testing.T) {
 
 	// Should add configs because ecs_service_discovery is explicitly configured
 	assert.Len(t, scrapeConfigs[0].RelabelConfigs, 13, "Should add relabel configs when ecs_service_discovery is explicitly configured")
-	validateRelabelFields(t, scrapeConfigs[0])
+	validateRelabelFields(t, scrapeConfigs[0], testClusterName)
 	assert.Empty(t, scrapeConfigs[1].RelabelConfigs, "Other job should not have relabel configs")
 	assert.Len(t, scrapeConfigs[2].RelabelConfigs, 15, "Should prepend relabel configs when customer provides relabel configs ")
-	validateRelabelFields(t, scrapeConfigs[2])
+	validateRelabelFields(t, scrapeConfigs[2], testClusterName)
 }
 
-func TestDontAddDefaultRelabelConfigs_notECS(t *testing.T) {
+func TestAddDefaultECSRelabelConfigs_ClusterNameProvided(t *testing.T) {
+	customClusterName := "custom-cluster-name"
+	ecsutil.GetECSUtilSingleton().Region = "us-test-2"
+
+	scrapeConfigWithFileSD := &config.ScrapeConfig{
+		JobName: "test-scrape-configs-job",
+		ServiceDiscoveryConfigs: discovery.Configs{
+			&file.SDConfig{
+				Files: []string{defaultECSSDfileName},
+			},
+		},
+		RelabelConfigs: []*relabel.Config{
+			{
+				Action:       relabel.Replace,
+				SourceLabels: model.LabelNames{"StartedBy"},
+				TargetLabel:  "CustomStartedBy",
+				Regex:        relabel.MustNewRegexp("(.*)"),
+			},
+			{
+				Action:      relabel.Replace,
+				TargetLabel: "ClusterName",
+				Replacement: customClusterName,
+			},
+		},
+	}
+
+	scrapeConfigs := []*config.ScrapeConfig{scrapeConfigWithFileSD}
+
+	// ecs_service_discovery is configured
+	conf := confmap.NewFromStringMap(map[string]any{
+		"logs": map[string]any{
+			"metrics_collected": map[string]any{
+				"prometheus": map[string]any{
+					"prometheus_config_path": "env:PROMETHEUS_CONFIG_CONTENT",
+					"ecs_service_discovery": map[string]any{
+						"sd_frequency":   "50s",
+						"sd_result_file": defaultECSSDfileName,
+					},
+				},
+			},
+		},
+	})
+
+	configKey := "logs.metrics_collected.prometheus"
+
+	addDefaultECSRelabelConfigs(scrapeConfigs, conf, configKey)
+
+	// Should add configs because ecs_service_discovery is explicitly configured
+	assert.Len(t, scrapeConfigs[0].RelabelConfigs, 14, "Should add relabel configs when ecs_service_discovery is explicitly configured")
+	validateRelabelFields(t, scrapeConfigs[0], customClusterName)
+}
+
+func TestDoesNot_AddDefaultRelabelConfigs_notECS(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = ""
 
 	scrapeConfigWithFileSD := &config.ScrapeConfig{
@@ -391,7 +445,7 @@ func TestDontAddDefaultRelabelConfigs_notECS(t *testing.T) {
 	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 0, "ScrapeConfig should have no relabel configs when not in ECS")
 }
 
-func TestDontAddDefaultRelabelConfigs_noEcsSdConfig(t *testing.T) {
+func TestDoesNot_AddDefaultRelabelConfigs_noEcsSdConfig(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
 
 	scrapeConfigWithFileSD := &config.ScrapeConfig{
@@ -424,7 +478,7 @@ func TestDontAddDefaultRelabelConfigs_noEcsSdConfig(t *testing.T) {
 	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 0, "ScrapeConfig should have no relabel configs when ecs_service_discovery is not configured")
 }
 
-func TestDontAddDefaultRelabelConfigs_mismatchEcsSdResultFile(t *testing.T) {
+func TestDoesNot_AddDefaultRelabelConfigs_mismatchEcsSdResultFile(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
 
 	scrapeConfigWithFileSD := &config.ScrapeConfig{
@@ -461,7 +515,7 @@ func TestDontAddDefaultRelabelConfigs_mismatchEcsSdResultFile(t *testing.T) {
 	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 0, "ScrapeConfig should have no relabel configs when sd_result_file doesn't match")
 }
 
-func TestDontAddDefaultRelabelConfigs_emptyScrapeConfigs(t *testing.T) {
+func TestDoesNot_AddDefaultRelabelConfigs_emptyScrapeConfigs(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
 
 	scrapeConfigs := []*config.ScrapeConfig{}
@@ -489,6 +543,8 @@ func TestDontAddDefaultRelabelConfigs_emptyScrapeConfigs(t *testing.T) {
 }
 
 func TestAppendCustomerRelabelConfigs(t *testing.T) {
+	testClusterName := "my-ecs-cluster-name"
+	ecsutil.GetECSUtilSingleton().Cluster = testClusterName
 	ecsutil.GetECSUtilSingleton().Region = "us-east-1"
 
 	customerRelabelConfig := &relabel.Config{
@@ -526,27 +582,24 @@ func TestAppendCustomerRelabelConfigs(t *testing.T) {
 	addDefaultECSRelabelConfigs(scrapeConfigs, conf, configKey)
 
 	assert.Len(t, scrapeConfigWithFileSD.RelabelConfigs, 14, "Should have 13 default + 1 customer relabel config")
-	validateRelabelFields(t, scrapeConfigWithFileSD)
+	validateRelabelFields(t, scrapeConfigWithFileSD, testClusterName)
 
 	customerProvidedConfig := scrapeConfigWithFileSD.RelabelConfigs[13]
 	assert.Equal(t, "CustomStartedBy", customerProvidedConfig.TargetLabel)
 	assert.Equal(t, model.LabelNames{"StartedBy"}, customerProvidedConfig.SourceLabels)
 }
 
-func validateRelabelFields(t *testing.T, scrapeConfigWithFileSD *config.ScrapeConfig) {
-	assert.Equal(t, "ClusterName", scrapeConfigWithFileSD.RelabelConfigs[0].TargetLabel)
-	assert.Equal(t, "TaskClusterName", scrapeConfigWithFileSD.RelabelConfigs[1].TargetLabel)
-	assert.Equal(t, "container_name", scrapeConfigWithFileSD.RelabelConfigs[2].TargetLabel)
-	assert.Equal(t, "LaunchType", scrapeConfigWithFileSD.RelabelConfigs[3].TargetLabel)
-	assert.Equal(t, "StartedBy", scrapeConfigWithFileSD.RelabelConfigs[4].TargetLabel)
-	assert.Equal(t, "TaskGroup", scrapeConfigWithFileSD.RelabelConfigs[5].TargetLabel)
-	assert.Equal(t, "TaskDefinitionFamily", scrapeConfigWithFileSD.RelabelConfigs[6].TargetLabel)
-	assert.Equal(t, "TaskRevision", scrapeConfigWithFileSD.RelabelConfigs[7].TargetLabel)
-	assert.Equal(t, "InstanceType", scrapeConfigWithFileSD.RelabelConfigs[8].TargetLabel)
-	assert.Equal(t, "SubnetId", scrapeConfigWithFileSD.RelabelConfigs[9].TargetLabel)
-	assert.Equal(t, "VpcId", scrapeConfigWithFileSD.RelabelConfigs[10].TargetLabel)
-	assert.Equal(t, "TaskId", scrapeConfigWithFileSD.RelabelConfigs[11].TargetLabel)
-	assert.Equal(t, "app_x", scrapeConfigWithFileSD.RelabelConfigs[12].TargetLabel)
+func validateRelabelFields(t *testing.T, scrapeConfigWithFileSD *config.ScrapeConfig, clusterNameValue string) {
+	// Find ClusterName config instead of assuming position
+	var clusterNameConfig *relabel.Config
+	for _, config := range scrapeConfigWithFileSD.RelabelConfigs {
+		if config.TargetLabel == "ClusterName" {
+			clusterNameConfig = config
+			break
+		}
+	}
+	assert.NotNil(t, clusterNameConfig, "ClusterName relabel config should exist")
+	assert.Equal(t, clusterNameValue, clusterNameConfig.Replacement)
 }
 
 func TestEscapeStrings(t *testing.T) {


### PR DESCRIPTION
# Description of the issue
When a customer defines clusterName in their provided prometheus config, we should prefer that value and not overwrite it

See original logic: https://github.com/aws/amazon-cloudwatch-agent/blob/75b8144b453928aeced75e39e973d4816d9d9496/plugins/inputs/prometheus/metrics_handler.go#L68-L75 


# Description of changes
This change introduces a check for any customer relabel configs targeting "ClusterName" and prefers that. Otherwise it injects a default ClusterName based on the ecs metadata.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests, verified all tests pass
E2E testing to verify customer-provided ClusterName takes priority

```
make lint
make fmt
make fmt-sh
make test
```

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



