### PR TITLE
Use InDelta for floating point comparisons for Histogram Unittest

### DIFF
--- a/plugins/outputs/cloudwatch/convert_otel_test.go
+++ b/plugins/outputs/cloudwatch/convert_otel_test.go
@@ -1003,7 +1003,7 @@ func TestConvertOtelExponentialHistogram(t *testing.T) {
 
 	// Since some of the values could be zero, we can't use InEpsilon (requires non-zero values to form relative error)
 	// We calculate the relative error directly and then use InDelta instead
-	const episilon = 0.0001
+	const epsilon = 0.0001
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(_ *testing.T) {
@@ -1011,17 +1011,17 @@ func TestConvertOtelExponentialHistogram(t *testing.T) {
 
 			assert.Equal(t, 1, len(dps))
 			for i, expectedDP := range tc.expected {
-				assert.InDelta(t, *expectedDP.StatisticValues.Maximum, dps[i].distribution.Maximum(), math.Abs(*expectedDP.StatisticValues.Maximum)*episilon, "datapoint Maximum mismatch at index %d", i)
-				assert.InDelta(t, *expectedDP.StatisticValues.Minimum, dps[i].distribution.Minimum(), math.Abs(*expectedDP.StatisticValues.Minimum)*episilon, "datapoint Minimum mismatch at index %d", i)
-				assert.InDelta(t, *expectedDP.StatisticValues.Sum, dps[i].distribution.Sum(), math.Abs(*expectedDP.StatisticValues.Sum)*episilon, "datapoint Sum mismatch at index %d", i)
+				assert.InDelta(t, *expectedDP.StatisticValues.Maximum, dps[i].distribution.Maximum(), math.Abs(*expectedDP.StatisticValues.Maximum)*epsilon, "datapoint Maximum mismatch at index %d", i)
+				assert.InDelta(t, *expectedDP.StatisticValues.Minimum, dps[i].distribution.Minimum(), math.Abs(*expectedDP.StatisticValues.Minimum)*epsilon, "datapoint Minimum mismatch at index %d", i)
+				assert.InDelta(t, *expectedDP.StatisticValues.Sum, dps[i].distribution.Sum(), math.Abs(*expectedDP.StatisticValues.Sum)*epsilon, "datapoint Sum mismatch at index %d", i)
 				assert.Equal(t, dps[i].distribution.SampleCount(), *expectedDP.StatisticValues.SampleCount, "datapoint Samplecount mismatch at index %d", i)
 
 				values, counts := dps[i].distribution.ValuesAndCounts()
 				for j, expectedValue := range tc.expectedValues[i] {
-					assert.InDelta(t, expectedValue, values[j], math.Abs(expectedValue)*episilon, "datapoint values mismatch at index %d, value %d", i, j)
+					assert.InDelta(t, expectedValue, values[j], math.Abs(expectedValue)*epsilon, "datapoint values mismatch at index %d, value %d", i, j)
 				}
 				for j, expectedCount := range tc.expectedCounts[i] {
-					assert.InDelta(t, expectedCount, counts[j], math.Abs(expectedCount)*episilon, "datapoint counts mismatch at index %d, count %d", i, j)
+					assert.InDelta(t, expectedCount, counts[j], math.Abs(expectedCount)*epsilon, "datapoint counts mismatch at index %d, count %d", i, j)
 				}
 			}
 		})


### PR DESCRIPTION
# Description of the issue
Unit tests for histograms are failing on some platforms because of floating point equality checks:
```
--- FAIL: TestConvertOtelExponentialHistogram (0.00s)
    convert_otel_test.go:1015:
            Error Trace:    /local/p4clients/pkgbuild-const/workspace/src/Go3p-Github-Aws-AmazonCloudwatchAgent/plugins/outputs/cloudwatch/convert_otel_test.go:1015
            Error:          Not equal:
                            expected: []float64{27.31370849898476, 19.31370849898476, 13.656854249492378, 9.656854249492378, 6.828427124746189, 4.82842712474619, 3.414213562373095, 2.414213562373095, 1.7071067811865475, 1.2071067811865475, 0, -1.2071067811865475, -1.7071067811865475, -2.414213562373095, -3.414213562373095, -4.82842712474619, -6.828427124746189, -9.656854249492378, -13.656854249492378, -19.31370849898476, -27.31370849898476}
                            actual  : []float64{27.31370849898476, 19.31370849898476, 13.65685424949238, 9.65685424949238, 6.828427124746189, 4.82842712474619, 3.414213562373095, 2.414213562373095, 1.7071067811865475, 1.2071067811865475, 0, -1.2071067811865475, -1.7071067811865475, -2.414213562373095, -3.414213562373095, -4.82842712474619, -6.828427124746189, -9.65685424949238, -13.65685424949238, -19.31370849898476, -27.31370849898476}
                            
                            Diff:
                            --- Expected
                            +++ Actual
                            @@ -3,4 +3,4 @@
                              (float64) 19.31370849898476,
                            - (float64) 13.656854249492378,
                            - (float64) 9.656854249492378,
                            + (float64) 13.65685424949238,
                            + (float64) 9.65685424949238,
                              (float64) 6.828427124746189,
                            @@ -18,4 +18,4 @@
                              (float64) -6.828427124746189,
                            - (float64) -9.656854249492378,
                            - (float64) -13.656854249492378,
                            + (float64) -9.65685424949238,
                            + (float64) -13.65685424949238,
                              (float64) -19.31370849898476,
            Test:           TestConvertOtelExponentialHistogram
            Messages:       datapoint values mismatch at index 0
```

# Description of changes
Use `assert.InDelta` instead of `assert.Equal` for offending floating point comparisons.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
`make test`

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



