### PR TITLE
Add optional usage metadata

### DIFF
--- a/extension/agenthealth/config.go
+++ b/extension/agenthealth/config.go
@@ -4,15 +4,28 @@
 package agenthealth
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/handler/stats/agent"
+	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth/metadata"
 )
 
 type Config struct {
-	IsUsageDataEnabled  bool               `mapstructure:"is_usage_data_enabled"`
-	Stats               *agent.StatsConfig `mapstructure:"stats,omitempty"`
-	IsStatusCodeEnabled bool               `mapstructure:"is_status_code_enabled,omitempty"`
+	IsUsageDataEnabled  bool                `mapstructure:"is_usage_data_enabled"`
+	Stats               *agent.StatsConfig  `mapstructure:"stats,omitempty"`
+	IsStatusCodeEnabled bool                `mapstructure:"is_status_code_enabled,omitempty"`
+	UsageMetadata       []metadata.Metadata `mapstructure:"usage_metadata,omitempty"`
 }
 
 var _ component.Config = (*Config)(nil)
+
+func (c *Config) Validate() error {
+	for _, m := range c.UsageMetadata {
+		if !metadata.IsSupported(m) {
+			return fmt.Errorf("usage metadata %q is not supported", m)
+		}
+	}
+	return nil
+}

--- a/extension/agenthealth/extension.go
+++ b/extension/agenthealth/extension.go
@@ -31,6 +31,7 @@ func (ah *agentHealth) Handlers() ([]awsmiddleware.RequestHandler, []awsmiddlewa
 		return requestHandlers, responseHandlers
 	}
 
+	useragent.Get().AddFeatureFlags(ah.cfg.UsageMetadata...)
 	statusCodeEnabled := ah.cfg.IsStatusCodeEnabled
 
 	var statsResponseHandlers []awsmiddleware.ResponseHandler

