### PR TITLE
skip service-events otlp pipelines when sigv4auth validation fails

### DIFF
--- a/translator/tocwconfig/sampleConfig/base_appsignals_no_credentials_config.conf
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_no_credentials_config.conf
@@ -1,0 +1,27 @@
+[agent]
+  collection_jitter = "0s"
+  debug = true
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[outputs]
+
+  [[outputs.cloudwatchlogs]]
+    endpoint_override = "https://fake_endpoint"
+    force_flush_interval = "5s"
+    log_stream_name = "host_name_from_env"
+    mode = "OP"
+    profile = "AmazonCloudWatchAgent"
+    region = "us-east-1"
+    region_type = "ACJ"
+    shared_credential_file = "fake-path"

--- a/translator/tocwconfig/sampleConfig/base_appsignals_no_credentials_config.json
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_no_credentials_config.json
@@ -1,0 +1,19 @@
+{
+  "agent": {
+    "region": "us-east-1",
+    "debug": true
+  },
+  "logs": {
+    "log_stream_name": "host_name_from_env",
+    "metrics_collected": {
+      "application_signals": {}
+    },
+    "endpoint_override":"https://fake_endpoint"
+  },
+  "traces": {
+    "traces_collected": {
+      "application_signals": {}
+    },
+    "endpoint_override":"https://fake_endpoint"
+  }
+}

