### PR TITLE
Add additional workloads to usage_metadata

### DIFF
--- a/extension/agenthealth/metadata/metadata.go
+++ b/extension/agenthealth/metadata/metadata.go
@@ -16,6 +16,7 @@ const (
 	ValueApplicationSignals   = "application_signals"
 	ValueCollectd             = "collectd"
 	ValueEC2Health            = "ec2_health"
+	ValueEC2HealthWindows     = "ec2_health_windows"
 	ValueEMF                  = "emf"
 	ValueJVM                  = "jvm"
 	ValueJVMEC2               = "jvm_ec2"
@@ -48,6 +49,7 @@ var (
 		Build(KeyObservabilitySolutions, ValueApplicationSignals),
 		Build(KeyObservabilitySolutions, ValueCollectd),
 		Build(KeyObservabilitySolutions, ValueEC2Health),
+		Build(KeyObservabilitySolutions, ValueEC2HealthWindows),
 		Build(KeyObservabilitySolutions, ValueEMF),
 		Build(KeyObservabilitySolutions, ValueJVM),
 		Build(KeyObservabilitySolutions, ValueKafkaBroker),

--- a/extension/agenthealth/metadata/metadata.go
+++ b/extension/agenthealth/metadata/metadata.go
@@ -13,38 +13,80 @@ type Metadata = string
 
 const (
 	KeyObservabilitySolutions = "ObservabilitySolution"
+	ValueApplicationSignals   = "application_signals"
+	ValueCollectd             = "collectd"
 	ValueEC2Health            = "ec2_health"
+	ValueEMF                  = "emf"
 	ValueJVM                  = "jvm"
-	ValueTomcat               = "tomcat"
+	ValueJVMEC2               = "jvm_ec2"
 	ValueKafkaBroker          = "kafka_broker"
 	ValueKafkaConsumer        = "kafka_consumer"
 	ValueKafkaProducer        = "kafka_producer"
+	ValueLogCollection        = "log_collection"
 	ValueNVIDIA               = "nvidia_gpu"
+	ValueNVIDIAEC2            = "nvidia_gpu_ec2"
+	ValueOtelMetrics          = "otel_metrics"
+	ValueOtelTraces           = "otel_traces"
+	ValueProcessMonitoring    = "process_monitoring"
+	ValuePrometheus           = "prometheus"
+	ValueStatsd               = "statsd"
+	ValueTomcat               = "tomcat"
+	ValueTomcatEC2            = "tomcat_ec2"
+	ValueWindowsEvents        = "windows_events"
+	ValueXrayTraces           = "xray_traces"
 
 	shortKeyObservabilitySolutions = "obs"
 	separator                      = "_"
 )
 
 var (
-	supportedMetadata = collections.NewSet(
-		Build(KeyObservabilitySolutions, ValueEC2Health),
-		Build(KeyObservabilitySolutions, ValueJVM),
-		Build(KeyObservabilitySolutions, ValueTomcat),
-		Build(KeyObservabilitySolutions, ValueKafkaBroker),
-		Build(KeyObservabilitySolutions, ValueKafkaConsumer),
-		Build(KeyObservabilitySolutions, ValueKafkaProducer),
-		Build(KeyObservabilitySolutions, ValueNVIDIA),
-	)
+	aliases         = map[Metadata]Metadata{}
 	shortKeyMapping = map[string]string{
 		strings.ToLower(KeyObservabilitySolutions): shortKeyObservabilitySolutions,
 	}
+	supportedMetadata = collections.NewSet(
+		Build(KeyObservabilitySolutions, ValueApplicationSignals),
+		Build(KeyObservabilitySolutions, ValueCollectd),
+		Build(KeyObservabilitySolutions, ValueEC2Health),
+		Build(KeyObservabilitySolutions, ValueEMF),
+		Build(KeyObservabilitySolutions, ValueJVM),
+		Build(KeyObservabilitySolutions, ValueKafkaBroker),
+		Build(KeyObservabilitySolutions, ValueKafkaConsumer),
+		Build(KeyObservabilitySolutions, ValueKafkaProducer),
+		Build(KeyObservabilitySolutions, ValueLogCollection),
+		Build(KeyObservabilitySolutions, ValueNVIDIA),
+		Build(KeyObservabilitySolutions, ValueOtelMetrics),
+		Build(KeyObservabilitySolutions, ValueOtelTraces),
+		Build(KeyObservabilitySolutions, ValueProcessMonitoring),
+		Build(KeyObservabilitySolutions, ValuePrometheus),
+		Build(KeyObservabilitySolutions, ValueStatsd),
+		Build(KeyObservabilitySolutions, ValueTomcat),
+		Build(KeyObservabilitySolutions, ValueWindowsEvents),
+		Build(KeyObservabilitySolutions, ValueXrayTraces),
+	)
 )
 
+func init() {
+	aliases[Build(KeyObservabilitySolutions, ValueJVMEC2)] = Build(KeyObservabilitySolutions, ValueJVM)
+	aliases[Build(KeyObservabilitySolutions, ValueTomcatEC2)] = Build(KeyObservabilitySolutions, ValueTomcat)
+	aliases[Build(KeyObservabilitySolutions, ValueNVIDIAEC2)] = Build(KeyObservabilitySolutions, ValueNVIDIA)
+}
+
 func IsSupported(m Metadata) bool {
+	if base, ok := aliases[m]; ok {
+		m = base
+	}
 	return supportedMetadata.Contains(m)
 }
 
-// Build finds any short key mappings and then adds them to the value.
+// Resolve returns the base value for an alias, or the input unchanged.
+func Resolve(m Metadata) Metadata {
+	if base, ok := aliases[m]; ok {
+		return base
+	}
+	return m
+}
+
 func Build(key, value string) Metadata {
 	key = strings.ToLower(key)
 	if shortKey, ok := shortKeyMapping[key]; ok {

--- a/extension/agenthealth/metadata/metadata_test.go
+++ b/extension/agenthealth/metadata/metadata_test.go
@@ -78,3 +78,20 @@ func TestIsSupportedAliasResolution(t *testing.T) {
 	assert.True(t, IsSupported("obs_tomcat"))
 	assert.True(t, IsSupported("obs_nvidia_gpu"))
 }
+
+func TestResolve(t *testing.T) {
+	testCases := []struct {
+		input string
+		want  string
+	}{
+		{input: "obs_jvm_ec2", want: "obs_jvm"},
+		{input: "obs_tomcat_ec2", want: "obs_tomcat"},
+		{input: "obs_nvidia_gpu_ec2", want: "obs_nvidia_gpu"},
+		{input: "obs_jvm", want: "obs_jvm"},
+		{input: "obs_ec2_health", want: "obs_ec2_health"},
+		{input: "obs_unknown", want: "obs_unknown"},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.want, Resolve(testCase.input))
+	}
+}

--- a/extension/agenthealth/metadata/metadata_test.go
+++ b/extension/agenthealth/metadata/metadata_test.go
@@ -15,11 +15,17 @@ func TestBuild(t *testing.T) {
 		value string
 		want  string
 	}{
+		{key: "ObservabilitySolution", value: "application_signals", want: "obs_application_signals"},
 		{key: "ObservabilitySolution", value: "ec2_health", want: "obs_ec2_health"},
+		{key: "ObservabilitySolution", value: "emf", want: "obs_emf"},
 		{key: "ObservabilitySolution", value: "JVM", want: "obs_jvm"},
-		{key: "OBSERVABILITYSOLUTION", value: "TOMCAT", want: "obs_tomcat"},
+		{key: "ObservabilitySolution", value: "jvm_ec2", want: "obs_jvm_ec2"},
 		{key: "observabilitysolution", value: "kafka_broker", want: "obs_kafka_broker"},
+		{key: "ObservabilitySolution", value: "log_collection", want: "obs_log_collection"},
 		{key: "ObservabilitySolution", value: "NVIDIA_GPU", want: "obs_nvidia_gpu"},
+		{key: "ObservabilitySolution", value: "nvidia_gpu_ec2", want: "obs_nvidia_gpu_ec2"},
+		{key: "OBSERVABILITYSOLUTION", value: "TOMCAT", want: "obs_tomcat"},
+		{key: "ObservabilitySolution", value: "tomcat_ec2", want: "obs_tomcat_ec2"},
 		{key: "unsupported", value: "Value", want: "unsupported_value"},
 	}
 	for _, testCase := range testCases {
@@ -32,14 +38,43 @@ func TestIsSupported(t *testing.T) {
 		input string
 		want  bool
 	}{
-		{input: "obs_jvm", want: true},
-		{input: "obs_tomcat", want: true},
-		{input: "obs_kafka_broker", want: true},
-		{input: "obs_nvidia_gpu", want: true},
+		{input: "obs_application_signals", want: true},
+		{input: "obs_collectd", want: true},
 		{input: "obs_ec2_health", want: true},
+		{input: "obs_emf", want: true},
+		{input: "obs_jvm", want: true},
+		{input: "obs_jvm_ec2", want: true},
+		{input: "obs_kafka_broker", want: true},
+		{input: "obs_kafka_consumer", want: true},
+		{input: "obs_kafka_producer", want: true},
+		{input: "obs_log_collection", want: true},
+		{input: "obs_nvidia_gpu", want: true},
+		{input: "obs_nvidia_gpu_ec2", want: true},
+		{input: "obs_otel_metrics", want: true},
+		{input: "obs_otel_traces", want: true},
+		{input: "obs_process_monitoring", want: true},
+		{input: "obs_prometheus", want: true},
+		{input: "obs_statsd", want: true},
+		{input: "obs_tomcat", want: true},
+		{input: "obs_tomcat_ec2", want: true},
+		{input: "obs_windows_events", want: true},
+		{input: "obs_xray_traces", want: true},
+		{input: "obs_unknown", want: false},
 		{input: "unsupported_value", want: false},
 	}
 	for _, testCase := range testCases {
 		assert.Equal(t, testCase.want, IsSupported(testCase.input))
 	}
+}
+
+func TestIsSupportedAliasResolution(t *testing.T) {
+	// _ec2 variants are accepted but resolve to canonical values
+	assert.True(t, IsSupported("obs_jvm_ec2"))
+	assert.True(t, IsSupported("obs_tomcat_ec2"))
+	assert.True(t, IsSupported("obs_nvidia_gpu_ec2"))
+
+	// canonical values are in the supported set directly
+	assert.True(t, IsSupported("obs_jvm"))
+	assert.True(t, IsSupported("obs_tomcat"))
+	assert.True(t, IsSupported("obs_nvidia_gpu"))
 }

--- a/translator/translate/otel/extension/agenthealth/translator.go
+++ b/translator/translate/otel/extension/agenthealth/translator.go
@@ -96,7 +96,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 				continue
 			}
 			if md := metadata.Build(k, valueStr); metadata.IsSupported(md) {
-				usageMetadataSet.Add(md)
+				usageMetadataSet.Add(metadata.Resolve(md))
 			}
 		}
 	}

