### PR TITLE
Bump GH runner from macOS 13 to 15

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -78,14 +78,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2022, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-2022, windows-latest, macos-15]
         include:
           - os: ubuntu-latest
             family: linux
             cache-path: |
               ~/.cache/go-build
               ~/go/pkg/mod
-          - os: macos-13
+          - os: macos-15
             family: darwin
             cache-path: |
               ~/Library/Caches/go-build

--- a/.github/workflows/test-build-packages.yml
+++ b/.github/workflows/test-build-packages.yml
@@ -62,7 +62,7 @@ on:
 jobs:
   MakeMacPkg:
     name: 'MakeMacPkg'
-    runs-on: macos-13
+    runs-on: macos-15
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
# Description of the issue
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

tl;dr: macOS 13 will be retired in December and will have brownouts in November.

# Description of changes
Bump the runners that use macOS 13 to macOS 15

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
GitHub checks

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



