### PR TITLE
Configure explicit batch sizes for opentelemetry shared pipelines

### DIFF
--- a/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_ec2_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_ec2_config.yaml
@@ -506,17 +506,17 @@ processors:
         timeout: 1m0s
     batch/opentelemetry:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 200ms
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 15s
     batch/opentelemetry_logs:
         metadata_cardinality_limit: 1000
         metadata_keys:
             - aws.log.group.name
             - aws.log.stream.name
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 1m0s
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 15s
     batch/xray:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -537,9 +537,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - InstanceId
             - InstanceType
             - ImageId
-            - InstanceId
         imds_retries: 1
         middleware: agenthealth/statuscode
         refresh_tags_interval: 0s
@@ -1427,13 +1427,13 @@ service:
                 - ec2tagger
                 - awsentity/resource
             receivers:
-                - telegraf_swap
-                - telegraf_cpu
-                - telegraf_processes
+                - telegraf_procstat/1917393364
                 - telegraf_netstat
+                - telegraf_processes
+                - telegraf_cpu
+                - telegraf_swap
                 - telegraf_mem
                 - telegraf_disk
-                - telegraf_procstat/1917393364
         metrics/host_insights:
             exporters:
                 - forward/opentelemetry
@@ -1447,8 +1447,8 @@ service:
                 - ec2tagger
                 - awsentity/service/telegraf
             receivers:
-                - telegraf_statsd
                 - telegraf_socket_listener
+                - telegraf_statsd
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -1457,8 +1457,8 @@ service:
                 - ec2tagger
                 - awsentity/resource
             receivers:
-                - telegraf_net
                 - telegraf_diskio
+                - telegraf_net
         metrics/opentelemetry:
             exporters:
                 - otlphttp/metrics

--- a/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_eks_config.yaml
@@ -639,17 +639,17 @@ processors:
         timeout: 1m0s
     batch/opentelemetry:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 200ms
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 15s
     batch/opentelemetry_logs:
         metadata_cardinality_limit: 1000
         metadata_keys:
             - aws.log.group.name
             - aws.log.stream.name
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 1m0s
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 15s
     batch/xray:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 0
@@ -670,9 +670,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
-            - InstanceType
             - ImageId
             - InstanceId
+            - InstanceType
         imds_retries: 1
         middleware: agenthealth/statuscode
         refresh_tags_interval: 0s
@@ -3251,13 +3251,13 @@ service:
                 - ec2tagger
                 - awsentity/resource
             receivers:
-                - telegraf_swap
-                - telegraf_netstat
-                - telegraf_procstat/1917393364
-                - telegraf_mem
-                - telegraf_disk
-                - telegraf_processes
                 - telegraf_cpu
+                - telegraf_disk
+                - telegraf_netstat
+                - telegraf_mem
+                - telegraf_processes
+                - telegraf_swap
+                - telegraf_procstat/1917393364
         metrics/host_insights:
             exporters:
                 - forward/opentelemetry
@@ -3271,8 +3271,8 @@ service:
                 - ec2tagger
                 - awsentity/service/telegraf
             receivers:
-                - telegraf_socket_listener
                 - telegraf_statsd
+                - telegraf_socket_listener
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch

--- a/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_config.yaml
@@ -179,9 +179,9 @@ processors:
         timeout: 10s
     batch/opentelemetry:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 200ms
+        send_batch_max_size: 1000
+        send_batch_size: 1000
+        timeout: 15s
     filter/cw_k8s_ci_v0_apiserver_build_info:
         error_mode: ignore
         logs: {}

--- a/translator/tocwconfig/sampleConfig/opentelemetry/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/dbi_config_linux.yaml
@@ -341,17 +341,17 @@ processors:
               key: aws.log.stream.name
     batch/opentelemetry:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 200ms
+        send_batch_max_size: 1000
+        send_batch_size: 1000
+        timeout: 15s
     batch/opentelemetry_logs:
         metadata_cardinality_limit: 1000
         metadata_keys:
             - aws.log.group.name
             - aws.log.stream.name
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 1m0s
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 15s
     filter/dbi_exclude_monitor_0:
         error_mode: propagate
         logs:

--- a/translator/tocwconfig/sampleConfig/opentelemetry/host_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/host_insights_config.yaml
@@ -49,9 +49,9 @@ extensions:
 processors:
     batch/opentelemetry:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 200ms
+        send_batch_max_size: 1000
+        send_batch_size: 1000
+        timeout: 15s
     resourcedetection/opentelemetry:
         aks:
             resource_attributes:

--- a/translator/tocwconfig/sampleConfig/opentelemetry/otlp_otel_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/otlp_otel_config.yaml
@@ -160,17 +160,17 @@ processors:
               key: aws.log.stream.name
     batch/opentelemetry:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 200ms
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 15s
     batch/opentelemetry_logs:
         metadata_cardinality_limit: 1000
         metadata_keys:
             - aws.log.group.name
             - aws.log.stream.name
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 1m0s
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 15s
     resourcedetection/opentelemetry:
         aks:
             resource_attributes:

