### PR TITLE
Rename EFA dimension attributes to CW-friendly short names

### DIFF
--- a/translator/translate/otel/pipeline/host/translator.go
+++ b/translator/translate/otel/pipeline/host/translator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/ec2taggerprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/metricsdecorator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/rollupprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/transformprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
@@ -88,6 +89,11 @@ func (t translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators,
 	if strings.HasPrefix(t.name, common.PipelineNameHostDeltaMetrics) || strings.HasPrefix(t.name, common.PipelineNameHostOtlpMetrics) {
 		log.Printf("D! delta processor required because metrics with diskio or net are set")
 		translators.Processors.Set(cumulativetodeltaprocessor.NewTranslator(common.WithName(t.name), cumulativetodeltaprocessor.WithDefaultKeys()))
+	}
+
+	if strings.HasPrefix(t.name, common.PipelineNameHostDeltaMetrics) &&
+		conf.IsSet(common.ConfigKey(common.MetricsKey, common.MetricsCollectedKey, common.EfaKey)) {
+		translators.Processors.Set(transformprocessor.NewTranslatorWithName(common.PipelineNameHostDeltaMetrics))
 	}
 
 	if t.Destination() != common.CloudWatchLogsKey {

--- a/translator/translate/otel/pipeline/host/translator_test.go
+++ b/translator/translate/otel/pipeline/host/translator_test.go
@@ -195,6 +195,25 @@ func TestTranslator(t *testing.T) {
 				extensions: []string{"k8smetadata", "agenthealth/logs", "agenthealth/statuscode"},
 			},
 		},
+		"WithDeltaMetricsAndEfa": {
+			input: map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"net": map[string]interface{}{},
+						"efa": map[string]interface{}{},
+					},
+				},
+			},
+			pipelineName: common.PipelineNameHostDeltaMetrics,
+			mode:         config.ModeEC2,
+			want: &want{
+				pipelineID: "metrics/hostDeltaMetrics",
+				receivers:  []string{"nop", "other"},
+				processors: []string{"cumulativetodelta/hostDeltaMetrics", "transform/hostDeltaMetrics", "awsentity/resource"},
+				exporters:  []string{"awscloudwatch"},
+				extensions: []string{"agenthealth/metrics", "agenthealth/statuscode"},
+			},
+		},
 		"WithMetricsKeyStatsD": {
 			input: map[string]interface{}{
 				"metrics": map[string]interface{}{

--- a/translator/translate/otel/processor/transformprocessor/transform_efa_config.yaml
+++ b/translator/translate/otel/processor/transformprocessor/transform_efa_config.yaml
@@ -1,0 +1,10 @@
+metric_statements:
+  - context: datapoint
+    error_mode: propagate
+    statements:
+      - set(attributes["device"], attributes["aws.efa.device"]) where attributes["aws.efa.device"] != nil
+      - delete_key(attributes, "aws.efa.device")
+      - set(attributes["port"], attributes["aws.efa.port"]) where attributes["aws.efa.port"] != nil
+      - delete_key(attributes, "aws.efa.port")
+      - set(attributes["eniId"], attributes["aws.efa.eni.id"]) where attributes["aws.efa.eni.id"] != nil
+      - delete_key(attributes, "aws.efa.eni.id")

--- a/translator/translate/otel/processor/transformprocessor/translate.go
+++ b/translator/translate/otel/processor/transformprocessor/translate.go
@@ -21,6 +21,9 @@ var transformJmxConfig string
 //go:embed transform_jmx_drop_config.yaml
 var transformJmxDropConfig string
 
+//go:embed transform_efa_config.yaml
+var transformEfaConfig string
+
 type translator struct {
 	name    string
 	factory processor.Factory
@@ -43,6 +46,9 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	}
 	if strings.HasPrefix(t.name, common.PipelineNameJmx) { // For JMX on EKS
 		return common.GetYamlFileToYamlConfig(cfg, transformJmxDropConfig)
+	}
+	if strings.HasPrefix(t.name, common.PipelineNameHostDeltaMetrics) {
+		return common.GetYamlFileToYamlConfig(cfg, transformEfaConfig)
 	}
 
 	return cfg, nil

--- a/translator/translate/otel/processor/transformprocessor/translator_test.go
+++ b/translator/translate/otel/processor/transformprocessor/translator_test.go
@@ -34,6 +34,26 @@ func TestContainerInsightsJmx(t *testing.T) {
 	assert.Equal(t, len(expectedCfg.MetricStatements), len(actualCfg.MetricStatements))
 }
 
+func TestEfaTranslate(t *testing.T) {
+	transl := NewTranslatorWithName(common.PipelineNameHostDeltaMetrics).(*translator)
+	expectedCfg := transl.factory.CreateDefaultConfig().(*transformprocessor.Config)
+	c := testutil.GetConf(t, "transform_efa_config.yaml")
+	require.NoError(t, c.Unmarshal(&expectedCfg))
+
+	conf := confmap.NewFromStringMap(testutil.GetJson(t, filepath.Join("testdata", "config.json")))
+	translatedCfg, err := transl.Translate(conf)
+	assert.NoError(t, err)
+	actualCfg, ok := translatedCfg.(*transformprocessor.Config)
+	assert.True(t, ok)
+	assert.Equal(t, len(expectedCfg.MetricStatements), len(actualCfg.MetricStatements))
+	assert.Equal(t, string(actualCfg.ErrorMode), "propagate")
+	// Verify EFA attribute renaming statements are present
+	require.Len(t, actualCfg.MetricStatements, 1)
+	assert.Contains(t, actualCfg.MetricStatements[0].Statements, `set(attributes["device"], attributes["aws.efa.device"]) where attributes["aws.efa.device"] != nil`)
+	assert.Contains(t, actualCfg.MetricStatements[0].Statements, `set(attributes["port"], attributes["aws.efa.port"]) where attributes["aws.efa.port"] != nil`)
+	assert.Contains(t, actualCfg.MetricStatements[0].Statements, `set(attributes["eniId"], attributes["aws.efa.eni.id"]) where attributes["aws.efa.eni.id"] != nil`)
+}
+
 func TestJmxTranslate(t *testing.T) {
 	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
 	transl := NewTranslatorWithName(common.PipelineNameJmx + "/drop").(*translator)


### PR DESCRIPTION


## Summary

Adds a transform processor to the EC2 host delta pipeline that renames EFA OTel-style dimension attributes to short CloudWatch-friendly names:

- `aws.efa.device` → `device`
- `aws.efa.port` → `port`
- `aws.efa.eni.id` → `eni_id`

## Motivation

The `awsefareceiver` uses OTel semantic conventions (dotted attribute names) however existing EC2 host metric plugins (diskio, net, nvidia_gpu, nvme) all use short lowercase dimension names. This transform processor ensures consistency for EC2 customers.

## Changes

- New `transform_efa_config.yaml` with OTTL datapoint-context rename statements
- Transform processor translator routes by `PipelineNameHostDeltaMetrics` name
- Host pipeline wires transform processor only when EFA is configured

## Testing

- Unit tests for transform processor config loading
- Unit tests for pipeline wiring with EFA present
- All existing tests pass
- Manual testing

<img width="1585" height="168" alt="Screenshot 2026-05-08 at 09 59 04" src="https://github.com/user-attachments/assets/071c27a2-59e5-43b3-82d8-fad2a7790108" />