### PR TITLE
Support labelmap relabel for ecs sd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver v0.0.0-20250814150312-af455c296233
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-20250814150312-af455c296233
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20250814150312-af455c296233
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250814150312-af455c296233
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903162352-e44b5cd1ef6d
 )
 
 // Temporary fix, pending PR https://github.com/shirou/gopsutil/pull/957

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver v0.0.0-20250814150312-af455c296233
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-20250814150312-af455c296233
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20250814150312-af455c296233
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903162352-e44b5cd1ef6d
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903144415-8d9305b72c38
 )
 
 // Temporary fix, pending PR https://github.com/shirou/gopsutil/pull/957

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayr
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-20250814150312-af455c296233/go.mod h1:74hHpQ6nCUSY4Diq81a6yrt1v82j6May2Yd0hv+quqY=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20250814150312-af455c296233 h1:oVNx6F2NRVUeLF2eFa0s2q18NtfvnLjJKMu4rCebKqw=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20250814150312-af455c296233/go.mod h1:PacmcX7JY00BzJeU2dEprhYzIA23HrZlPZmvse2cWN8=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250814150312-af455c296233 h1:nHaHVHwV57VGcqwz1DHfXQ0Hb3d9sOSh1+suGnm7keM=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250814150312-af455c296233/go.mod h1:10JuU241np104JVNq6YmBz1noDNt38gm01ftuEn1e+0=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903162352-e44b5cd1ef6d h1:A71aMfSrsNb/Ok1SuE8jgD+DuOAAP0/YEUyzhiC59oE=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903162352-e44b5cd1ef6d/go.mod h1:10JuU241np104JVNq6YmBz1noDNt38gm01ftuEn1e+0=
 github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9 h1:FXrPTd8Rdlc94dKccl7KPmdmIbVh/OjelJ8/vgMRzcQ=
 github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9/go.mod h1:eliMa/PW+RDr2QLWRmLH1R1ZA4RInpmvOzDDXtaIZkc=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayr
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-20250814150312-af455c296233/go.mod h1:74hHpQ6nCUSY4Diq81a6yrt1v82j6May2Yd0hv+quqY=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20250814150312-af455c296233 h1:oVNx6F2NRVUeLF2eFa0s2q18NtfvnLjJKMu4rCebKqw=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20250814150312-af455c296233/go.mod h1:PacmcX7JY00BzJeU2dEprhYzIA23HrZlPZmvse2cWN8=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903162352-e44b5cd1ef6d h1:A71aMfSrsNb/Ok1SuE8jgD+DuOAAP0/YEUyzhiC59oE=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903162352-e44b5cd1ef6d/go.mod h1:10JuU241np104JVNq6YmBz1noDNt38gm01ftuEn1e+0=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903144415-8d9305b72c38 h1:47ZoAPm3eAd6/xotsyT+3qlV8wGcCxtMuSGSysvRN8Y=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250903144415-8d9305b72c38/go.mod h1:10JuU241np104JVNq6YmBz1noDNt38gm01ftuEn1e+0=
 github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9 h1:FXrPTd8Rdlc94dKccl7KPmdmIbVh/OjelJ8/vgMRzcQ=
 github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9/go.mod h1:eliMa/PW+RDr2QLWRmLH1R1ZA4RInpmvOzDDXtaIZkc=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=

--- a/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
@@ -236,11 +236,9 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                          - __meta_ecs_container_labels_app_x
-                      target_label: app_x
+                    - action: labelmap
+                      regex: ^__meta_ecs_container_labels_(.+)$
+                      replacement: __capture_group_1__
                     - action: replace
                       replacement: $1
                       separator: ;
@@ -344,11 +342,9 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_container_labels_app_x
-                      target_label: app_x
+                    - action: labelmap
+                      regex: ^__meta_ecs_container_labels_(.+)$
+                      replacement: __capture_group_1__
                     - action: replace
                       replacement: $1
                       separator: ;
@@ -452,11 +448,9 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_container_labels_app_x
-                      target_label: app_x
+                    - action: labelmap
+                      regex: ^__meta_ecs_container_labels_(.+)$
+                      replacement: __capture_group_1__
                     - action: replace
                       replacement: $1
                       separator: ;

--- a/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
@@ -286,11 +286,9 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_container_labels_app_x
-                      target_label: app_x
+                    - action: labelmap
+                      regex: ^__meta_ecs_container_labels_(.+)$
+                      replacement: __capture_group_1__
                   sample_limit: 10000
                   scheme: http
                   scrape_interval: 5m
@@ -389,11 +387,9 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_container_labels_app_x
-                      target_label: app_x
+                    - action: labelmap
+                      regex: ^__meta_ecs_container_labels_(.+)$
+                      replacement: __capture_group_1__
                   sample_limit: 10000
                   scheme: http
                   scrape_interval: 5m
