### PR TITLE
update postgres filter to post(gres|master).*

### DIFF
--- a/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_ec2_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_ec2_config.yaml
@@ -1117,7 +1117,7 @@ receivers:
                 include:
                     match_type: regexp
                     names:
-                        - postgres.*
+                        - post(gres|master).*
                 metrics:
                     process.cpu.utilization:
                         enabled: true

--- a/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_eks_config.yaml
@@ -1659,7 +1659,7 @@ receivers:
                 include:
                     match_type: regexp
                     names:
-                        - postgres.*
+                        - post(gres|master).*
                 metrics:
                     process.cpu.utilization:
                         enabled: true

--- a/translator/tocwconfig/sampleConfig/opentelemetry/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/dbi_config_linux.yaml
@@ -852,7 +852,7 @@ receivers:
                 include:
                     match_type: regexp
                     names:
-                        - postgres.*
+                        - post(gres|master).*
                 metrics:
                     process.cpu.utilization:
                         enabled: true

--- a/translator/translate/otel/pipeline/opentelemetry/hostmetrics/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostmetrics/translator.go
@@ -41,7 +41,7 @@ func (t *hostMetricsTranslator) Translate(conf *confmap.Conf) (*common.Component
 		opts = append(opts, hostmetrics.WithProcessScraper(map[string]any{
 			"include": map[string]any{
 				"match_type": "regexp",
-				"names":      []string{"postgres.*"},
+				"names":      []string{"post(gres|master).*"},
 			},
 			"mute_process_all_errors": true,
 			"metrics": map[string]any{

--- a/translator/translate/otel/pipeline/opentelemetry/hostmetrics/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/hostmetrics/translator_test.go
@@ -109,7 +109,7 @@ func TestHostMetricsTranslator(t *testing.T) {
 					assert.True(t, exists, "expected process scraper")
 					include := processCfg["include"].(map[string]any)
 					assert.Equal(t, "regexp", include["match_type"])
-					assert.Equal(t, []string{"postgres.*"}, include["names"])
+					assert.Equal(t, []string{"post(gres|master).*"}, include["names"])
 				}
 			}
 		})


### PR DESCRIPTION
# Description of the issue
  On Amazon Linux 2, the PostgreSQL main process is named `postmaster` instead of `postgres`, causing
  the DBI process scraper to miss it.

  # Description of changes
  Updated process scraper regex from `postgres.*` to `post(gres|master).*` to match both process
  names.

  # License
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
  contribution, under the terms of your choice.

  # Tests
  Verified on AL2 that the process is `postmaster` and the updated regex matches both names.

  # Requirements
  1. Run `make fmt` and `make fmt-sh`
  2. Run `make lint`