### PR TITLE
 Add pipeline translator for database monitoring

### DIFF
--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.conf
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.conf
@@ -1,0 +1,15 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false

--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.json
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.json
@@ -1,0 +1,22 @@
+{
+  "agent": {
+    "region": "us-west-2"
+  },
+  "opentelemetry": {
+    "collect": {
+      "database_insights": {
+        "postgresql": [
+          {
+            "endpoint": "localhost:5432",
+            "instance_name": "pentest-postgres",
+            "username": "cw_monitor",
+            "password_file": "sampleConfig/testdata/.pgpass",
+            "logs": {
+              "file_path": "/var/lib/pgsql/data/log/postgresql-*.log"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
@@ -1,0 +1,1009 @@
+connectors:
+    count/dbi_dbload:
+        datapoints:
+            metric.datapoint.count:
+                description: The number of data points observed.
+        logs:
+            postgresql.active_sessions.by_app:
+                attributes:
+                    - key: db.system.name
+                    - key: postgresql.application_name
+                    - key: db.namespace
+                conditions:
+                    - attributes["postgresql.state"] == "active"
+                description: Active sessions by application
+            postgresql.active_sessions.by_db:
+                attributes:
+                    - key: db.system.name
+                    - key: db.namespace
+                conditions:
+                    - attributes["postgresql.state"] == "active"
+                description: Active sessions by database
+            postgresql.active_sessions.by_host:
+                attributes:
+                    - key: db.system.name
+                    - key: network.peer.address
+                    - key: db.namespace
+                conditions:
+                    - attributes["postgresql.state"] == "active"
+                description: Active sessions by host
+            postgresql.active_sessions.by_sql:
+                attributes:
+                    - key: db.system.name
+                    - key: postgresql.query_id
+                    - key: db.namespace
+                conditions:
+                    - attributes["postgresql.state"] == "active"
+                description: Active sessions by query
+            postgresql.active_sessions.by_sql_wait:
+                attributes:
+                    - key: db.system.name
+                    - key: postgresql.query_id
+                    - key: postgresql.wait_event_type
+                    - key: postgresql.wait_event
+                    - key: db.namespace
+                conditions:
+                    - attributes["postgresql.state"] == "active"
+                description: Active sessions by query and wait
+            postgresql.active_sessions.by_user:
+                attributes:
+                    - key: db.system.name
+                    - key: user.name
+                    - key: db.namespace
+                conditions:
+                    - attributes["postgresql.state"] == "active"
+                description: Active sessions by user
+            postgresql.active_sessions.by_wait:
+                attributes:
+                    - key: db.system.name
+                    - key: postgresql.wait_event_type
+                    - key: postgresql.wait_event
+                    - key: db.namespace
+                conditions:
+                    - attributes["postgresql.state"] == "active"
+                description: Active sessions by wait event
+            postgresql.active_sessions.count:
+                attributes:
+                    - key: db.system.name
+                    - key: db.namespace
+                conditions:
+                    - attributes["postgresql.state"] == "active"
+                description: Total active sessions
+        metrics:
+            metric.count:
+                description: The number of metrics observed.
+        spanevents:
+            trace.span.event.count:
+                description: The number of span events observed.
+        spans:
+            trace.span.count:
+                description: The number of spans observed.
+    forward/opentelemetry: {}
+    signaltometrics/dbi_topsql:
+        logs:
+            - attributes:
+                - key: db.system.name
+                  optional: false
+                - key: postgresql.queryid
+                  optional: false
+                - key: db.namespace
+                  optional: false
+                - key: postgresql.rolname
+                  optional: false
+              conditions:
+                - attributes["postgresql.calls"] != nil
+              description: SQL execution count
+              include_resource_attributes:
+                - key: service.instance.id
+                  optional: false
+              name: postgresql.calls
+              sum:
+                value: Int(attributes["postgresql.calls"])
+              unit: ""
+            - attributes:
+                - key: db.system.name
+                  optional: false
+                - key: postgresql.queryid
+                  optional: false
+                - key: db.namespace
+                  optional: false
+                - key: postgresql.rolname
+                  optional: false
+              conditions:
+                - attributes["postgresql.total_exec_time"] != nil
+              description: Total execution time in ms
+              include_resource_attributes:
+                - key: service.instance.id
+                  optional: false
+              name: postgresql.total_exec_time
+              sum:
+                value: Double(attributes["postgresql.total_exec_time"])
+              unit: ""
+            - attributes:
+                - key: db.system.name
+                  optional: false
+                - key: postgresql.queryid
+                  optional: false
+                - key: db.namespace
+                  optional: false
+                - key: postgresql.rolname
+                  optional: false
+              conditions:
+                - attributes["postgresql.total_plan_time"] != nil
+              description: Total plan time in ms
+              include_resource_attributes:
+                - key: service.instance.id
+                  optional: false
+              name: postgresql.total_plan_time
+              sum:
+                value: Double(attributes["postgresql.total_plan_time"])
+              unit: ""
+            - attributes:
+                - key: db.system.name
+                  optional: false
+                - key: postgresql.queryid
+                  optional: false
+                - key: db.namespace
+                  optional: false
+                - key: postgresql.rolname
+                  optional: false
+              conditions:
+                - attributes["postgresql.rows"] != nil
+              description: Rows affected
+              include_resource_attributes:
+                - key: service.instance.id
+                  optional: false
+              name: postgresql.rows
+              sum:
+                value: Int(attributes["postgresql.rows"])
+              unit: ""
+            - attributes:
+                - key: db.system.name
+                  optional: false
+                - key: postgresql.queryid
+                  optional: false
+                - key: db.namespace
+                  optional: false
+              conditions:
+                - attributes["postgresql.shared_blks_hit"] != nil
+              description: Shared blocks hit
+              include_resource_attributes:
+                - key: service.instance.id
+                  optional: false
+              name: postgresql.shared_blks_hit
+              sum:
+                value: Int(attributes["postgresql.shared_blks_hit"])
+              unit: ""
+            - attributes:
+                - key: db.system.name
+                  optional: false
+                - key: postgresql.queryid
+                  optional: false
+                - key: db.namespace
+                  optional: false
+              conditions:
+                - attributes["postgresql.shared_blks_read"] != nil
+              description: Shared blocks read
+              include_resource_attributes:
+                - key: service.instance.id
+                  optional: false
+              name: postgresql.shared_blks_read
+              sum:
+                value: Int(attributes["postgresql.shared_blks_read"])
+              unit: ""
+            - attributes:
+                - key: db.system.name
+                  optional: false
+                - key: postgresql.queryid
+                  optional: false
+                - key: db.namespace
+                  optional: false
+              conditions:
+                - attributes["postgresql.local_blks_hit"] != nil
+              description: Local blocks hit
+              include_resource_attributes:
+                - key: service.instance.id
+                  optional: false
+              name: postgresql.local_blks_hit
+              sum:
+                value: Int(attributes["postgresql.local_blks_hit"])
+              unit: ""
+            - attributes:
+                - key: db.system.name
+                  optional: false
+                - key: postgresql.queryid
+                  optional: false
+                - key: db.namespace
+                  optional: false
+              conditions:
+                - attributes["postgresql.local_blks_read"] != nil
+              description: Local blocks read
+              include_resource_attributes:
+                - key: service.instance.id
+                  optional: false
+              name: postgresql.local_blks_read
+              sum:
+                value: Int(attributes["postgresql.local_blks_read"])
+              unit: ""
+exporters:
+    otlphttp/logs:
+        auth:
+            authenticator: headers_setter/logs
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: https://logs.us-west-2.amazonaws.com/v1/logs
+        max_idle_conns: 100
+        metrics_endpoint: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
+    otlphttp/metrics:
+        auth:
+            authenticator: sigv4auth/monitoring
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: ""
+        max_idle_conns: 100
+        metrics_endpoint: https://monitoring.us-west-2.amazonaws.com/v1/metrics
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
+extensions:
+    awscloudwatchlogsprovisioner:
+        additional_auth: sigv4auth/logs
+        logs_provision_failure_backoff: 30s
+        logs_provision_timeout: 10s
+        region: us-west-2
+    entitystore:
+        mode: ec2
+        region: us-west-2
+    headers_setter/logs:
+        additional_auth: awscloudwatchlogsprovisioner
+        headers:
+            - action: upsert
+              from_context: aws.log.group.name
+              key: x-aws-log-group
+            - action: upsert
+              from_context: aws.log.stream.name
+              key: x-aws-log-stream
+    sigv4auth/logs:
+        assume_role:
+            sts_region: us-west-2
+        region: us-west-2
+        service: logs
+    sigv4auth/monitoring:
+        assume_role:
+            sts_region: us-west-2
+        region: us-west-2
+        service: monitoring
+processors:
+    attributestocontext:
+        actions:
+            - from_resource_attribute: aws.log.group.name
+              key: aws.log.group.name
+            - from_resource_attribute: aws.log.stream.name
+              key: aws.log.stream.name
+    batch/logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys:
+            - aws.log.group.name
+            - aws.log.stream.name
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 1m0s
+    batch/opentelemetry:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 200ms
+    filter/dbi_exclude_monitor_0:
+        error_mode: propagate
+        logs:
+            log_record:
+                - attributes["user.name"] == "cw_monitor" or attributes["postgresql.rolname"] == "cw_monitor"
+        metrics: {}
+        spans: {}
+        traces: {}
+    resourcedetection:
+        aks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        azure:
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            tags: []
+        consul:
+            address: ""
+            datacenter: ""
+            namespace: ""
+            resource_attributes:
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            token_file: ""
+        detectors:
+            - eks
+            - env
+            - ec2
+        docker:
+            resource_attributes:
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+        ec2:
+            fail_on_missing_metadata: false
+            max_attempts: 3
+            max_backoff: 20s
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+            tags:
+                - ^kubernetes.io/cluster/.*$
+                - ^aws:autoscaling:groupName
+        ecs:
+            resource_attributes:
+                aws.ecs.cluster.arn:
+                    enabled: true
+                aws.ecs.launchtype:
+                    enabled: true
+                aws.ecs.task.arn:
+                    enabled: true
+                aws.ecs.task.family:
+                    enabled: true
+                aws.ecs.task.id:
+                    enabled: true
+                aws.ecs.task.revision:
+                    enabled: true
+                aws.log.group.arns:
+                    enabled: true
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.arns:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+        eks:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: false
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        elasticbeanstalk:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                deployment.environment:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.version:
+                    enabled: true
+        gcp:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.id:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+                gcp.cloud_run.job.execution:
+                    enabled: true
+                gcp.cloud_run.job.task_index:
+                    enabled: true
+                gcp.gce.instance.hostname:
+                    enabled: false
+                gcp.gce.instance.name:
+                    enabled: false
+                gcp.gce.instance_group_manager.name:
+                    enabled: true
+                gcp.gce.instance_group_manager.region:
+                    enabled: true
+                gcp.gce.instance_group_manager.zone:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+        heroku:
+            resource_attributes:
+                cloud.provider:
+                    enabled: true
+                heroku.app.id:
+                    enabled: true
+                heroku.dyno.id:
+                    enabled: true
+                heroku.release.commit:
+                    enabled: true
+                heroku.release.creation_timestamp:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.name:
+                    enabled: true
+                service.version:
+                    enabled: true
+        idle_conn_timeout: 1m30s
+        k8snode:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            node_from_env_var: ""
+            resource_attributes:
+                k8s.node.name:
+                    enabled: true
+                k8s.node.uid:
+                    enabled: true
+        kubeadm:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            resource_attributes:
+                k8s.cluster.name:
+                    enabled: true
+                k8s.cluster.uid:
+                    enabled: true
+        lambda:
+            resource_attributes:
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.max_memory:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+        max_idle_conns: 100
+        middleware: agenthealth/statuscode
+        openshift:
+            address: ""
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+            tls: {}
+            token: ""
+        override: true
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.cpu.cache.l2.size:
+                    enabled: false
+                host.cpu.family:
+                    enabled: false
+                host.cpu.model.id:
+                    enabled: false
+                host.cpu.model.name:
+                    enabled: false
+                host.cpu.stepping:
+                    enabled: false
+                host.cpu.vendor.id:
+                    enabled: false
+                host.id:
+                    enabled: false
+                host.ip:
+                    enabled: false
+                host.mac:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: false
+                os.type:
+                    enabled: true
+                os.version:
+                    enabled: false
+        timeout: 2s
+    transform/dbi_fix_start_time:
+        error_mode: ignore
+        flatten_data: false
+        log_statements: []
+        metric_statements:
+            - context: datapoint
+              error_mode: ignore
+              statements:
+                - set(datapoint.start_time_unix_nano, datapoint.time_unix_nano) where datapoint.start_time_unix_nano == 0
+                - replace_match(datapoint.attributes["postgresql.wait_event_type"], "", "CPU")
+                - replace_match(datapoint.attributes["postgresql.wait_event"], "", "CPU")
+                - replace_match(datapoint.attributes["postgresql.application_name"], "", "unknown")
+                - replace_match(datapoint.attributes["network.peer.address"], "", "unknown")
+                - replace_match(datapoint.attributes["postgresql.query_id"], "", "unknown")
+                - replace_match(datapoint.attributes["user.name"], "", "unknown")
+        trace_statements: []
+    transform/dbi_logs_raw-events_0:
+        error_mode: propagate
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: propagate
+              statements:
+                - set(resource.attributes["aws.log.group.name"], "/aws/self-managed-database-insights/postgresql/raw-events")
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], "pentest-postgres"], "/"))
+        metric_statements: []
+        trace_statements: []
+    transform/dbi_logs_server-logs_0:
+        error_mode: propagate
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: propagate
+              statements:
+                - set(resource.attributes["aws.log.group.name"], "/aws/self-managed-database-insights/postgresql/server-logs")
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], "pentest-postgres"], "/"))
+        metric_statements: []
+        trace_statements: []
+    transform/dbi_resource_0:
+        error_mode: propagate
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: propagate
+              statements:
+                - set(resource.attributes["db.system.name"], "postgresql")
+                - set(resource.attributes["db.instance.name"], "pentest-postgres")
+        metric_statements:
+            - context: resource
+              error_mode: propagate
+              statements:
+                - set(resource.attributes["db.system.name"], "postgresql")
+                - set(resource.attributes["db.instance.name"], "pentest-postgres")
+        trace_statements: []
+    transform/logs_cleanup:
+        error_mode: propagate
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: propagate
+              statements:
+                - delete_key(resource.attributes, "aws.log.group.name")
+                - delete_key(resource.attributes, "aws.log.stream.name")
+        metric_statements: []
+        trace_statements: []
+receivers:
+    filelog/postgresql_0:
+        encoding: utf-8
+        exclude_older_than: 0s
+        fingerprint_size: 1000
+        force_flush_period: 500ms
+        id: file_input
+        include:
+            - /var/lib/pgsql/data/log/postgresql-*.log
+        include_file_name: true
+        initial_buffer_size: 16384
+        max_concurrent_files: 1024
+        max_log_size: 1048576
+        operators: []
+        poll_interval: 200ms
+        retry_on_failure:
+            enabled: false
+            initial_interval: 1s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+        start_at: end
+        type: file_input
+    postgresql/events_0:
+        collection_interval: 10s
+        endpoint: localhost:5432
+        events:
+            db.server.query_sample:
+                enabled: true
+            db.server.top_query:
+                enabled: true
+        initial_delay: 1s
+        metrics:
+            postgresql.backends:
+                enabled: true
+            postgresql.bgwriter.buffers.allocated:
+                enabled: true
+            postgresql.bgwriter.buffers.writes:
+                enabled: true
+            postgresql.bgwriter.checkpoint.count:
+                enabled: true
+            postgresql.bgwriter.duration:
+                enabled: true
+            postgresql.bgwriter.maxwritten:
+                enabled: true
+            postgresql.blks_hit:
+                enabled: false
+            postgresql.blks_read:
+                enabled: false
+            postgresql.blocks_read:
+                enabled: true
+            postgresql.commits:
+                enabled: true
+            postgresql.connection.max:
+                enabled: true
+            postgresql.database.count:
+                enabled: true
+            postgresql.database.locks:
+                enabled: false
+            postgresql.db_size:
+                enabled: true
+            postgresql.deadlocks:
+                enabled: false
+            postgresql.function.calls:
+                enabled: false
+            postgresql.index.scans:
+                enabled: true
+            postgresql.index.size:
+                enabled: true
+            postgresql.operations:
+                enabled: true
+            postgresql.replication.data_delay:
+                enabled: true
+            postgresql.rollbacks:
+                enabled: true
+            postgresql.rows:
+                enabled: true
+            postgresql.sequential_scans:
+                enabled: false
+            postgresql.sessions:
+                enabled: false
+            postgresql.table.count:
+                enabled: true
+            postgresql.table.size:
+                enabled: true
+            postgresql.table.vacuum.count:
+                enabled: true
+            postgresql.temp.io:
+                enabled: false
+            postgresql.temp_files:
+                enabled: false
+            postgresql.tup_deleted:
+                enabled: false
+            postgresql.tup_fetched:
+                enabled: false
+            postgresql.tup_inserted:
+                enabled: false
+            postgresql.tup_returned:
+                enabled: false
+            postgresql.tup_updated:
+                enabled: false
+            postgresql.wal.age:
+                enabled: true
+            postgresql.wal.delay:
+                enabled: false
+            postgresql.wal.lag:
+                enabled: true
+        passfile: sampleConfig/testdata/.pgpass
+        query_sample_collection:
+            collection_interval: 1m0s
+            enabled: true
+            max_rows_per_query: 500
+        resource_attributes:
+            postgresql.database.name:
+                enabled: true
+            postgresql.index.name:
+                enabled: true
+            postgresql.schema.name:
+                enabled: true
+            postgresql.table.name:
+                enabled: true
+            service.instance.id:
+                enabled: true
+        timeout: 0s
+        tls:
+            insecure: true
+            insecure_skip_verify: true
+        top_query_collection:
+            collection_interval: 1m0s
+            max_explain_each_interval: 0
+            max_rows_per_query: 5000
+            query_plan_cache_size: 1000
+            query_plan_cache_ttl: 1h0m0s
+            top_n_query: 200
+        transport: tcp
+        username: cw_monitor
+    postgresql/metrics_0:
+        collection_interval: 10s
+        endpoint: localhost:5432
+        events:
+            db.server.query_sample:
+                enabled: true
+            db.server.top_query:
+                enabled: true
+        initial_delay: 1s
+        metrics:
+            postgresql.backends:
+                enabled: true
+            postgresql.bgwriter.buffers.allocated:
+                enabled: true
+            postgresql.bgwriter.buffers.writes:
+                enabled: true
+            postgresql.bgwriter.checkpoint.count:
+                enabled: true
+            postgresql.bgwriter.duration:
+                enabled: true
+            postgresql.bgwriter.maxwritten:
+                enabled: true
+            postgresql.blks_hit:
+                enabled: false
+            postgresql.blks_read:
+                enabled: false
+            postgresql.blocks_read:
+                enabled: true
+            postgresql.commits:
+                enabled: true
+            postgresql.connection.max:
+                enabled: true
+            postgresql.database.count:
+                enabled: true
+            postgresql.database.locks:
+                enabled: false
+            postgresql.db_size:
+                enabled: true
+            postgresql.deadlocks:
+                enabled: false
+            postgresql.function.calls:
+                enabled: false
+            postgresql.index.scans:
+                enabled: true
+            postgresql.index.size:
+                enabled: true
+            postgresql.operations:
+                enabled: true
+            postgresql.replication.data_delay:
+                enabled: true
+            postgresql.rollbacks:
+                enabled: true
+            postgresql.rows:
+                enabled: true
+            postgresql.sequential_scans:
+                enabled: false
+            postgresql.sessions:
+                enabled: false
+            postgresql.table.count:
+                enabled: true
+            postgresql.table.size:
+                enabled: true
+            postgresql.table.vacuum.count:
+                enabled: true
+            postgresql.temp.io:
+                enabled: false
+            postgresql.temp_files:
+                enabled: false
+            postgresql.tup_deleted:
+                enabled: false
+            postgresql.tup_fetched:
+                enabled: false
+            postgresql.tup_inserted:
+                enabled: false
+            postgresql.tup_returned:
+                enabled: false
+            postgresql.tup_updated:
+                enabled: false
+            postgresql.wal.age:
+                enabled: true
+            postgresql.wal.delay:
+                enabled: false
+            postgresql.wal.lag:
+                enabled: true
+        passfile: sampleConfig/testdata/.pgpass
+        query_sample_collection:
+            collection_interval: 1s
+            enabled: true
+            max_rows_per_query: 500
+        resource_attributes:
+            postgresql.database.name:
+                enabled: true
+            postgresql.index.name:
+                enabled: true
+            postgresql.schema.name:
+                enabled: true
+            postgresql.table.name:
+                enabled: true
+            service.instance.id:
+                enabled: true
+        timeout: 0s
+        tls:
+            insecure: true
+            insecure_skip_verify: true
+        top_query_collection:
+            collection_interval: 1m0s
+            max_explain_each_interval: 0
+            max_rows_per_query: 5000
+            query_plan_cache_size: 1000
+            query_plan_cache_ttl: 1h0m0s
+            top_n_query: 200
+        transport: tcp
+        username: cw_monitor
+service:
+    extensions:
+        - sigv4auth/monitoring
+        - sigv4auth/logs
+        - awscloudwatchlogsprovisioner
+        - headers_setter/logs
+        - entitystore
+    pipelines:
+        logs/dbi_postgresql_0:
+            exporters:
+                - count/dbi_dbload
+                - signaltometrics/dbi_topsql
+            processors:
+                - filter/dbi_exclude_monitor_0
+            receivers:
+                - postgresql/metrics_0
+        logs/dbi_postgresql_rawevents_0:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/dbi_exclude_monitor_0
+                - resourcedetection
+                - transform/dbi_resource_0
+                - transform/dbi_logs_raw-events_0
+            receivers:
+                - postgresql/events_0
+        logs/dbi_postgresql_serverlogs_0:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - resourcedetection
+                - transform/dbi_resource_0
+                - transform/dbi_logs_server-logs_0
+            receivers:
+                - filelog/postgresql_0
+        logs/opentelemetry:
+            exporters:
+                - otlphttp/logs
+            processors:
+                - attributestocontext
+                - transform/logs_cleanup
+                - batch/logs
+            receivers:
+                - forward/opentelemetry
+        metrics/dbi_postgresql_0:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/dbi_resource_0
+                - transform/dbi_fix_start_time
+            receivers:
+                - postgresql/metrics_0
+                - count/dbi_dbload
+                - signaltometrics/dbi_topsql
+        metrics/opentelemetry:
+            exporters:
+                - otlphttp/metrics
+            processors:
+                - resourcedetection
+                - batch/opentelemetry
+            receivers:
+                - forward/opentelemetry
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/sampleConfig/testdata/.pgpass
+++ b/translator/tocwconfig/sampleConfig/testdata/.pgpass
@@ -1,0 +1,1 @@
+localhost:5432:*:cw_monitor:test_password

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -1051,7 +1051,7 @@ func verifyToYamlTranslation(t *testing.T, input interface{}, expectedYamlFilePa
 		yamlStr := toyamlconfig.ToYamlConfig(yamlConfig)
 		require.NoError(t, yaml.Unmarshal([]byte(yamlStr), &actual))
 
-		//assert.NoError(t, os.WriteFile(expectedYamlFilePath, []byte(yamlStr), 0644)) // useful for regenerating YAML
+		// assert.NoError(t, os.WriteFile(expectedYamlFilePath, []byte(yamlStr), 0644)) // useful for regenerating YAML
 
 		opt := cmpopts.SortSlices(func(x, y interface{}) bool {
 			return pretty.Sprint(x) < pretty.Sprint(y)

--- a/translator/tocwconfig/tocwconfig_unix_test.go
+++ b/translator/tocwconfig/tocwconfig_unix_test.go
@@ -7,7 +7,10 @@
 package tocwconfig
 
 import (
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/aws/amazon-cloudwatch-agent/tool/testutil"
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
@@ -81,4 +84,12 @@ func TestDropOriginConfig(t *testing.T) {
 	context.CurrentContext().SetMode(config.ModeEC2)
 	expectedEnvVars := map[string]string{}
 	checkTranslation(t, "drop_origin_linux", "linux", expectedEnvVars, "")
+}
+
+func TestDBIConfigLinux(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	require.NoError(t, os.Chmod("sampleConfig/testdata/.pgpass", 0600))
+	expectedEnvVars := map[string]string{}
+	checkTranslation(t, "dbi_config_linux", "linux", expectedEnvVars, "")
 }

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator.go
@@ -1,0 +1,158 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package databaseinsights
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/count"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/signaltometrics"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/filterprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/resourcedetection"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/transformprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/filelog"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/postgresql"
+)
+
+type dbiPipelineType int
+
+const (
+	dbiMetrics dbiPipelineType = iota
+	dbiLogToMetrics
+	dbiRawEvents
+	dbiServerLogs
+)
+
+type dbiTranslator struct {
+	pipelineType  dbiPipelineType
+	instanceIndex int
+	cfg           dbiInstanceConfig
+}
+
+var _ common.PipelineTranslator = (*dbiTranslator)(nil)
+
+func (t *dbiTranslator) ID() pipeline.ID {
+	idx := strconv.Itoa(t.instanceIndex)
+	switch t.pipelineType {
+	case dbiMetrics:
+		return pipeline.NewIDWithName(pipeline.SignalMetrics, "dbi_postgresql_"+idx)
+	case dbiLogToMetrics:
+		return pipeline.NewIDWithName(pipeline.SignalLogs, "dbi_postgresql_"+idx)
+	case dbiRawEvents:
+		return pipeline.NewIDWithName(pipeline.SignalLogs, "dbi_postgresql_rawevents_"+idx)
+	case dbiServerLogs:
+		return pipeline.NewIDWithName(pipeline.SignalLogs, "dbi_postgresql_serverlogs_"+idx)
+	}
+	return pipeline.NewID(pipeline.SignalMetrics)
+}
+
+func (t *dbiTranslator) Translate(_ *confmap.Conf) (*common.ComponentTranslators, error) {
+	switch t.pipelineType {
+	case dbiMetrics:
+		return t.translateMetrics()
+	case dbiLogToMetrics:
+		return t.translateLogToMetrics()
+	case dbiRawEvents:
+		return t.translateRawEvents()
+	case dbiServerLogs:
+		return t.translateServerLogs()
+	}
+	return nil, fmt.Errorf("unknown DBI pipeline type: %d", t.pipelineType)
+}
+
+func (t *dbiTranslator) translateMetrics() (*common.ComponentTranslators, error) {
+	idx := strconv.Itoa(t.instanceIndex)
+	fwd := forward.NewTranslator(common.OpenTelemetryKey)
+	countConn := count.NewTranslator(common.DbiConnectorDbload)
+	s2mConn := signaltometrics.NewTranslator(common.DbiConnectorTopsql)
+
+	return &common.ComponentTranslators{
+		Receivers:  common.NewTranslatorMap[component.Config, component.ID](t.pgReceiver("metrics"), countConn, s2mConn),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](transformprocessor.NewTranslatorWithName(common.DbiTransformResource+"_"+idx, transformprocessor.WithMetricStatements(t.resourceStatements())), transformprocessor.NewTranslatorWithName(common.DbiTransformFixStartTime)),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](fwd),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
+		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwd, countConn, s2mConn),
+	}, nil
+}
+
+func (t *dbiTranslator) translateLogToMetrics() (*common.ComponentTranslators, error) {
+	countConn := count.NewTranslator(common.DbiConnectorDbload)
+	s2mConn := signaltometrics.NewTranslator(common.DbiConnectorTopsql)
+
+	return &common.ComponentTranslators{
+		Receivers:  common.NewTranslatorMap[component.Config, component.ID](t.pgReceiver("metrics")),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](t.excludeMonitorFilter()),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](countConn, s2mConn),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
+		Connectors: common.NewTranslatorMap[component.Config, component.ID](countConn, s2mConn),
+	}, nil
+}
+
+func (t *dbiTranslator) translateRawEvents() (*common.ComponentTranslators, error) {
+	idx := strconv.Itoa(t.instanceIndex)
+	fwd := forward.NewTranslator(common.OpenTelemetryKey)
+
+	return &common.ComponentTranslators{
+		Receivers:  common.NewTranslatorMap[component.Config, component.ID](t.pgReceiver("events", postgresql.WithQuerySampleInterval(60*time.Second))),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](t.excludeMonitorFilter(), resourcedetection.NewTranslator(), transformprocessor.NewTranslatorWithName(common.DbiTransformResource+"_"+idx, transformprocessor.WithMetricStatements(t.resourceStatements()), transformprocessor.WithLogStatements(t.resourceStatements())), transformprocessor.NewTranslatorWithName(common.DbiTransformLogs+"_raw-events_"+idx, transformprocessor.WithLogStatements(t.logStatements("raw-events")))),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](fwd),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
+		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwd),
+	}, nil
+}
+
+func (t *dbiTranslator) translateServerLogs() (*common.ComponentTranslators, error) {
+	idx := strconv.Itoa(t.instanceIndex)
+	fwd := forward.NewTranslator(common.OpenTelemetryKey)
+
+	return &common.ComponentTranslators{
+		Receivers:  common.NewTranslatorMap[component.Config, component.ID](filelog.NewTranslator(filelog.WithNamePrefix("postgresql"), filelog.WithIndex(t.instanceIndex), filelog.WithFilePath(t.cfg.logFilePath))),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](resourcedetection.NewTranslator(), transformprocessor.NewTranslatorWithName(common.DbiTransformResource+"_"+idx, transformprocessor.WithMetricStatements(t.resourceStatements()), transformprocessor.WithLogStatements(t.resourceStatements())), transformprocessor.NewTranslatorWithName(common.DbiTransformLogs+"_server-logs_"+idx, transformprocessor.WithLogStatements(t.logStatements("server-logs")))),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](fwd),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
+		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwd),
+	}, nil
+}
+
+func (t *dbiTranslator) pgReceiver(name string, extraOpts ...postgresql.Option) common.ComponentTranslator {
+	opts := []postgresql.Option{
+		postgresql.WithName(name),
+		postgresql.WithIndex(t.instanceIndex),
+		postgresql.WithEndpoint(t.cfg.endpoint),
+		postgresql.WithUsername(t.cfg.username),
+		postgresql.WithPassfile(t.cfg.passfile),
+		postgresql.WithCAFile(t.cfg.caFile),
+		postgresql.WithIsLocalhost(t.cfg.isLocalhost),
+	}
+	opts = append(opts, extraOpts...)
+	return postgresql.NewTranslator(opts...)
+}
+
+func (t *dbiTranslator) excludeMonitorFilter() common.ComponentTranslator {
+	idx := strconv.Itoa(t.instanceIndex)
+	condition := fmt.Sprintf(`attributes["user.name"] == "%s" or attributes["postgresql.rolname"] == "%s"`, t.cfg.username, t.cfg.username)
+	return filterprocessor.NewTranslatorWithLogCondition(common.DbiFilterExcludeMonitor+"_"+idx, condition)
+}
+
+func (t *dbiTranslator) resourceStatements() []string {
+	return []string{
+		`set(resource.attributes["db.system.name"], "postgresql")`,
+		fmt.Sprintf(`set(resource.attributes["db.instance.name"], "%s")`, t.cfg.instanceName),
+	}
+}
+
+func (t *dbiTranslator) logStatements(destination string) []string {
+	return []string{
+		fmt.Sprintf(`set(resource.attributes["aws.log.group.name"], "/aws/self-managed-database-insights/postgresql/%s")`, destination),
+		fmt.Sprintf(`set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], "%s"], "/"))`, t.cfg.instanceName),
+	}
+}

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator_test.go
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package databaseinsights
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+func TestDbiTranslatorID(t *testing.T) {
+	tests := []struct {
+		name         string
+		pipelineType dbiPipelineType
+		index        int
+		want         string
+	}{
+		{"Metrics_0", dbiMetrics, 0, "metrics/dbi_postgresql_0"},
+		{"Metrics_1", dbiMetrics, 1, "metrics/dbi_postgresql_1"},
+		{"LogToMetrics_0", dbiLogToMetrics, 0, "logs/dbi_postgresql_0"},
+		{"RawEvents_0", dbiRawEvents, 0, "logs/dbi_postgresql_rawevents_0"},
+		{"ServerLogs_0", dbiServerLogs, 0, "logs/dbi_postgresql_serverlogs_0"},
+		{"ServerLogs_2", dbiServerLogs, 2, "logs/dbi_postgresql_serverlogs_2"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &dbiTranslator{pipelineType: tc.pipelineType, instanceIndex: tc.index}
+			assert.Equal(t, tc.want, tr.ID().String())
+		})
+	}
+}
+
+func TestDbiTranslate(t *testing.T) {
+	cfg := dbiInstanceConfig{
+		endpoint:     "localhost:5432",
+		username:     "cw_monitor",
+		passfile:     "/etc/.pgpass",
+		instanceName: "my-db",
+		logFilePath:  "/var/log/postgresql/postgresql.log",
+		isLocalhost:  true,
+	}
+
+	tests := []struct {
+		name       string
+		pipeline   dbiPipelineType
+		expectedID string
+		nRecv      int
+		nProc      int
+		nExp       int
+		nConn      int
+	}{
+		{"metrics", dbiMetrics, "metrics/dbi_postgresql_0", 3, 2, 1, 3},
+		{"log_to_metrics", dbiLogToMetrics, "logs/dbi_postgresql_0", 1, 1, 2, 2},
+		{"raw_events", dbiRawEvents, "logs/dbi_postgresql_rawevents_0", 1, 4, 1, 1},
+		{"server_logs", dbiServerLogs, "logs/dbi_postgresql_serverlogs_0", 1, 3, 1, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &dbiTranslator{pipelineType: tc.pipeline, instanceIndex: 0, cfg: cfg}
+			assert.Equal(t, tc.expectedID, tr.ID().String())
+
+			result, err := tr.Translate(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.nRecv, result.Receivers.Len())
+			assert.Equal(t, tc.nProc, result.Processors.Len())
+			assert.Equal(t, tc.nExp, result.Exporters.Len())
+			assert.Equal(t, tc.nConn, result.Connectors.Len())
+		})
+	}
+}
+
+func TestDbiTranslateMetrics_ComponentIDs(t *testing.T) {
+	tr := &dbiTranslator{
+		pipelineType:  dbiMetrics,
+		instanceIndex: 0,
+		cfg:           dbiInstanceConfig{instanceName: "mydb"},
+	}
+	result, err := tr.Translate(nil)
+	require.NoError(t, err)
+
+	var receivers, processors, exporters, connectors []string
+	result.Receivers.Range(func(c common.Translator[component.Config, component.ID]) {
+		receivers = append(receivers, c.ID().String())
+	})
+	result.Processors.Range(func(c common.Translator[component.Config, component.ID]) {
+		processors = append(processors, c.ID().String())
+	})
+	result.Exporters.Range(func(c common.Translator[component.Config, component.ID]) {
+		exporters = append(exporters, c.ID().String())
+	})
+	result.Connectors.Range(func(c common.Translator[component.Config, component.ID]) {
+		connectors = append(connectors, c.ID().String())
+	})
+
+	assert.ElementsMatch(t, []string{"postgresql/metrics_0", "count/dbi_dbload", "signaltometrics/dbi_topsql"}, receivers)
+	assert.Equal(t, []string{"transform/dbi_resource_0", "transform/dbi_fix_start_time"}, processors)
+	assert.ElementsMatch(t, []string{"forward/opentelemetry"}, exporters)
+	assert.ElementsMatch(t, []string{"forward/opentelemetry", "count/dbi_dbload", "signaltometrics/dbi_topsql"}, connectors)
+}
+
+

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator_test.go
@@ -103,5 +103,3 @@ func TestDbiTranslateMetrics_ComponentIDs(t *testing.T) {
 	assert.ElementsMatch(t, []string{"forward/opentelemetry"}, exporters)
 	assert.ElementsMatch(t, []string{"forward/opentelemetry", "count/dbi_dbload", "signaltometrics/dbi_topsql"}, connectors)
 }
