### PR TITLE
Add OTLP receiver pipeline and base traces pipeline

### DIFF
--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1817,6 +1817,21 @@
               },
               "required": ["config_path"],
               "additionalProperties": false
+            },
+            "otlp": {
+              "type": "object",
+              "properties": {
+                "grpc_endpoint": {
+                  "description": "OTLP gRPC receiver endpoint",
+                  "type": "string"
+                },
+                "http_endpoint": {
+                  "description": "OTLP HTTP receiver endpoint",
+                  "type": "string"
+                }
+              },
+              "required": ["grpc_endpoint", "http_endpoint"],
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1830,7 +1830,6 @@
                   "type": "string"
                 }
               },
-              "required": ["grpc_endpoint", "http_endpoint"],
               "additionalProperties": false
             }
           },

--- a/translator/tocwconfig/sampleConfig/otlp_otel_config.json
+++ b/translator/tocwconfig/sampleConfig/otlp_otel_config.json
@@ -1,0 +1,11 @@
+{
+  "agent": {"region": "us-west-2"},
+  "opentelemetry": {
+    "collect": {
+      "otlp": {
+        "grpc_endpoint": "127.0.0.1:4317",
+        "http_endpoint": "127.0.0.1:4318"
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/otlp_otel_config.yaml
+++ b/translator/tocwconfig/sampleConfig/otlp_otel_config.yaml
@@ -1,0 +1,60 @@
+connectors:
+    forward/opentelemetry: {}
+receivers:
+    otlp/grpc_127_0_0_1_4317:
+        protocols:
+            grpc:
+                endpoint: 127.0.0.1:4317
+                keepalive:
+                    enforcement_policy: {}
+                    server_parameters: {}
+                read_buffer_size: 524288
+                transport: tcp
+    otlp/http_127_0_0_1_4318:
+        protocols:
+            http:
+                cors: {}
+                endpoint: 127.0.0.1:4318
+                idle_timeout: 0s
+                logs_url_path: /v1/logs
+                metrics_url_path: /v1/metrics
+                read_header_timeout: 0s
+                traces_url_path: /v1/traces
+                write_timeout: 0s
+service:
+    extensions: []
+    pipelines:
+        logs/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors: []
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+        metrics/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors: []
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+        traces/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors: []
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -386,6 +386,12 @@ func TestSharedOtlp(t *testing.T) {
 	checkTranslation(t, "shared_otlp_config", "linux", nil, "")
 }
 
+func TestOtlpOtelConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	checkTranslationNoValidation(t, "otlp_otel_config", "linux", nil, "")
+}
+
 func TestProcstatMemorySwapConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(false)

--- a/translator/translate/otel/pipeline/opentelemetry/otlp/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/otlp/translator.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otlp
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
+	otlpreceiver "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/otlp"
+)
+
+const pipelineName = "otlp"
+
+var otlpKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)
+
+// NewTranslators returns OTLP pipeline translators for metrics, logs, and traces.
+// Each pipeline creates OTLP receivers (grpc + http) and forwards to the shared base pipeline.
+func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
+	translators := common.NewTranslatorMap[*common.ComponentTranslators, pipeline.ID]()
+	if conf == nil || !conf.IsSet(otlpKey) {
+		return translators
+	}
+
+	translators.Set(&otlpPipelineTranslator{signal: pipeline.SignalMetrics})
+	translators.Set(&otlpPipelineTranslator{signal: pipeline.SignalLogs})
+	translators.Set(&otlpPipelineTranslator{signal: pipeline.SignalTraces})
+
+	return translators
+}
+
+type otlpPipelineTranslator struct {
+	signal pipeline.Signal
+}
+
+var _ common.PipelineTranslator = (*otlpPipelineTranslator)(nil)
+
+func (t *otlpPipelineTranslator) ID() pipeline.ID {
+	return pipeline.NewIDWithName(t.signal, pipelineName)
+}
+
+func (t *otlpPipelineTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
+	if conf == nil || !conf.IsSet(otlpKey) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: otlpKey}
+	}
+
+	// Use the existing OTLP receiver translator which handles grpc_endpoint/http_endpoint parsing
+	receivers := otlpreceiver.NewTranslators(conf, pipelineName, otlpKey)
+
+	fwdConnector := forward.NewTranslator(common.OpenTelemetryKey)
+
+	return &common.ComponentTranslators{
+		Receivers:  receivers,
+		Processors: common.NewTranslatorMap[component.Config, component.ID](),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
+		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+	}, nil
+}

