### PR TITLE
Improve otel-fork-replace workflow: dynamic component discovery, changelog in PR

### DIFF
--- a/.github/workflows/PR-test.yml
+++ b/.github/workflows/PR-test.yml
@@ -355,6 +355,11 @@ jobs:
             exit 0
           fi
 
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip testing') }}" == "true" ]]; then
+            echo "'skip testing' label found - bypassing integration test requirement."
+            exit 0
+          fi
+
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ready for testing') }}" != "true" ]]; then
             echo "Missing 'ready for testing' label. Please add before merging."
             exit 1

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -38,12 +38,17 @@ jobs:
       - name: Get old commit sha from go.mod
         id: get-old-commit
         run: |
+          set -euo pipefail
           # Extract all distinct 12-char hash suffixes from fork pseudo-versions in go.mod.
           # Pseudo-versions look like: v0.0.0-20260407222105-72a988178008
           shas=$(grep 'amazon-contributing/opentelemetry-collector-contrib/' go.mod \
             | grep -oE 'v0\.0\.0-[0-9]+-[0-9a-f]{12}' \
             | awk -F'-' '{print $NF}' \
             | sort -u)
+          if [ -z "$shas" ]; then
+            echo "::error::No fork components found in go.mod. Nothing to update."
+            exit 1
+          fi
           count=$(echo "$shas" | wc -l | tr -d ' ')
           if [ "$count" -ne 1 ]; then
             echo "::error::Found $count distinct fork SHAs in go.mod. A component may be intentionally pinned. Aborting."

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get latest commit sha
         id: get-latest-commit
         run: |
-          if ["${{ inputs.CommitSha }}" == ""]; then
+          if [ "${{ inputs.CommitSha }}" == "" ]; then
             echo "sha=$(git ls-remote ${{ env.UPSTREAM }} ${{ env.UPSTREAM_BRANCH }} | awk '{print $1;}')" >> $GITHUB_OUTPUT
           else
             echo "sha=${{ inputs.CommitSha }}" >> $GITHUB_OUTPUT
@@ -35,48 +35,79 @@ jobs:
         with:
           go-version: ~1.25.8
           cache: false
-      - name: Update OTel fork components version
-        id: set-matrix
+      - name: Get old commit sha from go.mod
+        id: get-old-commit
         run: |