--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -38,6 +38,7 @@ const (
 	typeInputs     = "inputs"
 	typeProcessors = "processors"
 	typeOutputs    = "outputs"
+	typeFeature    = "feature"
 )
 
 var (
@@ -48,8 +49,10 @@ var (
 type UserAgent interface {
 	SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegraf.Config)
 	SetContainerInsightsFlag()
+	AddFeatureFlags(features ...string)
 	Header(isUsageDataEnabled bool) string
 	Listen(listener func())
+	Reset()
 }
 
 type userAgent struct {
@@ -63,15 +66,19 @@ type userAgent struct {
 	inputs     collections.Set[string]
 	processors collections.Set[string]
 	outputs    collections.Set[string]
+	feature    collections.Set[string]
 
 	inputsStr     atomic.String
 	processorsStr atomic.String
 	outputsStr    atomic.String
+	featureStr    atomic.String
 }
 
 var _ UserAgent = (*userAgent)(nil)
 
 func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegraf.Config) {
+	ua.dataLock.Lock()
+	defer ua.dataLock.Unlock()
 	for _, input := range telegrafCfg.Inputs {
 		ua.inputs.Add(input.Config.Name)
 	}
@@ -145,6 +152,37 @@ func (ua *userAgent) SetContainerInsightsFlag() {
 	}
 }
 
+func (ua *userAgent) AddFeatureFlags(features ...string) {
+	ua.dataLock.Lock()
+	defer ua.dataLock.Unlock()
+	featureCount := len(ua.feature)
+	for _, feature := range features {
+		if feature != "" {
+			ua.feature.Add(feature)
+		}
+	}
+	if len(ua.feature) > featureCount {
+		ua.featureStr.Store(componentsStr(typeFeature, ua.feature))
+		ua.notify()
+	}
+}
+
+// Reset allows tests to reset the user agent.
+func (ua *userAgent) Reset() {
+	ua.dataLock.Lock()
+	defer ua.dataLock.Unlock()
+	ua.inputs = collections.NewSet[string]()
+	ua.processors = collections.NewSet[string]()
+	ua.outputs = collections.NewSet[string]()
+	ua.feature = collections.NewSet[string]()
+
+	ua.inputsStr.Store("")
+	ua.processorsStr.Store("")
+	ua.outputsStr.Store("")
+	ua.featureStr.Store("")
+	ua.notify()
+}
+
 func (ua *userAgent) Listen(listener func()) {
 	ua.listenerLock.Lock()
 	defer ua.listenerLock.Unlock()
@@ -180,6 +218,10 @@ func (ua *userAgent) Header(isUsageDataEnabled bool) string {
 	if outputs != "" {
 		components = append(components, outputs)
 	}
+	feature := ua.featureStr.Load()
+	if feature != "" {
+		components = append(components, feature)
+	}
 
 	return strings.TrimSpace(fmt.Sprintf("%s ID/%s %s", version.Full(), ua.id, strings.Join(components, separator)))
 }
@@ -204,6 +246,7 @@ func newUserAgent() *userAgent {
 		inputs:     collections.NewSet[string](),
 		processors: collections.NewSet[string](),
 		outputs:    collections.NewSet[string](),
+		feature:    collections.NewSet[string](),
 	}
 }
 

--- a/extension/agenthealth/metadata/metadata.go
+++ b/extension/agenthealth/metadata/metadata.go
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package metadata
+
+import (
+	"strings"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/util/collections"
+)
+
+type Metadata = string
+
+const (
+	KeyObservabilitySolutions = "ObservabilitySolution"
+	ValueEC2Health            = "ec2_health"
+	ValueJVM                  = "jvm"
+	ValueTomcat               = "tomcat"
+	ValueKafkaBroker          = "kafka_broker"
+	ValueNVIDIA               = "nvidia_gpu"
+
+	shortKeyObservabilitySolutions = "obs"
+	separator                      = "_"
+)
+
+var (
+	supportedMetadata = collections.NewSet(
+		Build(KeyObservabilitySolutions, ValueEC2Health),
+		Build(KeyObservabilitySolutions, ValueJVM),
+		Build(KeyObservabilitySolutions, ValueTomcat),
+		Build(KeyObservabilitySolutions, ValueKafkaBroker),
+		Build(KeyObservabilitySolutions, ValueNVIDIA),
+	)
+	shortKeyMapping = map[string]string{
+		strings.ToLower(KeyObservabilitySolutions): shortKeyObservabilitySolutions,
+	}
+)
+
+func IsSupported(m Metadata) bool {
+	return supportedMetadata.Contains(m)
+}
+
+// Build finds any short key mappings and then adds them to the value.
+func Build(key, value string) Metadata {
+	key = strings.ToLower(key)
+	if shortKey, ok := shortKeyMapping[key]; ok {
+		key = shortKey
+	}
+	return key + separator + strings.ToLower(value)
+}

--- a/extension/agenthealth/metadata/metadata_test.go
+++ b/extension/agenthealth/metadata/metadata_test.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuild(t *testing.T) {
+	testCases := []struct {
+		key   string
+		value string
+		want  string
+	}{
+		{key: "ObservabilitySolution", value: "ec2_health", want: "obs_ec2_health"},
+		{key: "ObservabilitySolution", value: "JVM", want: "obs_jvm"},
+		{key: "OBSERVABILITYSOLUTION", value: "TOMCAT", want: "obs_tomcat"},
+		{key: "observabilitysolution", value: "kafka_broker", want: "obs_kafka_broker"},
+		{key: "ObservabilitySolution", value: "NVIDIA_GPU", want: "obs_nvidia_gpu"},
+		{key: "unsupported", value: "Value", want: "unsupported_value"},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.want, Build(testCase.key, testCase.value))
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	testCases := []struct {
+		input string
+		want  bool
+	}{
+		{input: "obs_jvm", want: true},
+		{input: "obs_tomcat", want: true},
+		{input: "obs_kafka_broker", want: true},
+		{input: "obs_nvidia_gpu", want: true},
+		{input: "obs_ec2_health", want: true},
+		{input: "unsupported_value", want: false},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.want, IsSupported(testCase.input))
+	}
+}

--- a/extension/agenthealth/testdata/config.yaml
+++ b/extension/agenthealth/testdata/config.yaml
@@ -6,3 +6,8 @@ agenthealth/2:
   stats:
     operations:
       - 'ListBuckets'
