### PR TITLE
[Fix] Added node_(gpu|efa|neuroncore)_request metric

### DIFF
--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
@@ -190,16 +190,19 @@ exporters:
                 - node_status_condition_unknown
                 - node_status_capacity_pods
                 - node_status_allocatable_pods
+                - node_gpu_request
                 - node_gpu_limit
                 - node_gpu_usage_total
                 - node_gpu_reserved_capacity
                 - node_gpu_unreserved_capacity
                 - node_gpu_available_capacity
+                - node_neuroncore_request
                 - node_neuroncore_limit
                 - node_neuroncore_usage_total
                 - node_neuroncore_reserved_capacity
                 - node_neuroncore_unreserved_capacity
                 - node_neuroncore_available_capacity
+                - node_efa_request
                 - node_efa_limit
                 - node_efa_usage_total
                 - node_efa_reserved_capacity

--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -156,9 +156,9 @@ func getNodeMetricDeclarations(conf *confmap.Conf) []*awsemfexporter.MetricDecla
 		"node_status_capacity_pods", "node_status_allocatable_pods",
 	}
 	if awscontainerinsight.AcceleratedComputeMetricsEnabled(conf) {
-		nodeMetrics = append(nodeMetrics, "node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity", "node_gpu_unreserved_capacity", "node_gpu_available_capacity")
-		nodeMetrics = append(nodeMetrics, "node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity", "node_neuroncore_available_capacity")
-		nodeMetrics = append(nodeMetrics, "node_efa_limit", "node_efa_usage_total", "node_efa_reserved_capacity", "node_efa_unreserved_capacity", "node_efa_available_capacity")
+		nodeMetrics = append(nodeMetrics, "node_gpu_request", "node_gpu_limit", "node_gpu_usage_total", "node_gpu_reserved_capacity", "node_gpu_unreserved_capacity", "node_gpu_available_capacity")
+		nodeMetrics = append(nodeMetrics, "node_neuroncore_request", "node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity", "node_neuroncore_available_capacity")
+		nodeMetrics = append(nodeMetrics, "node_efa_request", "node_efa_limit", "node_efa_usage_total", "node_efa_reserved_capacity", "node_efa_unreserved_capacity", "node_efa_available_capacity")
 	}
 	if enhancedContainerInsightsEnabled {
 		return []*awsemfexporter.MetricDeclaration{


### PR DESCRIPTION
This PR continues the work of my fellow noble and courageous intern @tudor-manea.
We were scraping already for the `node_(gpu|efa|neuroncore)_request` but somehow forgot to make the agent pick it up.
Link to IntegTests PR that made us realize: https://github.com/aws/amazon-cloudwatch-agent-test/pull/569