### PR TITLE
ci: declare permissions on the PR-build workflow

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: write   # actions/cache save path on cache miss
+
 jobs:
   changes:
     name: Check changes


### PR DESCRIPTION
`PR-build.yml` runs Go lint + tests across the matrix with `actions/cache@v3` for the Go module cache. It is the one workflow in `.github/workflows/` without an explicit `permissions:` block.

Scopes:
- `contents: read` — `actions/checkout`
- `actions: write` — `actions/cache@v3` save path. The action restores AND saves; once explicit permissions kick in (instead of repo default), the save call needs `actions: write`.

YAML validates.