### PR TITLE
Add host insights to database monitoring

### DIFF
--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
@@ -710,6 +710,24 @@ receivers:
             max_interval: 30s
         start_at: end
         type: file_input
+    hostmetrics:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        scrapers:
+            cpu: null
+            disk: null
+            filesystem: null
+            load: null
+            memory: null
+            network: null
+            process:
+                include:
+                    match_type: regexp
+                    names:
+                        - postgres.*
+                mute_process_all_errors: true
+            processes: null
+        timeout: 0s
     postgresql/events_0:
         collection_interval: 10s
         endpoint: localhost:5432
@@ -990,6 +1008,12 @@ service:
                 - postgresql/metrics_0
                 - count/dbi_dbload
                 - signaltometrics/dbi_topsql
+        metrics/host_insights:
+            exporters:
+                - forward/opentelemetry
+            processors: []
+            receivers:
+                - hostmetrics
         metrics/opentelemetry:
             exporters:
                 - otlphttp/metrics

--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
@@ -714,12 +714,40 @@ receivers:
         collection_interval: 1m0s
         initial_delay: 1s
         scrapers:
-            cpu: null
+            cpu:
+                metrics:
+                    system.cpu.frequency:
+                        enabled: true
+                    system.cpu.logical.count:
+                        enabled: true
+                    system.cpu.physical.count:
+                        enabled: true
+                    system.cpu.utilization:
+                        enabled: true
             disk: null
-            filesystem: null
+            filesystem:
+                metrics:
+                    system.filesystem.utilization:
+                        enabled: true
             load: null
-            memory: null
-            network: null
+            memory:
+                metrics:
+                    system.linux.memory.available:
+                        enabled: true
+                    system.linux.memory.dirty:
+                        enabled: true
+                    system.memory.limit:
+                        enabled: true
+                    system.memory.page_size:
+                        enabled: true
+                    system.memory.utilization:
+                        enabled: true
+            network:
+                metrics:
+                    system.network.conntrack.count:
+                        enabled: true
+                    system.network.conntrack.max:
+                        enabled: true
             process:
                 include:
                     match_type: regexp

--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
@@ -725,6 +725,11 @@ receivers:
                     match_type: regexp
                     names:
                         - postgres.*
+                metrics:
+                    process.cpu.utilization:
+                        enabled: true
+                    process.memory.utilization:
+                        enabled: true
                 mute_process_all_errors: true
             processes: null
         timeout: 0s

--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
@@ -711,7 +711,7 @@ receivers:
         start_at: end
         type: file_input
     hostmetrics:
-        collection_interval: 1m0s
+        collection_interval: 30s
         initial_delay: 1s
         scrapers:
             cpu:

--- a/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/dbi_config_linux.yaml
@@ -742,12 +742,7 @@ receivers:
                         enabled: true
                     system.memory.utilization:
                         enabled: true
-            network:
-                metrics:
-                    system.network.conntrack.count:
-                        enabled: true
-                    system.network.conntrack.max:
-                        enabled: true
+            network: null
             process:
                 include:
                     match_type: regexp

--- a/translator/tocwconfig/sampleConfig/host_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/host_insights_config.yaml
@@ -335,12 +335,40 @@ receivers:
         collection_interval: 10s
         initial_delay: 1s
         scrapers:
-            cpu: null
+            cpu:
+                metrics:
+                    system.cpu.frequency:
+                        enabled: true
+                    system.cpu.logical.count:
+                        enabled: true
+                    system.cpu.physical.count:
+                        enabled: true
+                    system.cpu.utilization:
+                        enabled: true
             disk: null
-            filesystem: null
+            filesystem:
+                metrics:
+                    system.filesystem.utilization:
+                        enabled: true
             load: null
-            memory: null
-            network: null
+            memory:
+                metrics:
+                    system.linux.memory.available:
+                        enabled: true
+                    system.linux.memory.dirty:
+                        enabled: true
+                    system.memory.limit:
+                        enabled: true
+                    system.memory.page_size:
+                        enabled: true
+                    system.memory.utilization:
+                        enabled: true
+            network:
+                metrics:
+                    system.network.conntrack.count:
+                        enabled: true
+                    system.network.conntrack.max:
+                        enabled: true
             processes: null
         timeout: 0s
 service:

