### PR TITLE
Revert "Bump Go (#1845)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-cloudwatch-agent
 
-go 1.25.0
+go 1.24.4
 
 replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20250113150713-a2dfaa4cdf6d
 


### PR DESCRIPTION
This reverts commit ed3141ea953caedee6fb7a3d574eb270ef5bfaae.

# Description of the issue
The Go bump PR didn't actually test anything because it pulled from the github cache and we're now running into issues. The linter we use is incomaptible with go1.25 and unit tests are regularly failing on windows-2022: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/17499483424/job/49712282164?pr=1849

# Description of changes
Reverting the commit. We will re-do the Go bump.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



