### PR TITLE
Move host_insights translator into its own package

### DIFF
--- a/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator.go
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-package opentelemetry
+package hostinsights
 
 import (
 	"go.opentelemetry.io/collector/component"
@@ -21,7 +21,7 @@ type hostInsightsTranslator struct{}
 
 var _ common.PipelineTranslator = (*hostInsightsTranslator)(nil)
 
-func NewHostInsightsTranslator() common.PipelineTranslator {
+func NewTranslator() common.PipelineTranslator {
 	return &hostInsightsTranslator{}
 }
 

--- a/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostinsights/translator_test.go
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-package opentelemetry
+package hostinsights
 
 import (
 	"testing"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestHostInsightsTranslator(t *testing.T) {
-	tt := NewHostInsightsTranslator()
+	tt := NewTranslator()
 	assert.EqualValues(t, "metrics/host_insights", tt.ID().String())
 
 	testCases := map[string]struct {

--- a/translator/translate/otel/pipeline/opentelemetry/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translators.go
@@ -10,13 +10,14 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	ci "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/containerinsights"
 	dbi "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/databaseinsights"
+	hi "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/hostinsights"
 )
 
 func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
 	translators := common.NewTranslatorMap[*common.ComponentTranslators, pipeline.ID]()
 	translators.Set(NewBaseMetricsTranslator())
 	translators.Set(NewBaseLogsTranslator())
-	translators.Set(NewHostInsightsTranslator())
+	translators.Set(hi.NewTranslator())
 	translators.Merge(dbi.NewTranslators(conf))
 	translators.Merge(ci.NewTranslators(conf))
 	return translators


### PR DESCRIPTION
## Description

Moves the host_insights pipeline translator from the parent `opentelemetry` package into a `hostinsights/` subdirectory, consistent with the structure of `containerinsights/` and `databaseinsights/`.

### Before
```
opentelemetry/
├── translator_host_insights.go
├── translator_host_insights_test.go
├── containerinsights/
└── databaseinsights/
```

### After
```
opentelemetry/
├── hostinsights/
│   ├── translator.go
│   └── translator_test.go
├── containerinsights/
└── databaseinsights/
```

No behavioral changes. The exported function is renamed from `NewHostInsightsTranslator()` to `hostinsights.NewTranslator()` following the package-scoped naming convention.

## Tests

- `TestHostInsightsConfig` golden file test passes
- `TestHostInsightsTranslator` unit test passes
- All existing tests pass
- `make fmt` ✓ | `make lint` ✓ | `go build` ✓