-
-

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators.go
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package databaseinsights
+
+import (
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+var (
+	dbiConfigKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.DatabaseInsightsKey)
+	dbiPgKey     = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.DatabaseInsightsKey, common.PostgreSQLKey)
+)
+
+type dbiInstanceConfig struct {
+	endpoint     string
+	username     string
+	passfile     string
+	caFile       string
+	instanceName string
+	logFilePath  string
+	isLocalhost  bool
+}
+
+func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
+	translators := common.NewTranslatorMap[*common.ComponentTranslators, pipeline.ID]()
+	if conf == nil || !conf.IsSet(dbiConfigKey) {
+		return translators
+	}
+
+	instances := parseDbiPostgresqlInstances(conf)
+	for i, cfg := range instances {
+		translators.Set(&dbiTranslator{pipelineType: dbiMetrics, instanceIndex: i, cfg: cfg})
+		translators.Set(&dbiTranslator{pipelineType: dbiLogToMetrics, instanceIndex: i, cfg: cfg})
+		translators.Set(&dbiTranslator{pipelineType: dbiRawEvents, instanceIndex: i, cfg: cfg})
+		if cfg.logFilePath != "" {
+			translators.Set(&dbiTranslator{pipelineType: dbiServerLogs, instanceIndex: i, cfg: cfg})
+		}
+	}
+	return translators
+}
+
+type pgRawInstance struct {
+	Endpoint     string `mapstructure:"endpoint"`
+	Username     string `mapstructure:"username"`
+	PasswordFile string `mapstructure:"password_file"`
+	CAFile       string `mapstructure:"ca_file"`
+	InstanceName string `mapstructure:"instance_name"`
+	Logs         struct {
+		FilePath string `mapstructure:"file_path"`
+	} `mapstructure:"logs"`
+}
+
+func parseDbiPostgresqlInstances(conf *confmap.Conf) []dbiInstanceConfig {
+	arr, _ := conf.Get(dbiPgKey).([]any)
+	var raw []pgRawInstance
+	if err := mapstructure.Decode(arr, &raw); err != nil {
+		return nil
+	}
+	instances := make([]dbiInstanceConfig, 0, len(raw))
+	for _, r := range raw {
+		instances = append(instances, dbiInstanceConfig{
+			endpoint:     r.Endpoint,
+			username:     r.Username,
+			passfile:     r.PasswordFile,
+			caFile:       r.CAFile,
+			instanceName: r.InstanceName,
+			logFilePath:  r.Logs.FilePath,
+			isLocalhost:  isLocalhostEndpoint(r.Endpoint),
+		})
+	}
+	return instances
+}
+
+func isLocalhostEndpoint(endpoint string) bool {
+	return strings.HasPrefix(endpoint, "localhost") ||
+		strings.HasPrefix(endpoint, "127.0.0.1") ||
+		strings.HasPrefix(endpoint, "::1")
+}

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators_test.go
@@ -1,0 +1,113 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package databaseinsights
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestNewTranslators_MissingKey(t *testing.T) {
+	assert.Equal(t, 0, NewTranslators(nil).Len())
+	assert.Equal(t, 0, NewTranslators(confmap.NewFromStringMap(map[string]interface{}{})).Len())
+}
+
+func TestNewTranslators_SingleInstanceWithLogs(t *testing.T) {
+	cfg := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"database_insights": map[string]interface{}{
+					"postgresql": []interface{}{
+						map[string]interface{}{
+							"endpoint":      "localhost:5432",
+							"username":      "cw_monitor",
+							"password_file": "/etc/.pgpass",
+							"instance_name": "my-db",
+							"logs": map[string]interface{}{
+								"file_path": "/var/log/postgresql/postgresql.log",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	translators := NewTranslators(cfg)
+	assert.Equal(t, 4, translators.Len())
+}
+
+func TestNewTranslators_SingleInstanceNoLogs(t *testing.T) {
+	cfg := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"database_insights": map[string]interface{}{
+					"postgresql": []interface{}{
+						map[string]interface{}{
+							"endpoint":      "db.example.com:5432",
+							"username":      "cw_monitor",
+							"password_file": "/etc/.pgpass",
+							"instance_name": "remote-db",
+						},
+					},
+				},
+			},
+		},
+	})
+	translators := NewTranslators(cfg)
+	assert.Equal(t, 3, translators.Len())
+}
+
+func TestNewTranslators_MultiInstance(t *testing.T) {
+	cfg := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"database_insights": map[string]interface{}{
+					"postgresql": []interface{}{
+						map[string]interface{}{
+							"endpoint":      "localhost:5432",
+							"username":      "cw_monitor",
+							"password_file": "/etc/.pgpass",
+							"instance_name": "db1",
+							"logs": map[string]interface{}{
+								"file_path": "/var/log/pg1.log",
+							},
+						},
+						map[string]interface{}{
+							"endpoint":      "db2.example.com:5432",
+							"username":      "monitor",
+							"password_file": "/etc/.pgpass2",
+							"instance_name": "db2",
+						},
+					},
+				},
+			},
+		},
+	})
+	translators := NewTranslators(cfg)
+	assert.Equal(t, 7, translators.Len()) // 4 + 3
+
+	var ids []string
+	for _, k := range translators.Keys() {
+		ids = append(ids, k.String())
+	}
+	expected := []string{
+		"metrics/dbi_postgresql_0",
+		"logs/dbi_postgresql_0",
+		"logs/dbi_postgresql_rawevents_0",
+		"logs/dbi_postgresql_serverlogs_0",
+		"metrics/dbi_postgresql_1",
+		"logs/dbi_postgresql_1",
+		"logs/dbi_postgresql_rawevents_1",
+	}
+	assert.ElementsMatch(t, expected, ids)
+}
+
+func TestIsLocalhostEndpoint(t *testing.T) {
+	assert.True(t, isLocalhostEndpoint("localhost:5432"))
+	assert.True(t, isLocalhostEndpoint("127.0.0.1:5432"))
+	assert.False(t, isLocalhostEndpoint("db.example.com:5432"))
+	assert.False(t, isLocalhostEndpoint(""))
+}