--- a/translator/translate/otel/pipeline/opentelemetry/otlp/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/otlp/translator_test.go
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otlp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+
+	otlpreceiver "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/otlp"
+)
+
+func TestNewTranslators(t *testing.T) {
+	testCases := map[string]struct {
+		input map[string]interface{}
+		want  int
+	}{
+		"NilConf": {
+			input: nil,
+			want:  0,
+		},
+		"NoOtlpKey": {
+			input: map[string]interface{}{},
+			want:  0,
+		},
+		"WithOtlpKey": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"otlp": map[string]interface{}{
+							"grpc_endpoint": "127.0.0.1:4317",
+							"http_endpoint": "127.0.0.1:4318",
+						},
+					},
+				},
+			},
+			want: 3, // metrics, logs, traces
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var conf *confmap.Conf
+			if tc.input != nil {
+				conf = confmap.NewFromStringMap(tc.input)
+			}
+			translators := NewTranslators(conf)
+			assert.Equal(t, tc.want, translators.Len())
+		})
+	}
+}
+
+func TestOtlpPipelineTranslator(t *testing.T) {
+	otlpreceiver.ClearConfigCache()
+	conf := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"otlp": map[string]interface{}{
+					"grpc_endpoint": "127.0.0.1:4317",
+					"http_endpoint": "127.0.0.1:4318",
+				},
+			},
+		},
+	})
+
+	translators := NewTranslators(conf)
+	assert.Equal(t, 3, translators.Len())
+
+	// Verify each signal pipeline
+	signals := []pipeline.Signal{pipeline.SignalMetrics, pipeline.SignalLogs, pipeline.SignalTraces}
+	for _, signal := range signals {
+		t.Run(signal.String(), func(t *testing.T) {
+			id := pipeline.NewIDWithName(signal, "otlp")
+			translator, ok := translators.Get(id)
+			require.True(t, ok)
+
+			got, err := translator.Translate(conf)
+			require.NoError(t, err)
+			assert.Equal(t, 2, got.Receivers.Len())  // grpc + http
+			assert.Equal(t, 0, got.Processors.Len()) // no processors
+			assert.Equal(t, 1, got.Exporters.Len())  // forward connector
+			assert.Equal(t, 1, got.Connectors.Len()) // forward connector
+		})
+	}
+}

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
@@ -39,7 +39,7 @@ func (t *baseLogsTranslator) ID() pipeline.ID {
 func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
 	otlpKey := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)
 	if conf == nil || (!conf.IsSet(common.OtelCollectLogsConfigKey) && !conf.IsSet(common.DatabaseInsightsConfigKey) && !conf.IsSet(otlpKey)) {
-		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: common.OtelCollectLogsConfigKey}
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey + " or " + otlpKey}
 	}
 
 	region := agent.Global_Config.Region

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
@@ -37,8 +37,9 @@ func (t *baseLogsTranslator) ID() pipeline.ID {
 }
 
 func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
