### PR TITLE
Add prometheus pipeline translator under opentelemetry config

### DIFF
--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1809,6 +1809,10 @@
                 "config_path": {
                   "description": "Path to the Prometheus scrape configuration file",
                   "type": "string"
+                },
+                "cluster_name": {
+                  "description": "The name of the EKS cluster",
+                  "type": "string"
                 }
               },
               "required": ["config_path"],

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1802,6 +1802,17 @@
               },
               "required": ["cluster_name"],
               "additionalProperties": false
+            },
+            "prometheus": {
+              "type": "object",
+              "properties": {
+                "config_path": {
+                  "description": "Path to the Prometheus scrape configuration file",
+                  "type": "string"
+                }
+              },
+              "required": ["config_path"],
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/translator/tocwconfig/sampleConfig/prometheus_otel_pipeline_config.json
+++ b/translator/tocwconfig/sampleConfig/prometheus_otel_pipeline_config.json
@@ -1,0 +1,12 @@
+{
+  "agent": {
+    "region": "us-east-1"
+  },
+  "opentelemetry": {
+    "collect": {
+      "prometheus": {
+        "config_path": "./sampleConfig/prometheus_otel_scrape_config.yaml"
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/prometheus_otel_pipeline_config.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_otel_pipeline_config.yaml
@@ -38,7 +38,7 @@ receivers:
 service:
     extensions: []
     pipelines:
-        metrics/prometheus:
+        metrics/otel_prometheus:
             exporters:
                 - forward/opentelemetry
             processors: []

--- a/translator/tocwconfig/sampleConfig/prometheus_otel_pipeline_config.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_otel_pipeline_config.yaml
@@ -1,0 +1,59 @@
+connectors:
+    forward/opentelemetry: {}
+receivers:
+    prometheus:
+        config:
+            global:
+                evaluation_interval: 1m
+                scrape_interval: 30s
+                scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                scrape_timeout: 10s
+            scrape_configs:
+                - enable_compression: true
+                  enable_http2: true
+                  follow_redirects: true
+                  honor_timestamps: true
+                  job_name: test_app
+                  metrics_path: /metrics
+                  scheme: http
+                  scrape_interval: 30s
+                  scrape_protocols:
+                    - OpenMetricsText1.0.0
+                    - OpenMetricsText0.0.1
+                    - PrometheusText1.0.0
+                    - PrometheusText0.0.4
+                  scrape_timeout: 10s
+                  static_configs:
+                    - targets:
+                        - localhost:9090
+                  track_timestamps_staleness: false
+        report_extra_scrape_metrics: false
+        start_time_metric_regex: ""
+        trim_metric_suffixes: false
+        use_start_time_metric: false
+service:
+    extensions: []
+    pipelines:
+        metrics/prometheus:
+            exporters:
+                - forward/opentelemetry
+            processors: []
+            receivers:
+                - prometheus
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/sampleConfig/prometheus_otel_scrape_config.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_otel_scrape_config.yaml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 30s
+  scrape_timeout: 10s
+scrape_configs:
+  - job_name: 'test_app'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -345,6 +345,12 @@ func TestContainerInsightsConfig(t *testing.T) {
 	checkTranslationNoValidation(t, "container_insights_config", "linux", nil, "")
 }
 
+func TestPrometheusOtelPipelineConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	checkTranslationNoValidation(t, "prometheus_otel_pipeline_config", "linux", nil, "")
+}
+
 func TestOtlpMetricsConfigKubernetes(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetMode(config.ModeEC2)

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
@@ -6,7 +6,6 @@ package prometheus
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 	"go.opentelemetry.io/collector/component"
@@ -20,8 +19,7 @@ import (
 )
 
 const (
-	pipelineName           = "otel_prometheus"
-	otelConfigParsingError = "has invalid keys: global"
+	pipelineName = "otel_prometheus"
 )
 
 var prometheusKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.PrometheusKey)
@@ -110,20 +108,14 @@ func (t *prometheusReceiverTranslator) Translate(conf *confmap.Conf) (component.
 	// references (os.Expand), which can cause failures or empty replacements.
 	// This is a known limitation when prometheus configs with relabel_configs
 	// are loaded through the OTel config resolver pipeline.
-	if err := componentParser.Unmarshal(&cfg); err != nil {
-		// Config is in plain prometheus format, not OTel wrapper
-		if !strings.Contains(err.Error(), otelConfigParsingError) {
-			return nil, fmt.Errorf("unable to unmarshal prometheus config from %s: %w", configPath, err)
-		}
 
-		var promCfg prometheusreceiver.PromConfig
-		if err := componentParser.Unmarshal(&promCfg); err != nil {
-			return nil, fmt.Errorf("unable to unmarshal plain prometheus config from %s: %w", configPath, err)
-		}
-		cfg.PrometheusConfig.GlobalConfig = promCfg.GlobalConfig
-		cfg.PrometheusConfig.ScrapeConfigs = promCfg.ScrapeConfigs
-		cfg.PrometheusConfig.TracingConfig = promCfg.TracingConfig
+	var promCfg prometheusreceiver.PromConfig
+	if err := componentParser.Unmarshal(&promCfg); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal prometheus config from %s: %w", configPath, err)
 	}
+	cfg.PrometheusConfig.GlobalConfig = promCfg.GlobalConfig
+	cfg.PrometheusConfig.ScrapeConfigs = promCfg.ScrapeConfigs
+	cfg.PrometheusConfig.TracingConfig = promCfg.TracingConfig
 
 	return cfg, nil
 }

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/transformprocessor"
 )
 
 const (
@@ -29,6 +30,7 @@ const (
 
 var prometheusKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.PrometheusKey)
 var configPathKey = common.ConfigKey(prometheusKey, "config_path")
+var clusterNameKey = common.ConfigKey(prometheusKey, "cluster_name")
 
 type translator struct{}
 
@@ -50,9 +52,18 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 	fwdConnector := forward.NewTranslator(common.OpenTelemetryKey)
 	receiver := &prometheusReceiverTranslator{}
 
+	processors := common.NewTranslatorMap[component.Config, component.ID]()
+	if clusterName, ok := common.GetString(conf, clusterNameKey); ok && clusterName != "" {
+		processors.Set(transformprocessor.NewTranslatorWithName("set_cluster_name",
+			transformprocessor.WithMetricStatements([]string{
+				fmt.Sprintf(`set(resource.attributes["k8s.cluster.name"], "%s")`, clusterName),
+			}),
+		))
+	}
+
 	return &common.ComponentTranslators{
 		Receivers:  common.NewTranslatorMap[component.Config, component.ID](receiver),
-		Processors: common.NewTranslatorMap[component.Config, component.ID](),
+		Processors: processors,
 		Exporters:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
 		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
@@ -92,6 +103,11 @@ func (t *prometheusReceiverTranslator) Translate(conf *confmap.Conf) (component.
 	}
 
 	componentParser := confmap.NewFromStringMap(stringMap)
+	// NOTE: Prometheus relabel configs use $1, $2 for capture group references.
+	// The OTel confmap expandconverter interprets these as environment variable
+	// references (os.Expand), which can cause failures or empty replacements.
+	// This is a known limitation when prometheus configs with relabel_configs
+	// are loaded through the OTel config resolver pipeline.
 	if err := componentParser.Unmarshal(&cfg); err != nil {
 		// Config is in plain prometheus format, not OTel wrapper
 		if !strings.Contains(err.Error(), otelConfigParsingError) {

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 	"go.opentelemetry.io/collector/component"
@@ -23,9 +22,6 @@ import (
 const (
 	pipelineName           = "otel_prometheus"
 	otelConfigParsingError = "has invalid keys: global"
-	defaultTLSCaPath       = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
-	defaultTLSCertPath     = "/etc/amazon-cloudwatch-observability-agent-ta-client-cert/client.crt"
-	defaultTLSKeyPath      = "/etc/amazon-cloudwatch-observability-agent-ta-client-cert/client.key"
 )
 
 var prometheusKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.PrometheusKey)
@@ -127,21 +123,6 @@ func (t *prometheusReceiverTranslator) Translate(conf *confmap.Conf) (component.
 		cfg.PrometheusConfig.GlobalConfig = promCfg.GlobalConfig
 		cfg.PrometheusConfig.ScrapeConfigs = promCfg.ScrapeConfigs
 		cfg.PrometheusConfig.TracingConfig = promCfg.TracingConfig
-	} else {
-		// OTel format — check if target allocator is configured.
-		// Only inject default TLS paths if the customer hasn't provided their own.
-		if cfg.TargetAllocator != nil && len(cfg.TargetAllocator.CollectorID) > 0 {
-			if cfg.TargetAllocator.TLSSetting.CAFile == "" {
-				cfg.TargetAllocator.TLSSetting.CAFile = defaultTLSCaPath
-			}
-			if cfg.TargetAllocator.TLSSetting.CertFile == "" {
-				cfg.TargetAllocator.TLSSetting.CertFile = defaultTLSCertPath
-			}
-			if cfg.TargetAllocator.TLSSetting.KeyFile == "" {
-				cfg.TargetAllocator.TLSSetting.KeyFile = defaultTLSKeyPath
-			}
-			cfg.TargetAllocator.TLSSetting.ReloadInterval = 10 * time.Second
-		}
 	}
 
 	return cfg, nil

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
@@ -54,6 +54,12 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 
 	processors := common.NewTranslatorMap[component.Config, component.ID]()
 	if clusterName, ok := common.GetString(conf, clusterNameKey); ok && clusterName != "" {
+		// Validate cluster_name to prevent OTTL injection (must be alphanumeric, hyphens, dots, underscores)
+		for _, c := range clusterName {
+			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '-' && c != '.' && c != '_' {
+				return nil, fmt.Errorf("cluster_name contains invalid character %q", c)
+			}
+		}
 		processors.Set(transformprocessor.NewTranslatorWithName("set_cluster_name",
 			transformprocessor.WithMetricStatements([]string{
 				fmt.Sprintf(`set(resource.attributes["k8s.cluster.name"], "%s")`, clusterName),

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	pipelineName           = "prometheus"
+	pipelineName           = "otel_prometheus"
 	otelConfigParsingError = "has invalid keys: global"
 	defaultTLSCaPath       = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
 	defaultTLSCertPath     = "/etc/amazon-cloudwatch-observability-agent-ta-client-cert/client.crt"
@@ -128,11 +128,18 @@ func (t *prometheusReceiverTranslator) Translate(conf *confmap.Conf) (component.
 		cfg.PrometheusConfig.ScrapeConfigs = promCfg.ScrapeConfigs
 		cfg.PrometheusConfig.TracingConfig = promCfg.TracingConfig
 	} else {
-		// OTel format — check if target allocator is configured
+		// OTel format — check if target allocator is configured.
+		// Only inject default TLS paths if the customer hasn't provided their own.
 		if cfg.TargetAllocator != nil && len(cfg.TargetAllocator.CollectorID) > 0 {
-			cfg.TargetAllocator.TLSSetting.CAFile = defaultTLSCaPath
-			cfg.TargetAllocator.TLSSetting.CertFile = defaultTLSCertPath
-			cfg.TargetAllocator.TLSSetting.KeyFile = defaultTLSKeyPath
+			if cfg.TargetAllocator.TLSSetting.CAFile == "" {
+				cfg.TargetAllocator.TLSSetting.CAFile = defaultTLSCaPath
+			}
+			if cfg.TargetAllocator.TLSSetting.CertFile == "" {
+				cfg.TargetAllocator.TLSSetting.CertFile = defaultTLSCertPath
+			}
+			if cfg.TargetAllocator.TLSSetting.KeyFile == "" {
+				cfg.TargetAllocator.TLSSetting.KeyFile = defaultTLSKeyPath
+			}
 			cfg.TargetAllocator.TLSSetting.ReloadInterval = 10 * time.Second
 		}
 	}

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
@@ -6,6 +6,8 @@ package prometheus
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"regexp"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 	"go.opentelemetry.io/collector/component"
@@ -21,6 +23,8 @@ import (
 const (
 	pipelineName = "otel_prometheus"
 )
+
+var clusterNameRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 var prometheusKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.PrometheusKey)
 var configPathKey = common.ConfigKey(prometheusKey, "config_path")
@@ -48,11 +52,8 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 
 	processors := common.NewTranslatorMap[component.Config, component.ID]()
 	if clusterName, ok := common.GetString(conf, clusterNameKey); ok && clusterName != "" {
-		// Validate cluster_name to prevent OTTL injection (must be alphanumeric, hyphens, dots, underscores)
-		for _, c := range clusterName {
-			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '-' && c != '.' && c != '_' {
-				return nil, fmt.Errorf("cluster_name contains invalid character %q", c)
-			}
+		if !clusterNameRegex.MatchString(clusterName) {
+			return nil, fmt.Errorf("cluster_name contains invalid characters: %q", clusterName)
 		}
 		processors.Set(transformprocessor.NewTranslatorWithName("set_cluster_name",
 			transformprocessor.WithMetricStatements([]string{
@@ -91,6 +92,7 @@ func (t *prometheusReceiverTranslator) Translate(conf *confmap.Conf) (component.
 	if configPath == "" {
 		return nil, fmt.Errorf("config_path must not be empty for opentelemetry prometheus receiver")
 	}
+	configPath = filepath.Clean(configPath)
 
 	content, err := os.ReadFile(configPath)
 	if err != nil {

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator.go
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package prometheus
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+	"gopkg.in/yaml.v3"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
+)
+
+const (
+	pipelineName           = "prometheus"
+	otelConfigParsingError = "has invalid keys: global"
+	defaultTLSCaPath       = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
+	defaultTLSCertPath     = "/etc/amazon-cloudwatch-observability-agent-ta-client-cert/client.crt"
+	defaultTLSKeyPath      = "/etc/amazon-cloudwatch-observability-agent-ta-client-cert/client.key"
+)
+
+var prometheusKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.PrometheusKey)
+var configPathKey = common.ConfigKey(prometheusKey, "config_path")
+
+type translator struct{}
+
+var _ common.PipelineTranslator = (*translator)(nil)
+
+func NewTranslator() common.PipelineTranslator {
+	return &translator{}
+}
+
+func (t *translator) ID() pipeline.ID {
+	return pipeline.NewIDWithName(pipeline.SignalMetrics, pipelineName)
+}
+
+func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
+	if conf == nil || !conf.IsSet(prometheusKey) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: prometheusKey}
+	}
+
+	fwdConnector := forward.NewTranslator(common.OpenTelemetryKey)
+	receiver := &prometheusReceiverTranslator{}
+
+	return &common.ComponentTranslators{
+		Receivers:  common.NewTranslatorMap[component.Config, component.ID](receiver),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
+		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+	}, nil
+}
+
+// prometheusReceiverTranslator reads the prometheus config from config_path.
+type prometheusReceiverTranslator struct{}
+
+var _ common.ComponentTranslator = (*prometheusReceiverTranslator)(nil)
+
+func (t *prometheusReceiverTranslator) ID() component.ID {
+	return component.NewIDWithName(prometheusreceiver.NewFactory().Type(), "")
+}
+
+func (t *prometheusReceiverTranslator) Translate(conf *confmap.Conf) (component.Config, error) {
+	factory := prometheusreceiver.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*prometheusreceiver.Config)
+
+	if !conf.IsSet(configPathKey) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: configPathKey}
+	}
+
+	configPath, _ := common.GetString(conf, configPathKey)
+	if configPath == "" {
+		return nil, fmt.Errorf("config_path must not be empty for opentelemetry prometheus receiver")
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read prometheus config from path %s: %w", configPath, err)
+	}
+
+	var stringMap map[string]interface{}
+	if err := yaml.Unmarshal(content, &stringMap); err != nil {
+		return nil, fmt.Errorf("unable to parse prometheus config from %s: %w", configPath, err)
+	}
+
+	componentParser := confmap.NewFromStringMap(stringMap)
+	if err := componentParser.Unmarshal(&cfg); err != nil {
+		// Config is in plain prometheus format, not OTel wrapper
+		if !strings.Contains(err.Error(), otelConfigParsingError) {
+			return nil, fmt.Errorf("unable to unmarshal prometheus config from %s: %w", configPath, err)
+		}
+
+		var promCfg prometheusreceiver.PromConfig
+		if err := componentParser.Unmarshal(&promCfg); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal plain prometheus config from %s: %w", configPath, err)
+		}
+		cfg.PrometheusConfig.GlobalConfig = promCfg.GlobalConfig
+		cfg.PrometheusConfig.ScrapeConfigs = promCfg.ScrapeConfigs
+		cfg.PrometheusConfig.TracingConfig = promCfg.TracingConfig
+	} else {
+		// OTel format — check if target allocator is configured
+		if cfg.TargetAllocator != nil && len(cfg.TargetAllocator.CollectorID) > 0 {
+			cfg.TargetAllocator.TLSSetting.CAFile = defaultTLSCaPath
+			cfg.TargetAllocator.TLSSetting.CertFile = defaultTLSCertPath
+			cfg.TargetAllocator.TLSSetting.KeyFile = defaultTLSKeyPath
+			cfg.TargetAllocator.TLSSetting.ReloadInterval = 10 * time.Second
+		}
+	}
+
+	return cfg, nil
+}

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator_test.go
@@ -177,11 +177,10 @@ func TestPrometheusReceiverTranslatorMissingFile(t *testing.T) {
 
 func createTempPromConfig(t *testing.T) string {
 	t.Helper()
-	content := []byte(`config:
-  scrape_configs:
-    - job_name: test
-      static_configs:
-        - targets: ['localhost:9090']
+	content := []byte(`scrape_configs:
+  - job_name: test
+    static_configs:
+      - targets: ['localhost:9090']
 `)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "prometheus.yml")

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator_test.go
@@ -41,6 +41,44 @@ func TestPrometheusTranslator(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		"WithClusterName": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"prometheus": map[string]interface{}{
+							"config_path":  createTempPromConfig(t),
+							"cluster_name": "my-cluster",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		"WithInvalidClusterName": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"prometheus": map[string]interface{}{
+							"config_path":  createTempPromConfig(t),
+							"cluster_name": `bad"name`,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"WithMissingConfigFile": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"prometheus": map[string]interface{}{
+							"config_path": "/nonexistent/path.yml",
+						},
+					},
+				},
+			},
+			wantErr: false, // pipeline translates fine; file error surfaces at receiver Translate time
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -56,7 +94,6 @@ func TestPrometheusTranslator(t *testing.T) {
 				require.NoError(t, err)
 				assert.NotNil(t, got)
 				assert.Equal(t, 1, got.Receivers.Len())
-				assert.Equal(t, 0, got.Processors.Len())
 				assert.Equal(t, 1, got.Exporters.Len())
 				assert.Equal(t, 1, got.Connectors.Len())
 				assert.Equal(t, "prometheus", got.Receivers.Keys()[0].String())
@@ -64,6 +101,42 @@ func TestPrometheusTranslator(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrometheusTranslatorClusterNameProcessor(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"config_path":  createTempPromConfig(t),
+					"cluster_name": "test-cluster",
+				},
+			},
+		},
+	})
+
+	tt := NewTranslator()
+	got, err := tt.Translate(conf)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Processors.Len())
+	assert.Equal(t, "transform/set_cluster_name", got.Processors.Keys()[0].String())
+}
+
+func TestPrometheusTranslatorNoClusterNameProcessor(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"config_path": createTempPromConfig(t),
+				},
+			},
+		},
+	})
+
+	tt := NewTranslator()
+	got, err := tt.Translate(conf)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.Processors.Len())
 }
 
 func TestPrometheusReceiverTranslator(t *testing.T) {
@@ -82,6 +155,24 @@ func TestPrometheusReceiverTranslator(t *testing.T) {
 	cfg, err := receiver.Translate(conf)
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
+}
+
+func TestPrometheusReceiverTranslatorMissingFile(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"config_path": "/nonexistent/path.yml",
+				},
+			},
+		},
+	})
+
+	receiver := &prometheusReceiverTranslator{}
+	cfg, err := receiver.Translate(conf)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "unable to read prometheus config")
 }
 
 func createTempPromConfig(t *testing.T) string {

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator_test.go
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package prometheus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestPrometheusTranslator(t *testing.T) {
+	tt := NewTranslator()
+	assert.EqualValues(t, "metrics/prometheus", tt.ID().String())
+
+	testCases := map[string]struct {
+		input   map[string]interface{}
+		wantErr bool
+	}{
+		"WithNilConf": {
+			input:   nil,
+			wantErr: true,
+		},
+		"WithoutPrometheusKey": {
+			input:   map[string]interface{}{},
+			wantErr: true,
+		},
+		"WithValidConfig": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"prometheus": map[string]interface{}{
+							"config_path": createTempPromConfig(t),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var conf *confmap.Conf
+			if tc.input != nil {
+				conf = confmap.NewFromStringMap(tc.input)
+			}
+			got, err := tt.Translate(conf)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, 1, got.Receivers.Len())
+				assert.Equal(t, 0, got.Processors.Len())
+				assert.Equal(t, 1, got.Exporters.Len())
+				assert.Equal(t, 1, got.Connectors.Len())
+				assert.Equal(t, "prometheus", got.Receivers.Keys()[0].String())
+				assert.Equal(t, "forward/opentelemetry", got.Exporters.Keys()[0].String())
+			}
+		})
+	}
+}
+
+func TestPrometheusReceiverTranslator(t *testing.T) {
+	configPath := createTempPromConfig(t)
+	conf := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"config_path": configPath,
+				},
+			},
+		},
+	})
+
+	receiver := &prometheusReceiverTranslator{}
+	cfg, err := receiver.Translate(conf)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+}
+
+func createTempPromConfig(t *testing.T) string {
+	t.Helper()
+	content := []byte(`config:
+  scrape_configs:
+    - job_name: test
+      static_configs:
+        - targets: ['localhost:9090']
+`)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prometheus.yml")
+	require.NoError(t, os.WriteFile(path, content, 0600))
+	return path
+}

