### PR TITLE
Adding ipv6 to useragent

### DIFF
--- a/extension/agenthealth/handler/useragent/useragent.go
+++ b/extension/agenthealth/handler/useragent/useragent.go
@@ -141,9 +141,15 @@ func (ua *userAgent) SetComponents(otelCfg *otelcol.Config, telegrafCfg *telegra
 		ua.inputs.Add(flagRunAsUser)
 	}
 
+	// Add ipv6 feature flag if dualstack endpoint is enabled
+	if os.Getenv(envconfig.AWS_USE_DUALSTACK_ENDPOINT) == "true" {
+		ua.feature.Add("ipv6")
+	}
+
 	ua.inputsStr.Store(componentsStr(typeInputs, ua.inputs))
 	ua.processorsStr.Store(componentsStr(typeProcessors, ua.processors))
 	ua.outputsStr.Store(componentsStr(typeOutputs, ua.outputs))
+	ua.featureStr.Store(componentsStr(typeFeature, ua.feature))
 	ua.notify()
 }
 


### PR DESCRIPTION
# Description of the issue
Adding ipv6 to customer useragent. The agent set's `AWS_USE_DUALSTACK_ENDPOINT` to true if `use_dualstack_endpoint` is passed into the agent configuration and set to true. Having AWS_USE_DUALSTACK_ENDPOINT to true makes it so that all sdk calls make dualstack endpoint calls which makes the agent work on ipv6 environments. 

# Description of changes
Adding a check to see if the AWS_USE_DUALSTACK_ENDPOINT exist and if so we'll add ipv6 as part of feature flag for it to get parsed.


### Tested change - Useragent string has ipv6
<img width="1792" height="47" alt="Screenshot 2025-10-30 at 4 45 45 PM" src="https://github.com/user-attachments/assets/bdd535ca-9a87-4f2c-91e3-0acaba5e398d" />