--- a/translator/tocwconfig/sampleConfig/host_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/host_insights_config.yaml
@@ -363,12 +363,7 @@ receivers:
                         enabled: true
                     system.memory.utilization:
                         enabled: true
-            network:
-                metrics:
-                    system.network.conntrack.count:
-                        enabled: true
-                    system.network.conntrack.max:
-                        enabled: true
+            network: null
             processes: null
         timeout: 0s
 service:

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -148,6 +148,11 @@ const (
 	DbiConnectorTopsql       = "dbi_topsql"
 )
 
+var (
+	DatabaseInsightsConfigKey   = ConfigKey(OpenTelemetryKey, CollectKey, DatabaseInsightsKey)
+	DatabaseInsightsPostgresKey = ConfigKey(OpenTelemetryKey, CollectKey, DatabaseInsightsKey, PostgreSQLKey)
+)
+
 const (
 	DiskIOPrefix = "diskio_"
 )
@@ -174,6 +179,7 @@ var (
 	MetricsAggregationDimensionsKey = ConfigKey(MetricsKey, AggregationDimensionsKey)
 	OTLPLogsKey                     = ConfigKey(LogsKey, MetricsCollectedKey, OtlpKey)
 	OTLPMetricsKey                  = ConfigKey(MetricsKey, MetricsCollectedKey, OtlpKey)
+	OtelCollectLogsConfigKey        = ConfigKey(OpenTelemetryKey, CollectKey, LogsKey)
 )
 
 type TranslatorID interface {

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators.go
@@ -13,11 +13,6 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
-var (
-	dbiConfigKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.DatabaseInsightsKey)
-	dbiPgKey     = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.DatabaseInsightsKey, common.PostgreSQLKey)
-)
-
 type dbiInstanceConfig struct {
 	endpoint     string
 	username     string
@@ -30,7 +25,7 @@ type dbiInstanceConfig struct {
 
 func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
 	translators := common.NewTranslatorMap[*common.ComponentTranslators, pipeline.ID]()
-	if conf == nil || !conf.IsSet(dbiConfigKey) {
+	if conf == nil || !conf.IsSet(common.DatabaseInsightsConfigKey) {
 		return translators
 	}
 
@@ -58,7 +53,7 @@ type pgRawInstance struct {
 }
 
 func parseDbiPostgresqlInstances(conf *confmap.Conf) []dbiInstanceConfig {
-	arr, _ := conf.Get(dbiPgKey).([]any)
+	arr, _ := conf.Get(common.DatabaseInsightsPostgresKey).([]any)
 	var raw []pgRawInstance
 	if err := mapstructure.Decode(arr, &raw); err != nil {
 		return nil

--- a/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator.go
@@ -30,14 +30,25 @@ func (t *hostInsightsTranslator) ID() pipeline.ID {
 }
 
 func (t *hostInsightsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
-	if conf == nil || !conf.IsSet(hostInsightsKey) {
-		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: hostInsightsKey}
+	if conf == nil || (!conf.IsSet(hostInsightsKey) && !conf.IsSet(common.DatabaseInsightsConfigKey)) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: hostInsightsKey + " or " + common.DatabaseInsightsConfigKey}
+	}
+
+	var opts []hostmetrics.Option
+	if conf.IsSet(common.DatabaseInsightsConfigKey) {
+		opts = append(opts, hostmetrics.WithProcessScraper(map[string]any{
+			"include": map[string]any{
+				"match_type": "regexp",
+				"names":      []string{"postgres.*"},
+			},
+			"mute_process_all_errors": true,
+		}))
 	}
 
 	fwdConnector := forward.NewTranslator(common.OpenTelemetryKey)
 
 	return &common.ComponentTranslators{
-		Receivers:  common.NewTranslatorMap[component.Config, component.ID](hostmetrics.NewTranslator()),
+		Receivers:  common.NewTranslatorMap[component.Config, component.ID](hostmetrics.NewTranslator(opts...)),
 		Processors: common.NewTranslatorMap[component.Config, component.ID](),
 		Exporters:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](),

--- a/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator.go
@@ -42,6 +42,14 @@ func (t *hostInsightsTranslator) Translate(conf *confmap.Conf) (*common.Componen
 				"names":      []string{"postgres.*"},
 			},
 			"mute_process_all_errors": true,
+			"metrics": map[string]any{
+				"process.cpu.utilization": map[string]any{
+					"enabled": true,
+				},
+				"process.memory.utilization": map[string]any{
+					"enabled": true,
+				},
+			},
 		}))
 	}
 

