### PR TITLE
limit application-signals service-event metrics OTLP batch to 1000 datapoints per request

### DIFF
--- a/translator/tocwconfig/sampleConfig/appsignals_and_ecs_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_ecs_config.yaml
@@ -325,8 +325,8 @@ processors:
         timeout: 5s
     batch/application_signals_metrics_otlp_destination:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
+        send_batch_max_size: 1000
+        send_batch_size: 1000
         timeout: 1m0s
     metricstransform/application_signals:
         transforms:

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -459,8 +459,8 @@ processors:
         timeout: 5s
     batch/application_signals_metrics_otlp_destination:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
+        send_batch_max_size: 1000
+        send_batch_size: 1000
         timeout: 1m0s
     batch/containerinsights:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -460,8 +460,8 @@ processors:
         timeout: 5s
     batch/application_signals_metrics_otlp_destination:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
+        send_batch_max_size: 1000
+        send_batch_size: 1000
         timeout: 1m0s
     batch/containerinsights:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.yaml
@@ -459,8 +459,8 @@ processors:
         timeout: 5s
     batch/application_signals_metrics_otlp_destination:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
+        send_batch_max_size: 1000
+        send_batch_size: 1000
         timeout: 1m0s
     batch/containerinsights:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.yaml
@@ -459,8 +459,8 @@ processors:
         timeout: 5s
     batch/application_signals_metrics_otlp_destination:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
+        send_batch_max_size: 1000
+        send_batch_size: 1000
         timeout: 1m0s
     batch/containerinsights:
         metadata_cardinality_limit: 1000

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -343,8 +343,8 @@ processors:
         timeout: 5s
     batch/application_signals_metrics_otlp_destination:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
+        send_batch_max_size: 1000
+        send_batch_size: 1000
         timeout: 1m0s
     metricstransform/application_signals:
         transforms:

--- a/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.yaml
@@ -333,8 +333,8 @@ processors:
         timeout: 5s
     batch/application_signals_metrics_otlp_destination:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
+        send_batch_max_size: 1000
+        send_batch_size: 1000
         timeout: 1m0s
     metricstransform/application_signals:
         transforms:

--- a/translator/translate/otel/pipeline/applicationsignals/translator.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translator.go
@@ -243,7 +243,7 @@ func (t *translator) translateMetricsRouteToOtlp(_ *confmap.Conf) (*common.Compo
 
 	translators.Receivers.Set(connectorTranslator)
 
-	translators.Processors.Set(batchproc.NewTranslator(common.WithName(metricsVariantOtlpDest), batchproc.WithTelemetrySection(common.MetricsKey)))
+	translators.Processors.Set(batchproc.NewTranslator(common.WithName(metricsVariantOtlpDest), batchproc.WithTelemetrySection(common.MetricsKey), batchproc.WithSendBatchMaxSize(1000), batchproc.WithSendBatchSize(1000)))
 	translators.Exporters.Set(otlphttp.NewTranslatorWithName(metricsVariantOtlpDest, metricsEndpoint,
 		otlphttp.WithAuthenticator(sigv4Ext.ID()),
 	))

--- a/translator/translate/otel/processor/batchprocessor/translator.go
+++ b/translator/translate/otel/processor/batchprocessor/translator.go
@@ -47,12 +47,32 @@ func WithMetadataKeys(keys []string) common.TranslatorOption {
 	}
 }
 
+// WithSendBatchSize sets the preferred number of items per batch export.
+func WithSendBatchSize(size uint32) common.TranslatorOption {
+	return func(target any) {
+		if t, ok := target.(*translator); ok {
+			t.sendBatchSize = size
+		}
+	}
+}
+
+// WithSendBatchMaxSize sets the maximum number of items per batch export.
+func WithSendBatchMaxSize(size uint32) common.TranslatorOption {
+	return func(target any) {
+		if t, ok := target.(*translator); ok {
+			t.sendBatchMaxSize = size
+		}
+	}
+}
+
 type translator struct {
 	factory processor.Factory
 	common.NameProvider
 	telemetrySectionKey string
 	timeout             *time.Duration
 	metadataKeys        []string
+	sendBatchSize       uint32
+	sendBatchMaxSize    uint32
 }
 
 var _ common.ComponentTranslator = (*translator)(nil)
@@ -94,6 +114,12 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 
 	if len(t.metadataKeys) > 0 {
 		cfg.MetadataKeys = t.metadataKeys
+	}
+	if t.sendBatchSize > 0 {
+		cfg.SendBatchSize = t.sendBatchSize
+	}
+	if t.sendBatchMaxSize > 0 {
+		cfg.SendBatchMaxSize = t.sendBatchMaxSize
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
# Description of the issue
CW OTLP metrics endpoint has a 1000 datapoints/request limit.

# Description of changes
Set send_batch_size and send_batch_max_size to 1000 to prevent exceeding this limit when multiple SDK instances report to the same CWAgent.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested CWAgent in a Java EKS application and locally.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