--- a/translator/translate/otel/pipeline/opentelemetry/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translators.go
@@ -8,11 +8,13 @@ import (
 	"go.opentelemetry.io/collector/pipeline"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	dbi "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/databaseinsights"
 )
 
-func NewTranslators(_ *confmap.Conf) common.PipelineTranslatorMap {
+func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
 	translators := common.NewTranslatorMap[*common.ComponentTranslators, pipeline.ID]()
 	translators.Set(NewBaseMetricsTranslator())
 	translators.Set(NewBaseLogsTranslator())
+	translators.Merge(dbi.NewTranslators(conf))
 	return translators
 }

--- a/translator/translate/otel/receiver/postgresql/translator.go
+++ b/translator/translate/otel/receiver/postgresql/translator.go
@@ -27,7 +27,6 @@ type translator struct {
 	isLocalhost         bool
 	index               int
 	querySampleInterval time.Duration
-	maxRowsPerQuery     int64
 }
 
 func WithName(name string) Option   { return func(t *translator) { t.name = name } }
@@ -40,14 +39,12 @@ func WithIndex(i int) Option        { return func(t *translator) { t.index = i }
 func WithQuerySampleInterval(d time.Duration) Option {
 	return func(t *translator) { t.querySampleInterval = d }
 }
-func WithMaxRowsPerQuery(n int64) Option { return func(t *translator) { t.maxRowsPerQuery = n } }
 
 func NewTranslator(opts ...Option) common.ComponentTranslator {
 	t := &translator{
 		factory:             postgresqlreceiver.NewFactory(),
 		name:                "metrics",
 		querySampleInterval: time.Second,
-		maxRowsPerQuery:     500,
 	}
 	for _, opt := range opts {
 		opt(t)
@@ -88,7 +85,7 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 
 	cfg.Enabled = true
 	cfg.QuerySampleCollection.CollectionInterval = t.querySampleInterval
-	cfg.QuerySampleCollection.MaxRowsPerQuery = t.maxRowsPerQuery
+	cfg.QuerySampleCollection.MaxRowsPerQuery = 500
 
 	cfg.TopQueryCollection.CollectionInterval = 60 * time.Second
 	cfg.TopNQuery = 200

--- a/translator/translate/otel/receiver/postgresql/translator_test.go
+++ b/translator/translate/otel/receiver/postgresql/translator_test.go
@@ -53,7 +53,6 @@ func TestTranslator_Translate_Events(t *testing.T) {
 		WithIsLocalhost(false),
 		WithIndex(0),
 		WithQuerySampleInterval(60*time.Second),
-		WithMaxRowsPerQuery(500),
 	)
 	cfg, err := tr.Translate(nil)
 	require.NoError(t, err)
@@ -74,12 +73,11 @@ func TestTranslator_Translate_CustomInterval(t *testing.T) {
 		WithPassfile("p"),
 		WithIsLocalhost(true),
 		WithQuerySampleInterval(5*time.Second),
-		WithMaxRowsPerQuery(200),
 	)
 	cfg, err := tr.Translate(nil)
 	require.NoError(t, err)
 	pgCfg := cfg.(*postgresqlreceiver.Config)
 
 	assert.Equal(t, 5*time.Second, pgCfg.QuerySampleCollection.CollectionInterval)
-	assert.Equal(t, int64(200), pgCfg.QuerySampleCollection.MaxRowsPerQuery)
+	assert.Equal(t, int64(500), pgCfg.QuerySampleCollection.MaxRowsPerQuery)
 }


### PR DESCRIPTION
# Description of the issue

Adds pipeline translator to wire self-managed PostgreSQL monitoring components into OTel Collector pipelines.

# Description of changes

- Pipeline translator that generates per-instance metrics, log-to-metrics, raw events, and server logs pipelines from JSON config
- Removes unused WithMaxRowsPerQuery option from postgresql receiver translator
- Golden test config files for end-to-end validation

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- Unit tests covering pipeline ID generation, component wiring, multi-instance creation, and conditional server logs pipeline
- Golden integration test validating full JSON → YAML translation

# Requirements

1. [x] Run make fmt and make fmt-sh
2. [x] Run make lint