### PR TITLE
Isolate unit test AWS credential chain from test environment

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -712,6 +712,8 @@ func TestWriteToCloudWatchEntity(t *testing.T) {
 }
 
 func TestUserAgentFeatureFlags(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
 	testCases := []struct {
 		name               string
 		metricNames        []string

--- a/plugins/processors/ec2tagger/factory_test.go
+++ b/plugins/processors/ec2tagger/factory_test.go
@@ -26,6 +26,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 }
 
 func TestCreateProcessor(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
 	factory := NewFactory()
 	require.NotNil(t, factory)
 


### PR DESCRIPTION
# Description of the issue
There are still a couple of unit tests that will try to use the AWS credential chain to try to get credentials from the test environment. This results in inconsistent runs across different test environments.

# Description of changes
Adds the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to the tests so they short circuit the credential chain.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the tests.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