@@ -492,11 +488,9 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_container_labels_app_x
-                      target_label: app_x
+                    - action: labelmap
+                      regex: ^__meta_ecs_container_labels_(.+)$
+                      replacement: __capture_group_1__
                   sample_limit: 10000
                   scheme: http
                   scrape_interval: 5m

--- a/translator/translate/otel/receiver/prometheus/translator.go
+++ b/translator/translate/otel/receiver/prometheus/translator.go
@@ -198,7 +198,7 @@ func addDefaultECSRelabelConfigs(scrapeConfigs []*config.ScrapeConfig, conf *con
 		{SourceLabels: model.LabelNames{"__meta_ecs_ec2_subnet_id"}, Action: relabel.Replace, TargetLabel: "SubnetId", Regex: relabel.MustNewRegexp("(.*)")},
 		{SourceLabels: model.LabelNames{"__meta_ecs_ec2_vpc_id"}, Action: relabel.Replace, TargetLabel: "VpcId", Regex: relabel.MustNewRegexp("(.*)")},
 		{SourceLabels: model.LabelNames{"__meta_ecs_source"}, Regex: relabel.MustNewRegexp("^arn:aws:ecs:.*:.*:task.*\\/(.*)$"), Action: relabel.Replace, TargetLabel: "TaskId"},
-		{SourceLabels: model.LabelNames{"__meta_ecs_container_labels_app_x"}, Action: relabel.Replace, TargetLabel: "app_x", Regex: relabel.MustNewRegexp("(.*)")},
+		{Regex: relabel.MustNewRegexp("^__meta_ecs_container_labels_(.+)$"), Action: relabel.LabelMap, Replacement: prometheusreceiver.EscapedCaptureGroupOne},
 	}
 
 	for _, scrapeConfig := range scrapeConfigs {

--- a/translator/translate/otel/receiver/prometheus/translator_test.go
+++ b/translator/translate/otel/receiver/prometheus/translator_test.go
@@ -546,7 +546,8 @@ func validateRelabelFields(t *testing.T, scrapeConfigWithFileSD *config.ScrapeCo
 	assert.Equal(t, "SubnetId", scrapeConfigWithFileSD.RelabelConfigs[9].TargetLabel)
 	assert.Equal(t, "VpcId", scrapeConfigWithFileSD.RelabelConfigs[10].TargetLabel)
 	assert.Equal(t, "TaskId", scrapeConfigWithFileSD.RelabelConfigs[11].TargetLabel)
-	assert.Equal(t, "app_x", scrapeConfigWithFileSD.RelabelConfigs[12].TargetLabel)
+	assert.Equal(t, relabel.LabelMap, scrapeConfigWithFileSD.RelabelConfigs[12].Action)
+	assert.Equal(t, prometheusreceiver.EscapedCaptureGroupOne, scrapeConfigWithFileSD.RelabelConfigs[12].Replacement)
 }
 
 func TestEscapeStrings(t *testing.T) {


### PR DESCRIPTION
# Description of the issue
Support labelmap actions for ecs service discovery for all docker labels.

By default, ECS Observer will prefix all docker label config with `__meta_ecs_container_labels_` and therefore prometheus receiver will drop them. The Telegraf-based ecs_service_discovery feature captured docker labels without the prefix, preventing the prometheus receiver from dropping them. As a result, this change serves to loop through all dockerlabels captured by the otel-based ecs observer, and discard the prefix to restore parity with the telegraf-based ecs service discovery.

Ex: `__meta_ecs_container_labels_app_x` will be relabeled to `app_x`
Ex: `__meta_ecs_container_labels_ECS_PROMETHEUS_EXPORTER_PORT` will be relabeled to `ECS_PROMETHEUS_EXPORTER_PORT`

# Description of changes
Pulls in otel `prometheusreceiver.EscapedCaptureGroupOne` 
Validates the relabel config is added correctly
Removes explicit relabeling of `app_x` as that is an optional label, which is now relabeled vai the new labelmap action.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Validated with unit tests & Integration tests
```
make fmt
make fmt-sh
make lint
make test
```

Example metric from integration test run including change: (see captured `ECS_PROMETHEUS_EXPORTER_PORT` field
<img width="325" height="388" alt="Screenshot 2025-09-08 at 2 32 47 PM" src="https://github.com/user-attachments/assets/b5004544-820b-4fce-baa8-8e9dfd18b2e3" />

See example ecs_sd_resultfile.yaml contents that capture dockerlabels with prefix:
<img width="1215" height="346" alt="Screenshot 2025-09-08 at 2 45 23 PM" src="https://github.com/user-attachments/assets/b97f3623-de0c-4f97-9468-2d93c1d51ad3" />

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



