### PR TITLE
Add OTLP logs pipeline for application signals

### DIFF
--- a/translator/cmdutil/translatorutil.go
+++ b/translator/cmdutil/translatorutil.go
@@ -251,7 +251,64 @@ func TranslateJsonMapToYamlConfig(jsonConfigValue interface{}) (interface{}, err
 	if err != nil {
 		return nil, err
 	}
-	return mapstructure.Marshal(cfg)
+	result, err := mapstructure.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// configopaque.String values are nil'd during marshal to prevent secret leakage.
+	// Restore non-secret headers for otlphttp/application_signals exporter (log group/stream).
+	injectAppSignalsLogsHeaders(result, jsonConfigValue)
+	return result, nil
+}
+
+// injectAppSignalsLogsHeaders restores x-aws-log-group and x-aws-log-stream headers
+// on the otlphttp/application_signals exporter. These are nil'd by NilHookFunc during
+// mapstructure marshal because configopaque.String is treated as a secret, but log
+// group/stream names are not sensitive and must survive the YAML round-trip.
+func injectAppSignalsLogsHeaders(yamlMap map[string]any, jsonConfig interface{}) {
+	jsonMap, ok := jsonConfig.(map[string]interface{})
+	if !ok {
+		return
+	}
+	exporters, ok := yamlMap["exporters"].(map[string]any)
+	if !ok {
+		return
+	}
+	exporterCfg, ok := exporters["otlphttp/application_signals"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	// Read log_group_name and log_stream_name from JSON config
+	logGroup := "/aws/application-signals/data"
+	logStream := "default"
+	if logs, ok := jsonMap["logs"].(map[string]interface{}); ok {
+		if lc, ok := logs["logs_collected"].(map[string]interface{}); ok {
+			if as, ok := lc["application_signals"].(map[string]interface{}); ok {
+				if v, ok := as["log_group_name"].(string); ok && v != "" {
+					logGroup = v
+				}
+				if v, ok := as["log_stream_name"].(string); ok && v != "" {
+					logStream = v
+				}
+			} else if as, ok := lc["app_signals"].(map[string]interface{}); ok {
+				if v, ok := as["log_group_name"].(string); ok && v != "" {
+					logGroup = v
+				}
+				if v, ok := as["log_stream_name"].(string); ok && v != "" {
+					logStream = v
+				}
+			}
+		}
+	}
+
+	headers, ok := exporterCfg["headers"].(map[string]any)
+	if !ok {
+		headers = make(map[string]any)
+		exporterCfg["headers"] = headers
+	}
+	headers["x-aws-log-group"] = logGroup
+	headers["x-aws-log-stream"] = logStream
 }
 
 func ConfigToTomlFile(config interface{}, tomlConfigFilePath string) error {

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -633,6 +633,34 @@
             },
             "windows_events": {
               "$ref": "#/definitions/logsDefinition/definitions/logsWindowsEventsDefinition"
+            },
+            "application_signals": {
+              "type": "object",
+              "properties": {
+                "log_group_name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "log_stream_name": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": true
+            },
+            "app_signals": {
+              "type": "object",
+              "properties": {
+                "log_group_name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "log_stream_name": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": true
             }
           },
           "minProperties": 1,

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -136,12 +136,15 @@ const (
 var (
 	AppSignalsTraces          = ConfigKey(TracesKey, TracesCollectedKey, AppSignals)
 	AppSignalsMetrics         = ConfigKey(LogsKey, MetricsCollectedKey, AppSignals)
+	AppSignalsLogs            = ConfigKey(LogsKey, LogsCollectedKey, AppSignals)
 	AppSignalsTracesFallback  = ConfigKey(TracesKey, TracesCollectedKey, AppSignalsFallback)
 	AppSignalsMetricsFallback = ConfigKey(LogsKey, MetricsCollectedKey, AppSignalsFallback)
+	AppSignalsLogsFallback    = ConfigKey(LogsKey, LogsCollectedKey, AppSignalsFallback)
 
 	AppSignalsConfigKeys = map[pipeline.Signal][]string{
 		pipeline.SignalTraces:  {AppSignalsTraces, AppSignalsTracesFallback},
 		pipeline.SignalMetrics: {AppSignalsMetrics, AppSignalsMetricsFallback},
+		pipeline.SignalLogs:    {AppSignalsLogs, AppSignalsLogsFallback},
 	}
 	SystemMetricsEnabledConfigKey = ConfigKey(AgentKey, SystemMetricsEnabledKey)
 	JmxConfigKey                  = ConfigKey(MetricsKey, MetricsCollectedKey, JmxKey)

--- a/translator/translate/otel/exporter/otlphttp/translator.go
+++ b/translator/translate/otel/exporter/otlphttp/translator.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otlphttp
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configauth"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+type translator struct {
+	name    string
+	factory exporter.Factory
+}
+
+var _ common.ComponentTranslator = (*translator)(nil)
+
+func NewTranslatorWithName(name string) common.ComponentTranslator {
+	return &translator{name, otlphttpexporter.NewFactory()}
+}
+
+func (t *translator) ID() component.ID {
+	return component.NewIDWithName(t.factory.Type(), t.name)
+}
+
+// Translate creates an otlphttp exporter config that sends OTLP logs to the
+// CloudWatch OTLP endpoint with SigV4 authentication.
+func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
+	cfg := t.factory.CreateDefaultConfig().(*otlphttpexporter.Config)
+
+	region := agent.Global_Config.Region
+	if region == "" {
+		return nil, fmt.Errorf("region is required for otlphttp exporter")
+	}
+
+	cfg.ClientConfig.Endpoint = fmt.Sprintf("https://logs.%s.amazonaws.com", region)
+	cfg.ClientConfig.Auth = &configauth.Authentication{
+		AuthenticatorID: component.NewID(component.MustNewType(common.SigV4Auth)),
+	}
+
+	// Note: x-aws-log-group and x-aws-log-stream headers are injected as raw strings
+	// in translatorutil.go:injectAppSignalsLogsHeaders() because configopaque.String
+	// values are nil'd during mapstructure marshal (NilHookFunc) to prevent secret leakage.
+
+	return cfg, nil
+}

--- a/translator/translate/otel/pipeline/applicationsignals/translator.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translator.go
@@ -15,9 +15,11 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awsemf"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/awsxray"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/debug"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/otlphttp"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/awsproxy"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/k8smetadata"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/awsapplicationsignals"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/awsentity"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/metricstransformprocessor"
@@ -56,6 +58,20 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 		Processors: common.NewTranslatorMap[component.Config, component.ID](),
 		Exporters:  common.NewTranslatorMap[component.Config, component.ID](),
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
+	}
+
+	if t.signal == pipeline.SignalLogs {
+		// OTLP Logs pipeline: receive OTLP logs from instrumentation, forward to
+		// CloudWatch OTLP endpoint via otlphttp exporter with SigV4 auth.
+		// No processors needed — logs are forwarded as-is to preserve full OTLP structure.
+		if enabled, _ := common.GetBool(conf, common.AgentDebugConfigKey); enabled {
+			translators.Exporters.Set(debug.NewTranslator(common.WithName(common.AppSignals)))
+		}
+		translators.Exporters.Set(otlphttp.NewTranslatorWithName(common.AppSignals))
+		translators.Extensions.Set(sigv4auth.NewTranslator())
+		translators.Extensions.Set(agenthealth.NewTranslator(agenthealth.LogsName, []string{agenthealth.OperationPutLogEvents}))
+		translators.Extensions.Set(agenthealth.NewTranslatorWithStatusCode(agenthealth.StatusCodeName, nil, true))
+		return translators, nil
 	}
 
 	if t.signal == pipeline.SignalMetrics {

--- a/translator/translate/otel/pipeline/applicationsignals/translator_test.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translator_test.go
@@ -339,3 +339,77 @@ func TestTranslatorMetricsForECS(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslatorLogs(t *testing.T) {
+	type want struct {
+		receivers  []string
+		processors []string
+		exporters  []string
+		extensions []string
+	}
+	tt := NewTranslator(pipeline.SignalLogs)
+	assert.EqualValues(t, "logs/application_signals", tt.ID().String())
+	testCases := map[string]struct {
+		input      map[string]interface{}
+		want       *want
+		wantErr    error
+		isEKSCache func() eksdetector.IsEKSCache
+	}{
+		"WithoutLogsCollectedKey": {
+			input:   map[string]interface{}{},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: fmt.Sprint(common.AppSignalsLogs)},
+		},
+		"WithAppSignalsEnabledLogs": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"logs_collected": map[string]interface{}{
+						"application_signals": map[string]interface{}{},
+					},
+				},
+			},
+			want: &want{
+				receivers:  []string{"otlp/grpc_0_0_0_0_4315", "otlp/http_0_0_0_0_4316"},
+				processors: []string{},
+				exporters:  []string{"otlphttp/application_signals"},
+				extensions: []string{"sigv4auth", "agenthealth/logs", "agenthealth/statuscode"},
+			},
+			isEKSCache: eksdetector.TestIsEKSCacheEKS,
+		},
+		"WithAppSignalsLogsAndDebug": {
+			input: map[string]interface{}{
+				"agent": map[string]interface{}{
+					"debug": true,
+				},
+				"logs": map[string]interface{}{
+					"logs_collected": map[string]interface{}{
+						"application_signals": map[string]interface{}{},
+					},
+				},
+			},
+			want: &want{
+				receivers:  []string{"otlp/grpc_0_0_0_0_4315", "otlp/http_0_0_0_0_4316"},
+				processors: []string{},
+				exporters:  []string{"debug/application_signals", "otlphttp/application_signals"},
+				extensions: []string{"sigv4auth", "agenthealth/logs", "agenthealth/statuscode"},
+			},
+			isEKSCache: eksdetector.TestIsEKSCacheEKS,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			eksdetector.IsEKS = testCase.isEKSCache
+			conf := confmap.NewFromStringMap(testCase.input)
+			got, err := tt.Translate(conf)
+			assert.Equal(t, testCase.wantErr, err)
+			if testCase.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, testCase.want.receivers, collections.MapSlice(got.Receivers.Keys(), component.ID.String))
+				assert.Equal(t, testCase.want.processors, collections.MapSlice(got.Processors.Keys(), component.ID.String))
+				assert.Equal(t, testCase.want.exporters, collections.MapSlice(got.Exporters.Keys(), component.ID.String))
+				assert.Equal(t, testCase.want.extensions, collections.MapSlice(got.Extensions.Keys(), component.ID.String))
+			}
+		})
+	}
+}