--- a/translator/tocwconfig/sampleConfig/base_appsignals_no_credentials_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_no_credentials_config.yaml
@@ -1,0 +1,1409 @@
+exporters:
+    awsemf/application_signals:
+        add_entity: false
+        certificate_file_path: ""
+        detailed_metrics: false
+        dimension_rollup_option: NoDimensionRollup
+        disable_metric_extraction: false
+        eks_fargate_container_insights_enabled: false
+        endpoint: https://fake_endpoint
+        enhanced_container_insights: false
+        external_id: ""
+        imds_retries: 1
+        local_mode: true
+        log_group_name: /aws/application-signals/data
+        log_retention: 0
+        log_stream_name: ""
+        max_retries: 2
+        metric_declarations:
+            - dimensions:
+                - - Environment
+                  - Operation
+                  - Service
+                - - Environment
+                  - Service
+              label_matchers:
+                - label_names:
+                    - Telemetry.Source
+                  regex: ^(ServerSpan|LocalRootSpan)$
+                  separator: ;
+              metric_name_selectors:
+                - Latency
+                - Fault
+                - Error
+            - dimensions:
+                - - Environment
+                  - Operation
+                  - RemoteEnvironment
+                  - RemoteOperation
+                  - RemoteResourceIdentifier
+                  - RemoteResourceType
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - Operation
+                  - RemoteEnvironment
+                  - RemoteOperation
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - Operation
+                  - RemoteOperation
+                  - RemoteResourceIdentifier
+                  - RemoteResourceType
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - Operation
+                  - RemoteOperation
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - RemoteEnvironment
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - RemoteEnvironment
+                  - RemoteOperation
+                  - RemoteResourceIdentifier
+                  - RemoteResourceType
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - RemoteEnvironment
+                  - RemoteOperation
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - RemoteOperation
+                  - RemoteResourceIdentifier
+                  - RemoteResourceType
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - RemoteOperation
+                  - RemoteService
+                  - Service
+                - - Environment
+                  - RemoteResourceIdentifier
+                  - RemoteResourceType
+                  - RemoteService
+                  - Service
+                - - RemoteResourceIdentifier
+                  - RemoteResourceType
+                  - RemoteService
+                - - RemoteService
+              label_matchers:
+                - label_names:
+                    - Telemetry.Source
+                  regex: ^(ClientSpan|ProducerSpan|ConsumerSpan)$
+                  separator: ;
+              metric_name_selectors:
+                - Latency
+                - Fault
+                - Error
+            - dimensions:
+                - - Environment
+                  - Service
+              label_matchers:
+                - label_names:
+                    - Telemetry.Source
+                  regex: ^RuntimeMetric$
+                  separator: ;
+              metric_name_selectors:
+                - ^.*$
+        middleware: agenthealth/logs
+        namespace: ApplicationSignals
+        no_verify_ssl: false
+        num_workers: 8
+        output_destination: cloudwatch
+        profile: AmazonCloudWatchAgent
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        resource_to_telemetry_conversion:
+            enabled: false
+        retain_initial_value_of_delta_metric: false
+        role_arn: ""
+        shared_credentials_file:
+            - fake-path
+        version: "1"
+    awsxray/application_signals:
+        certificate_file_path: ""
+        endpoint: https://fake_endpoint
+        external_id: ""
+        imds_retries: 1
+        index_all_attributes: false
+        indexed_attributes:
+            - aws.local.service
+            - aws.local.operation
+            - aws.local.environment
+            - aws.remote.service
+            - aws.remote.operation
+            - aws.remote.environment
+            - aws.remote.resource.identifier
+            - aws.remote.resource.type
+        local_mode: true
+        max_retries: 2
+        middleware: agenthealth/traces
+        no_verify_ssl: false
+        num_workers: 8
+        profile: AmazonCloudWatchAgent
+        proxy_address: ""
+        region: us-east-1
+        request_timeout_seconds: 30
+        resource_arn: ""
+        role_arn: ""
+        shared_credentials_file:
+            - fake-path
+        telemetry:
+            enabled: true
+            include_metadata: true
+    debug/application_signals:
+        sampling_initial: 2
+        sampling_thereafter: 500
+        use_internal_logger: true
+        verbosity: Detailed
+extensions:
+    agenthealth/logs:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutLogEvents
+            usage_flags:
+                mode: OP
+                region_type: ACJ
+    agenthealth/statuscode:
+        is_status_code_enabled: true
+        is_usage_data_enabled: true
+        stats:
+            usage_flags:
+                mode: OP
+                region_type: ACJ
+    agenthealth/traces:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutTraceSegments
+            usage_flags:
+                mode: OP
+                region_type: ACJ
+    awsproxy/application_signals:
+        additional_routing_rules:
+            - aws_endpoint: https://application-signals.us-east-1.api.aws
+              paths:
+                - list-instrumentation-configurations
+                - report-instrumentation-configuration-status
+              region: ""
+              role_arn: ""
+              service_name: application-signals
+        aws_endpoint: https://fake_endpoint
+        certificate_file_path: ""
+        endpoint: 0.0.0.0:2000
+        imds_retries: 1
+        local_mode: true
+        profile: AmazonCloudWatchAgent
+        proxy_address: ""
+        region: us-east-1
+        role_arn: ""
+        service_name: ""
+        shared_credentials_file:
+            - fake-path
+    entitystore:
+        mode: onPremise
+        profile: AmazonCloudWatchAgent
+        region: us-east-1
+        shared_credential_file: fake-path
+processors:
+    awsapplicationsignals:
+        resolvers:
+            - name: ""
+              platform: generic
+    awsentity/service/application_signals:
+        entity_type: Service
+        platform: onPremise
+    metricstransform/application_signals:
+        transforms:
+            - action: update
+              aggregation_type: ""
+              include: jvm.cpu.recent_utilization
+              match_type: ""
+              new_name: JVMCpuRecentUtilization
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: jvm.cpu.time
+              match_type: ""
+              new_name: JVMCpuTime
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: jvm.classes.loaded
+              match_type: ""
+              new_name: JVMClassLoaded
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: jvm.threads.count
+              match_type: ""
+              new_name: JVMThreadCount
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: jvm.memory.nonheap.used
+              match_type: ""
+              new_name: JVMMemoryNonHeapUsed
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: jvm.memory.pool.used_after_last_gc
+              match_type: ""
+              new_name: JVMMemoryUsedAfterLastGC
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: jvm.memory.heap.used
+              match_type: ""
+              new_name: JVMMemoryHeapUsed
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                name: .*Old\sGen$
+              include: jvm.memory.pool.used
+              match_type: regexp
+              new_name: JVMMemoryOldGenUsed
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                name: .*Survivor\sSpace$
+              include: jvm.memory.pool.used
+              match_type: regexp
+              new_name: JVMMemorySurvivorSpaceUsed
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                name: .*Eden\sSpace$
+              include: jvm.memory.pool.used
+              match_type: regexp
+              new_name: JVMMemoryEdenSpaceUsed
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: jvm.gc.collections.elapsed
+              match_type: ""
+              new_name: JVMGCDuration
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: jvm.gc.collections.count
+              match_type: ""
+              new_name: JVMGCCount
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                name: G1 Old Generation
+              include: jvm.gc.collections.elapsed
+              match_type: strict
+              new_name: JVMGCOldGenDuration
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                name: G1 Young Generation
+              include: jvm.gc.collections.elapsed
+              match_type: strict
+              new_name: JVMGCYoungGenDuration
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                name: G1 Old Generation
+              include: jvm.gc.collections.count
+              match_type: strict
+              new_name: JVMGCOldGenCount
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                name: G1 Young Generation
+              include: jvm.gc.collections.count
+              match_type: strict
+              new_name: JVMGCYoungGenCount
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              include: ^process\.runtime\.(.*)\.gc_count$$
+              match_type: regexp
+              new_name: PythonProcessGCCount
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                count: "0"
+              include: ^process\.runtime\.(.*)\.gc_count$$
+              match_type: regexp
+              new_name: PythonProcessGCGen0Count
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                count: "1"
+              include: ^process\.runtime\.(.*)\.gc_count$$
+              match_type: regexp
+              new_name: PythonProcessGCGen1Count
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                count: "2"
+              include: ^process\.runtime\.(.*)\.gc_count$$
+              match_type: regexp
+              new_name: PythonProcessGCGen2Count
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: ^process\.runtime\.(.*)\.thread_count$$
+              match_type: regexp
+              new_name: PythonProcessThreadCount
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: ^process\.runtime\.(.*)\.cpu_time$$
+              match_type: regexp
+              new_name: PythonProcessCpuTime
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: ^process\.runtime\.(.*)\.cpu\.utilization$$
+              match_type: regexp
+              new_name: PythonProcessCpuUtilization
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                type: vms
+              include: ^process\.runtime\.(.*)\.memory$$
+              match_type: regexp
+              new_name: PythonProcessVMSMemoryUsed
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                type: rss
+              include: ^process\.runtime\.(.*)\.memory$$
+              match_type: regexp
+              new_name: PythonProcessRSSMemoryUsed
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                generation: gen0
+              include: process.runtime.dotnet.gc.collections.count
+              match_type: ""
+              new_name: DotNetGCGen0Count
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                generation: gen1
+              include: process.runtime.dotnet.gc.collections.count
+              match_type: ""
+              new_name: DotNetGCGen1Count
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                generation: gen2
+              include: process.runtime.dotnet.gc.collections.count
+              match_type: ""
+              new_name: DotNetGCGen2Count
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: process.runtime.dotnet.gc.duration
+              match_type: ""
+              new_name: DotNetGCDuration
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                generation: gen0
+              include: process.runtime.dotnet.gc.heap.size
+              match_type: ""
+              new_name: DotNetGCGen0HeapSize
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                generation: gen1
+              include: process.runtime.dotnet.gc.heap.size
+              match_type: ""
+              new_name: DotNetGCGen1HeapSize
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                generation: gen2
+              include: process.runtime.dotnet.gc.heap.size
+              match_type: ""
+              new_name: DotNetGCGen2HeapSize
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                generation: loh
+              include: process.runtime.dotnet.gc.heap.size
+              match_type: ""
+              new_name: DotNetGCLOHHeapSize
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: insert
+              aggregation_type: ""
+              experimental_match_labels:
+                generation: poh
+              include: process.runtime.dotnet.gc.heap.size
+              match_type: ""
+              new_name: DotNetGCPOHHeapSize
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: process.runtime.dotnet.thread_pool.threads.count
+              match_type: ""
+              new_name: DotNetThreadCount
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+            - action: update
+              aggregation_type: ""
+              include: process.runtime.dotnet.thread_pool.queue.length
+              match_type: ""
+              new_name: DotNetThreadQueueLength
+              operations:
+                - action: aggregate_labels
+                  aggregation_type: sum
+                  experimental_scale: 0
+                  label: ""
+                  label_set: []
+                  label_value: ""
+                  new_label: ""
+                  new_value: ""
+                - action: add_label
+                  aggregation_type: ""
+                  experimental_scale: 0
+                  label: ""
+                  label_value: ""
+                  new_label: Telemetry.Source
+                  new_value: RuntimeMetric
+              submatch_case: ""
+    resourcedetection:
+        aks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        azure:
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            tags: []
+        consul:
+            address: ""
+            datacenter: ""
+            namespace: ""
+            resource_attributes:
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            token_file: ""
+        detectors:
+            - eks
+            - env
+            - ec2
+        docker:
+            resource_attributes:
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+        ec2:
+            fail_on_missing_metadata: false
+            max_attempts: 3
+            max_backoff: 20s
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+            tags:
+                - ^kubernetes.io/cluster/.*$
+                - ^aws:autoscaling:groupName
+        ecs:
+            resource_attributes:
+                aws.ecs.cluster.arn:
+                    enabled: true
+                aws.ecs.launchtype:
+                    enabled: true
+                aws.ecs.task.arn:
+                    enabled: true
+                aws.ecs.task.family:
+                    enabled: true
+                aws.ecs.task.id:
+                    enabled: true
+                aws.ecs.task.revision:
+                    enabled: true
+                aws.log.group.arns:
+                    enabled: true
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.arns:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+        eks:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: false
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        elasticbeanstalk:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                deployment.environment:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.version:
+                    enabled: true
+        gcp:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.id:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+                gcp.cloud_run.job.execution:
+                    enabled: true
+                gcp.cloud_run.job.task_index:
+                    enabled: true
+                gcp.gce.instance.hostname:
+                    enabled: false
+                gcp.gce.instance.name:
+                    enabled: false
+                gcp.gce.instance_group_manager.name:
+                    enabled: true
+                gcp.gce.instance_group_manager.region:
+                    enabled: true
+                gcp.gce.instance_group_manager.zone:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+        heroku:
+            resource_attributes:
+                cloud.provider:
+                    enabled: true
+                heroku.app.id:
+                    enabled: true
+                heroku.dyno.id:
+                    enabled: true
+                heroku.release.commit:
+                    enabled: true
+                heroku.release.creation_timestamp:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.name:
+                    enabled: true
+                service.version:
+                    enabled: true
+        idle_conn_timeout: 1m30s
+        k8snode:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            node_from_env_var: ""
+            resource_attributes:
+                k8s.node.name:
+                    enabled: true
+                k8s.node.uid:
+                    enabled: true
+        kubeadm:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            resource_attributes:
+                k8s.cluster.name:
+                    enabled: true
+                k8s.cluster.uid:
+                    enabled: true
+        lambda:
+            resource_attributes:
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.max_memory:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+        max_idle_conns: 100
+        middleware: agenthealth/statuscode
+        openshift:
+            address: ""
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+            tls: {}
+            token: ""
+        override: true
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.cpu.cache.l2.size:
+                    enabled: false
+                host.cpu.family:
+                    enabled: false
+                host.cpu.model.id:
+                    enabled: false
+                host.cpu.model.name:
+                    enabled: false
+                host.cpu.stepping:
+                    enabled: false
+                host.cpu.vendor.id:
+                    enabled: false
+                host.id:
+                    enabled: false
+                host.ip:
+                    enabled: false
+                host.mac:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: false
+                os.type:
+                    enabled: true
+                os.version:
+                    enabled: false
+        timeout: 2s
+receivers:
+    otlp/grpc_0_0_0_0_4315:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:4315
+                keepalive:
+                    enforcement_policy: {}
+                    server_parameters: {}
+                read_buffer_size: 524288
+                transport: tcp
+    otlp/http_0_0_0_0_4316:
+        protocols:
+            http:
+                cors: {}
+                endpoint: 0.0.0.0:4316
+                idle_timeout: 0s
+                logs_url_path: /v1/logs
+                metrics_url_path: /v1/metrics
+                read_header_timeout: 0s
+                traces_url_path: /v1/traces
+                write_timeout: 0s
+service:
+    extensions:
+        - awsproxy/application_signals
+        - agenthealth/traces
+        - agenthealth/statuscode
+        - agenthealth/logs
+        - entitystore
+    pipelines:
+        metrics/application_signals_metrics_default:
+            exporters:
+                - debug/application_signals
+                - awsemf/application_signals
+            processors:
+                - metricstransform/application_signals
+                - resourcedetection
+                - awsapplicationsignals
+                - awsentity/service/application_signals
+            receivers:
+                - otlp/grpc_0_0_0_0_4315
+                - otlp/http_0_0_0_0_4316
+        traces/application_signals:
+            exporters:
+                - debug/application_signals
+                - awsxray/application_signals
+            processors:
+                - resourcedetection
+                - awsapplicationsignals
+            receivers:
+                - otlp/grpc_0_0_0_0_4315
+                - otlp/http_0_0_0_0_4316
+    telemetry:
+        logs:
+            encoding: console
+            level: debug
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/tocwconfig/toyamlconfig"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
 	systemmetricspipeline "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/systemmetrics"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/otlp"
 	translateutil "github.com/aws/amazon-cloudwatch-agent/translator/translate/util"
