### PR TITLE
Drop Docker Job label when JobName configured for ecs_sd

### DIFF
--- a/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
@@ -286,12 +286,10 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      replacement: ""
+                    - action: drop
+                      regex: .*
                       source_labels:
                         - __meta_ecs_container_labels_job
-                      target_label: __meta_ecs_container_labels_job
                     - action: labelmap
                       regex: ^__meta_ecs_container_labels_(.+)$
                       replacement: __capture_group_1__
@@ -393,12 +391,10 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      replacement: ""
+                    - action: drop
+                      regex: .*
                       source_labels:
                         - __meta_ecs_container_labels_job
-                      target_label: __meta_ecs_container_labels_job
                     - action: labelmap
                       regex: ^__meta_ecs_container_labels_(.+)$
                       replacement: __capture_group_1__
@@ -500,12 +496,10 @@ receivers:
                       source_labels:
                         - __meta_ecs_source
                       target_label: TaskId
-                    - action: replace
-                      regex: (.*)
-                      replacement: ""
+                    - action: drop
+                      regex: .*
                       source_labels:
                         - __meta_ecs_container_labels_job
-                      target_label: __meta_ecs_container_labels_job
                     - action: labelmap
                       regex: ^__meta_ecs_container_labels_(.+)$
                       replacement: __capture_group_1__

--- a/translator/translate/otel/receiver/prometheus/translator_test.go
+++ b/translator/translate/otel/receiver/prometheus/translator_test.go
@@ -682,7 +682,8 @@ func validateRelabelFields(t *testing.T, scrapeConfigWithFileSD *config.ScrapeCo
 	assert.Equal(t, "TaskId", scrapeConfigWithFileSD.RelabelConfigs[11].TargetLabel)
 
 	if hasConfiguredJob {
-		assert.Equal(t, "__meta_ecs_container_labels_job", scrapeConfigWithFileSD.RelabelConfigs[12].TargetLabel)
+		assert.Equal(t, relabel.Drop, scrapeConfigWithFileSD.RelabelConfigs[12].Action)
+		assert.Equal(t, model.LabelNames{"__meta_ecs_container_labels_job"}, scrapeConfigWithFileSD.RelabelConfigs[12].SourceLabels)
 		assert.Equal(t, relabel.LabelMap, scrapeConfigWithFileSD.RelabelConfigs[13].Action)
 		assert.Equal(t, prometheusreceiver.EscapedCaptureGroupOne, scrapeConfigWithFileSD.RelabelConfigs[13].Replacement)
 	} else {


### PR DESCRIPTION
# Description of the issue
When a customer configures a JobName or a JobNameLabel, we should use that as the "job" label in the collected metrics. Currently a docker label of "job" will overwrite the configured JobName as its preserved by the labelmap relabel config. We should drop the docker__label of "job" if a JobName or JobNameLabel is explicitly configured. The final "job" label is appended by Prometheus Receiver

# Description of changes
Drop dockerlabel job if JobName or custom JobNameLabel is configured in ecs_service_discovery config.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Unit tests passing, and added specific scenarios

```
make fmt
make fmt-sh
make lint
make test
```

Integration tests also pass using sample config, verified custom JobName is captured in the metric (previously not)

<Pending add screenshot of integ test result>


# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