--- a/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
@@ -55,7 +55,7 @@ func TestHostInsightsTranslator(t *testing.T) {
 			input: map[string]interface{}{
 				"opentelemetry": map[string]interface{}{
 					"collect": map[string]interface{}{
-						"host_insights":     map[string]interface{}{},
+						"host_insights": map[string]interface{}{},
 						"database_insights": map[string]interface{}{
 							"postgresql": []interface{}{
 								map[string]interface{}{"endpoint": "localhost:5432", "username": "cwagent"},

--- a/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
@@ -8,18 +8,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 
+	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
+	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/hostmetrics"
 )
 
 func TestHostInsightsTranslator(t *testing.T) {
+	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
 	tt := NewTranslator()
 	assert.EqualValues(t, "metrics/host_insights", tt.ID().String())
 
 	testCases := map[string]struct {
-		input   map[string]interface{}
-		wantErr error
+		input         map[string]interface{}
+		wantErr       error
+		expectProcess bool
 	}{
 		"WithNilConf": {
 			input:   nil,
@@ -50,6 +56,7 @@ func TestHostInsightsTranslator(t *testing.T) {
 					},
 				},
 			},
+			expectProcess: true,
 		},
 		"WithBothKeys": {
 			input: map[string]interface{}{
@@ -64,6 +71,7 @@ func TestHostInsightsTranslator(t *testing.T) {
 					},
 				},
 			},
+			expectProcess: true,
 		},
 	}
 	for name, tc := range testCases {
@@ -88,6 +96,20 @@ func TestHostInsightsTranslator(t *testing.T) {
 				assert.Equal(t, "hostmetrics", got.Receivers.Keys()[0].String())
 				assert.Equal(t, "forward/opentelemetry", got.Exporters.Keys()[0].String())
 				assert.Equal(t, "forward/opentelemetry", got.Connectors.Keys()[0].String())
+
+				if tc.expectProcess {
+					// Verify process scraper is configured for DBI
+					rcvTranslator, ok := got.Receivers.Get(component.NewIDWithName(component.MustNewType("hostmetrics"), ""))
+					require.True(t, ok)
+					rcvCfg, err := rcvTranslator.Translate(conf)
+					require.NoError(t, err)
+					hmCfg := rcvCfg.(*hostmetrics.HostMetricsConfig)
+					processCfg, exists := hmCfg.Scrapers["process"]
+					assert.True(t, exists, "expected process scraper")
+					include := processCfg["include"].(map[string]any)
+					assert.Equal(t, "regexp", include["match_type"])
+					assert.Equal(t, []string{"postgres.*"}, include["names"])
+				}
 			}
 		})
 	}

--- a/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
@@ -23,17 +23,44 @@ func TestHostInsightsTranslator(t *testing.T) {
 	}{
 		"WithNilConf": {
 			input:   nil,
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: hostInsightsKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: hostInsightsKey + " or " + common.DatabaseInsightsConfigKey},
 		},
 		"WithoutHostInsightsKey": {
 			input:   map[string]interface{}{},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: hostInsightsKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: hostInsightsKey + " or " + common.DatabaseInsightsConfigKey},
 		},
 		"WithHostInsightsKey": {
 			input: map[string]interface{}{
 				"opentelemetry": map[string]interface{}{
 					"collect": map[string]interface{}{
 						"host_insights": map[string]interface{}{},
+					},
+				},
+			},
+		},
+		"WithDatabaseInsightsOnlyKey": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"database_insights": map[string]interface{}{
+							"postgresql": []interface{}{
+								map[string]interface{}{"endpoint": "localhost:5432", "username": "cwagent"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"WithBothKeys": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"host_insights":     map[string]interface{}{},
+						"database_insights": map[string]interface{}{
+							"postgresql": []interface{}{
+								map[string]interface{}{"endpoint": "localhost:5432", "username": "cwagent"},
+							},
+						},
 					},
 				},
 			},