@@ -192,6 +193,7 @@ func TestAppSignalsLogsStaticConfig(t *testing.T) {
 
 func TestAppSignalsNoCredentialsConfig(t *testing.T) {
 	resetContext(t)
+	sigv4auth.ResetCredentialsCache()
 	context.CurrentContext().SetRunInContainer(false)
 	context.CurrentContext().SetMode(config.ModeOnPremise)
 	t.Setenv(config.HOST_NAME, "host_name_from_env")
@@ -994,6 +996,7 @@ func readCommonConfig(t *testing.T, commonConfigFilePath string) {
 }
 
 func resetContext(t *testing.T) {
+	sigv4auth.ResetCredentialsCache()
 	t.Setenv(envconfig.IMDS_NUMBER_RETRY, strconv.Itoa(retryer.DefaultImdsRetries))
 	t.Setenv(envconfig.SystemMetricsEnabled, "false")
 	// sigv4auth.Validate() eagerly resolves a credential provider. Set fake

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -190,6 +190,21 @@ func TestAppSignalsLogsStaticConfig(t *testing.T) {
 	checkTranslation(t, "appsignals_logs_static_config", "linux", expectedEnvVars, "")
 }
 
+func TestAppSignalsNoCredentialsConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetRunInContainer(false)
+	context.CurrentContext().SetMode(config.ModeOnPremise)
+	t.Setenv(config.HOST_NAME, "host_name_from_env")
+	t.Setenv(config.HOST_IP, "127.0.0.1")
+	// Clear credentials to simulate on-prem without AWS creds
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent")
+	t.Setenv("AWS_CONFIG_FILE", "/nonexistent")
+	expectedEnvVars := map[string]string{"CWAGENT_LOG_LEVEL": "DEBUG"}
+	checkTranslation(t, "base_appsignals_no_credentials_config", "linux", expectedEnvVars, "")
+}
+
 func TestAppSignalsFavorOverFallbackConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(true)

--- a/translator/translate/otel/extension/sigv4auth/translator.go
+++ b/translator/translate/otel/extension/sigv4auth/translator.go
@@ -4,11 +4,12 @@
 package sigv4auth
 
 import (
-	"go.opentelemetry.io/collector/confmap/xconfmap"
+	"sync"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/extension"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
@@ -47,14 +48,30 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	return cfg, nil
 }
 
+var (
+	canResolveOnce   sync.Once
+	canResolveResult bool
+)
+
+// ResetCredentialsCache resets the cached credential check result
+// Only used for testing
+func ResetCredentialsCache() {
+	canResolveOnce = sync.Once{}
+	canResolveResult = false
+}
+
 // CanResolveCredentials checks whether sigv4auth credentials can be resolved
 // with the current environment. Returns true if credentials are available,
 // false if the sigv4auth Validate() would fail (e.g. on-prem without AWS creds).
+// Result is cached after the first call.
 func CanResolveCredentials() bool {
-	cfg := sigv4authextension.NewFactory().CreateDefaultConfig().(*sigv4authextension.Config)
-	cfg.Region = agent.Global_Config.Region
-	if agent.Global_Config.Role_arn != "" {
-		cfg.AssumeRole = sigv4authextension.AssumeRole{ARN: agent.Global_Config.Role_arn, STSRegion: agent.Global_Config.Region}
-	}
-	return xconfmap.Validate(cfg) == nil
+	canResolveOnce.Do(func() {
+		cfg := sigv4authextension.NewFactory().CreateDefaultConfig().(*sigv4authextension.Config)
+		cfg.Region = agent.Global_Config.Region
+		if agent.Global_Config.Role_arn != "" {
+			cfg.AssumeRole = sigv4authextension.AssumeRole{ARN: agent.Global_Config.Role_arn, STSRegion: agent.Global_Config.Region}
+		}
+		canResolveResult = xconfmap.Validate(cfg) == nil
+	})
+	return canResolveResult
 }

--- a/translator/translate/otel/extension/sigv4auth/translator.go
+++ b/translator/translate/otel/extension/sigv4auth/translator.go
@@ -4,6 +4,8 @@
 package sigv4auth
 
 import (
+	"go.opentelemetry.io/collector/confmap/xconfmap"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
@@ -43,4 +45,16 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// CanResolveCredentials checks whether sigv4auth credentials can be resolved
+// with the current environment. Returns true if credentials are available,
+// false if the sigv4auth Validate() would fail (e.g. on-prem without AWS creds).
+func CanResolveCredentials() bool {
+	cfg := sigv4authextension.NewFactory().CreateDefaultConfig().(*sigv4authextension.Config)
+	cfg.Region = agent.Global_Config.Region
+	if agent.Global_Config.Role_arn != "" {
+		cfg.AssumeRole = sigv4authextension.AssumeRole{ARN: agent.Global_Config.Role_arn, STSRegion: agent.Global_Config.Region}
+	}
+	return xconfmap.Validate(cfg) == nil
 }

--- a/translator/translate/otel/pipeline/applicationsignals/translator.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translator.go
@@ -45,6 +45,7 @@ const (
 	metricsVariantRoute    = "application_signals_metrics_route"
 	metricsVariantLogDest  = "application_signals_metrics_logs_destination"
 	metricsVariantOtlpDest = "application_signals_metrics_otlp_destination"
+	metricsVariantDefault  = "application_signals_metrics_default"
 )
 
 const (
@@ -127,6 +128,8 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 			return t.translateMetricsRouteToLogs(conf)
 		case metricsVariantOtlpDest:
 			return t.translateMetricsRouteToOtlp(conf)
+		case metricsVariantDefault:
+			return t.translateMetricsDefault(conf)
 		}
 	}
 
@@ -198,6 +201,40 @@ func (t *translator) translateMetricsRouteToLogs(conf *confmap.Conf) (*common.Co
 	}
 
 	translators.Receivers.Set(connectorTranslator)
+
+	translators.Processors.Set(metricstransformprocessor.NewTranslatorWithName(common.AppSignals))
+	translators.Processors.Set(resourcedetection.NewTranslator(resourcedetection.WithSignal(t.signal)))
+	translators.Processors.Set(awsapplicationsignals.NewTranslator(awsapplicationsignals.WithSignal(t.signal)))
+
+	isECS := ecsutil.GetECSUtilSingleton().IsECS()
+	if !isECS {
+		translators.Processors.Set(awsentity.NewTranslatorWithEntityType(awsentity.Service, common.AppSignals, false))
+		if context.CurrentContext().KubernetesMode() != "" {
+			translators.Extensions.Set(k8smetadata.NewTranslator())
+		}
+	}
+
+	if enabled, _ := common.GetBool(conf, common.AgentDebugConfigKey); enabled {
+		translators.Exporters.Set(debug.NewTranslator(common.WithName(common.AppSignals)))
+	}
+
+	translators.Exporters.Set(awsemf.NewTranslatorWithName(common.AppSignals))
+	translators.Extensions.Set(agenthealth.NewTranslator(agenthealth.LogsName, []string{agenthealth.OperationPutLogEvents}))
+	translators.Extensions.Set(agenthealth.NewTranslatorWithStatusCode(agenthealth.StatusCodeName, nil, true))
+
+	return translators, nil
+}
+
+// translateMetricsDefault creates the AppSignals metrics pipeline without routing.
+// Used when sigv4auth credentials are unavailable (on-prem fallback).
+// All metrics go directly to EMF exporter.
+func (t *translator) translateMetricsDefault(conf *confmap.Conf) (*common.ComponentTranslators, error) {
+	translators := &common.ComponentTranslators{
+		Receivers:  otlp.NewTranslators(conf, common.AppSignals, t.signal.String()),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
+	}
 
 	translators.Processors.Set(metricstransformprocessor.NewTranslatorWithName(common.AppSignals))
 	translators.Processors.Set(resourcedetection.NewTranslator(resourcedetection.WithSignal(t.signal)))

--- a/translator/translate/otel/pipeline/applicationsignals/translator_test.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translator_test.go
@@ -346,6 +346,36 @@ func TestTranslatorMetricsForECS(t *testing.T) {
 	}
 }
 
+func TestTranslatorMetricsDefault(t *testing.T) {
+	agent.Global_Config.Region = "us-east-1"
+	input := map[string]interface{}{
+		"logs": map[string]interface{}{
+			"metrics_collected": map[string]interface{}{
+				"application_signals": map[string]interface{}{},
+			},
+		},
+	}
+	conf := confmap.NewFromStringMap(input)
+	tt := newTranslator(pipeline.SignalMetrics, setVariant(metricsVariantDefault))
+	assert.EqualValues(t, "metrics/application_signals_metrics_default", tt.ID().String())
+
+	got, err := tt.Translate(conf)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// Receives from OTLP (not routing connector)
+	assert.Equal(t, []string{"otlp/grpc_0_0_0_0_4315", "otlp/http_0_0_0_0_4316"}, collections.MapSlice(got.Receivers.Keys(), component.ID.String))
+	// Same processors as logDest variant
+	assert.Contains(t, collections.MapSlice(got.Processors.Keys(), component.ID.String), "metricstransform/application_signals")
+	assert.Contains(t, collections.MapSlice(got.Processors.Keys(), component.ID.String), "awsapplicationsignals")
+	// Exports to EMF
+	assert.Equal(t, []string{"awsemf/application_signals"}, collections.MapSlice(got.Exporters.Keys(), component.ID.String))
+	// No sigv4auth extension
+	for _, ext := range collections.MapSlice(got.Extensions.Keys(), component.ID.String) {
+		assert.NotContains(t, ext, "sigv4auth")
+	}
+}
+
 func TestTranslatorLogsRoute(t *testing.T) {
 	type want struct {
 		receivers  []string

--- a/translator/translate/otel/pipeline/applicationsignals/translators.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translators.go
@@ -4,10 +4,13 @@
 package applicationsignals
 
 import (
+	"log"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/pipeline"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
 )
 
 func isLogsDisabled(conf *confmap.Conf) bool {
@@ -18,6 +21,8 @@ func isLogsDisabled(conf *confmap.Conf) bool {
 // NewTranslators returns pipeline translators for Application Signals.
 // For traces, returns a single pipeline. For metrics/logs, returns 3 pipelines
 // (receive, export_1, export_2) connected via a routing connector.
+// If sigv4auth credentials are unavailable, the OTLP metrics pipeline and
+// logs pipelines are skipped to avoid blocking startup for on-prem customers.
 func NewTranslators(conf *confmap.Conf, signal pipeline.Signal) common.PipelineTranslatorMap {
 	translators := common.NewTranslatorMap[*common.ComponentTranslators, pipeline.ID]()
 
@@ -25,11 +30,20 @@ func NewTranslators(conf *confmap.Conf, signal pipeline.Signal) common.PipelineT
 	case pipeline.SignalTraces:
 		translators.Set(newTranslator(signal))
 	case pipeline.SignalMetrics:
-		translators.Set(newTranslator(signal, setVariant(metricsVariantRoute)))
-		translators.Set(newTranslator(signal, setVariant(metricsVariantLogDest)))
-		translators.Set(newTranslator(signal, setVariant(metricsVariantOtlpDest)))
+		if sigv4auth.CanResolveCredentials() {
+			translators.Set(newTranslator(signal, setVariant(metricsVariantRoute)))
+			translators.Set(newTranslator(signal, setVariant(metricsVariantLogDest)))
+			translators.Set(newTranslator(signal, setVariant(metricsVariantOtlpDest)))
+		} else {
+			log.Println("W! Skipping Application Signals OTLP metrics pipeline: AWS credentials unavailable for sigv4auth")
+			translators.Set(newTranslator(signal, setVariant(metricsVariantDefault)))
+		}
 	case pipeline.SignalLogs:
 		if conf == nil || isLogsDisabled(conf) {
+			break
+		}
+		if !sigv4auth.CanResolveCredentials() {
+			log.Println("W! Skipping Application Signals logs pipeline: AWS credentials unavailable for sigv4auth")
 			break
 		}
 		translators.Set(newTranslator(signal, setVariant(logsVariantRoute)))

--- a/translator/translate/otel/pipeline/applicationsignals/translators_test.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translators_test.go
@@ -296,3 +296,45 @@ func TestNewTranslatorsLogsDisabled(t *testing.T) {
 	translators := NewTranslators(conf, pipeline.SignalLogs)
 	assert.Equal(t, 0, translators.Len())
 }
+
+func TestNewTranslatorsMetricsNoCredentials(t *testing.T) {
+	// Clear all AWS credential sources to simulate on-prem without credentials
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent")
+	t.Setenv("AWS_CONFIG_FILE", "/nonexistent")
+	agent.Global_Config.Region = "us-east-1"
+
+	input := map[string]interface{}{
+		"logs": map[string]interface{}{
+			"metrics_collected": map[string]interface{}{
+				"application_signals": map[string]interface{}{},
+			},
+		},
+	}
+	conf := confmap.NewFromStringMap(input)
+	translators := NewTranslators(conf, pipeline.SignalMetrics)
+	// Should have single default pipeline (no routing, no OTLP)
+	assert.Equal(t, 1, translators.Len())
+}
+
+func TestNewTranslatorsLogsNoCredentials(t *testing.T) {
+	// Clear all AWS credential sources to simulate on-prem without credentials
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent")
+	t.Setenv("AWS_CONFIG_FILE", "/nonexistent")
+	agent.Global_Config.Region = "us-east-1"
+
+	input := map[string]interface{}{
+		"logs": map[string]interface{}{
+			"metrics_collected": map[string]interface{}{
+				"application_signals": map[string]interface{}{},
+			},
+		},
+	}
+	conf := confmap.NewFromStringMap(input)
+	translators := NewTranslators(conf, pipeline.SignalLogs)
+	// Should skip all logs pipelines
+	assert.Equal(t, 0, translators.Len())
+}

--- a/translator/translate/otel/pipeline/applicationsignals/translators_test.go
+++ b/translator/translate/otel/pipeline/applicationsignals/translators_test.go
@@ -15,7 +15,19 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/internal/util/collections"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
 )
+
+// resetCredentialsContext resets the sigv4auth credential cache and sets static
+// credentials so CanResolveCredentials() resolves to true. Because the cache is
+// process-global, every test that expects the full (credentialed) pipeline must
+// call this so its result does not depend on test execution order (e.g. -shuffle)
+// or the ambient credential environment.
+func resetCredentialsContext(t *testing.T) {
+	sigv4auth.ResetCredentialsCache()
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+}
 
 func TestNewTranslatorsTraces(t *testing.T) {
 	input := map[string]interface{}{
@@ -31,6 +43,7 @@ func TestNewTranslatorsTraces(t *testing.T) {
 }
 
 func TestNewTranslatorsMetrics(t *testing.T) {
+	resetCredentialsContext(t)
 	input := map[string]interface{}{
 		"logs": map[string]interface{}{
 			"metrics_collected": map[string]interface{}{
@@ -44,6 +57,7 @@ func TestNewTranslatorsMetrics(t *testing.T) {
 }
 
 func TestNewTranslatorsLogs(t *testing.T) {
+	resetCredentialsContext(t)
 	input := map[string]interface{}{
 		"logs": map[string]interface{}{
 			"metrics_collected": map[string]interface{}{
@@ -57,6 +71,7 @@ func TestNewTranslatorsLogs(t *testing.T) {
 }
 
 func TestNewTranslatorsLogsNotEnabled(t *testing.T) {
+	resetCredentialsContext(t)
 	input := map[string]interface{}{}
 	conf := confmap.NewFromStringMap(input)
 	translators := NewTranslators(conf, pipeline.SignalLogs)
@@ -70,6 +85,7 @@ func TestNewTranslatorsLogsNotEnabled(t *testing.T) {
 }
 
 func TestNewTranslatorsLogsAutoOptIn(t *testing.T) {
+	resetCredentialsContext(t)
 	input := map[string]interface{}{
 		"logs": map[string]interface{}{
 			"metrics_collected": map[string]interface{}{
@@ -220,6 +236,7 @@ func TestTranslatorLogsReceiveToRouteDynamic(t *testing.T) {
 }
 
 func TestNewTranslatorsNilConf(t *testing.T) {
+	resetCredentialsContext(t)
 	translators := NewTranslators(nil, pipeline.SignalMetrics)
 	// Translators are always registered; Translate returns error when conf is nil
 	assert.Equal(t, 3, translators.Len())
@@ -298,6 +315,7 @@ func TestNewTranslatorsLogsDisabled(t *testing.T) {
 }
 
 func TestNewTranslatorsMetricsNoCredentials(t *testing.T) {
+	sigv4auth.ResetCredentialsCache()
 	// Clear all AWS credential sources to simulate on-prem without credentials
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
@@ -319,6 +337,7 @@ func TestNewTranslatorsMetricsNoCredentials(t *testing.T) {
 }
 
 func TestNewTranslatorsLogsNoCredentials(t *testing.T) {
+	sigv4auth.ResetCredentialsCache()
 	// Clear all AWS credential sources to simulate on-prem without credentials
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")


### PR DESCRIPTION
# Description of the issue
Prevent CWAgent startup failure when Application Signals is enabled but the sigv4auth extension cannot resolve AWS credentials via the AWS SDK Go v2 default chain — most commonly on-prem hosts.

The Application Signals OTLP metrics export and the logs pipelines route data through the OTel `sigv4auth` extension, which signs requests using the AWS SDK **Go v2** default credential chain. `sigv4auth.Validate()` eagerly *resolves* credentials during the collector's config-validation phase. If the v2 chain cannot resolve credentials, validation fails and **CWAgent fails to start**.

# Description of changes
Pre-check whether sigv4auth can resolve credentials before registering the pipelines that depend on it, and degrade gracefully instead of failing startup.

1. **`translator/translate/otel/extension/sigv4auth/translator.go — CanResolveCredentials()`** new method builds a throwaway sigv4auth config with the same region/role the real extension would use and runs `xconfmap.Validate()` on it — exercising the exact code path that would otherwise fail at collector startup. No sigv4auth instance exists at translation time, so a throwaway instance is needed.

2. **translator/translate/otel/pipeline/applicationsignals/translators.go — `NewTranslators()`** — updated so that when credentials cannot be resolved:
    - Metrics: register a single default pipeline (OTLP receiver → AppSignals processors → EMF exporter), with no routing connector and no OTLP export — it never references sigv4auth.
    - Logs: skip entirely.

The check runs the same resolution the real extension would, in the same credential environment, moments before the collector's own validation. If it passes, the real sigv4auth instances will also pass, and if it fails, the real sigv4auth instances will also fail identically, so we avoid creating them and log a warning instead.

Behavior summary:
| sigv4auth creds resolvable | Metrics | Logs |
|---|---|---|
| Yes | Routing → EMF + OTLP destinations (unchanged) | Full logs pipelines (unchanged) |
| No  | Single default pipeline: OTLP → EMF only | None (skipped) |

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Run CWAgent with ApplicationSignals configuration in Docker environment without fix and without credentials:
```
  -e AWS_ACCESS_KEY_ID="" \
  -e AWS_SECRET_ACCESS_KEY="" \
  -e AWS_SHARED_CREDENTIALS_FILE="/nonexistent" \
  -e AWS_CONFIG_FILE="/nonexistent" \
  -e AWS_EC2_METADATA_DISABLED="true" \
```

```
E! [EC2] Fetch identity document from EC2 metadata fail: EC2MetadataRequestError: failed to get EC2 instance identity document
2026/06/02 02:50:59 W! retry [0/3], unable to get http response from http://169.254.170.2/v2/metadata, error: unable to get response from http://169.254.170.2/v2/metadata, error: Get "http://169.254.170.2/v2/metadata": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2026/06/02 02:51:00 W! retry [1/3], unable to get http response from http://169.254.170.2/v2/metadata, error: unable to get response from http://169.254.170.2/v2/metadata, error: Get "http://169.254.170.2/v2/metadata": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2026/06/02 02:51:01 W! retry [2/3], unable to get http response from http://169.254.170.2/v2/metadata, error: unable to get response from http://169.254.170.2/v2/metadata, error: Get "http://169.254.170.2/v2/metadata": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2026/06/02 02:51:01 I! access ECS task metadata fail with response unable to get response from http://169.254.170.2/v2/metadata, error: Get "http://169.254.170.2/v2/metadata": context deadline exceeded (Client.Timeout exceeded while awaiting headers), assuming I'm not running in ECS.

...

2026/06/02 02:51:01 E! failed to generate YAML configuration validation content: invalid otel config: extensions::sigv4auth/logs: could not retrieve credential provider: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
extensions::sigv4auth/monitoring: could not retrieve credential provider: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
```

Run CWAgent with same configuration/environment with fix:
```
/opt/aws/amazon-cloudwatch-agent/bin/default_linux_config.json does not exist or cannot read. Skipping it.
2026/06/02 02:54:03 W! Skipping Application Signals OTLP metrics pipeline: AWS credentials unavailable for sigv4auth
2026/06/02 02:54:03 W! Skipping Application Signals logs pipeline: AWS credentials unavailable for sigv4auth
    shared_credential_file = "/root/.aws/credentials"
        shared_credentials_file:
            - /root/.aws/credentials
        shared_credentials_file:
            - /root/.aws/credentials
        shared_credentials_file:
            - /root/.aws/credentials

...

2026/06/02 02:54:00 I! attempt to access ECS task metadata to determine whether I'm running in ECS.
2026/06/02 02:54:03 I! access ECS task metadata fail with response unable to get response from http://169.254.170.2/v2/metadata, error: Get "http://169.254.170.2/v2/metadata": context deadline exceeded (Client.Timeout exceeded while awaiting headers), assuming I'm not running in ECS.
2026-06-02T02:54:03Z I! {"caller":"service@v0.124.0/service.go:266","msg":"Starting CWAgent...","Version":"Unknown","NumCPU":14}
2026-06-02T02:54:03Z I! {"caller":"service@v0.124.0/service.go:289","msg":"Everything is ready. Begin running and processing data."}
...
```

Also added unit and sampleConfig tests:
- `TestNewTranslatorsMetricsNoCredentials` — 1 translator (default) when creds unresolvable
- `TestNewTranslatorsLogsNoCredentials` — 0 log translators when creds unresolvable
- `TestTranslatorMetricsDefault` — default metrics pipeline structure (OTLP → EMF)
- `TestAppSignalsNoCredentialsConfig` — sampleConfig YAML for the no-credentials config


# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