--- a/translator/translate/otel/pipeline/opentelemetry/prometheus/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/prometheus/translator_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestPrometheusTranslator(t *testing.T) {
 	tt := NewTranslator()
-	assert.EqualValues(t, "metrics/prometheus", tt.ID().String())
+	assert.EqualValues(t, "metrics/otel_prometheus", tt.ID().String())
 
 	testCases := map[string]struct {
 		input   map[string]interface{}
@@ -187,4 +187,36 @@ func createTempPromConfig(t *testing.T) string {
 	path := filepath.Join(dir, "prometheus.yml")
 	require.NoError(t, os.WriteFile(path, content, 0600))
 	return path
+}
+
+func createTempPlainPromConfig(t *testing.T) string {
+	t.Helper()
+	content := []byte(`global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: plain_test
+    static_configs:
+      - targets: ['localhost:9090']
+`)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prometheus.yml")
+	require.NoError(t, os.WriteFile(path, content, 0600))
+	return path
+}
+
+func TestPrometheusReceiverTranslatorPlainFormat(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"config_path": createTempPlainPromConfig(t),
+				},
+			},
+		},
+	})
+
+	receiver := &prometheusReceiverTranslator{}
+	cfg, err := receiver.Translate(conf)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
 }

--- a/translator/translate/otel/pipeline/opentelemetry/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translators.go
@@ -11,6 +11,7 @@ import (
 	ci "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/containerinsights"
 	dbi "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/databaseinsights"
 	hi "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/hostinsights"
+	prom "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/prometheus"
 )
 
 func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
