### PR TITLE
Add tests for Prometheus ClusterName

### DIFF
--- a/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
@@ -177,9 +177,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex:
+                      replacement: myTestCluster
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)
@@ -245,6 +244,10 @@ receivers:
                       source_labels:
                         - StartedBy
                       target_label: CustomStartedBy
+                    - action: replace
+                      replacement: custom-ecs-cluster-name
+                      separator: ;
+                      target_label: ClusterName
                   scheme: http
                   scrape_interval: 1m
                   scrape_protocols:
@@ -283,9 +286,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex: 
+                      replacement: myTestCluster
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)
@@ -351,6 +353,10 @@ receivers:
                       source_labels:
                         - StartedBy
                       target_label: CustomStartedBy
+                    - action: replace
+                      replacement: custom-ecs-cluster-name
+                      separator: ;
+                      target_label: ClusterName
                   scheme: http
                   scrape_interval: 1m
                   scrape_protocols:
@@ -389,9 +395,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex:
+                      replacement: myTestCluster
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)
@@ -457,6 +462,10 @@ receivers:
                       source_labels:
                         - StartedBy
                       target_label: CustomStartedBy
+                    - action: replace
+                      replacement: custom-ecs-cluster-name
+                      separator: ;
+                      target_label: ClusterName
                   scheme: http
                   scrape_interval: 1m
                   scrape_protocols:

--- a/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_customer_relabel_config_linux.yaml
@@ -177,7 +177,7 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex:
+                      regex: (.*)
                       replacement: myTestCluster
                       target_label: ClusterName
                     - action: replace
@@ -286,7 +286,7 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: 
+                      regex: (.*)
                       replacement: myTestCluster
                       target_label: ClusterName
                     - action: replace
@@ -395,7 +395,7 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex:
+                      regex: (.*)
                       replacement: myTestCluster
                       target_label: ClusterName
                     - action: replace

--- a/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
@@ -227,9 +227,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex:
+                      replacement: test-ecs-cluster-0123456789
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)
@@ -332,9 +331,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex:
+                      replacement: test-ecs-cluster-0123456789
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)
@@ -437,9 +435,8 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex: (.*)
-                      source_labels:
-                        - __meta_ecs_cluster_name
+                      regex:
+                      replacement: TestCluster
                       target_label: ClusterName
                     - action: replace
                       regex: (.*)

--- a/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_ecs_sd_config_linux.yaml
@@ -227,7 +227,7 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex:
+                      regex: (.*)
                       replacement: test-ecs-cluster-0123456789
                       target_label: ClusterName
                     - action: replace
@@ -331,7 +331,7 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex:
+                      regex: (.*)
                       replacement: test-ecs-cluster-0123456789
                       target_label: ClusterName
                     - action: replace
@@ -435,7 +435,7 @@ receivers:
                   metrics_path: /metrics
                   relabel_configs:
                     - action: replace
-                      regex:
+                      regex: (.*)
                       replacement: TestCluster
                       target_label: ClusterName
                     - action: replace

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -560,6 +560,7 @@ func TestPrometheusEcsSdConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetMode(config.ModeEC2)
 	ecsutil.GetECSUtilSingleton().Region = "us-west-2"
+	ecsutil.GetECSUtilSingleton().Cluster = "test-ecs-cluster-0123456789"
 	testutil.SetPrometheusRemoteWriteTestingEnv(t)
 	t.Setenv(config.HOST_NAME, "host_name_from_env")
 	temp := t.TempDir()
@@ -1002,6 +1003,7 @@ func verifyToYamlTranslation(t *testing.T, input interface{}, expectedYamlFilePa
 		require.NoError(t, err)
 		yamlStr := toyamlconfig.ToYamlConfig(yamlConfig)
 		require.NoError(t, yaml.Unmarshal([]byte(yamlStr), &actual))
+		// assert.NoError(t, os.WriteFile(expectedYamlFilePath, []byte(yamlStr), 0644)) // useful for regenerating YAML
 		opt := cmpopts.SortSlices(func(x, y interface{}) bool {
 			return pretty.Sprint(x) < pretty.Sprint(y)
 		})
@@ -1045,7 +1047,10 @@ scrape_configs:
     relabel_configs:
       - action: replace
         source_labels: [StartedBy]
-        target_label: CustomStartedBy`
+        target_label: CustomStartedBy
+      - action: replace
+        replacement: custom-ecs-cluster-name
+        target_label: ClusterName`
 
 	err := os.WriteFile(prometheusConfigFileName, []byte(testPrometheusConfig), os.ModePerm)
 	require.NoError(t, err)

--- a/translator/translate/otel/receiver/prometheus/translator.go
+++ b/translator/translate/otel/receiver/prometheus/translator.go
@@ -19,8 +19,9 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"gopkg.in/yaml.v3"
 
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
-	"github.com/aws/amazon-cloudwatch-agent/translator/util"
+	translatorutil "github.com/aws/amazon-cloudwatch-agent/translator/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
 
@@ -81,7 +82,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	}
 
 	configPath, _ := common.GetString(conf, configPathKey)
