### PR TITLE
Add agenthealth metrics to opentelemetry shared pipeline

### DIFF
--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
@@ -255,7 +255,7 @@ exporters:
         write_buffer_size: 524288
     otlphttp/metrics:
         auth:
-            authenticator: agenthealth/metrics
+            authenticator: agenthealth/otlphttp_metrics
         compression: gzip
         encoding: proto
         idle_conn_timeout: 1m30s
@@ -281,7 +281,7 @@ exporters:
         traces_endpoint: ""
         write_buffer_size: 524288
 extensions:
-    agenthealth/metrics:
+    agenthealth/otlphttp_metrics:
         additional_auth: sigv4auth/monitoring
         is_usage_data_enabled: true
         stats:
@@ -939,7 +939,7 @@ receivers:
 service:
     extensions:
         - sigv4auth/monitoring
-        - agenthealth/metrics
+        - agenthealth/otlphttp_metrics
         - sigv4auth/logs
         - awscloudwatchlogsprovisioner
         - headers_setter/logs

--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
@@ -226,9 +226,36 @@ connectors:
                 value: Int(attributes["postgresql.local_blks_read"])
               unit: ""
 exporters:
+    otlphttp/logs:
+        auth:
+            authenticator: headers_setter/logs
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: https://logs.us-west-2.amazonaws.com/v1/logs
+        max_idle_conns: 100
+        metrics_endpoint: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
     otlphttp/metrics:
         auth:
-            authenticator: sigv4auth/monitoring
+            authenticator: agenthealth/metrics
         compression: gzip
         encoding: proto
         idle_conn_timeout: 1m30s
@@ -254,12 +281,54 @@ exporters:
         traces_endpoint: ""
         write_buffer_size: 524288
 extensions:
+    agenthealth/metrics:
+        additional_auth: sigv4auth/monitoring
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    awscloudwatchlogsprovisioner:
+        additional_auth: sigv4auth/logs
+        logs_provision_failure_backoff: 30s
+        logs_provision_timeout: 10s
+        region: us-west-2
+    headers_setter/logs:
+        additional_auth: awscloudwatchlogsprovisioner
+        headers:
+            - action: upsert
+              from_context: aws.log.group.name
+              key: x-aws-log-group
+            - action: upsert
+              from_context: aws.log.stream.name
+              key: x-aws-log-stream
+    sigv4auth/logs:
+        assume_role:
+            sts_region: us-west-2
+        region: us-west-2
+        service: logs
     sigv4auth/monitoring:
         assume_role:
             sts_region: us-west-2
         region: us-west-2
         service: monitoring
 processors:
+    attributestocontext:
+        actions:
+            - from_resource_attribute: aws.log.group.name
+              key: aws.log.group.name
+            - from_resource_attribute: aws.log.stream.name
+              key: aws.log.stream.name
+    batch/logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys:
+            - aws.log.group.name
+            - aws.log.stream.name
+        send_batch_max_size: 0
+        send_batch_size: 8192
+        timeout: 1m0s
     batch/opentelemetry:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -608,6 +677,17 @@ processors:
                 - set(resource.attributes["db.system.name"], "postgresql")
                 - set(resource.attributes["db.instance.name"], "pentest-postgres")
         trace_statements: []
+    transform/logs_cleanup:
+        error_mode: propagate
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: propagate
+              statements:
+                - delete_key(resource.attributes, "aws.log.group.name")
+                - delete_key(resource.attributes, "aws.log.stream.name")
+        metric_statements: []
+        trace_statements: []
 receivers:
     filelog/postgresql_0:
         encoding: utf-8
@@ -859,6 +939,10 @@ receivers:
 service:
     extensions:
         - sigv4auth/monitoring
+        - agenthealth/metrics
+        - sigv4auth/logs
+        - awscloudwatchlogsprovisioner
+        - headers_setter/logs
     pipelines:
         logs/dbi_postgresql_0:
             exporters:
@@ -887,6 +971,15 @@ service:
                 - transform/dbi_logs_server-logs_0
             receivers:
                 - filelog/postgresql_0
