### PR TITLE
Revert "Address goroutine leak with dynamically determined log destin…"

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -65,13 +65,13 @@ type LogBackend interface {
 // e.g. a particular log stream in cloudwatchlogs.
 type LogDest interface {
 	Publish(events []LogEvent) error
-	NotifySourceStopped()
 }
 
 // LogAgent is the agent handles pure log pipelines
 type LogAgent struct {
 	Config                    *config.Config
 	backends                  map[string]LogBackend
+	destNames                 map[LogDest]string
 	collections               []LogCollection
 	retentionAlreadyAttempted map[string]bool
 }
@@ -80,6 +80,7 @@ func NewLogAgent(c *config.Config) *LogAgent {
 	return &LogAgent{
 		Config:                    c,
 		backends:                  make(map[string]LogBackend),
+		destNames:                 make(map[LogDest]string),
 		retentionAlreadyAttempted: make(map[string]bool),
 	}
 }
@@ -135,6 +136,7 @@ func (l *LogAgent) Run(ctx context.Context) {
 					}
 					retention = l.checkRetentionAlreadyAttempted(retention, logGroup)
 					dest := backend.CreateDest(logGroup, logStream, retention, logGroupClass, src)
+					l.destNames[dest] = dname
 					log.Printf("I! [logagent] piping log from %s/%s(%s) to %s with retention %d", logGroup, logStream, description, dname, retention)
 					go l.runSrcToDest(src, dest)
 				}
