### PR TITLE
Fix: resolve commit SHA to Go pseudo-version, use gh api

### DIFF
--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -65,7 +65,6 @@ jobs:
         run: |
           set -euo pipefail
           REPO_URL="https://github.com/amazon-contributing/opentelemetry-collector-contrib"
-          # Use GitHub API instead of cloning — faster, no disk usage (capped at 250 commits)
           echo "Fetching changelog: ${OLD_SHA}...${NEW_SHA}"
           if ! raw=$(gh api "repos/amazon-contributing/opentelemetry-collector-contrib/compare/${OLD_SHA}...${NEW_SHA}" \
             --jq '.commits[] | "\(.sha[:10]) \(.commit.message | split("\n")[0])"' 2>&1); then
@@ -130,24 +129,31 @@ jobs:
 
           go mod tidy
 
-          echo "=== DRY RUN: would commit and push here ==="
-          echo "=== go.mod diff ==="
-          git diff go.mod | head -100
-      # - name: Create pull request (disabled for testing)
-      - name: Log PR description (dry run)
-        run: |
-          cat <<'EOF'
-          # Description of the issue
-          An automated PR to update the OTel fork components to point to [${{ steps.get-latest-commit.outputs.sha }}](https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${{ steps.get-latest-commit.outputs.sha }}).
+          git commit -am "Update OTel fork components to https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${SHA}"
+          git push -u origin HEAD
+      - name: Create pull request
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
+        with:
+          source_branch: otel-fork-replace-${{ steps.get-latest-commit.outputs.sha }}
+          destination_branch: main
+          pr_title: "Update OTel fork components to ${{ steps.get-latest-commit.outputs.sha }}"
+          pr_allow_empty: false
+          pr_body: |
+            # Description of the issue
+            An automated PR to update the OTel fork components to point to [${{ steps.get-latest-commit.outputs.sha }}](https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${{ steps.get-latest-commit.outputs.sha }}).
 
-          ## Commits since last update
-          Previous SHA: `${{ steps.get-old-commit.outputs.sha }}`
+            ## Commits since last update
+            Previous SHA: `${{ steps.get-old-commit.outputs.sha }}`
 
-          ${{ steps.changelog.outputs.log }}
+            ${{ steps.changelog.outputs.log }}
 
-          # License
-          By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+            # License
+            By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
 
-          # Tests
-          n/a
-          EOF
+            # Tests
+            n/a
+
+            # Requirements
+            _Before commit the code, please do the following steps._
+            1. Run `make fmt` and `make fmt-sh`
+            2. Run `make lint`

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -67,8 +67,8 @@ jobs:
           REPO_URL="https://github.com/amazon-contributing/opentelemetry-collector-contrib"
           echo "Fetching changelog: ${OLD_SHA}...${NEW_SHA}"
           if ! raw=$(gh api "repos/amazon-contributing/opentelemetry-collector-contrib/compare/${OLD_SHA}...${NEW_SHA}" \
-            --jq '.commits[] | "\(.sha[:10]) \(.commit.message | split("\n")[0])"' 2>&1); then
-            echo "gh api failed: ${raw}"
+            --jq '.commits[] | "\(.sha[:10]) \(.commit.message | split("\n")[0])"'); then
+            echo "gh api failed (see above for error)"
             raw=""
           else
             echo "Found $(echo "$raw" | grep -c . || true) commits"
@@ -111,6 +111,7 @@ jobs:
           PSEUDO_VERSION=$(GONOSUMCHECK='github.com/amazon-contributing/*' \
             go list -m "github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws@${SHA}" \
             | awk '{print $2}')
+          [ -n "$PSEUDO_VERSION" ] || { echo "::error::go list -m returned empty version for ${SHA}"; exit 1; }
           echo "Resolved pseudo-version: ${PSEUDO_VERSION}"
 
           # Parse go.mod for all replace directives pointing to the fork,

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -64,10 +64,9 @@ jobs:
         run: |
           set -euo pipefail
           REPO_URL="https://github.com/amazon-contributing/opentelemetry-collector-contrib"