+        logs/opentelemetry:
+            exporters:
+                - otlphttp/logs
+            processors:
+                - attributestocontext
+                - transform/logs_cleanup
+                - batch/logs
+            receivers:
+                - forward/opentelemetry
         metrics/dbi_postgresql_0:
             exporters:
                 - forward/opentelemetry

--- a/translator/tocwconfig/sampleConfig/host_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/host_insights_config.yaml
@@ -3,7 +3,7 @@ connectors:
 exporters:
     otlphttp/metrics:
         auth:
-            authenticator: sigv4auth/monitoring
+            authenticator: agenthealth/metrics
         compression: gzip
         encoding: proto
         idle_conn_timeout: 1m30s
@@ -29,6 +29,15 @@ exporters:
         traces_endpoint: ""
         write_buffer_size: 524288
 extensions:
+    agenthealth/metrics:
+        additional_auth: sigv4auth/monitoring
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
     sigv4auth/monitoring:
         assume_role:
             sts_region: us-west-2
@@ -337,6 +346,7 @@ receivers:
 service:
     extensions:
         - sigv4auth/monitoring
+        - agenthealth/metrics
     pipelines:
         metrics/host_insights:
             exporters:

--- a/translator/tocwconfig/sampleConfig/host_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/host_insights_config.yaml
@@ -3,7 +3,7 @@ connectors:
 exporters:
     otlphttp/metrics:
         auth:
-            authenticator: agenthealth/metrics
+            authenticator: agenthealth/otlphttp_metrics
         compression: gzip
         encoding: proto
         idle_conn_timeout: 1m30s
@@ -29,7 +29,7 @@ exporters:
         traces_endpoint: ""
         write_buffer_size: 524288
 extensions:
-    agenthealth/metrics:
+    agenthealth/otlphttp_metrics:
         additional_auth: sigv4auth/monitoring
         is_usage_data_enabled: true
         stats:
@@ -346,7 +346,7 @@ receivers:
 service:
     extensions:
         - sigv4auth/monitoring
-        - agenthealth/metrics
+        - agenthealth/otlphttp_metrics
     pipelines:
         metrics/host_insights:
             exporters:

--- a/translator/translate/otel/extension/agenthealth/translator.go
+++ b/translator/translate/otel/extension/agenthealth/translator.go
@@ -41,10 +41,11 @@ var (
 type Name string
 
 var (
-	MetricsName    = Name(pipeline.SignalMetrics.String())
-	LogsName       = Name(pipeline.SignalLogs.String())
-	TracesName     = Name(pipeline.SignalTraces.String())
-	StatusCodeName = Name("statuscode")
+	MetricsName     = Name(pipeline.SignalMetrics.String())
+	OtelMetricsName = Name("otlphttp_metrics")
+	LogsName        = Name(pipeline.SignalLogs.String())
+	TracesName      = Name(pipeline.SignalTraces.String())
+	StatusCodeName  = Name("statuscode")
 )
 
 type Option func(*translator)

--- a/translator/translate/otel/extension/agenthealth/translator.go
+++ b/translator/translate/otel/extension/agenthealth/translator.go
@@ -47,12 +47,21 @@ var (
 	StatusCodeName = Name("statuscode")
 )
 
+type Option func(*translator)
+
+func WithAdditionalAuth(id component.ID) Option {
+	return func(t *translator) {
+		t.additionalAuth = &id
+	}
+}
+
 type translator struct {
 	name                string
 	operations          []string
 	isUsageDataEnabled  bool
 	factory             extension.Factory
 	isStatusCodeEnabled bool
+	additionalAuth      *component.ID
 }
 
 var _ common.ComponentTranslator = (*translator)(nil)
@@ -67,13 +76,17 @@ func NewTranslatorWithStatusCode(name Name, operations []string, isStatusCodeEna
 	}
 }
 