@@ -146,10 +148,8 @@ func (l *LogAgent) Run(ctx context.Context) {
 }
 
 func (l *LogAgent) runSrcToDest(src LogSrc, dest LogDest) {
-
 	eventsCh := make(chan LogEvent)
 	defer src.Stop()
-	defer dest.NotifySourceStopped()
 
 	closed := false
 	src.SetOutput(func(e LogEvent) {
@@ -168,11 +168,11 @@ func (l *LogAgent) runSrcToDest(src LogSrc, dest LogDest) {
 	for e := range eventsCh {
 		err := dest.Publish([]LogEvent{e})
 		if err == ErrOutputStopped {
-			log.Printf("I! [logagent] Log destination %v has stopped, finalizing %v/%v", src.Destination(), src.Group(), src.Stream())
+			log.Printf("I! [logagent] Log destination %v has stopped, finalizing %v/%v", l.destNames[dest], src.Group(), src.Stream())
 			return
 		}
 		if err != nil {
-			log.Printf("E! [logagent] Failed to publish log to %v, error: %v", src.Destination(), err)
+			log.Printf("E! [logagent] Failed to publish log to %v, error: %v", l.destNames[dest], err)
 			return
 		}
 	}

--- a/plugins/inputs/logfile/logfile.go
+++ b/plugins/inputs/logfile/logfile.go
@@ -41,9 +41,8 @@ type LogFile struct {
 	started           bool
 }
 
-var _ logs.LogCollection = (*LogFile)(nil)
-
 func NewLogFile() *LogFile {
+
 	return &LogFile{
 		configs:           make(map[*FileConfig]map[string]*tailerSrc),
 		done:              make(chan struct{}),
@@ -250,6 +249,11 @@ func (t *LogFile) FindLogSrc() []logs.LogSrc {
 				} else {
 					streamName = generateLogStreamName(filename, fileconfig.LogStreamName)
 				}
+			}
+
+			destination := fileconfig.Destination
+			if destination == "" {
+				destination = t.Destination
 			}
 
 			src := NewTailerSrc(

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -4,6 +4,7 @@
 package cloudwatchlogs
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/logs"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatchlogs/internal/pusher"
 	"github.com/aws/amazon-cloudwatch-agent/sdk/service/cloudwatchlogs"
+	"github.com/aws/amazon-cloudwatch-agent/tool/util"
 )
 
 const (
@@ -38,7 +40,10 @@ const (
 
 	defaultFlushTimeout = 5 * time.Second
 
-	maxRetryTimeout = 14*24*time.Hour + 10*time.Minute
+	maxRetryTimeout    = 14*24*time.Hour + 10*time.Minute
+	metricRetryTimeout = 2 * time.Minute
+
+	attributesInFields = "attributesInFields"
 )
 
 var (
@@ -69,24 +74,22 @@ type CloudWatchLogs struct {
 
 	Log telegraf.Logger `toml:"-"`
 
+	pusherStopChan  chan struct{}
 	pusherWaitGroup sync.WaitGroup
 	cwDests         sync.Map
 	workerPool      pusher.WorkerPool
 	targetManager   pusher.TargetManager
 	once            sync.Once
 	middleware      awsmiddleware.Middleware
-	configurer      *awsmiddleware.Configurer
-	configurerOnce  sync.Once
 }
-
-var _ logs.LogBackend = (*CloudWatchLogs)(nil)
-var _ telegraf.Output = (*CloudWatchLogs)(nil)
 
 func (c *CloudWatchLogs) Connect() error {
 	return nil
 }
 
 func (c *CloudWatchLogs) Close() error {
+	close(c.pusherStopChan)
+	c.pusherWaitGroup.Wait()
 
 	c.cwDests.Range(func(_, value interface{}) bool {
 		if d, ok := value.(*cwDest); ok {
@@ -94,8 +97,6 @@ func (c *CloudWatchLogs) Close() error {
 		}
 		return true
 	})
-
-	c.pusherWaitGroup.Wait()
 
 	if c.workerPool != nil {
 		c.workerPool.Stop()
@@ -105,8 +106,10 @@ func (c *CloudWatchLogs) Close() error {
 }
 
 func (c *CloudWatchLogs) Write(metrics []telegraf.Metric) error {
-	// we no longer expect this to be used. We now use the OTel awsemfexporter for sending EMF metrics to CloudWatch Logs
-	return fmt.Errorf("unexpected call to Write")
+	for _, m := range metrics {
+		c.writeMetricAsStructuredLog(m)
+	}
+	return nil
 }
 
 func (c *CloudWatchLogs) CreateDest(group, stream string, retention int, logGroupClass string, logSrc logs.LogSrc) logs.LogDest {
@@ -131,13 +134,7 @@ func (c *CloudWatchLogs) CreateDest(group, stream string, retention int, logGrou
 
 func (c *CloudWatchLogs) getDest(t pusher.Target, logSrc logs.LogSrc) *cwDest {
 	if cwd, ok := c.cwDests.Load(t); ok {
-		d := cwd.(*cwDest)
-		d.Lock()
-		defer d.Unlock()
-		if !d.stopped {
-			d.refCount++
-			return d
-		}
+		return cwd.(*cwDest)
 	}
 
 	logThrottleRetryer := retryer.NewLogThrottleRetryer(c.Log)
@@ -153,15 +150,8 @@ func (c *CloudWatchLogs) getDest(t pusher.Target, logSrc logs.LogSrc) *cwDest {
 		}
 		c.targetManager = pusher.NewTargetManager(c.Log, client)
 	})
-	p := pusher.NewPusher(c.Log, t, client, c.targetManager, logSrc, c.workerPool, c.ForceFlushInterval.Duration, maxRetryTimeout, &c.pusherWaitGroup)
-	cwd := &cwDest{
-		pusher:   p,
-		retryer:  logThrottleRetryer,
-		refCount: 1,
-		onStopFunc: func() {
-			c.cwDests.Delete(t)
-		},
-	}
+	p := pusher.NewPusher(c.Log, t, client, c.targetManager, logSrc, c.workerPool, c.ForceFlushInterval.Duration, maxRetryTimeout, c.pusherStopChan, &c.pusherWaitGroup)
+	cwd := &cwDest{pusher: p, retryer: logThrottleRetryer}
 	c.cwDests.Store(t, cwd)
 	return cwd
 }
@@ -187,16 +177,193 @@ func (c *CloudWatchLogs) createClient(retryer aws.RequestRetryer) *cloudwatchlog
 	)
 	client.Handlers.Build.PushBackNamed(handlers.NewRequestCompressionHandler([]string{"PutLogEvents"}))
 	if c.middleware != nil {
-		c.configurerOnce.Do(func() {
-			c.configurer = awsmiddleware.NewConfigurer(c.middleware.Handlers())
-		})
-		if err := c.configurer.Configure(awsmiddleware.SDKv1(&client.Handlers)); err != nil {
+		if err := awsmiddleware.NewConfigurer(c.middleware.Handlers()).Configure(awsmiddleware.SDKv1(&client.Handlers)); err != nil {
 			c.Log.Errorf("Unable to configure middleware on cloudwatch logs client: %v", err)
 		} else {
 			c.Log.Debug("Configured middleware on AWS client")
 		}
 	}
 	return client
+}
+
+func (c *CloudWatchLogs) writeMetricAsStructuredLog(m telegraf.Metric) {
+	t, err := c.getTargetFromMetric(m)
+	if err != nil {
+		c.Log.Errorf("Failed to find target: %v", err)
+	}
+	cwd := c.getDest(t, nil)
+	if cwd == nil {
+		c.Log.Warnf("unable to find log destination, group: %v, stream: %v", t.Group, t.Stream)
+		return
+	}
+	cwd.switchToEMF()
+	cwd.pusher.Sender.SetRetryDuration(metricRetryTimeout)
+
+	e := c.getLogEventFromMetric(m)
+	if e == nil {
+		return
+	}
+
+	cwd.AddEvent(e)
+}
+
+func (c *CloudWatchLogs) getTargetFromMetric(m telegraf.Metric) (pusher.Target, error) {
+	tags := m.Tags()
+	logGroup, ok := tags[LogGroupNameTag]
+	if !ok {
+		return pusher.Target{}, fmt.Errorf("structuredlog receive a metric with name '%v' without log group name", m.Name())
+	} else {
+		m.RemoveTag(LogGroupNameTag)
+	}
+
+	logStream, ok := tags[LogStreamNameTag]
+	if ok {
+		m.RemoveTag(LogStreamNameTag)
+	} else if logStream == "" {
+		logStream = c.LogStreamName
+	}
+
+	return pusher.Target{Group: logGroup, Stream: logStream, Class: util.StandardLogGroupClass, Retention: -1}, nil
+}
+
+func (c *CloudWatchLogs) getLogEventFromMetric(metric telegraf.Metric) *structuredLogEvent {
+	var message string
+	if metric.HasField(LogEntryField) {
+		var ok bool
+		if message, ok = metric.Fields()[LogEntryField].(string); !ok {
+			c.Log.Warnf("The log entry value field is not string type: %v", metric.Fields())
+			return nil
+		}
+	} else {
+		content := map[string]interface{}{}
+		tags := metric.Tags()
+		// build all the attributesInFields
+		if val, ok := tags[attributesInFields]; ok {
+			attributes := strings.Split(val, ",")
+			mFields := metric.Fields()
+			for _, attr := range attributes {
+				if fieldVal, ok := mFields[attr]; ok {
+					content[attr] = fieldVal
+					metric.RemoveField(attr)
+				}
+			}
+			metric.RemoveTag(attributesInFields)
+			delete(tags, attributesInFields)
+		}
+
+		// build remaining attributes
+		for k := range tags {
+			content[k] = tags[k]
+		}
+
+		for k, v := range metric.Fields() {
+			var value interface{}
+
+			switch t := v.(type) {
+			case int:
+				value = float64(t)
+			case int32:
+				value = float64(t)
+			case int64:
+				value = float64(t)
+			case uint:
+				value = float64(t)
+			case uint32:
+				value = float64(t)
+			case uint64:
+				value = float64(t)
+			case float64:
+				value = t
+			case bool:
+				value = t
+			case string:
+				value = t
+			case time.Time:
+				value = float64(t.Unix())
+
+			default:
+				c.Log.Errorf("Detected unexpected fields (%s,%v) when encoding structured log event, value type %T is not supported", k, v, v)
+				return nil
+			}
+			content[k] = value
+		}
+
+		jsonMap, err := json.Marshal(content)
+		if err != nil {
+			c.Log.Errorf("Unalbe to marshal structured log content: %v", err)
+		}
+		message = string(jsonMap)
+	}
+
+	return &structuredLogEvent{
+		msg: message,
+		t:   metric.Time(),
+	}
+}
+
+type structuredLogEvent struct {
+	msg string
+	t   time.Time
+}
+
+func (e *structuredLogEvent) Message() string {
+	return e.msg
+}
+
+func (e *structuredLogEvent) Time() time.Time {
+	return e.t
+}
+
+func (e *structuredLogEvent) Done() {}
+
+type cwDest struct {
+	pusher *pusher.Pusher
+	sync.Mutex
+	isEMF   bool
+	stopped bool
+	retryer *retryer.LogThrottleRetryer
+}
+
+func (cd *cwDest) Publish(events []logs.LogEvent) error {
+	for _, e := range events {
+		if !cd.isEMF {
+			msg := e.Message()
+			if strings.HasPrefix(msg, "{") && strings.HasSuffix(msg, "}") && strings.Contains(msg, "\"CloudWatchMetrics\"") {
+				cd.switchToEMF()
+			}
+		}
+		cd.AddEvent(e)
+	}
+	if cd.stopped {
+		return logs.ErrOutputStopped
+	}
+	return nil
+}
+
+func (cd *cwDest) Stop() {
+	cd.retryer.Stop()
+	cd.stopped = true
+}
+
+func (cd *cwDest) AddEvent(e logs.LogEvent) {
+	// Drop events for metric path logs when queue is full
+	if cd.isEMF {
+		cd.pusher.AddEventNonBlocking(e)
+	} else {
+		cd.pusher.AddEvent(e)
+	}
+}
+
+func (cd *cwDest) switchToEMF() {
+	cd.Lock()
+	defer cd.Unlock()
+	if !cd.isEMF {
+		cd.isEMF = true
+		cwl, ok := cd.pusher.Service.(*cloudwatchlogs.CloudWatchLogs)
+		if ok {
+			cwl.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("x-amzn-logs-format", "json/emf"))
+		}
+	}
 }
 
 // Description returns a one-sentence description on the Output
@@ -232,100 +399,11 @@ func (c *CloudWatchLogs) SampleConfig() string {
 	return sampleConfig
 }
 
-// cwDest is responsible for publishing logs from log files to a log group + log stream.
-// Logs from more than one log file may be published to the same destination. cwDest closes
-// itself when all log file tailers which referenced this cwDest are closed.
-// All exported functions should practice thread-safety by acquiring lock the cwDest
-// and not calling any other function which requires the lock.
-type cwDest struct {
-	pusher *pusher.Pusher
-	sync.Mutex
-	isEMF   bool
-	retryer *retryer.LogThrottleRetryer
-
-	// refCount keeps track of how many LogSrc objects are referencing
-	// this cwDest object at any given time. Once there are no more
-	// references, the cwDest object stops itself, closing all goroutines,
-	// and it can no longer be used
-	refCount   int
-	stopped    bool
-	onStopFunc func()
-}
-
-var _ logs.LogDest = (*cwDest)(nil)
-
-func (cd *cwDest) Publish(events []logs.LogEvent) error {
-	cd.Lock()
-	defer cd.Unlock()
-	if cd.stopped {
-		return logs.ErrOutputStopped
-	}
-	for _, e := range events {
-		if !cd.isEMF {
-			msg := e.Message()
-			if strings.HasPrefix(msg, "{") && strings.HasSuffix(msg, "}") && strings.Contains(msg, "\"CloudWatchMetrics\"") {
-				cd.switchToEMF()
-			}
-		}
-		cd.addEvent(e)
-	}
-	return nil
-}
-
-func (cd *cwDest) NotifySourceStopped() {
-	cd.Lock()
-	defer cd.Unlock()
-	cd.refCount--
-	if cd.refCount <= 0 {
-		cd.stop()
-	}
-
-	if cd.refCount < 0 {
-		fmt.Printf("E! Negative refCount on cwDest detected. refCount: %d, logGroup: %s, logStream: %s", cd.refCount, cd.pusher.Group, cd.pusher.Stream)
-	}
-}
-
-func (cd *cwDest) Stop() {
-	cd.Lock()
-	defer cd.Unlock()
-	cd.stop()
-}
-
-func (cd *cwDest) stop() {
-	if cd.stopped {
-		return
-	}
-	cd.retryer.Stop()
-	cd.pusher.Stop()
-	cd.stopped = true
-	if cd.onStopFunc != nil {
-		cd.onStopFunc()
-	}
-}
-
-func (cd *cwDest) addEvent(e logs.LogEvent) {
-	// Drop events for metric path logs when queue is full
-	if cd.isEMF {
-		cd.pusher.AddEventNonBlocking(e)
-	} else {
-		cd.pusher.AddEvent(e)
-	}
-}
-
-func (cd *cwDest) switchToEMF() {
-	if !cd.isEMF {
-		cd.isEMF = true
-		cwl, ok := cd.pusher.Service.(*cloudwatchlogs.CloudWatchLogs)
-		if ok {
-			cwl.Handlers.Build.PushBackNamed(handlers.NewCustomHeaderHandler("x-amzn-logs-format", "json/emf"))
-		}
-	}
-}
-
 func init() {
 	outputs.Add("cloudwatchlogs", func() telegraf.Output {
 		return &CloudWatchLogs{
 			ForceFlushInterval: internal.Duration{Duration: defaultFlushTimeout},
+			pusherStopChan:     make(chan struct{}),
 			cwDests:            sync.Map{},
 			middleware: agenthealth.NewAgentHealth(
 				zap.NewNop(),

--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs_test.go
@@ -69,12 +69,13 @@ func TestCreateDestination(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			c := &CloudWatchLogs{
-				Log:           testutil.Logger{Name: "test"},
-				LogGroupName:  "G1",
-				LogStreamName: "S1",
-				AccessKey:     "access_key",
-				SecretKey:     "secret_key",
-				cwDests:       sync.Map{},
+				Log:            testutil.Logger{Name: "test"},
+				LogGroupName:   "G1",
+				LogStreamName:  "S1",
+				AccessKey:      "access_key",
+				SecretKey:      "secret_key",
+				pusherStopChan: make(chan struct{}),
+				cwDests:        sync.Map{},
 			}
 			dest := c.CreateDest(testCase.cfgLogGroup, testCase.cfgLogStream, testCase.cfgLogRetention, testCase.cfgLogClass, testCase.cfgTailerSrc).(*cwDest)
 			require.Equal(t, testCase.expectedLogGroup, dest.pusher.Group)
@@ -88,10 +89,11 @@ func TestCreateDestination(t *testing.T) {
 
 func TestDuplicateDestination(t *testing.T) {
 	c := &CloudWatchLogs{
-		Log:       testutil.Logger{Name: "test"},
-		AccessKey: "access_key",
-		SecretKey: "secret_key",
-		cwDests:   sync.Map{},
+		Log:            testutil.Logger{Name: "test"},
+		AccessKey:      "access_key",
+		SecretKey:      "secret_key",
+		cwDests:        sync.Map{},
+		pusherStopChan: make(chan struct{}),
 	}
 	// Given the same log group, log stream, same retention, and logClass
 	d1 := c.CreateDest("FILENAME", "", -1, util.InfrequentAccessLogGroupClass, nil)

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/pool.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/pool.go
@@ -109,11 +109,6 @@ func (s *senderPool) Send(batch *logEventBatch) {
 	})
 }
 
-func (s *senderPool) Stop() {
-	// workerpool is stopped by the plugin
-	s.sender.Stop()
-}
-
 // SetRetryDuration sets the retry duration on the wrapped Sender.
 func (s *senderPool) SetRetryDuration(duration time.Duration) {
 	s.sender.SetRetryDuration(duration)

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/pool_test.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/pool_test.go
@@ -105,9 +105,10 @@ func TestWorkerPool(t *testing.T) {
 
 func TestSenderPool(t *testing.T) {
 	logger := testutil.NewNopLogger()
+	stop := make(chan struct{})
 	mockService := new(mockLogsService)
 	mockService.On("PutLogEvents", mock.Anything).Return(&cloudwatchlogs.PutLogEventsOutput{}, nil)
-	s := newSender(logger, mockService, nil, time.Second)
+	s := newSender(logger, mockService, nil, time.Second, stop)
 	p := NewWorkerPool(12)
 	sp := newSenderPool(p, s)
 
@@ -131,6 +132,5 @@ func TestSenderPool(t *testing.T) {
 	}
 
 	p.Stop()
-	s.Stop()
 	assert.Equal(t, int32(200), completed.Load())
 }

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/pusher_test.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/pusher_test.go
@@ -20,21 +20,23 @@ const eventCount = 100000
 func TestPusher(t *testing.T) {
 	t.Run("WithSender", func(t *testing.T) {
 		t.Parallel()
+		stop := make(chan struct{})
 		var wg sync.WaitGroup
-		pusher := setupPusher(t, nil, &wg)
+		pusher := setupPusher(t, nil, stop, &wg)
 
 		var completed atomic.Int32
 		generateEvents(t, pusher, &completed)
 
-		pusher.Stop()
+		close(stop)
 		wg.Wait()
 	})
 
 	t.Run("WithSenderPool", func(t *testing.T) {
 		t.Parallel()
+		stop := make(chan struct{})
 		var wg sync.WaitGroup
 		wp := NewWorkerPool(5)
-		pusher := setupPusher(t, wp, &wg)
+		pusher := setupPusher(t, wp, stop, &wg)
 
 		_, isSenderPool := pusher.Sender.(*senderPool)
 		assert.True(t, isSenderPool)
@@ -42,39 +44,10 @@ func TestPusher(t *testing.T) {
 		var completed atomic.Int32
 		generateEvents(t, pusher, &completed)
 
-		pusher.Stop()
+		close(stop)
 		wg.Wait()
 		wp.Stop()
 	})
-}
-
-func TestPusherStop(t *testing.T) {
-	var wg sync.WaitGroup
-
-	s := &mockSender{}
-	s.On("Stop").Return()
-
-	logger := testutil.NewNopLogger()
-	target := Target{}
-	service := new(stubLogsService)
-	service.ple = func(*cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {
-		return &cloudwatchlogs.PutLogEventsOutput{}, nil
-	}
-	mockManager := new(mockTargetManager)
-	q := newQueue(logger, target, time.Second, nil, s, &wg)
-	pusher := &Pusher{
-		Target:         target,
-		Queue:          q,
-		Service:        service,
-		TargetManager:  mockManager,
-		EntityProvider: nil,
-		Sender:         s,
-	}
-
-	pusher.Stop()
-
-	s.AssertCalled(t, "Stop")
-
 }
 
 func generateEvents(t *testing.T, pusher *Pusher, completed *atomic.Int32) {
@@ -90,7 +63,7 @@ func generateEvents(t *testing.T, pusher *Pusher, completed *atomic.Int32) {
 	}
 }
 
-func setupPusher(t *testing.T, workerPool WorkerPool, wg *sync.WaitGroup) *Pusher {
+func setupPusher(t *testing.T, workerPool WorkerPool, stop chan struct{}, wg *sync.WaitGroup) *Pusher {
 	t.Helper()
 	logger := testutil.NewNopLogger()
 	target := Target{Group: "G", Stream: "S", Retention: 7}
@@ -112,6 +85,7 @@ func setupPusher(t *testing.T, workerPool WorkerPool, wg *sync.WaitGroup) *Pushe
 		workerPool,
 		time.Second,
 		time.Minute,
+		stop,
 		wg,
 	)
 

--- a/plugins/outputs/cloudwatchlogs/internal/pusher/sender.go
+++ b/plugins/outputs/cloudwatchlogs/internal/pusher/sender.go
@@ -26,7 +26,6 @@ type Sender interface {
 	Send(*logEventBatch)
 	SetRetryDuration(time.Duration)
 	RetryDuration() time.Duration
-	Stop()
 }
 
 type sender struct {
@@ -34,24 +33,21 @@ type sender struct {
 	retryDuration atomic.Value
 	targetManager TargetManager
 	logger        telegraf.Logger
-	stopCh        chan struct{}
-	stopped       bool
+	stop          <-chan struct{}
 }
-
-var _ (Sender) = (*sender)(nil)
 
 func newSender(
 	logger telegraf.Logger,
 	service cloudWatchLogsService,
 	targetManager TargetManager,
 	retryDuration time.Duration,
+	stop <-chan struct{},
 ) Sender {
 	s := &sender{
 		logger:        logger,
 		service:       service,
 		targetManager: targetManager,
-		stopCh:        make(chan struct{}),
-		stopped:       false,
+		stop:          stop,
 	}
 	s.retryDuration.Store(retryDuration)
 	return s
@@ -129,21 +125,13 @@ func (s *sender) Send(batch *logEventBatch) {
 		s.logger.Warnf("Retried %v time, going to sleep %v before retrying.", retryCountShort+retryCountLong-1, wait)
 
 		select {
-		case <-s.stopCh:
+		case <-s.stop:
 			s.logger.Errorf("Stop requested after %v retries to %v/%v failed for PutLogEvents, request dropped.", retryCountShort+retryCountLong-1, batch.Group, batch.Stream)
 			batch.updateState()
 			return
 		case <-time.After(wait):
 		}
 	}
-}
-
-func (s *sender) Stop() {
-	if s.stopped {
-		return
-	}
-	close(s.stopCh)
-	s.stopped = true
 }
 
 // SetRetryDuration sets the maximum duration for retrying failed log sends.


### PR DESCRIPTION
# Description of changes
Reverting change to address goroutine leak.

See previous PR: https://github.com/aws/amazon-cloudwatch-agent/pull/1848

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Will run integ tests

# Requirements
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