-	if conf == nil || (!conf.IsSet(common.OtelCollectLogsConfigKey) && !conf.IsSet(common.DatabaseInsightsConfigKey)) {
-		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey}
+	otlpKey := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)
+	if conf == nil || (!conf.IsSet(common.OtelCollectLogsConfigKey) && !conf.IsSet(common.DatabaseInsightsConfigKey) && !conf.IsSet(otlpKey)) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: common.OtelCollectLogsConfigKey}
 	}
 
 	region := agent.Global_Config.Region

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
@@ -24,11 +24,11 @@ func TestBaseLogsTranslator(t *testing.T) {
 	}{
 		"WithNilConf": {
 			input:   nil,
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey},
 		},
 		"WithoutCollectKey": {
 			input:   map[string]interface{}{},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey},
 		},
 		"WithCollectKeyButNoLogs": {
 			input: map[string]interface{}{
@@ -36,7 +36,7 @@ func TestBaseLogsTranslator(t *testing.T) {
 					"collect": map[string]interface{}{},
 				},
 			},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey},
 		},
 		"WithCollectLogsKey": {
 			input: map[string]interface{}{

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
@@ -24,11 +24,11 @@ func TestBaseLogsTranslator(t *testing.T) {
 	}{
 		"WithNilConf": {
 			input:   nil,
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey + " or " + common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)},
 		},
 		"WithoutCollectKey": {
 			input:   map[string]interface{}{},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey + " or " + common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)},
 		},
 		"WithCollectKeyButNoLogs": {
 			input: map[string]interface{}{
@@ -36,7 +36,7 @@ func TestBaseLogsTranslator(t *testing.T) {
 					"collect": map[string]interface{}{},
 				},
 			},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey + " or " + common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)},
 		},
 		"WithCollectLogsKey": {
 			input: map[string]interface{}{

--- a/translator/translate/otel/pipeline/opentelemetry/translator_traces.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_traces.go
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package opentelemetry
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/otlphttp"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/resourcedetection"
+)
+
+type baseTracesTranslator struct{}
+
+var _ common.PipelineTranslator = (*baseTracesTranslator)(nil)
+
+func NewBaseTracesTranslator() common.PipelineTranslator {
+	return &baseTracesTranslator{}
+}
+
+func (t *baseTracesTranslator) ID() pipeline.ID {
+	return pipeline.NewIDWithName(pipeline.SignalTraces, common.OpenTelemetryKey)
+}
+
+// Translate creates the shared traces export pipeline. It activates when a
+// traces source (otlp) is configured under opentelemetry.collect.
+func (t *baseTracesTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
+	otlpTracesKey := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)
+	if conf == nil || !conf.IsSet(otlpTracesKey) {
+		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: otlpTracesKey}
+	}
+
+	region := agent.Global_Config.Region
+	if region == "" {
+		return nil, fmt.Errorf("region is required for %s traces pipeline", common.OpenTelemetryKey)
+	}
+	tracesEndpoint := common.ServiceEndpoint("xray", region, "/v1/traces")
+	sigv4Ext := sigv4auth.NewTranslatorWithService("xray")
+
+	fwdConnector := forward.NewTranslator(common.OpenTelemetryKey)
+
+	return &common.ComponentTranslators{
+		Receivers:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](resourcedetection.NewTranslator(), batchprocessor.NewTranslator(common.WithName(common.OpenTelemetryKey))),
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("traces", otlphttp.EndpointConfig{TracesEndpoint: tracesEndpoint}, otlphttp.WithAuthenticator(sigv4Ext.ID()))),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](sigv4Ext),
+		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+	}, nil
+}

--- a/translator/translate/otel/pipeline/opentelemetry/translator_traces_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_traces_test.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package opentelemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+func TestBaseTracesTranslator(t *testing.T) {
+	tt := NewBaseTracesTranslator()
+	assert.EqualValues(t, "traces/opentelemetry", tt.ID().String())
+
+	otlpTracesKey := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)
+	testCases := map[string]struct {
+		input   map[string]interface{}
+		wantErr error
+	}{
+		"WithNilConf": {
+			input:   nil,
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otlpTracesKey},
+		},
+		"WithoutOtlpKey": {
+			input:   map[string]interface{}{},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otlpTracesKey},
+		},
+		"WithOtlpKey": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"otlp": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			agent.Global_Config.Region = "us-west-2"
+			var conf *confmap.Conf
+			if tc.input != nil {
+				conf = confmap.NewFromStringMap(tc.input)
+			}
+			got, err := tt.Translate(conf)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, 1, got.Receivers.Len())
+				assert.Equal(t, 2, got.Processors.Len())
+				assert.Equal(t, 1, got.Exporters.Len())
+				assert.Equal(t, 1, got.Extensions.Len())
+				assert.Equal(t, 1, got.Connectors.Len())
+				assert.Equal(t, "forward/opentelemetry", got.Receivers.Keys()[0].String())
+				assert.Equal(t, "otlphttp/traces", got.Exporters.Keys()[0].String())
+				assert.Equal(t, "sigv4auth/xray", got.Extensions.Keys()[0].String())
+				assert.Equal(t, "forward/opentelemetry", got.Connectors.Keys()[0].String())
+			}
+		})
+	}
+}
+
+func TestBaseTracesTranslatorEmptyRegion(t *testing.T) {
+	agent.Global_Config.Region = ""
+	tt := NewBaseTracesTranslator()
+	conf := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"otlp": map[string]interface{}{},
+			},
+		},
+	})
+	got, err := tt.Translate(conf)
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "region is required")
+}

