### PR TITLE
Fix relabelConfig duplication bug

### DIFF
--- a/translator/translate/otel/receiver/prometheus/translator.go
+++ b/translator/translate/otel/receiver/prometheus/translator.go
@@ -206,8 +206,9 @@ func addDefaultECSRelabelConfigs(scrapeConfigs []*config.ScrapeConfig, conf *con
 			if fileSDConfig, ok := sdConfig.(*file.SDConfig); ok {
 				for _, filePath := range fileSDConfig.Files {
 					if filePath == ecsSDFileName {
-						// Prepend defaultRelabelConfigs to customer configs for ecs_service_discovery. 
+						// Prepend defaultRelabelConfigs to customer configs for ecs_service_discovery.
 						scrapeConfig.RelabelConfigs = append(defaultRelabelConfigs, scrapeConfig.RelabelConfigs...)
+						break
 					}
 				}
 			}

--- a/translator/translate/otel/receiver/prometheus/translator_test.go
+++ b/translator/translate/otel/receiver/prometheus/translator_test.go
@@ -315,10 +315,10 @@ func TestAddDefaultECSRelabelConfigs_Success(t *testing.T) {
 			},
 		},
 		{
-			JobName: "ecs-job2",
+			JobName: "ecs-job-dont-duplicate-default-relabel-configs",
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&file.SDConfig{
-					Files: []string{defaultECSSDfileName},
+					Files: []string{defaultECSSDfileName, defaultECSSDfileName},
 				},
 			},
 			RelabelConfigs: []*relabel.Config{


### PR DESCRIPTION
# Description of the issue
Bugfix: relabelConfigs can be duplicated if filenames are provided repeatedly in a given scrapeConfig

# Description of changes
Only set defaultRelabelConfig once if a valid ECS SD filename is present in scrape config.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests updated & run

```
make test
make fmt
make fmt-sh
make lint
```

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