-          git clone --bare ${{ env.UPSTREAM }} /tmp/otel-fork
-          # old_sha is a 12-char prefix, git log handles prefix matching
-          raw=$(git -C /tmp/otel-fork log --oneline "${OLD_SHA}..${NEW_SHA}" 2>/dev/null || true)
-          rm -rf /tmp/otel-fork
+          # Use GitHub API instead of cloning — faster, no disk usage (capped at 250 commits)
+          raw=$(gh api "repos/amazon-contributing/opentelemetry-collector-contrib/compare/${OLD_SHA}...${NEW_SHA}" \
+            --jq '.commits[] | "\(.sha[:10]) \(.commit.message | split("\n")[0])"' 2>/dev/null || true)
           {
             echo "log<<CHANGELOG_EOF"
             if [ -z "$raw" ]; then
@@ -78,6 +77,7 @@ jobs:
               echo "$raw" | while IFS= read -r line; do
                 sha=$(echo "$line" | awk '{print $1}')
                 msg=$(echo "$line" | cut -d' ' -f2-)
+                msg=$(echo "$msg" | sed 's/|/\\|/g')
                 # Extract (#NNN) from end of message if present
                 if echo "$msg" | grep -qE '\(#[0-9]+\)$'; then
                   pr_num=$(echo "$msg" | grep -oE '#[0-9]+\)$' | tr -d ')' )
@@ -100,9 +100,15 @@ jobs:
           git config user.email 'action@github.com'
           git checkout -b "otel-fork-replace-${SHA}"
 
+          # Resolve the commit SHA to a Go pseudo-version (e.g. v0.0.0-20260410000839-bf7ae656c809).
+          # go mod edit requires a valid version, not a bare SHA.
+          PSEUDO_VERSION=$(GONOSUMCHECK='github.com/amazon-contributing/*' \
+            go list -m "github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws@${SHA}" \
+            | awk '{print $2}')
+          echo "Resolved pseudo-version: ${PSEUDO_VERSION}"
+
           # Parse go.mod for all replace directives pointing to the fork,
-          # then rewrite each one to the new SHA. This ensures the workflow
-          # automatically covers any components added or removed in go.mod.
+          # then rewrite each one to the new pseudo-version.
           grep 'amazon-contributing/opentelemetry-collector-contrib/' go.mod \
             | grep '=>' \
             | sed 's/^[[:space:]]*//' \
@@ -111,8 +117,8 @@ jobs:
                 # Extract: left => right (ignoring version suffix)
                 left=$(echo "$line" | awk -F' => ' '{print $1}')
                 right=$(echo "$line" | awk -F' => ' '{print $2}' | awk '{print $1}')
-                echo "Updating: ${left} => ${right}@${SHA}"
-                go mod edit -replace "${left}=${right}@${SHA}"
+                echo "Updating: ${left} => ${right}@${PSEUDO_VERSION}"
+                go mod edit -replace "${left}=${right}@${PSEUDO_VERSION}"
               done
 
           go mod tidy

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -65,8 +65,14 @@ jobs:
           set -euo pipefail
           REPO_URL="https://github.com/amazon-contributing/opentelemetry-collector-contrib"
           # Use GitHub API instead of cloning — faster, no disk usage (capped at 250 commits)
-          raw=$(gh api "repos/amazon-contributing/opentelemetry-collector-contrib/compare/${OLD_SHA}...${NEW_SHA}" \
-            --jq '.commits[] | "\(.sha[:10]) \(.commit.message | split("\n")[0])"' 2>/dev/null || true)
+          echo "Fetching changelog: ${OLD_SHA}...${NEW_SHA}"
+          if ! raw=$(gh api "repos/amazon-contributing/opentelemetry-collector-contrib/compare/${OLD_SHA}...${NEW_SHA}" \
+            --jq '.commits[] | "\(.sha[:10]) \(.commit.message | split("\n")[0])"' 2>&1); then
+            echo "gh api failed: ${raw}"
+            raw=""
+          else
+            echo "Found $(echo "$raw" | grep -c . || true) commits"
+          fi
           {
             echo "log<<CHANGELOG_EOF"
             if [ -z "$raw" ]; then
@@ -123,31 +129,24 @@ jobs:
 
           go mod tidy
 
-          git commit -am "Update OTel fork components to https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${SHA}"
-          git push -u origin HEAD
-      - name: Create pull request
-        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
-        with:
-          source_branch: otel-fork-replace-${{ steps.get-latest-commit.outputs.sha }}
-          destination_branch: main
-          pr_title: "Update OTel fork components to ${{ steps.get-latest-commit.outputs.sha }}"
-          pr_allow_empty: false
-          pr_body: |
-            # Description of the issue
-            An automated PR to update the OTel fork components to point to [${{ steps.get-latest-commit.outputs.sha }}](https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${{ steps.get-latest-commit.outputs.sha }}).
+          echo "=== DRY RUN: would commit and push here ==="
+          echo "=== go.mod diff ==="
+          git diff go.mod | head -100
+      # - name: Create pull request (disabled for testing)
+      - name: Log PR description (dry run)
+        run: |
+          cat <<'EOF'
+          # Description of the issue
+          An automated PR to update the OTel fork components to point to [${{ steps.get-latest-commit.outputs.sha }}](https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/${{ steps.get-latest-commit.outputs.sha }}).
 
-            ## Commits since last update
-            Previous SHA: `${{ steps.get-old-commit.outputs.sha }}`
+          ## Commits since last update
+          Previous SHA: `${{ steps.get-old-commit.outputs.sha }}`
 
-            ${{ steps.changelog.outputs.log }}
+          ${{ steps.changelog.outputs.log }}
 
-            # License
-            By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+          # License
+          By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
 
-            # Tests
-            n/a
-
-            # Requirements
-            _Before commit the code, please do the following steps._
-            1. Run `make fmt` and `make fmt-sh`
-            2. Run `make lint`
+          # Tests
+          n/a
+          EOF

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Generate changelog
         id: changelog
         env:
+          GH_TOKEN: ${{ github.token }}
           NEW_SHA: ${{ steps.get-latest-commit.outputs.sha }}
           OLD_SHA: ${{ steps.get-old-commit.outputs.sha }}
         run: |

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -108,7 +108,7 @@ jobs:
 
           # Resolve the commit SHA to a Go pseudo-version (e.g. v0.0.0-20260410000839-bf7ae656c809).
           # go mod edit requires a valid version, not a bare SHA.
-          PSEUDO_VERSION=$(GONOSUMCHECK='github.com/amazon-contributing/*' \
+          PSEUDO_VERSION=$(GONOSUMDB='github.com/amazon-contributing/*' \
             go list -m "github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws@${SHA}" \
             | awk '{print $2}')
           [ -n "$PSEUDO_VERSION" ] || { echo "::error::go list -m returned empty version for ${SHA}"; exit 1; }

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -66,6 +66,8 @@ jobs:
           set -euo pipefail
           REPO_URL="https://github.com/amazon-contributing/opentelemetry-collector-contrib"
           echo "Fetching changelog: ${OLD_SHA}...${NEW_SHA}"
+          # OLD_SHA is a 12-char prefix from the pseudo-version. GitHub's API resolves
+          # short SHAs in most cases; if ambiguous, the fallback produces a missing changelog.
           if ! raw=$(gh api "repos/amazon-contributing/opentelemetry-collector-contrib/compare/${OLD_SHA}...${NEW_SHA}" \
             --jq '.commits[] | "\(.sha[:10]) \(.commit.message | split("\n")[0])"'); then
             echo "gh api failed (see above for error)"
@@ -108,6 +110,7 @@ jobs:
 
           # Resolve the commit SHA to a Go pseudo-version (e.g. v0.0.0-20260410000839-bf7ae656c809).
           # go mod edit requires a valid version, not a bare SHA.
+          # Uses override/aws as the submodule since this is a multi-module repo with no root go.mod.
           PSEUDO_VERSION=$(GONOSUMDB='github.com/amazon-contributing/*' \
             go list -m "github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws@${SHA}" \
             | awk '{print $2}')


### PR DESCRIPTION
## Description of the issue

Follow-up fix to #2086. The otel-fork-replace workflow was passing bare commit SHAs to `go mod edit -replace`, which requires a valid Go version (`v0.0.0-<timestamp>-<sha12>`).

1. `go mod edit -replace` was passed bare commit SHAs instead of valid Go pseudo-versions (`v0.0.0-<timestamp>-<sha12>`), causing `go mod` to reject them
2. `gh api` requires `GH_TOKEN` to be explicitly set in GitHub Actions workflows — without it, the changelog step silently failed
3. Pipe characters (`|`) in commit messages could break the markdown changelog table

## Changes

- Use `go list -m` to resolve commit SHA → Go pseudo-version before `go mod edit -replace`
- Add `GH_TOKEN: ${{ github.token }}` to the changelog generation step
- Escape `|` in commit messages for markdown table safety
- Add logging to `gh api` call for easier debugging

## Tests
- GH run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/24534482790
- Sample PR: https://github.com/aws/amazon-cloudwatch-agent/pull/2089

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



