### PR TITLE
Separate out the shared copy into a different target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ clean::
 	rm -f CWAGENT_VERSION
 
 copy-tools:
+	mkdir -p $(BUILD_SPACE)
 	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 
 package-prepare-rpm: amazon-cloudwatch-agent-linux copy-tools

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,10 @@ clean::
 	rm -rf release/ build/
 	rm -f CWAGENT_VERSION
 
-package-prepare-rpm: amazon-cloudwatch-agent-linux
+copy-tools:
+	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
+
+package-prepare-rpm: amazon-cloudwatch-agent-linux copy-tools
 	# amd64 rpm
 	mkdir -p $(BUILD_SPACE)/private/linux/amd64/rpm/amazon-cloudwatch-agent-pre-pkg
 	cp $(BUILD_SPACE)/bin/linux_amd64/* $(BUILD_SPACE)/private/linux/amd64/rpm/amazon-cloudwatch-agent-pre-pkg/
@@ -281,9 +284,8 @@ package-prepare-rpm: amazon-cloudwatch-agent-linux
 	cp $(BASE_SPACE)/packaging/linux/amazon-cloudwatch-agent.spec $(BUILD_SPACE)/private/linux/arm64/rpm/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/translator/config/schema.json $(BUILD_SPACE)/private/linux/arm64/rpm/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent-schema.json
 	cp $(BASE_SPACE)/packaging/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/linux/arm64/rpm/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
-	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 
-package-prepare-deb: amazon-cloudwatch-agent-linux
+package-prepare-deb: amazon-cloudwatch-agent-linux copy-tools
 	# amd64 deb
 	mkdir -p $(BUILD_SPACE)/private/linux/amd64/deb/amazon-cloudwatch-agent-pre-pkg
 	cp $(BUILD_SPACE)/bin/linux_amd64/* $(BUILD_SPACE)/private/linux/amd64/deb/amazon-cloudwatch-agent-pre-pkg/
@@ -310,10 +312,9 @@ package-prepare-deb: amazon-cloudwatch-agent-linux
 	cp $(BASE_SPACE)/translator/config/schema.json $(BUILD_SPACE)/private/linux/arm64/deb/amazon-cloudwatch-agent-pre-pkg/amazon-cloudwatch-agent-schema.json
 	cp $(BASE_SPACE)/packaging/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/linux/arm64/deb/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
 
-	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 	cp -rf $(BASE_SPACE)/packaging $(BUILD_SPACE)/
 
-package-prepare-win-zip: amazon-cloudwatch-agent-windows
+package-prepare-win-zip: amazon-cloudwatch-agent-windows copy-tools
 	# amd64 win
 	mkdir -p $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg
 	cp $(BUILD_SPACE)/bin/windows_amd64/* $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg/
@@ -326,9 +327,8 @@ package-prepare-win-zip: amazon-cloudwatch-agent-windows
 	cp ${BASE_SPACE}/packaging/windows/install.ps1 $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg/
 	cp ${BASE_SPACE}/packaging/windows/uninstall.ps1 $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/windows/amd64/zip/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
-	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 
-package-prepare-darwin-tar: amazon-cloudwatch-agent-darwin
+package-prepare-darwin-tar: amazon-cloudwatch-agent-darwin copy-tools
 	# amd64 darwin
 	mkdir -p $(BUILD_SPACE)/private/darwin/amd64/tar/amazon-cloudwatch-agent-pre-pkg
 	cp $(BUILD_SPACE)/bin/darwin_amd64/* $(BUILD_SPACE)/private/darwin/amd64/tar/amazon-cloudwatch-agent-pre-pkg/
@@ -352,8 +352,6 @@ package-prepare-darwin-tar: amazon-cloudwatch-agent-darwin
 	cp $(BASE_SPACE)/packaging/darwin/amazon-cloudwatch-agent-ctl $(BUILD_SPACE)/private/darwin/arm64/tar/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/darwin/com.amazon.cloudwatch.agent.plist $(BUILD_SPACE)/private/darwin/arm64/tar/amazon-cloudwatch-agent-pre-pkg/
 	cp $(BASE_SPACE)/packaging/opentelemetry-jmx-metrics.jar $(BUILD_SPACE)/private/darwin/arm64/tar/amazon-cloudwatch-agent-pre-pkg/opentelemetry-jmx-metrics.jar
-
-	cp -rf $(BASE_SPACE)/Tools $(BUILD_SPACE)/
 
 .PHONY: package-rpm
 package-rpm: package-prepare-rpm


### PR DESCRIPTION
# Description of the issue
There's a race condition in the build now after the `-j4` Make flags were added. The package targets all try to copy the same tools into the build space. https://github.com/aws/amazon-cloudwatch-agent/actions/runs/27688884571/job/81894397818

> cp -rf /home/runner/work/amazon-cloudwatch-agent/amazon-cloudwatch-agent/Tools /home/runner/work/amazon-cloudwatch-agent/amazon-cloudwatch-agent/build/
cp: cannot create regular file '/home/runner/work/amazon-cloudwatch-agent/amazon-cloudwatch-agent/build/Tools/src/create_deb.sh': File exists 

# Description of changes
Splits out the copy into a separate Makefile target so they dedup.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran packaging locally with `-j4` and verified that there's only a single copy of the tools.

https://github.com/aws/amazon-cloudwatch-agent/actions/runs/27720354317/job/82003970563

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