-	processedConfigPath, err := util.GetConfigPath("prometheus.yaml", configPathKey, configPath, nil)
+	processedConfigPath, err := translatorutil.GetConfigPath("prometheus.yaml", configPathKey, configPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to process prometheus config with given config: %w", err)
 	}
@@ -172,30 +173,6 @@ func escapeStrings(node any) {
 	}
 }
 
-func getClusterNameFromConfig(conf *confmap.Conf, promConfigKey string) string {
-	// Check if cluster_name is set in prometheus config
-	clusterNameKey := common.ConfigKey(promConfigKey, common.ClusterNameKey)
-	if conf.IsSet(clusterNameKey) {
-		if clusterName, ok := conf.Get(clusterNameKey).(string); ok && clusterName != "" {
-			return clusterName
-		}
-	}
-
-	// Check environment variable
-	if envClusterName := os.Getenv("K8S_CLUSTER_NAME"); envClusterName != "" {
-		return envClusterName
-	}
-
-	// Try ECS metadata auto-detection
-	if ecsutil.GetECSUtilSingleton().IsECS() {
-		if ecsCluster := ecsutil.GetECSUtilSingleton().Cluster; ecsCluster != "" {
-			return ecsCluster
-		}
-	}
-
-	return ""
-}
-
 func addDefaultECSRelabelConfigs(scrapeConfigs []*config.ScrapeConfig, conf *confmap.Conf, promConfigKey string) {
 	// ECS Service Discovery Relabel Configs should only be added if enabled on ECS and configs are valid:
 	if !ecsutil.GetECSUtilSingleton().IsECS() || !conf.IsSet(ecsSDKey) || len(scrapeConfigs) == 0 {
@@ -239,6 +216,31 @@ func addDefaultECSRelabelConfigs(scrapeConfigs []*config.ScrapeConfig, conf *con
 			}
 		}
 	}
+}
+
+func getClusterNameFromConfig(conf *confmap.Conf, promConfigKey string) string {
+	// Get the prometheus config section
+	var prometheusConfig map[string]interface{}
+	prometheusConfig = make(map[string]interface{})
+	if conf.IsSet(promConfigKey) {
+		if promConfig := conf.Get(promConfigKey); promConfig != nil {
+			if promConfigMap, ok := promConfig.(map[string]interface{}); ok {
+				prometheusConfig = promConfigMap
+			}
+		}
+	}
+
+	const clusterNameSectionKey = "cluster_name"
+
+	// Try EKS cluster name first (matches original ruleClusterName logic)
+	clusterName := util.GetEKSClusterName(clusterNameSectionKey, prometheusConfig)
+
+	if clusterName == "" {
+		// Try ECS cluster name if EKS returns empty
+		clusterName = util.GetECSClusterName(clusterNameSectionKey, prometheusConfig)
+	}
+	
+	return clusterName
 }
 
 func appendDockerLabelRelabelConfigs(conf *confmap.Conf, defaultRelabelConfigs []*relabel.Config) []*relabel.Config {

--- a/translator/translate/otel/receiver/prometheus/translator_test.go
+++ b/translator/translate/otel/receiver/prometheus/translator_test.go
@@ -708,7 +708,8 @@ func TestGetClusterNameFromConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "test-cluster-from-config",
+			ecsCluster: "my-test-cluster",
+			expected:   "test-cluster-from-config", // clusterName from Config is highest priority
 		},
 		"cluster_name_from_ecs": {
 			input: map[string]any{
@@ -719,7 +720,7 @@ func TestGetClusterNameFromConfig(t *testing.T) {
 				},
 			},
 			ecsCluster: "my-test-cluster",
-			expected:   "my-test-cluster",
+			expected:   "my-test-cluster", // clusterName from ECS Metadata is fallback when not configured in json
 		},
 		"empty_cluster_name": {
 			input: map[string]any{


### PR DESCRIPTION
# Description of the issue
Adding tests for prometheus clusterName readin

# Description of changes
This validates the correct clusterName is read in when configured multiple ways. 
Also leverages the existing code in the ecs and eks utils, rather than using new custom code.


# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Introduced translator unit testing and config translation testing
```
make test
make lint
make fmt
make fmt-sh
```

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