-func NewTranslator(name Name, operations []string) common.ComponentTranslator {
-	return &translator{
+func NewTranslator(name Name, operations []string, opts ...Option) common.ComponentTranslator {
+	t := &translator{
 		name:               string(name),
 		operations:         operations,
 		factory:            agenthealth.NewFactory(),
 		isUsageDataEnabled: envconfig.IsUsageDataEnabled(),
 	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 func (t *translator) ID() component.ID {
@@ -104,6 +117,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		cfg.UsageMetadata = slices.Sorted(maps.Keys(usageMetadataSet))
 	}
 	cfg.IsStatusCodeEnabled = t.isStatusCodeEnabled
+	cfg.AdditionalAuth = t.additionalAuth
 	cfg.Stats = &agent.StatsConfig{
 		Operations: t.operations,
 		UsageFlags: map[agent.Flag]any{

--- a/translator/translate/otel/extension/agenthealth/translator_test.go
+++ b/translator/translate/otel/extension/agenthealth/translator_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/aws/amazon-cloudwatch-agent/extension/agenthealth"
@@ -210,4 +211,18 @@ func TestTranslate(t *testing.T) {
 			assert.Equal(t, testCase.want, got)
 		})
 	}
+}
+
+func TestTranslateWithAdditionalAuth(t *testing.T) {
+	context.CurrentContext().SetMode(config.ModeEC2)
+	translateagent.Global_Config.RegionType = config.RegionTypeNotFound
+	authID := component.MustNewIDWithName("sigv4auth", "monitoring")
+	tt := NewTranslator(MetricsName, []string{"*"}, WithAdditionalAuth(authID)).(*translator)
+	tt.isUsageDataEnabled = true
+	conf := confmap.NewFromStringMap(map[string]any{"agent": map[string]any{}})
+	got, err := tt.Translate(conf)
+	assert.NoError(t, err)
+	cfg := got.(*agenthealth.Config)
+	assert.NotNil(t, cfg.AdditionalAuth)
+	assert.Equal(t, authID, *cfg.AdditionalAuth)
 }

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
@@ -32,6 +32,7 @@ var _ common.PipelineTranslator = (*baseLogsTranslator)(nil)
 // The base logs pipeline only activates when at least one log source feeds logs
 // through the forward/opentelemetry connector.
 var otelCollectLogsKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.LogsKey)
+var otelCollectDbiKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.DatabaseInsightsKey)
 
 func NewBaseLogsTranslator() common.PipelineTranslator {
 	return &baseLogsTranslator{}
@@ -42,8 +43,8 @@ func (t *baseLogsTranslator) ID() pipeline.ID {
 }
 
 func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
-	if conf == nil || !conf.IsSet(otelCollectLogsKey) {
-		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: otelCollectLogsKey}
+	if conf == nil || (!conf.IsSet(otelCollectLogsKey) && !conf.IsSet(otelCollectDbiKey)) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: otelCollectLogsKey + " or " + otelCollectDbiKey}
 	}
 
 	region := agent.Global_Config.Region

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
@@ -24,11 +24,11 @@ func TestBaseLogsTranslator(t *testing.T) {
 	}{
 		"WithNilConf": {
 			input:   nil,
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey + " or " + otelCollectDbiKey},
 		},
 		"WithoutCollectKey": {
 			input:   map[string]interface{}{},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey + " or " + otelCollectDbiKey},
 		},
 		"WithCollectKeyButNoLogs": {
 			input: map[string]interface{}{
@@ -36,7 +36,7 @@ func TestBaseLogsTranslator(t *testing.T) {
 					"collect": map[string]interface{}{},
 				},
 			},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey + " or " + otelCollectDbiKey},
 		},
 		"WithCollectLogsKey": {
 			input: map[string]interface{}{

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
@@ -47,6 +47,17 @@ func TestBaseLogsTranslator(t *testing.T) {
 				},
 			},
 		},