--- a/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
@@ -103,7 +103,7 @@ func TestHostInsightsTranslator(t *testing.T) {
 					require.True(t, ok)
 					rcvCfg, err := rcvTranslator.Translate(conf)
 					require.NoError(t, err)
-					hmCfg := rcvCfg.(*hostmetrics.HostMetricsConfig)
+					hmCfg := rcvCfg.(*hostmetrics.Config)
 					processCfg, exists := hmCfg.Scrapers["process"]
 					assert.True(t, exists, "expected process scraper")
 					include := processCfg["include"].(map[string]any)

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
@@ -28,12 +28,6 @@ type baseLogsTranslator struct{}
 
 var _ common.PipelineTranslator = (*baseLogsTranslator)(nil)
 
-// otelCollectLogsKey is the config key that indicates log sources are configured.
-// The base logs pipeline only activates when at least one log source feeds logs
-// through the forward/opentelemetry connector.
-var otelCollectLogsKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.LogsKey)
-var otelCollectDbiKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.DatabaseInsightsKey)
-
 func NewBaseLogsTranslator() common.PipelineTranslator {
 	return &baseLogsTranslator{}
 }
@@ -43,8 +37,8 @@ func (t *baseLogsTranslator) ID() pipeline.ID {
 }
 
 func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
-	if conf == nil || (!conf.IsSet(otelCollectLogsKey) && !conf.IsSet(otelCollectDbiKey)) {
-		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: otelCollectLogsKey + " or " + otelCollectDbiKey}
+	if conf == nil || (!conf.IsSet(common.OtelCollectLogsConfigKey) && !conf.IsSet(common.DatabaseInsightsConfigKey)) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey}
 	}
 
 	region := agent.Global_Config.Region

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
@@ -24,11 +24,11 @@ func TestBaseLogsTranslator(t *testing.T) {
 	}{
 		"WithNilConf": {
 			input:   nil,
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey + " or " + otelCollectDbiKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey},
 		},
 		"WithoutCollectKey": {
 			input:   map[string]interface{}{},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey + " or " + otelCollectDbiKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey},
 		},
 		"WithCollectKeyButNoLogs": {
 			input: map[string]interface{}{
@@ -36,7 +36,7 @@ func TestBaseLogsTranslator(t *testing.T) {
 					"collect": map[string]interface{}{},
 				},
 			},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectLogsKey + " or " + otelCollectDbiKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey},
 		},
 		"WithCollectLogsKey": {
 			input: map[string]interface{}{

--- a/translator/translate/otel/receiver/hostmetrics/scrapers_linux.yaml
+++ b/translator/translate/otel/receiver/hostmetrics/scrapers_linux.yaml
@@ -1,0 +1,35 @@
+cpu:
+  metrics:
+    system.cpu.frequency:
+      enabled: true
+    system.cpu.logical.count:
+      enabled: true
+    system.cpu.physical.count:
+      enabled: true
+    system.cpu.utilization:
+      enabled: true
+disk: {}
+filesystem:
+  metrics:
+    system.filesystem.utilization:
+      enabled: true
+load: {}
+memory:
+  metrics:
+    system.linux.memory.available:
+      enabled: true
+    system.linux.memory.dirty:
+      enabled: true
+    system.memory.limit:
+      enabled: true
+    system.memory.page_size:
+      enabled: true
+    system.memory.utilization:
+      enabled: true
+network:
+  metrics:
+    system.network.conntrack.count:
+      enabled: true
+    system.network.conntrack.max:
+      enabled: true
+processes: {}

--- a/translator/translate/otel/receiver/hostmetrics/scrapers_linux.yaml
+++ b/translator/translate/otel/receiver/hostmetrics/scrapers_linux.yaml
@@ -26,10 +26,5 @@ memory:
       enabled: true
     system.memory.utilization:
       enabled: true
-network:
-  metrics:
-    system.network.conntrack.count:
-      enabled: true
-    system.network.conntrack.max:
-      enabled: true
+network: {}
 processes: {}

--- a/translator/translate/otel/receiver/hostmetrics/scrapers_windows.yaml
+++ b/translator/translate/otel/receiver/hostmetrics/scrapers_windows.yaml
@@ -1,0 +1,23 @@
+cpu:
+  metrics:
+    system.cpu.logical.count:
+      enabled: true
+    system.cpu.physical.count:
+      enabled: true
+    system.cpu.utilization:
+      enabled: true
+disk:
+filesystem:
+  metrics:
+    system.filesystem.utilization:
+      enabled: true
+load:
+memory:
+  metrics:
+    system.memory.limit:
+      enabled: true
+    system.memory.page_size:
+      enabled: true
+    system.memory.utilization:
+      enabled: true
+network:

--- a/translator/translate/otel/receiver/hostmetrics/translator.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator.go
@@ -60,9 +60,38 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	if conf == nil {
 		conf = confmap.NewFromStringMap(map[string]interface{}{})
 	}
-	scrapers := make(map[string]map[string]any, len(defaultScrapers))
-	for _, s := range defaultScrapers {
-		scrapers[s] = nil
+	scrapers := map[string]map[string]any{
+		"cpu": {
+			"metrics": map[string]any{
+				"system.cpu.frequency":      map[string]any{"enabled": true},
+				"system.cpu.logical.count":  map[string]any{"enabled": true},
+				"system.cpu.physical.count": map[string]any{"enabled": true},
+				"system.cpu.utilization":    map[string]any{"enabled": true},
+			},
+		},
+		"disk":    nil,
+		"filesystem": {
+			"metrics": map[string]any{
+				"system.filesystem.utilization": map[string]any{"enabled": true},
+			},
+		},
+		"load":    nil,
+		"memory": {
+			"metrics": map[string]any{
+				"system.linux.memory.available": map[string]any{"enabled": true},
+				"system.linux.memory.dirty":     map[string]any{"enabled": true},
+				"system.memory.limit":           map[string]any{"enabled": true},
+				"system.memory.page_size":       map[string]any{"enabled": true},
+				"system.memory.utilization":     map[string]any{"enabled": true},
+			},
+		},
+		"network": {
+			"metrics": map[string]any{
+				"system.network.conntrack.count": map[string]any{"enabled": true},
+				"system.network.conntrack.max":   map[string]any{"enabled": true},
+			},
+		},
+		"processes": nil,
 	}
 	if t.processScraper != nil {
 		scrapers["process"] = t.processScraper

--- a/translator/translate/otel/receiver/hostmetrics/translator.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator.go
@@ -4,6 +4,8 @@
 package hostmetrics
 
 import (
+	_ "embed"
+	"fmt"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
@@ -11,23 +13,30 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
+	"gopkg.in/yaml.v3"
 
+	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
+	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
-var defaultScrapers = []string{"cpu", "disk", "filesystem", "memory", "network", "load", "processes"}
+//go:embed scrapers_linux.yaml
+var scrapersLinuxConfig []byte
 
-// hostMetricsConfig is a serializable representation of
+//go:embed scrapers_windows.yaml
+var scrapersWindowsConfig []byte
+
+// HostMetricsConfig is a serializable representation of
 // hostmetricsreceiver.Config. The upstream type uses mapstructure:"-" on its
 // Scrapers field which prevents confmap serialization, so we define our own
 // struct with an explicit scrapers field.
-type hostMetricsConfig struct {
+type HostMetricsConfig struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	Scrapers                       map[string]map[string]any `mapstructure:"scrapers"`
 }
 
 // Validate is intentionally a no-op; the upstream hostmetricsreceiver handles its own validation.
-func (c *hostMetricsConfig) Validate() error {
+func (c *HostMetricsConfig) Validate() error {
 	return nil
 }
 
@@ -38,8 +47,8 @@ type translator struct {
 
 type Option func(*translator)
 
-func WithProcessScraper(filter map[string]any) Option {
-	return func(t *translator) { t.processScraper = filter }
+func WithProcessScraper(scraperConfig map[string]any) Option {
+	return func(t *translator) { t.processScraper = scraperConfig }
 }
 
 var _ common.ComponentTranslator = (*translator)(nil)
@@ -60,49 +69,32 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	if conf == nil {
 		conf = confmap.NewFromStringMap(map[string]interface{}{})
 	}
-	scrapers := map[string]map[string]any{
-		"cpu": {
-			"metrics": map[string]any{
-				"system.cpu.frequency":      map[string]any{"enabled": true},
-				"system.cpu.logical.count":  map[string]any{"enabled": true},
-				"system.cpu.physical.count": map[string]any{"enabled": true},
-				"system.cpu.utilization":    map[string]any{"enabled": true},
-			},
-		},
-		"disk":    nil,
-		"filesystem": {
-			"metrics": map[string]any{
-				"system.filesystem.utilization": map[string]any{"enabled": true},
-			},
-		},
-		"load":    nil,
-		"memory": {
-			"metrics": map[string]any{
-				"system.linux.memory.available": map[string]any{"enabled": true},
-				"system.linux.memory.dirty":     map[string]any{"enabled": true},
-				"system.memory.limit":           map[string]any{"enabled": true},
-				"system.memory.page_size":       map[string]any{"enabled": true},
-				"system.memory.utilization":     map[string]any{"enabled": true},
-			},
-		},
-		"network": {
-			"metrics": map[string]any{
-				"system.network.conntrack.count": map[string]any{"enabled": true},
-				"system.network.conntrack.max":   map[string]any{"enabled": true},
-			},
-		},
-		"processes": nil,
+
+	// Select platform-specific scrapers config
+	var scrapersYaml []byte
+	if translatorcontext.CurrentContext().Os() == translatorconfig.OS_TYPE_WINDOWS {
+		scrapersYaml = scrapersWindowsConfig
+	} else {
+		scrapersYaml = scrapersLinuxConfig
 	}
+
+	var scrapers map[string]map[string]any
+	if err := yaml.Unmarshal(scrapersYaml, &scrapers); err != nil {
+		return nil, fmt.Errorf("failed to parse scrapers config: %w", err)
+	}
+
+	// Add process scraper if DBI configured
 	if t.processScraper != nil {
 		scrapers["process"] = t.processScraper
 	}
+
 	intervalKeyChain := []string{
 		common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.HostInsightsKey, common.MetricsCollectionIntervalKey),
 		common.ConfigKey(common.AgentKey, common.MetricsCollectionIntervalKey),
 	}
-	return &hostMetricsConfig{
+	return &HostMetricsConfig{
 		ControllerConfig: scraperhelper.ControllerConfig{
-			CollectionInterval: common.GetOrDefaultDuration(conf, intervalKeyChain, 60*time.Second),
+			CollectionInterval: common.GetOrDefaultDuration(conf, intervalKeyChain, 30*time.Second),
 			InitialDelay:       time.Second,
 		},
 		Scrapers: scrapers,

--- a/translator/translate/otel/receiver/hostmetrics/translator.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator.go
@@ -26,17 +26,17 @@ var scrapersLinuxConfig []byte
 //go:embed scrapers_windows.yaml
 var scrapersWindowsConfig []byte
 
-// HostMetricsConfig is a serializable representation of
+// Config is a serializable representation of
 // hostmetricsreceiver.Config. The upstream type uses mapstructure:"-" on its
 // Scrapers field which prevents confmap serialization, so we define our own
 // struct with an explicit scrapers field.
-type HostMetricsConfig struct {
+type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	Scrapers                       map[string]map[string]any `mapstructure:"scrapers"`
 }
 
 // Validate is intentionally a no-op; the upstream hostmetricsreceiver handles its own validation.
-func (c *HostMetricsConfig) Validate() error {
+func (c *Config) Validate() error {
 	return nil
 }
 
@@ -92,7 +92,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.HostInsightsKey, common.MetricsCollectionIntervalKey),
 		common.ConfigKey(common.AgentKey, common.MetricsCollectionIntervalKey),
 	}
-	return &HostMetricsConfig{
+	return &Config{
 		ControllerConfig: scraperhelper.ControllerConfig{
 			CollectionInterval: common.GetOrDefaultDuration(conf, intervalKeyChain, 30*time.Second),
 			InitialDelay:       time.Second,

--- a/translator/translate/otel/receiver/hostmetrics/translator.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator.go
@@ -32,13 +32,24 @@ func (c *hostMetricsConfig) Validate() error {
 }
 
 type translator struct {
-	factory receiver.Factory
+	factory        receiver.Factory
+	processScraper map[string]any
+}
+
+type Option func(*translator)
+
+func WithProcessScraper(filter map[string]any) Option {
+	return func(t *translator) { t.processScraper = filter }
 }
 
 var _ common.ComponentTranslator = (*translator)(nil)
 
-func NewTranslator() common.ComponentTranslator {
-	return &translator{factory: hostmetricsreceiver.NewFactory()}
+func NewTranslator(opts ...Option) common.ComponentTranslator {
+	t := &translator{factory: hostmetricsreceiver.NewFactory()}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 func (t *translator) ID() component.ID {
@@ -52,6 +63,9 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	scrapers := make(map[string]map[string]any, len(defaultScrapers))
 	for _, s := range defaultScrapers {
 		scrapers[s] = nil
+	}
+	if t.processScraper != nil {
+		scrapers["process"] = t.processScraper
 	}
 	intervalKeyChain := []string{
 		common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.HostInsightsKey, common.MetricsCollectionIntervalKey),

--- a/translator/translate/otel/receiver/hostmetrics/translator_test.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestTranslate(t *testing.T) {
+	orig := translatorcontext.CurrentContext().Os()
+	t.Cleanup(func() { translatorcontext.CurrentContext().SetOs(orig) })
 	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
 	testCases := map[string]struct {
 		input            map[string]interface{}
@@ -85,6 +87,8 @@ func TestTranslate(t *testing.T) {
 }
 
 func TestTranslateDefaultScrapers(t *testing.T) {
+	orig := translatorcontext.CurrentContext().Os()
+	t.Cleanup(func() { translatorcontext.CurrentContext().SetOs(orig) })
 	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
 	conf := confmap.NewFromStringMap(map[string]interface{}{})
 	cfg, err := NewTranslator().Translate(conf)
@@ -100,6 +104,8 @@ func TestTranslateDefaultScrapers(t *testing.T) {
 }
 
 func TestTranslateWithProcessScraper(t *testing.T) {
+	orig := translatorcontext.CurrentContext().Os()
+	t.Cleanup(func() { translatorcontext.CurrentContext().SetOs(orig) })
 	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
 	filter := map[string]any{
 		"include": map[string]any{

--- a/translator/translate/otel/receiver/hostmetrics/translator_test.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator_test.go
@@ -77,7 +77,7 @@ func TestTranslate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 
-			hmCfg, ok := cfg.(*HostMetricsConfig)
+			hmCfg, ok := cfg.(*Config)
 			require.True(t, ok)
 			assert.Equal(t, tc.expectedInterval, hmCfg.CollectionInterval)
 		})
@@ -90,7 +90,7 @@ func TestTranslateDefaultScrapers(t *testing.T) {
 	cfg, err := NewTranslator().Translate(conf)
 	require.NoError(t, err)
 
-	hmCfg := cfg.(*HostMetricsConfig)
+	hmCfg := cfg.(*Config)
 	expectedScrapers := []string{"cpu", "disk", "filesystem", "memory", "network", "load", "processes"}
 	assert.Equal(t, len(expectedScrapers), len(hmCfg.Scrapers))
 	for _, s := range expectedScrapers {
@@ -120,7 +120,7 @@ func TestTranslateWithProcessScraper(t *testing.T) {
 	cfg, err := NewTranslator(WithProcessScraper(filter)).Translate(conf)
 	require.NoError(t, err)
 
-	hmCfg := cfg.(*HostMetricsConfig)
+	hmCfg := cfg.(*Config)
 	assert.Equal(t, 8, len(hmCfg.Scrapers))
 	assert.Equal(t, filter, hmCfg.Scrapers["process"])
 }

--- a/translator/translate/otel/receiver/hostmetrics/translator_test.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator_test.go
@@ -101,6 +101,14 @@ func TestTranslateWithProcessScraper(t *testing.T) {
 			"names":      []string{"postgres.*"},
 		},
 		"mute_process_all_errors": true,
+		"metrics": map[string]any{
+			"process.cpu.utilization": map[string]any{
+				"enabled": true,
+			},
+			"process.memory.utilization": map[string]any{
+				"enabled": true,
+			},
+		},
 	}
 	conf := confmap.NewFromStringMap(map[string]interface{}{})
 	cfg, err := NewTranslator(WithProcessScraper(filter)).Translate(conf)

--- a/translator/translate/otel/receiver/hostmetrics/translator_test.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator_test.go
@@ -93,3 +93,20 @@ func TestTranslateDefaultScrapers(t *testing.T) {
 		assert.True(t, exists, "expected scraper %q to be present", s)
 	}
 }
+
+func TestTranslateWithProcessScraper(t *testing.T) {
+	filter := map[string]any{
+		"include": map[string]any{
+			"match_type": "regexp",
+			"names":      []string{"postgres.*"},
+		},
+		"mute_process_all_errors": true,
+	}
+	conf := confmap.NewFromStringMap(map[string]interface{}{})
+	cfg, err := NewTranslator(WithProcessScraper(filter)).Translate(conf)
+	require.NoError(t, err)
+
+	hmCfg := cfg.(*hostMetricsConfig)
+	assert.Equal(t, 8, len(hmCfg.Scrapers))
+	assert.Equal(t, filter, hmCfg.Scrapers["process"])
+}

--- a/translator/translate/otel/receiver/hostmetrics/translator_test.go
+++ b/translator/translate/otel/receiver/hostmetrics/translator_test.go
@@ -10,9 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
+
+	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
+	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
 )
 
 func TestTranslate(t *testing.T) {
+	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
 	testCases := map[string]struct {
 		input            map[string]interface{}
 		nilInput         bool
@@ -20,11 +24,11 @@ func TestTranslate(t *testing.T) {
 	}{
 		"NilConf": {
 			nilInput:         true,
-			expectedInterval: 60 * time.Second,
+			expectedInterval: 30 * time.Second,
 		},
 		"DefaultInterval": {
 			input:            map[string]interface{}{},
-			expectedInterval: 60 * time.Second,
+			expectedInterval: 30 * time.Second,
 		},
 		"AgentLevelInterval": {
 			input: map[string]interface{}{
@@ -73,7 +77,7 @@ func TestTranslate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 
-			hmCfg, ok := cfg.(*hostMetricsConfig)
+			hmCfg, ok := cfg.(*HostMetricsConfig)
 			require.True(t, ok)
 			assert.Equal(t, tc.expectedInterval, hmCfg.CollectionInterval)
 		})
@@ -81,11 +85,12 @@ func TestTranslate(t *testing.T) {
 }
 
 func TestTranslateDefaultScrapers(t *testing.T) {
+	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
 	conf := confmap.NewFromStringMap(map[string]interface{}{})
 	cfg, err := NewTranslator().Translate(conf)
 	require.NoError(t, err)
 
-	hmCfg := cfg.(*hostMetricsConfig)
+	hmCfg := cfg.(*HostMetricsConfig)
 	expectedScrapers := []string{"cpu", "disk", "filesystem", "memory", "network", "load", "processes"}
 	assert.Equal(t, len(expectedScrapers), len(hmCfg.Scrapers))
 	for _, s := range expectedScrapers {
@@ -95,6 +100,7 @@ func TestTranslateDefaultScrapers(t *testing.T) {
 }
 
 func TestTranslateWithProcessScraper(t *testing.T) {
+	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
 	filter := map[string]any{
 		"include": map[string]any{
 			"match_type": "regexp",
@@ -114,7 +120,7 @@ func TestTranslateWithProcessScraper(t *testing.T) {
 	cfg, err := NewTranslator(WithProcessScraper(filter)).Translate(conf)
 	require.NoError(t, err)
 
-	hmCfg := cfg.(*hostMetricsConfig)
+	hmCfg := cfg.(*HostMetricsConfig)
 	assert.Equal(t, 8, len(hmCfg.Scrapers))
 	assert.Equal(t, filter, hmCfg.Scrapers["process"])
 }


### PR DESCRIPTION
# Description of the issue

When database monitoring is configured, there is no host-level process visibility for PostgreSQL. The agent needs to collect process metrics (CPU,memory, disk I/O) filtered to PostgreSQL processes to support the self-managed monitoring use case.

# Description of changes

- Added WithProcessScraper option to the hostmetrics receiver translator, allowing callers to inject a process scraper with custom filter config
- Expanded the metrics/host_insights pipeline gate to activate when either host_insights or database_insights is configured
- When database monitoring is present, the hostmetrics receiver includes a process scraper filtered to postgres.* with process.cpu.utilization and process.memory.utilization enabled
- Consolidated duplicate config key definitions (DatabaseInsightsConfigKey, DatabaseInsightsPostgresKey, OtelCollectLogsConfigKey) into exported constants in common.go

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- Unit tested
- E2E validated on EC2: process metrics emitted for postgres processes

# Requirements

1. [x] Run make fmt and make fmt-sh
2. [x] Run make lint