### PR TITLE
Ensure use_dualstack_endpoint rule is applied first 

### DIFF
--- a/translator/processRuleToApply.go
+++ b/translator/processRuleToApply.go
@@ -6,7 +6,19 @@ package translator
 // ProcessRuleToApply check if the specification configuration provide some configs that need translation with some rules
 // In json the default configuration should be like "cpu":{"per_cpu":false}
 func ProcessRuleToApply(input interface{}, childRule map[string]Rule, result map[string]interface{}) map[string]interface{} {
-	for _, rule := range childRule {
+	// Process use_dualstack_endpoint rule first if it exists to ensure dualstack endpoint is set
+	if rule, exists := childRule["use_dualstack_endpoint"]; exists {
+		key, val := rule.ApplyRule(input)
+		if key != "" {
+			result[key] = val
+		}
+	}
+
+	for ruleKey, rule := range childRule {
+		// Skip use_dualstack_endpoint as it has already been set
+		if ruleKey == "use_dualstack_endpoint" {
+			continue
+		}
 		key, val := rule.ApplyRule(input)
 		if key != "" {
 			result[key] = val


### PR DESCRIPTION
# Description

Currently, IPv6 is enabled by setting an environment variable for the dualstack endpoint. This is applied during agent translation when all agent child rules are processed. If the agent child rule `use_dualstack_endpoint` is set to true, we set the environment variable. However, if a future child rule in the agent section requires the dualstack endpoint but is applied before the environment variable is set, the agent will fail to start. To prevent this, we need to ensure that the `use_dualstack_endpoint` rule is applied first.

# Description of changes

This PR future-proofs the dualstack endpoint translation by ensuring that the environment variable for the agent is set as the first child rule. This guarantees that the agent will use the dualstack endpoint for all subsequent child rules.