+		"WithDbiOnly": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"database_insights": map[string]interface{}{
+							"postgresql": []any{map[string]any{"endpoint": "localhost:5432"}},
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/otlphttp"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/resourcedetection"
@@ -47,14 +48,15 @@ func (t *baseMetricsTranslator) Translate(conf *confmap.Conf) (*common.Component
 	}
 	metricsEndpoint := common.ServiceEndpoint("monitoring", region, "/v1/metrics")
 	sigv4Ext := sigv4auth.NewTranslatorWithService("monitoring")
+	agentHealthExt := agenthealth.NewTranslator(agenthealth.MetricsName, []string{"*"}, agenthealth.WithAdditionalAuth(sigv4Ext.ID()))
 
 	fwdConnector := forward.NewTranslator(common.OpenTelemetryKey)
 
 	return &common.ComponentTranslators{
 		Receivers:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
 		Processors: common.NewTranslatorMap[component.Config, component.ID](resourcedetection.NewTranslator(), batchprocessor.NewTranslator(common.WithName(common.OpenTelemetryKey))),
-		Exporters:  common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("metrics", otlphttp.EndpointConfig{MetricsEndpoint: metricsEndpoint}, otlphttp.WithAuthenticator(sigv4Ext.ID()))),
-		Extensions: common.NewTranslatorMap[component.Config, component.ID](sigv4Ext),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("metrics", otlphttp.EndpointConfig{MetricsEndpoint: metricsEndpoint}, otlphttp.WithAuthenticator(agentHealthExt.ID()))),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](sigv4Ext, agentHealthExt),
 		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
 	}, nil
 }

--- a/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
@@ -48,7 +48,7 @@ func (t *baseMetricsTranslator) Translate(conf *confmap.Conf) (*common.Component
 	}
 	metricsEndpoint := common.ServiceEndpoint("monitoring", region, "/v1/metrics")
 	sigv4Ext := sigv4auth.NewTranslatorWithService("monitoring")
-	agentHealthExt := agenthealth.NewTranslator(agenthealth.MetricsName, []string{"*"}, agenthealth.WithAdditionalAuth(sigv4Ext.ID()))
+	agentHealthExt := agenthealth.NewTranslator(agenthealth.OtelMetricsName, []string{"*"}, agenthealth.WithAdditionalAuth(sigv4Ext.ID()))
 
 	fwdConnector := forward.NewTranslator(common.OpenTelemetryKey)
 

--- a/translator/translate/otel/pipeline/opentelemetry/translator_metrics_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_metrics_test.go
@@ -56,7 +56,7 @@ func TestBaseMetricsTranslator(t *testing.T) {
 				assert.Equal(t, 1, got.Receivers.Len())
 				assert.Equal(t, 2, got.Processors.Len())
 				assert.Equal(t, 1, got.Exporters.Len())
-				assert.Equal(t, 1, got.Extensions.Len())
+				assert.Equal(t, 2, got.Extensions.Len())
 				assert.Equal(t, 1, got.Connectors.Len())
 				assert.Equal(t, "forward/opentelemetry", got.Receivers.Keys()[0].String())
 				assert.Equal(t, "otlphttp/metrics", got.Exporters.Keys()[0].String())


### PR DESCRIPTION
# Description of the issue

The shared metrics/opentelemetry pipeline lacked agent health tracking, meaning OTLP metrics traffic had no adoption or operational health visibility in MWS. Additionally, the base logs pipeline did not activate for database monitoring configs after the host_insights PR narrowed the activation condition.

# Description of changes

- Added WithAdditionalAuth option to the agenthealth extension translator, enabling it to chain with another auth extension
- Wired agenthealth/metrics as the authenticator for otlphttp/metrics in the shared metrics pipeline, with sigv4auth/monitoring as additional auth
- Fixed base logs pipeline activation to also trigger when database configs are present (not just opentelemetry.collect.logs)
- Updated YAML test files for database monitoring and host_insights configs

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Validated E2E on EC2: confirmed CWAgentPlugin:receiver:postgresql and CWAgentPlugin:receiver:hostmetrics visible 

# Requirements

1. [x] Run make fmt and make fmt-sh
2. [x] Run make lint