### PR TITLE
feat: automatic log group/stream creation at startup when using otlphttp exporter for logs

### DIFF
--- a/service/configprovider/otlphttp_log_provisioner.go
+++ b/service/configprovider/otlphttp_log_provisioner.go
@@ -1,0 +1,259 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package configprovider
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+// cwLogsEndpointPattern matches CloudWatch Logs OTLP endpoints like
+// https://logs.us-east-1.amazonaws.com/v1/logs
+var cwLogsEndpointPattern = regexp.MustCompile(`^https://logs\.([a-z0-9-]+)\.amazonaws\.com`)
+
+const (
+	headerLogGroup  = "x-aws-log-group"
+	headerLogStream = "x-aws-log-stream"
+)
+
+// otlphttpLogProvisioner is a confmap.Converter that auto-creates CloudWatch
+// log groups and log streams for otlphttp exporters targeting CW Logs OTLP endpoints.
+// It runs once at startup before the OTel collector starts.
+type otlphttpLogProvisioner struct{}
+
+// NewOTLPHTTPLogProvisionerFactory returns a factory for creating the log provisioner.
+func NewOTLPHTTPLogProvisionerFactory() confmap.ConverterFactory {
+	return confmap.NewConverterFactory(func(_ confmap.ConverterSettings) confmap.Converter {
+		return &otlphttpLogProvisioner{}
+	})
+}
+
+// logTarget represents a (log group, log stream, region) tuple to be provisioned.
+type logTarget struct {
+	logGroupName  string
+	logStreamName string
+	region        string
+}
+
+// Convert scans the config for otlphttp exporters used in logs pipelines that target
+// CW Logs OTLP endpoints, and auto-creates the log groups and log streams.
+func (p *otlphttpLogProvisioner) Convert(_ context.Context, conf *confmap.Conf) error {
+	targets := p.findLogTargets(conf)
+	if len(targets) == 0 {
+		return nil
+	}
+
+	for _, t := range targets {
+		if err := provisionLogGroupAndStream(t); err != nil {
+			// Log warning but don't block startup
+			log.Printf("W! Failed to auto-create log group/stream (group=%s, stream=%s, region=%s): %v",
+				t.logGroupName, t.logStreamName, t.region, err)
+		} else {
+			log.Printf("I! Auto-provisioned log group/stream (group=%s, stream=%s, region=%s)",
+				t.logGroupName, t.logStreamName, t.region)
+		}
+	}
+
+	// Never return error — provisioning failures should not block CWAgent startup
+	return nil
+}
+
+// findLogTargets identifies otlphttp exporters in logs pipelines that target CW Logs
+// OTLP endpoints, and extracts the log group/stream from their headers.
+func (p *otlphttpLogProvisioner) findLogTargets(conf *confmap.Conf) []logTarget {
+	// 1. Get all exporters used in logs/* pipelines
+	logsExporterNames := p.getLogsExporterNames(conf)
+	if len(logsExporterNames) == 0 {
+		return nil
+	}
+
+	// 2. Get exporter configs
+	exportersVal := conf.Get("exporters")
+	if exportersVal == nil {
+		return nil
+	}
+	exporters, ok := exportersVal.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var targets []logTarget
+
+	for name, cfg := range exporters {
+		// Only otlphttp exporters
+		if name != "otlphttp" && !strings.HasPrefix(name, "otlphttp/") {
+			continue
+		}
+		// Only exporters used in logs pipelines
+		if !logsExporterNames[name] {
+			continue
+		}
+
+		exporterCfg, ok := cfg.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Check if logs_endpoint or endpoint targets CW Logs
+		endpoint := ""
+		if ep, ok := exporterCfg["logs_endpoint"].(string); ok && ep != "" {
+			endpoint = ep
+		} else if ep, ok := exporterCfg["endpoint"].(string); ok && ep != "" {
+			endpoint = ep
+		}
+
+		region := extractRegionFromLogsEndpoint(endpoint)
+		if region == "" {
+			continue // Not a CW Logs endpoint
+		}
+
+		// Extract log group and stream from headers
+		headers, ok := exporterCfg["headers"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		logGroup, _ := headers[headerLogGroup].(string)
+		logStream, _ := headers[headerLogStream].(string)
+
+		if logGroup == "" {
+			continue // No log group configured
+		}
+		if logStream == "" {
+			logStream = "default"
+		}
+
+		targets = append(targets, logTarget{
+			logGroupName:  logGroup,
+			logStreamName: logStream,
+			region:        region,
+		})
+	}
+
+	return targets
+}
+
+// getLogsExporterNames returns the set of exporter names used in logs/* pipelines.
+func (p *otlphttpLogProvisioner) getLogsExporterNames(conf *confmap.Conf) map[string]bool {
+	result := make(map[string]bool)
+
+	serviceVal := conf.Get("service")
+	if serviceVal == nil {
+		return result
+	}
+	service, ok := serviceVal.(map[string]any)
+	if !ok {
+		return result
+	}
+	pipelines, ok := service["pipelines"].(map[string]any)
+	if !ok {
+		return result
+	}
+
+	for pipelineName, pipelineCfg := range pipelines {
+		if !strings.HasPrefix(pipelineName, "logs") {
+			continue
+		}
+		pipeline, ok := pipelineCfg.(map[string]any)
+		if !ok {
+			continue
+		}
+		exporters, ok := pipeline["exporters"].([]any)
+		if !ok {
+			continue
+		}
+		for _, exp := range exporters {
+			if name, ok := exp.(string); ok {
+				result[name] = true
+			}
+		}
+	}
+
+	return result
+}
+
+// extractRegionFromLogsEndpoint extracts the AWS region from a CW Logs OTLP endpoint.
+// Returns empty string if the endpoint is not a CW Logs endpoint.
+func extractRegionFromLogsEndpoint(endpoint string) string {
+	matches := cwLogsEndpointPattern.FindStringSubmatch(endpoint)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+// provisionLogGroupAndStream creates the log group and log stream if they don't exist.
+// Follows the same pattern as cwlogs.Client.CreateStream:
+// 1. Try CreateLogStream
+// 2. If ResourceNotFoundException -> CreateLogGroup -> retry CreateLogStream
+// 3. If ResourceAlreadyExistsException -> ignore (idempotent)
+func provisionLogGroupAndStream(t logTarget) error {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(t.region),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create AWS session: %w", err)
+	}
+
+	svc := cloudwatchlogs.New(sess)
+	logGroup := aws.String(t.logGroupName)
+	logStream := aws.String(t.logStreamName)
+
+	// Try creating the log stream first
+	_, err = svc.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
+		LogGroupName:  logGroup,
+		LogStreamName: logStream,
+	})
+	if err == nil {
+		return nil
+	}
+
+	awsErr, ok := err.(awserr.Error)
+	if !ok {
+		return err
+	}
+
+	switch awsErr.Code() {
+	case cloudwatchlogs.ErrCodeResourceAlreadyExistsException:
+		return nil
+
+	case cloudwatchlogs.ErrCodeResourceNotFoundException:
+		// Log group doesn't exist — create it, then retry stream creation
+		_, err = svc.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+			LogGroupName: logGroup,
+		})
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cloudwatchlogs.ErrCodeResourceAlreadyExistsException {
+				// Race condition: another process created it
+			} else {
+				return fmt.Errorf("failed to create log group %q: %w", t.logGroupName, err)
+			}
+		}
+
+		// Retry creating the log stream
+		_, err = svc.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
+			LogGroupName:  logGroup,
+			LogStreamName: logStream,
+		})
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cloudwatchlogs.ErrCodeResourceAlreadyExistsException {
+				return nil
+			}
+			return fmt.Errorf("failed to create log stream %q in group %q: %w", t.logStreamName, t.logGroupName, err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unexpected error creating log stream: %w", err)
+	}
+}

