### PR TITLE
test(systemmetricsreceiver): drop redundant host-dependent JVM no-op test

### DIFF
--- a/receiver/systemmetricsreceiver/scraper_jvm_linux_test.go
+++ b/receiver/systemmetricsreceiver/scraper_jvm_linux_test.go
@@ -6,7 +6,6 @@
 package systemmetricsreceiver
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -20,14 +19,6 @@ import (
 func TestJVMScraperName(t *testing.T) {
 	s := newJVMScraper(zap.NewNop())
 	assert.Equal(t, "jvm", s.Name())
-}
-
-func TestJVMScraperNoSocketsIsNoop(t *testing.T) {
-	s := newJVMScraper(zap.NewNop())
-	metrics := pmetric.NewMetrics()
-	err := s.Scrape(context.Background(), metrics)
-	require.NoError(t, err)
-	assert.Equal(t, 0, metrics.ResourceMetrics().Len())
 }
 
 func TestParseHeap(t *testing.T) {


### PR DESCRIPTION
# Description of the issue

`TestJVMScraperNoSocketsIsNoop` read the real `/proc/net/unix` instead of an isolated fixture. On any host where another JVM exposes an `@aws-jvm-metrics-<pid>` socket, the scraper discovered that socket and emitted metrics, so the test asserting "no sockets → no metrics" failed with results that depended entirely on ambient host state.

# Description of changes
The no-matching-sockets behavior is already covered hermetically by `TestDiscoverSockets` — its `"header only (no sockets)"` and `"missing file returns nil"` cases exercise the same path via the injectable `procNetUnixPath`. This test added no unique coverage beyond `Scrape()`'s trivial empty-result early return, while being non-deterministic across environments.

Removing it (and the now-unused `context` import) eliminates the flaky, environment-sensitive test without losing meaningful coverage.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Unit tests pass

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.