--- a/translator/tocwconfig/sampleConfig/opentelemetry/prometheus_otel_pipeline_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/prometheus_otel_pipeline_config.yaml
@@ -49,9 +49,9 @@ extensions:
 processors:
     batch/opentelemetry:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 0
-        send_batch_size: 8192
-        timeout: 200ms
+        send_batch_max_size: 1000
+        send_batch_size: 1000
+        timeout: 15s
     resourcedetection/opentelemetry:
         aks:
             resource_attributes:

--- a/translator/translate/otel/common/endpoints.go
+++ b/translator/translate/otel/common/endpoints.go
@@ -5,8 +5,18 @@ package common //nolint:revive // existing package name
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+)
+
+// CloudWatch OTLP endpoint batch limits.
+// See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OTLPEndpoint.html
+const (
+	MaxMetricsPerRequest = 1000
+	MaxLogsPerRequest    = 10000
+	MaxSpansPerRequest   = 10000
+	BatchTimeout         = 15 * time.Second
 )
 
 func ServiceEndpoint(service, region, path string) string {

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
@@ -5,7 +5,6 @@ package opentelemetry
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
 	"go.opentelemetry.io/collector/component"
@@ -81,7 +80,9 @@ func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTra
 	)
 	batch := batchprocessor.NewTranslator(
 		common.WithName("opentelemetry_logs"),
-		batchprocessor.WithTimeout(1*time.Minute),
+		batchprocessor.WithSendBatchSize(common.MaxLogsPerRequest),
+		batchprocessor.WithSendBatchMaxSize(common.MaxLogsPerRequest),
+		batchprocessor.WithTimeout(common.BatchTimeout),
 		batchprocessor.WithMetadataKeys([]string{"aws.log.group.name", "aws.log.stream.name"}),
 	)
 

--- a/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
@@ -54,7 +54,7 @@ func (t *baseMetricsTranslator) Translate(conf *confmap.Conf) (*common.Component
 
 	return &common.ComponentTranslators{
 		Receivers:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
-		Processors: common.NewTranslatorMap[component.Config, component.ID](resourcedetection.NewTranslator(resourcedetection.WithName(common.OpenTelemetryKey)), batchprocessor.NewTranslator(common.WithName(common.OpenTelemetryKey))),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](resourcedetection.NewTranslator(resourcedetection.WithName(common.OpenTelemetryKey)), batchprocessor.NewTranslator(common.WithName(common.OpenTelemetryKey), batchprocessor.WithSendBatchSize(common.MaxMetricsPerRequest), batchprocessor.WithSendBatchMaxSize(common.MaxMetricsPerRequest), batchprocessor.WithTimeout(common.BatchTimeout))),
 		Exporters:  common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("metrics", otlphttp.EndpointConfig{MetricsEndpoint: metricsEndpoint}, otlphttp.WithAuthenticator(agentHealthExt.ID()))),
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](sigv4Ext, agentHealthExt),
 		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),

--- a/translator/translate/otel/pipeline/opentelemetry/translator_traces.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_traces.go
@@ -52,7 +52,7 @@ func (t *baseTracesTranslator) Translate(conf *confmap.Conf) (*common.ComponentT
 
 	return &common.ComponentTranslators{
 		Receivers:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
-		Processors: common.NewTranslatorMap[component.Config, component.ID](resourcedetection.NewTranslator(resourcedetection.WithName(common.OpenTelemetryKey)), batchprocessor.NewTranslator(common.WithName(common.OpenTelemetryKey))),
+		Processors: common.NewTranslatorMap[component.Config, component.ID](resourcedetection.NewTranslator(resourcedetection.WithName(common.OpenTelemetryKey)), batchprocessor.NewTranslator(common.WithName(common.OpenTelemetryKey), batchprocessor.WithSendBatchSize(common.MaxSpansPerRequest), batchprocessor.WithSendBatchMaxSize(common.MaxSpansPerRequest), batchprocessor.WithTimeout(common.BatchTimeout))),
 		Exporters:  common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("traces", otlphttp.EndpointConfig{TracesEndpoint: tracesEndpoint}, otlphttp.WithAuthenticator(agentHealthExt.ID()))),
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](sigv4Ext, agentHealthExt),
 		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),


### PR DESCRIPTION
## Description

Configures explicit batch processor settings for all three shared export pipelines in the `opentelemetry.collect` section. Values are derived from the CloudWatch OTLP endpoint documented limits and exposed as shared constants.

## Changes

Constants added to `translator/translate/otel/common/endpoints.go`:
- `MaxMetricsPerRequest = 1000`
- `MaxLogsPerRequest = 10000`
- `MaxSpansPerRequest = 10000`
- `BatchTimeout = 15s`

Resulting batch configuration:

| Pipeline | send_batch_size | send_batch_max_size | timeout | metadata_keys |
|----------|:-:|:-:|:-:|:-:|
| batch/metrics | 1000 | 1000 | 15s | — |
| batch/logs | 10000 | 10000 | 15s | aws.log.group.name, aws.log.stream.name |
| batch/traces | 10000 | 10000 | 15s | — |

Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OTLPEndpoint.html

## Tests

- Unit tests pass for all pipeline translators
- Golden file tests updated
- Import ordering (impi) verified
- Full build passes

## License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.