+agenthealth/3:
+  is_usage_data_enabled: true
+  usage_metadata:
+    - 'obs_jvm'
+    - 'obs_tomcat'

--- a/translator/translate/agent/ruleUsageMetadata.go
+++ b/translator/translate/agent/ruleUsageMetadata.go
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"github.com/aws/amazon-cloudwatch-agent/translator/jsonconfig/mergeJsonRule"
+	"github.com/aws/amazon-cloudwatch-agent/translator/jsonconfig/mergeJsonUtil"
+)
+
+type ruleUsageMetadata struct {
+}
+
+const sectionKeyUsageMetadata = "usage_metadata"
+
+var _ mergeJsonRule.MergeRule = (*ruleUsageMetadata)(nil)
+
+func (r *ruleUsageMetadata) Merge(source map[string]any, result map[string]any) {
+	mergeJsonUtil.MergeList(source, result, sectionKeyUsageMetadata)
+}
+
+func init() {
+	r := new(ruleUsageMetadata)
+	MergeRuleMap[sectionKeyUsageMetadata] = r
+}

--- a/translator/translate/agent/testdata/config1.json
+++ b/translator/translate/agent/testdata/config1.json
@@ -1,0 +1,8 @@
+{
+  "agent": {
+    "debug": true,
+    "usage_metadata": [
+      {"ObservabilitySolution": "JVM"}
+    ]
+  }
+}

--- a/translator/translate/agent/testdata/config2.json
+++ b/translator/translate/agent/testdata/config2.json
@@ -1,0 +1,8 @@
+{
+  "agent": {
+    "usage_metadata": [
+      {"ObservabilitySolution": "TOMCAT"},
+      {"ObservabilitySolution": "EC2_HEALTH"}
+    ]
+  }
+}

--- a/translator/translate/agent/testdata/config3.json
+++ b/translator/translate/agent/testdata/config3.json
@@ -1,0 +1,8 @@
+{
+  "agent": {
+    "omit_hostname": false,
+    "usage_metadata": [
+      {"ObservabilitySolution": "TOMCAT"}
+    ]
+  }
+}

--- a/translator/translate/otel/extension/agenthealth/testdata/config.json
+++ b/translator/translate/otel/extension/agenthealth/testdata/config.json
@@ -1,0 +1,7 @@
+{
+  "agent": {
+    "usage_metadata": [
+      {"ObservabilitySolution": "JVM"}
+    ]
+  }
+}


### PR DESCRIPTION
# Description of changes
Adds support for a `usage_metadata` field in the `agent` section of the configuration. The agent supports a fixed list of metadata values and the translator will filter out any unsupported ones. If the agent is started using the YAML directly, the configuration will also fail at startup.

```json
{
  "agent": {
    "usage_metadata": [
      {"ObservabilitySolution": "JVM"},
      {"ObservabilitySolution": "TOMCAT"}
    ]
  }
}
```
will get translated as part of the `agenthealth` extension into
```yaml
agenthealth:
  usage_metadata:
    - 'obs_jvm'
    - 'obs_tomcat'
```

Notes: 
- The `agent` section of the schema.json already allows `additionalProperties`
https://github.com/aws/amazon-cloudwatch-agent/blob/95fbd164cc3491acffafa1cd17c461869cd5cf06/translator/config/schema.json#L69 
which makes it so older versions of the agent will ignore the `usage_metadata` field.
- The section in the user agent has been retained as `feature` instead of the plural `features` like the other sections due to the pre-existing naming and parsing.
- Replaces the `cloudwatch` exporter `FeatureUserAgent`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests.

With `LogDebug` enabled and including the configuration above,
```
2025-10-15T23:55:24Z I! DEBUG: Request monitoring/PutMetricData Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: monitoring.us-east-1.amazonaws.com
User-Agent: CWAgent/1.300060.0-14-g546478f1b (go1.24.7; linux; amd64) ID/7247bf36-7269-4dff-82d5-2e869cd24a63 inputs:(cpu) processors:(awsentity) outputs:(awscloudwatch cloudwatch) feature:(obs_jvm obs_tomcat) aws-sdk-go/1.48.6 (go1.24.7; linux; amd64)
```

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`