--- a/translator/translate/otel/translate_otel.go
+++ b/translator/translate/otel/translate_otel.go
@@ -73,6 +73,7 @@ func Translate(jsonConfig interface{}, os string) (*otelcol.Config, error) {
 	translators.Merge(containerInsightsTranslators)
 	translators.Set(applicationsignals.NewTranslator(pipeline.SignalTraces))
 	translators.Set(applicationsignals.NewTranslator(pipeline.SignalMetrics))
+	translators.Set(applicationsignals.NewTranslator(pipeline.SignalLogs))
 	translators.Merge(prometheus.NewTranslators(conf))
 	translators.Set(emf_logs.NewTranslator())
 	translators.Set(xray.NewTranslator())


### PR DESCRIPTION
# Description of the issue
Application Signals currently supports traces and metrics pipelines, but has no built-in support for forwarding OTLP logs to CloudWatch. ADOT-instrumented applications (Java, Node.js, Python) may emit telemetry as OTLP log records to the CWAgent's existing OTLP receiver (ports 4315/4316), but without a logs pipeline these records are silently dropped.

Customers must manually configure an `otelConfig` with `otlphttp` exporter, `sigv4auth`, and header injection to route OTLP logs to the CloudWatch Logs OTLP endpoint — a complex setup that should be handled natively by the Application Signals pipeline.

# Description of changes
Adds a built-in `logs/application_signals` pipeline that receives OTLP logs on the existing Application Signals OTLP receiver (4315/4316) and forwards them to the CloudWatch Logs OTLP endpoint via `otlphttp` exporter with SigV4 authentication.

**Activation:** Customers add `application_signals` under `logs.logs_collected` in the CWAgent JSON config:

```json
{
  "logs": {
    "logs_collected": {
      "application_signals": {
        "log_group_name": "/test/telemetry",
        "log_stream_name": "default"
      }
    }
  }
}
```

Changes:

- `translator/translate/otel/translate_otel.go` — Registers `applicationsignals.NewTranslator(pipeline.SignalLogs)` alongside existing traces/metrics translators.
- `translator/translate/otel/pipeline/applicationsignals/translator.go` — Adds SignalLogs branch that creates a logs pipeline that reuses existing AppSignals OTLP receivers (4315/4316), and uses otlphttp/application_signals (new Exporter) with sigv4auth & agenthealth Extensions. No processors.
- `translator/translate/otel/exporter/otlphttp/translator.go` — New translator that creates an otlphttp exporter config pointing to `https://logs.<region>.amazonaws.com` with sigv4auth authentication.
- `translator/cmdutil/translatorutil.go` — Adds injectAppSignalsLogsHeaders() workaround to restore x-aws-log-group and x-aws-log-stream headers after mapstructure marshal. These headers are nil'd during serialization because configopaque.String treats all header values as secrets, but log group/stream names are not sensitive and must survive the YAML round-trip.
- `translator/config/schema.json` — Adds application_signals (and app_signals fallback) under logs_collected with log_group_name and log_stream_name properties.
- `translator/translate/otel/common/common.go` — Adds AppSignalsLogs and AppSignalsLogsFallback config key constants, and registers pipeline.SignalLogs in AppSignalsConfigKeys.
- `translator/translate/otel/pipeline/applicationsignals/translator_test.go` — Adds TestTranslatorLogs with test cases for: missing config key, enabled logs pipeline, and enabled with debug exporter.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. Deployed Java sample application on EKS with CW Observability add-on, patched add-on to use custom image for CWAgent containing my changes

2. Configured logs.logs_collected.application_signals with /test/telemetry log group and default stream
```
{
  "traces": {
    "traces_collected": {
      "application_signals": {}
    }
  },
  "logs": {
    "metrics_collected": {
      "application_signals": {}
    },
    "logs_collected": {
      "application_signals": {
        "log_group_name": "/test/telemetry",
        "log_stream_name": "default"
      }
    }
  }
}
```
3. Verified that OTLP logs from an implemented OtlpEmitter in ADOT Java SDK will flow through the logs/application_signals pipeline to CloudWatch Logs OTLP endpoint
    - Confirmed logs appear in `/test/telemetry` log group with correct `default log` stream

Also added `TestTranslatorLogs` in `translator_test.go` covering cases where (1) application_signals is not configured under logs_collected, (2) create pipeline with expected receivers, extensions, and exporter (which includes otlphttp/application_signals), and (3) includes debug/application_signals exporter when agent debug mode is enabled

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