@@ -18,6 +19,7 @@ func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
 	translators.Set(NewBaseMetricsTranslator())
 	translators.Set(NewBaseLogsTranslator())
 	translators.Set(hi.NewTranslator())
+	translators.Set(prom.NewTranslator())
 	translators.Merge(dbi.NewTranslators(conf))
 	translators.Merge(ci.NewTranslators(conf))
 	return translators


### PR DESCRIPTION
## Description

Adds support for `opentelemetry.collect.prometheus` configuration that reads an external Prometheus scrape config file and generates an OTel prometheus receiver pipeline feeding into the shared base metrics pipeline.

### Config

```json
{
  "opentelemetry": {
    "collect": {
      "prometheus": {
        "config_path": "/opt/aws/prometheus.yml",
        "cluster_name": "my-cluster"
      }
    }
  }
}
```

| Field | Required | Description |
|-------|----------|-------------|
| config_path | Yes | Path to external Prometheus scrape config YAML |
| cluster_name | No | EKS cluster name (sets `k8s.cluster.name` resource attribute) |

### Behavior

- References external YAML (open-ended scrape config, cannot be validated by JSON schema)
- Translator auto-detects OTel wrapper format vs plain Prometheus format
- When `cluster_name` is set, adds a transform processor to tag metrics with `k8s.cluster.name`
- Pipeline name: `metrics/otel_prometheus` (avoids conflict with V1 `metrics/prometheus/*`)
- Pipeline: prometheus receiver → forward/opentelemetry connector → shared base metrics pipeline (resourcedetection, batch, otlphttp)

