### PR TITLE
Bump minimum go version to 1.24.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-cloudwatch-agent
 
-go 1.24.4
+go 1.24.7
 
 replace github.com/influxdata/telegraf => github.com/aws/telegraf v0.10.2-0.20250113150713-a2dfaa4cdf6d
 


### PR DESCRIPTION
# Description of the issue
Go released a new minor version of 1.24 (https://go.dev/doc/devel/release#go1.24.minor). The previous revert of the Go bump was due to complications to 1.25 (https://github.com/aws/amazon-cloudwatch-agent/pull/1851) with the linter. As a minor version bump, this should not be impacted in the same way

# Description of changes
Updates the minimum go version for the build.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran `make fmt lint`.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