-          git config --global user.name 'Github Action'
-          git config --global user.email 'action@github.com'
-          git checkout -b otel-fork-replace-${{ steps.get-latest-commit.outputs.sha }}
-          go mod edit -replace go.opentelemetry.io/collector/config/confighttp=github.com/amazon-contributing/opentelemetry-collector-contrib/config/confighttp@${{ steps.get-latest-commit.outputs.sha }}
+          # Extract the 12-char hash suffix from the first fork pseudo-version in go.mod.
+          # Pseudo-versions look like: v0.0.0-20260407222105-72a988178008
+          old_sha=$(grep -m1 'amazon-contributing/opentelemetry-collector-contrib/.*v0\.0\.0-' go.mod \
+            | grep -oE 'v0\.0\.0-[0-9]+-[0-9a-f]{12}' \
+            | head -1 \
+            | awk -F'-' '{print $NF}')
+          echo "sha=${old_sha}" >> $GITHUB_OUTPUT
+      - name: Generate changelog
+        id: changelog
+        env:
+          NEW_SHA: ${{ steps.get-latest-commit.outputs.sha }}
+          OLD_SHA: ${{ steps.get-old-commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          REPO_URL="https://github.com/amazon-contributing/opentelemetry-collector-contrib"
+          git clone --bare ${{ env.UPSTREAM }} /tmp/otel-fork
+          # old_sha is a 12-char prefix, git log handles prefix matching
+          raw=$(git -C /tmp/otel-fork log --oneline "${OLD_SHA}..${NEW_SHA}" 2>/dev/null || true)
+          rm -rf /tmp/otel-fork
+          {
+            echo "log<<CHANGELOG_EOF"
+            if [ -z "$raw" ]; then
+              echo "Could not generate changelog (old SHA ${OLD_SHA} not found in history)"
+            else
+              echo "| Commit | Description | PR |"
+              echo "| ------ | ----------- | -- |"
+              echo "$raw" | while IFS= read -r line; do
+                sha=$(echo "$line" | awk '{print $1}')
+                msg=$(echo "$line" | cut -d' ' -f2-)
+                # Extract (#NNN) from end of message if present
+                if echo "$msg" | grep -qE '\(#[0-9]+\)$'; then
+                  pr_num=$(echo "$msg" | grep -oE '#[0-9]+\)$' | tr -d ')' )
+                  msg=$(echo "$msg" | sed 's/ *(#[0-9]*)$//')
+                  pr_link="[${pr_num}](${REPO_URL}/pull/${pr_num#\#})"
+                else
+                  pr_link=""
+                fi
+                echo "| [\`${sha}\`](${REPO_URL}/commit/${sha}) | ${msg} | ${pr_link} |"
+              done
+            fi
+            echo "CHANGELOG_EOF"
+          } >> $GITHUB_OUTPUT
+      - name: Update OTel fork components version
+        env:
+          SHA: ${{ steps.get-latest-commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name 'Github Action'
+          git config user.email 'action@github.com'
+          git checkout -b "otel-fork-replace-${SHA}"
+
+          # Parse go.mod for all replace directives pointing to the fork,
+          # then rewrite each one to the new SHA. This ensures the workflow
+          # automatically covers any components added or removed in go.mod.
+          grep 'amazon-contributing/opentelemetry-collector-contrib/' go.mod \
+            | grep '=>' \
+            | sed 's/^[[:space:]]*//' \
+            | sed 's/^replace //' \
+            | while IFS= read -r line; do
+                # Extract: left => right (ignoring version suffix)
+                left=$(echo "$line" | awk -F' => ' '{print $1}')
+                right=$(echo "$line" | awk -F' => ' '{print $2}' | awk '{print $1}')
+                echo "Updating: ${left} => ${right}@${SHA}"
+                go mod edit -replace "${left}=${right}@${SHA}"
+              done
+
           go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor=github.com/amazon-contributing/opentelemetry-collector-contrib/processor/resourcedetectionprocessor@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter=github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awsemfexporter@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter=github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awsxrayexporter@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/xray@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight=github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/containerinsight@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s=github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver=github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver=github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus=github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/translator/prometheus@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs=github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter=github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver=github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws=github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          go mod edit -replace github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/stanza=github.com/amazon-contributing/opentelemetry-collector-contrib/pkg/stanza@${{ steps.get-latest-commit.outputs.sha }}
-          go mod tidy
-          git commit -am "Update OTel fork components to https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${{ steps.get-latest-commit.outputs.sha }}"
+
+          git commit -am "Update OTel fork components to https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${SHA}"
           git push -u origin HEAD
-          git config --global --unset user.name
-          git config --global --unset user.email
       - name: Create pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
         with:
@@ -87,13 +118,18 @@ jobs:
           pr_body: |
             # Description of the issue
             An automated PR to update the OTel fork components to point to [${{ steps.get-latest-commit.outputs.sha }}](https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${{ steps.get-latest-commit.outputs.sha }}).
-            
+
+            ## Commits since last update
+            Previous SHA: `${{ steps.get-old-commit.outputs.sha }}`
+
+            ${{ steps.changelog.outputs.log }}
+
             # License
             By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
-            
+
             # Tests
             n/a
-            
+
             # Requirements
             _Before commit the code, please do the following steps._
             1. Run `make fmt` and `make fmt-sh`

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -44,7 +44,7 @@ jobs:
           shas=$(grep 'amazon-contributing/opentelemetry-collector-contrib/' go.mod \
             | grep -oE 'v0\.0\.0-[0-9]+-[0-9a-f]{12}' \
             | awk -F'-' '{print $NF}' \
-            | sort -u)
+            | sort -u || true)
           if [ -z "$shas" ]; then
             echo "::error::No fork components found in go.mod. Nothing to update."
             exit 1

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -38,13 +38,19 @@ jobs:
       - name: Get old commit sha from go.mod
         id: get-old-commit
         run: |
-          # Extract the 12-char hash suffix from the first fork pseudo-version in go.mod.
+          # Extract all distinct 12-char hash suffixes from fork pseudo-versions in go.mod.
           # Pseudo-versions look like: v0.0.0-20260407222105-72a988178008
-          old_sha=$(grep -m1 'amazon-contributing/opentelemetry-collector-contrib/.*v0\.0\.0-' go.mod \
+          shas=$(grep 'amazon-contributing/opentelemetry-collector-contrib/' go.mod \
             | grep -oE 'v0\.0\.0-[0-9]+-[0-9a-f]{12}' \
-            | head -1 \
-            | awk -F'-' '{print $NF}')
-          echo "sha=${old_sha}" >> $GITHUB_OUTPUT
+            | awk -F'-' '{print $NF}' \
+            | sort -u)
+          count=$(echo "$shas" | wc -l | tr -d ' ')
+          if [ "$count" -ne 1 ]; then
+            echo "::error::Found $count distinct fork SHAs in go.mod. A component may be intentionally pinned. Aborting."
+            echo "$shas"
+            exit 1
+          fi
+          echo "sha=${shas}" >> $GITHUB_OUTPUT
       - name: Generate changelog
         id: changelog
         env:


### PR DESCRIPTION
# Description of changes
## Changes to otel-fork-replace workflow
- Parse go.mod dynamically instead of hardcoding fork components, so the workflow never goes stale when components are added/removed
- Fix shell syntax bug in commit SHA conditional (missing spaces)
- Add changelog table to PR description with commit and PR links
- Run go mod tidy once instead of after every go mod edit
- Add set -euo pipefail for fail-fast error handling
- Use repo-local git config instead of global with fragile cleanup
- Adds a safeguard that aborts if fork components point to multiple distinct SHAs (indicating an intentional pin).
## Changes to PR-test workflow
- Allow a "skip testing" label to be set on the PR to bypass testing and still satisfy GH checks. Should only be used for PRs that do no impact functionality of the agent such as doc updates, workflow file updates etc.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested the chunks locally.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