### Known limitation

Prometheus relabel configs using `$1`, `$2` capture group references can conflict with the OTel confmap `expandconverter` which interprets `$` as environment variable substitution. Documented in code comment.

## Tests

### Unit tests
- `TestPrometheusTranslator` — nil conf, missing key, valid config, cluster_name, invalid cluster_name, missing file
- `TestPrometheusReceiverTranslator` — OTel format parsing
- `TestPrometheusReceiverTranslatorPlainFormat` — plain Prometheus format (global + scrape_configs)
- `TestPrometheusReceiverTranslatorMissingFile` — file not found error
- `TestPrometheusTranslatorClusterNameProcessor` / `NoClusterNameProcessor` — conditional processor
- `TestPrometheusOtelPipelineConfig` — golden file test (end-to-end translation)

### EC2 integration test (us-west-2, `mitsalvi-otel-test`)
- Deployed custom agent binary to t3.medium instance
- Prometheus receiver scraping node_exporter on localhost:9100
- Metrics successfully exported to CloudWatch Monitoring endpoint ✅

### EKS integration test (us-east-1, `cwa-otel-test`)
- Deployed custom agent as pod with prometheus scrape config targeting kubernetes API server
- Config with `cluster_name: "cwa-otel-test"`
- `k8s.cluster.name` resource attribute applied via transform processor ✅
- Metrics successfully exported to CloudWatch Monitoring endpoint ✅

### Linting
- `make fmt` ✓ | `make lint` ✓ (only pre-existing plugins/plugins.go impi issue) | `go build` ✓