--- a/translator/translate/otel/extension/agenthealth/translator_test.go
+++ b/translator/translate/otel/extension/agenthealth/translator_test.go
@@ -132,6 +132,72 @@ func TestTranslate(t *testing.T) {
 				UsageMetadata: []metadata.Metadata{"obs_jvm"},
 			},
 		},
+		"WithUsageMetadata/AliasResolution": {
+			input: map[string]any{
+				"agent": map[string]any{
+					"usage_data": true,
+					"usage_metadata": []any{
+						map[string]any{"ObservabilitySolution": "jvm_ec2"},
+						map[string]any{"ObservabilitySolution": "tomcat_ec2"},
+						map[string]any{"ObservabilitySolution": "nvidia_gpu_ec2"},
+					},
+				},
+			},
+			isEnvUsageData: true,
+			want: &agenthealth.Config{
+				IsUsageDataEnabled: true,
+				Stats: &agent.StatsConfig{
+					Operations: operations,
+					UsageFlags: usageFlags,
+				},
+				UsageMetadata: []metadata.Metadata{"obs_jvm", "obs_nvidia_gpu", "obs_tomcat"},
+			},
+		},
+		"WithUsageMetadata/AllWorkloads": {
+			input: map[string]any{
+				"agent": map[string]any{
+					"usage_data": true,
+					"usage_metadata": []any{
+						map[string]any{"ObservabilitySolution": "ec2_health"},
+						map[string]any{"ObservabilitySolution": "jvm_ec2"},
+						map[string]any{"ObservabilitySolution": "tomcat_ec2"},
+						map[string]any{"ObservabilitySolution": "kafka_broker"},
+						map[string]any{"ObservabilitySolution": "kafka_producer"},
+						map[string]any{"ObservabilitySolution": "kafka_consumer"},
+						map[string]any{"ObservabilitySolution": "nvidia_gpu_ec2"},
+						map[string]any{"ObservabilitySolution": "application_signals"},
+						map[string]any{"ObservabilitySolution": "statsd"},
+						map[string]any{"ObservabilitySolution": "collectd"},
+						map[string]any{"ObservabilitySolution": "prometheus"},
+						map[string]any{"ObservabilitySolution": "otel_metrics"},
+						map[string]any{"ObservabilitySolution": "process_monitoring"},
+					},
+				},
+			},
+			isEnvUsageData: true,
+			want: &agenthealth.Config{
+				IsUsageDataEnabled: true,
+				Stats: &agent.StatsConfig{
+					Operations: operations,
+					UsageFlags: usageFlags,
+				},
+				UsageMetadata: []metadata.Metadata{
+					"obs_application_signals",
+					"obs_collectd",
+					"obs_ec2_health",
+					"obs_jvm",
+					"obs_kafka_broker",
+					"obs_kafka_consumer",
+					"obs_kafka_producer",
+					"obs_nvidia_gpu",
+					"obs_otel_metrics",
+					"obs_process_monitoring",
+					"obs_prometheus",
+					"obs_statsd",
+					"obs_tomcat",
+				},
+			},
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
# Description of the issue

Adding support for additional `usage_metadata` entries to help indicate which observability solutions are active.

Previously, only 7 values were supported and unsupported values were silently dropped by `metadata.IsSupported()`.

# Description of changes

Adds new workload values to the agent's supported metadata set:

- `jvm_ec2`, `tomcat_ec2`, `nvidia_gpu_ec2` (Variants of existing workloads)
- `log_collection`, `windows_events`, `xray_traces`, `otel_traces`
- `application_signals`, `statsd`, `collectd`, `prometheus`
- `otel_metrics`, `emf`, `process_monitoring`

Existing values (`jvm`, `tomcat`, `nvidia_gpu`) are kept for backward compatibility.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- Extension integration test verifying feature flags propagate to User-Agent header
- All existing tests pass
- Verified end-to-end on EC2 instance: translator accepts all 18 values and writes them to OTEL config

```
usage_metadata:
    - obs_application_signals
    - obs_collectd
    - obs_ec2_health
    - obs_jvm              ← jvm_ec2 resolved to jvm ✓
    - obs_kafka_broker
    - obs_kafka_consumer
    - obs_kafka_producer
    - obs_nvidia_gpu       ← nvidia_gpu_ec2 resolved to nvidia_gpu ✓
    - obs_otel_metrics
    - obs_process_monitoring
    - obs_prometheus
    - obs_statsd
    - obs_tomcat           ← tomcat_ec2 resolved to tomcat ✓
```


# Requirements

1. [x] Run `make fmt` and `make fmt-sh`
2. [x] Run `make lint`