--- a/service/configprovider/otlphttp_log_provisioner_test.go
+++ b/service/configprovider/otlphttp_log_provisioner_test.go
@@ -1,0 +1,223 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package configprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestExtractRegionFromLogsEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		expected string
+	}{
+		{
+			name:     "valid us-east-1",
+			endpoint: "https://logs.us-east-1.amazonaws.com/v1/logs",
+			expected: "us-east-1",
+		},
+		{
+			name:     "valid eu-west-1",
+			endpoint: "https://logs.eu-west-1.amazonaws.com/v1/logs",
+			expected: "eu-west-1",
+		},
+		{
+			name:     "not a logs endpoint",
+			endpoint: "https://xray.us-east-1.amazonaws.com/v1/traces",
+			expected: "",
+		},
+		{
+			name:     "empty",
+			endpoint: "",
+			expected: "",
+		},
+		{
+			name:     "non-AWS endpoint",
+			endpoint: "http://localhost:4318",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractRegionFromLogsEndpoint(tt.endpoint)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFindLogTargets(t *testing.T) {
+	p := &otlphttpLogProvisioner{}
+
+	tests := []struct {
+		name     string
+		config   map[string]any
+		expected []logTarget
+	}{
+		{
+			name: "single otlphttp exporter in logs pipeline",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp/cw-logs": map[string]any{
+						"logs_endpoint": "https://logs.us-east-1.amazonaws.com/v1/logs",
+						"headers": map[string]any{
+							"x-aws-log-group":  "/test/telemetry",
+							"x-aws-log-stream": "default",
+						},
+					},
+				},
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"logs/test": map[string]any{
+							"exporters": []any{"otlphttp/cw-logs"},
+						},
+					},
+				},
+			},
+			expected: []logTarget{
+				{logGroupName: "/test/telemetry", logStreamName: "default", region: "us-east-1"},
+			},
+		},
+		{
+			name: "otlphttp exporter not in logs pipeline",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp/metrics": map[string]any{
+						"endpoint": "https://logs.us-east-1.amazonaws.com/v1/logs",
+						"headers": map[string]any{
+							"x-aws-log-group": "/some/group",
+						},
+					},
+				},
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"metrics/something": map[string]any{
+							"exporters": []any{"otlphttp/metrics"},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "non-CW endpoint ignored",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp": map[string]any{
+						"endpoint": "http://localhost:4318",
+						"headers": map[string]any{
+							"x-aws-log-group": "/some/group",
+						},
+					},
+				},
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"logs/local": map[string]any{
+							"exporters": []any{"otlphttp"},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "missing log group header",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp/cw": map[string]any{
+						"logs_endpoint": "https://logs.us-west-2.amazonaws.com/v1/logs",
+						"headers":       map[string]any{},
+					},
+				},
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"logs/test": map[string]any{
+							"exporters": []any{"otlphttp/cw"},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "default log stream when not specified",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp/cw": map[string]any{
+						"logs_endpoint": "https://logs.ap-southeast-1.amazonaws.com/v1/logs",
+						"headers": map[string]any{
+							"x-aws-log-group": "/my/logs",
+						},
+					},
+				},
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"logs/app": map[string]any{
+							"exporters": []any{"otlphttp/cw"},
+						},
+					},
+				},
+			},
+			expected: []logTarget{
+				{logGroupName: "/my/logs", logStreamName: "default", region: "ap-southeast-1"},
+			},
+		},
+		{
+			name: "multiple exporters in multiple pipelines",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp/test": map[string]any{
+						"logs_endpoint": "https://logs.us-east-1.amazonaws.com/v1/logs",
+						"headers": map[string]any{
+							"x-aws-log-group":  "/test/telemetry",
+							"x-aws-log-stream": "test",
+						},
+					},
+					"otlphttp/app-logs": map[string]any{
+						"logs_endpoint": "https://logs.us-east-1.amazonaws.com/v1/logs",
+						"headers": map[string]any{
+							"x-aws-log-group":  "/app/logs",
+							"x-aws-log-stream": "app",
+						},
+					},
+				},
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"logs/test": map[string]any{
+							"exporters": []any{"otlphttp/test"},
+						},
+						"logs/app": map[string]any{
+							"exporters": []any{"otlphttp/app-logs"},
+						},
+					},
+				},
+			},
+			expected: []logTarget{
+				{logGroupName: "/test/telemetry", logStreamName: "test", region: "us-east-1"},
+				{logGroupName: "/app/logs", logStreamName: "app", region: "us-east-1"},
+			},
+		},
+		{
+			name:     "no exporters",
+			config:   map[string]any{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := confmap.NewFromStringMap(tt.config)
+			result := p.findLogTargets(conf)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.ElementsMatch(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/service/configprovider/provider.go
+++ b/service/configprovider/provider.go
@@ -24,6 +24,7 @@ func GetSettings(uris []string, logger *zap.Logger) otelcol.ConfigProviderSettin
 			ConverterFactories: []confmap.ConverterFactory{
 				expandconverter.NewFactory(), //nolint:staticcheck // TODO: breaks logging if updated, migrate later
 				NewOTLPHTTPValidatorFactory(),
+				NewOTLPHTTPLogProvisionerFactory(),
 			},
 			ConverterSettings: confmap.ConverterSettings{Logger: logger},
 		},


### PR DESCRIPTION
# Description of the issue
The CloudWatch OTLP Logs endpoint (`https://logs.<region>.amazonaws.com/v1/logs`) requires the target log group and log stream to already exist before accepting log data. Unlike the native `PutLogEvents` API used by `awscloudwatchlogsexporter` — which auto-creates log groups and streams on first write — the `otlphttp` exporter sends standard OTLP HTTP requests with no built-in CW resource provisioning.

This forces customers to manually pre-create log groups and streams) before CWAgent can export logs via the OTLP path, adding friction to the setup experience.

# Description of changes
Adds a `confmap.Converter` that runs during CWAgent's config resolution phase — after the JSON config is translated to OTel YAML but before the OTel pipeline components (receivers, processors, exporters) are started.

**How it works:**

1. Scans the merged OTel config for all `otlphttp` and `otlphttp/*` exporters
2. Filters to only those used in `logs/*` pipelines (via `service.pipelines` cross-reference)
3. Checks if their `logs_endpoint` or `endpoint` matches the CW Logs OTLP pattern (`https://logs.<region>.amazonaws.com`)
4. Extracts `x-aws-log-group` and `x-aws-log-stream` from the exporter's `headers` config
5. Calls `CreateLogGroup` then `CreateLogStream` via the AWS SDK (both idempotent — `ResourceAlreadyExistsException` is silently ignored)

**Files added:**
- `service/configprovider/otlphttp_log_provisioner.go` — `confmap.Converter` implementation with config scanning, CW endpoint detection, and log group/stream creation
- `service/configprovider/otlphttp_log_provisioner_test.go` — Unit tests covering: single exporter, exporter not in logs pipeline, non-CW endpoint ignored, missing log group header, default log stream fallback, multiple exporters, empty config, and region extraction

**Files modified:**
- `service/configprovider/provider.go` — Registered `NewOTLPHTTPLogProvisionerFactory()` in the converter chain after `otlphttpValidator`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
**Unit tests:**
- `TestExtractRegionFromLogsEndpoint` — validates region extraction from CW Logs OTLP endpoints (us-east-1, eu-west-1, non-logs endpoint, empty, non-AWS endpoint)
- `TestFindLogTargets` — validates config scanning logic for when to create log group/stream and when not to based on the configuration.

**E2E testing:**
- Deployed on EKS with CW Observability add-on, and patched CWAgent with my changes
- Configured `otelConfig` with `otlphttp` exporter targeting CW Logs OTLP endpoint with `x-aws-log-group` and `x-aws-log-stream` headers
- Verified log group and stream were auto-created at CWAgent startup, through AWS CloudWatch console

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