--- a/translator/translate/otel/pipeline/opentelemetry/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translators.go
@@ -11,6 +11,7 @@ import (
 	ci "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/containerinsights"
 	dbi "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/databaseinsights"
 	hi "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/hostinsights"
+	otelotlp "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/otlp"
 	prom "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/prometheus"
 )
 
@@ -18,9 +19,11 @@ func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
 	translators := common.NewTranslatorMap[*common.ComponentTranslators, pipeline.ID]()
 	translators.Set(NewBaseMetricsTranslator())
 	translators.Set(NewBaseLogsTranslator())
+	translators.Set(NewBaseTracesTranslator())
 	translators.Set(hi.NewTranslator())
 	translators.Set(prom.NewTranslator())
 	translators.Merge(dbi.NewTranslators(conf))
 	translators.Merge(ci.NewTranslators(conf))
+	translators.Merge(otelotlp.NewTranslators(conf))
 	return translators
 }


### PR DESCRIPTION
## Description

Adds support for `opentelemetry.collect.otlp` configuration that creates OTLP gRPC and HTTP receivers, feeding metrics, logs, and traces into their respective shared base pipelines.

### Config

```json
{
  "opentelemetry": {
    "collect": {
      "otlp": {
        "grpc_endpoint": "127.0.0.1:4317",
        "http_endpoint": "127.0.0.1:4318"
      }
    }
  }
}
```

| Field | Required | Description |
|-------|----------|-------------|
| grpc_endpoint | Yes | OTLP gRPC receiver endpoint |
| http_endpoint | Yes | OTLP HTTP receiver endpoint |

### Pipelines generated

| Pipeline | Flow |
|----------|------|
| `metrics/otlp` | OTLP receivers → forward → base metrics (monitoring.{region}.amazonaws.com/v1/metrics) |
| `logs/otlp` | OTLP receivers → forward → base logs (logs.{region}.amazonaws.com/v1/logs) |
| `traces/otlp` | OTLP receivers → forward → base traces (xray.{region}.amazonaws.com/v1/traces) |

### New: Base traces pipeline

Adds `traces/opentelemetry` shared pipeline (same pattern as base metrics/logs):
- Receiver: forward/opentelemetry connector
- Processors: resourcedetection, batch
- Exporter: otlphttp/traces → `https://xray.{region}.amazonaws.com/v1/traces` with SigV4 auth
- Activates only when `otlp` key is present (no false activation on metrics/logs-only configs)

### Base logs pipeline fix

Updated activation condition to include `otlp` key (since OTLP can receive logs), preventing orphaned `logs/otlp` pipeline errors.

## Tests

### Unit tests
- `TestNewTranslators` — nil conf, missing key, with otlp key (3 pipelines created)
- `TestOtlpPipelineTranslator` — verifies each signal (metrics/logs/traces) produces 2 receivers, 0 processors, 1 exporter
- `TestOtlpOtelConfig` — golden file test (end-to-end translation)
- All existing tests pass (including DBI, host_insights)

### EC2 manual test 
- OTLP gRPC :4317 listening ✅
- OTLP HTTP :4318 listening ✅
- Metrics via HTTP POST /v1/metrics — 200 `{"partialSuccess":{}}` ✅
- Traces via HTTP POST /v1/traces — 200 `{"partialSuccess":{}}` ✅
- Metrics exported to monitoring.us-west-2.amazonaws.com ✅
- Traces exported to xray.us-west-2.amazonaws.com ✅

### Linting
- `make fmt` ✓ | `make lint` ✓ (only pre-existing plugins/plugins.go impi issue) | `go build` ✓