### PR TITLE
fix(eksdetector): add IRSA and Pod Identity env var checks before JWT fallback

### DIFF
--- a/translator/util/eksdetector/eksdetector.go
+++ b/translator/util/eksdetector/eksdetector.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -20,6 +21,7 @@ type IsEKSCache struct {
 
 var (
 	getInClusterConfig = func() (*rest.Config, error) { return rest.InClusterConfig() }
+	getEnv             = os.Getenv
 	// IsEKS is a function variable that can be overridden in tests
 	IsEKS = isEKS
 
@@ -32,6 +34,13 @@ var (
 // checking if it contains "eks". The result is cached to avoid repeated expensive operations.
 func isEKS() IsEKSCache {
 	once.Do(func() {
+		// Fast path: check IRSA and Pod Identity env vars (no I/O)
+		if checkEnvVars() {
+			isEKSCacheSingleton = IsEKSCache{Value: true, Err: nil}
+			return
+		}
+
+		// Fallback: parse JWT token issuer
 		var err error
 		var value bool
 		issuer, err := getIssuer()
@@ -41,6 +50,18 @@ func isEKS() IsEKSCache {
 		isEKSCacheSingleton = IsEKSCache{Value: value, Err: err}
 	})
 	return isEKSCacheSingleton
+}
+
+// checkEnvVars checks IRSA and Pod Identity environment variables for EKS indicators.
+// Returns true if either env var indicates an EKS environment.
+func checkEnvVars() bool {
+	if strings.Contains(getEnv("AWS_WEB_IDENTITY_TOKEN_FILE"), "eks.amazonaws.com") {
+		return true
+	}
+	if strings.Contains(getEnv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"), "eks-pod-identity") {
+		return true
+	}
+	return false
 }
 
 // getIssuer retrieves the issuer ("iss") from the service account token

--- a/translator/util/eksdetector/eksdetector_test.go
+++ b/translator/util/eksdetector/eksdetector_test.go
@@ -5,6 +5,7 @@ package eksdetector
 
 import (
 	"encoding/base64"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -76,4 +77,129 @@ func Test_getIssuer(t *testing.T) {
 func resetCacheForTesting() {
 	isEKSCacheSingleton = IsEKSCache{}
 	once = sync.Once{}
+}
+
+func TestEKS_IRSA_EnvVar(t *testing.T) {
+	resetCacheForTesting()
+	origGetEnv := getEnv
+	defer func() { getEnv = origGetEnv }()
+
+	getEnv = func(key string) string {
+		if key == "AWS_WEB_IDENTITY_TOKEN_FILE" {
+			return "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+		}
+		return ""
+	}
+	getInClusterConfig = func() (*rest.Config, error) {
+		return nil, fmt.Errorf("should not be called")
+	}
+
+	result := IsEKS()
+	assert.True(t, result.Value)
+	assert.NoError(t, result.Err)
+}
+
+func TestEKS_PodIdentity_EnvVar(t *testing.T) {
+	resetCacheForTesting()
+	origGetEnv := getEnv
+	defer func() { getEnv = origGetEnv }()
+
+	getEnv = func(key string) string {
+		if key == "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE" {
+			return "/var/run/secrets/pods.eks-pod-identity.amazonaws.com/serviceaccount/token"
+		}
+		return ""
+	}
+	getInClusterConfig = func() (*rest.Config, error) {
+		return nil, fmt.Errorf("should not be called")
+	}
+
+	result := IsEKS()
+	assert.True(t, result.Value)
+	assert.NoError(t, result.Err)
+}
+
+func TestEKS_EnvVarsAbsent_FallsThrough(t *testing.T) {
+	resetCacheForTesting()
+	origGetEnv := getEnv
+	defer func() { getEnv = origGetEnv }()
+
+	getEnv = func(_ string) string { return "" }
+
+	payload := `{"iss":"https://oidc.eks.us-west-2.amazonaws.com/id/someid"}`
+	encodedPayload := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	dummyToken := "header." + encodedPayload + ".signature"
+	getInClusterConfig = func() (*rest.Config, error) {
+		return &rest.Config{BearerToken: dummyToken}, nil
+	}
+
+	result := IsEKS()
+	assert.True(t, result.Value)
+	assert.NoError(t, result.Err)
+}
+
+func TestNonEKS_EnvVarsAbsent_NonEKSToken(t *testing.T) {
+	resetCacheForTesting()
+	origGetEnv := getEnv
+	defer func() { getEnv = origGetEnv }()
+
+	getEnv = func(_ string) string { return "" }
+
+	payload := `{"iss":"https://kubernetes.default.svc.cluster.local"}`
+	encodedPayload := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	dummyToken := "header." + encodedPayload + ".signature"
+	getInClusterConfig = func() (*rest.Config, error) {
+		return &rest.Config{BearerToken: dummyToken}, nil
+	}
+
+	result := IsEKS()
+	assert.False(t, result.Value)
+	assert.NoError(t, result.Err)
+}
+
+func TestEKS_PartialEnvVars_IRSAWithoutEKS(t *testing.T) {
+	resetCacheForTesting()
+	origGetEnv := getEnv
+	defer func() { getEnv = origGetEnv }()
+
+	getEnv = func(key string) string {
+		if key == "AWS_WEB_IDENTITY_TOKEN_FILE" {
+			return "/var/run/secrets/some-other-provider/token"
+		}
+		return ""
+	}
+
+	payload := `{"iss":"https://oidc.eks.us-west-2.amazonaws.com/id/someid"}`
+	encodedPayload := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	dummyToken := "header." + encodedPayload + ".signature"
+	getInClusterConfig = func() (*rest.Config, error) {
+		return &rest.Config{BearerToken: dummyToken}, nil
+	}
+
+	result := IsEKS()
+	assert.True(t, result.Value)
+	assert.NoError(t, result.Err)
+}
+
+func TestEKS_BothEnvVarsSet(t *testing.T) {
+	resetCacheForTesting()
+	origGetEnv := getEnv
+	defer func() { getEnv = origGetEnv }()
+
+	getEnv = func(key string) string {
+		switch key {
+		case "AWS_WEB_IDENTITY_TOKEN_FILE":
+			return "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+		case "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE":
+			return "/var/run/secrets/pods.eks-pod-identity.amazonaws.com/serviceaccount/token"
+		}
+		return ""
+	}
+	getInClusterConfig = func() (*rest.Config, error) {
+		return nil, fmt.Errorf("should not be called")
+	}
+
+	result := IsEKS()
+	assert.True(t, result.Value)
+	assert.NoError(t, result.Err)
 }


### PR DESCRIPTION
# Description of the issue

The CWA `eksdetector` parses the JWT token issuer to detect EKS. This fails on:
- Custom OIDC providers (non-EKS issuers)
- Opaque tokens (no parseable JWT payload)
- Token mount race conditions (file not yet available at startup)

# Description of changes

Add fast-path environment variable checks before the existing JWT fallback:
- Check for IRSA token path (`AWS_WEB_IDENTITY_TOKEN_FILE`)
- Check for Pod Identity path (EKS Pod Identity agent endpoint)
- Zero-cost: no I/O, no network calls
- Falls back to existing JWT parsing if env vars are absent

> [!IMPORTANT]
> **Co-PRs:** [amazon-contributing/opentelemetry-collector-contrib#520](https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/520)

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

## Setup

EKS cluster with `authentication_mode = API` (Access Entries only, no `aws-auth` ConfigMap). 1× t3.medium managed node group. IRSA configured via OIDC provider. Custom CWA image built with this PR's eksdetector changes + OTEL fork fix (PR #520). Deployed via mainline `amazon-cloudwatch-observability` helm chart with mainline operator. Sample OTEL-instrumented Python app deployed to generate traces and metrics through the App Signals pipeline.

## Unit Tests

10 tests (4 existing + 6 new). All pass:
```
=== RUN   TestEKS
--- PASS: TestEKS (0.00s)
=== RUN   TestNonEKS
--- PASS: TestNonEKS (0.00s)
=== RUN   TestEmptyToken
--- PASS: TestEmptyToken (0.00s)
=== RUN   Test_getIssuer
--- PASS: Test_getIssuer (0.00s)
=== RUN   TestEKS_IRSA_EnvVar
--- PASS: TestEKS_IRSA_EnvVar (0.00s)
=== RUN   TestEKS_PodIdentity_EnvVar
--- PASS: TestEKS_PodIdentity_EnvVar (0.00s)
=== RUN   TestEKS_EnvVarsAbsent_FallsThrough
--- PASS: TestEKS_EnvVarsAbsent_FallsThrough (0.00s)
=== RUN   TestNonEKS_EnvVarsAbsent_NonEKSToken
--- PASS: TestNonEKS_EnvVarsAbsent_NonEKSToken (0.00s)
=== RUN   TestEKS_PartialEnvVars_IRSAWithoutEKS
--- PASS: TestEKS_PartialEnvVars_IRSAWithoutEKS (0.00s)
=== RUN   TestEKS_BothEnvVarsSet
--- PASS: TestEKS_BothEnvVarsSet (0.00s)
PASS
ok      github.com/aws/amazon-cloudwatch-agent/translator/util/eksdetector      0.005s
```

## E2E — CWA eksdetector enables App Signals and Entity pipelines

The CWA eksdetector result (`IsEKS() = true`) gates whether App Signals and Entity processors are wired into the OTEL pipeline. The generated pipeline config confirms `isEKS()` returned true via the env var fast-path:

```yaml
pipelines:
    metrics/application_signals:
        processors:
            - resourcedetection
            - awsapplicationsignals
            - awsentity/service/application_signals
    traces/application_signals:
        processors:
            - resourcedetection
            - awsapplicationsignals
```

`awsentity/service/application_signals`, `k8smetadata`, and `entitystore` are only added when `KubernetesMode == "EKS"`.

## E2E — IRSA env var fast-path exercised

The ServiceAccount has the IRSA annotation, causing EKS to inject `AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token`. The `checkEnvVars()` fast-path detects `eks.amazonaws.com` in this path and returns true immediately — the JWT fallback is never reached.

```yaml
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<CLUSTER>-cwagent
```

## E2E — App Signals metrics with correct Environment

15 metrics in `ApplicationSignals` namespace confirm the CWA eksdetector drove the `EKSResolver`, producing `eks:` environment labels:

```
Environment=eks:<CLUSTER>/sample-app
Service=sample-app
```

Metrics: `PythonProcessRSSMemoryUsed`, `PythonProcessGCGen1Count`, `PythonProcessThreadCount`, etc.

## E2E — X-Ray traces with correct Entity metadata

X-Ray segments confirm entity metadata is correct (driven by `awsentity` which reads `KubernetesMode`):

```json
{
  "PlatformType": "AWS::EKS",
  "EKS.Cluster": "<CLUSTER>",
  "K8s.Namespace": "sample-app"
}
```

Entry point type: `AWS::EKS::Container`

## E2E — No aws-auth ConfigMap

```
$ kubectl get configmap aws-auth -n kube-system
Error from server (NotFound): configmaps "aws-auth" not found
```