### PR TITLE
Allow concurrent runs of test-artifacts if on different branches

### DIFF
--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -67,7 +67,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.build_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ inputs.build_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -347,7 +347,8 @@ jobs:
 
   StartLocalStackITAR:
     name: 'StartLocalStackITAR'
-    needs: [OutputEnvVariables]
+    needs: [OutputEnvVariables, GenerateTestMatrix]
+    if: ${{ needs.GenerateTestMatrix.outputs.ec2_linux_itar_matrix != '[]' }}
     uses: ./.github/workflows/start-localstack.yml
     secrets:
       AWS_PRIVATE_KEY: ${{ secrets.AWS_PRIVATE_KEY_ITAR }}
@@ -366,7 +367,8 @@ jobs:
 
   StartLocalStackCN:
     name: 'StartLocalStackCN'
-    needs: [ OutputEnvVariables, UploadDependenciesCN ]
+    needs: [ OutputEnvVariables, UploadDependenciesCN, GenerateTestMatrix ]
+    if: ${{ needs.GenerateTestMatrix.outputs.ec2_linux_china_matrix != '[]' }}
     uses: ./.github/workflows/start-localstack.yml
     secrets:
       AWS_PRIVATE_KEY: ${{ secrets.AWS_PRIVATE_KEY_CN }}
@@ -385,7 +387,8 @@ jobs:
 
   UploadDependenciesCN:
     name: 'UploadDependenciesCN'
-    needs: [ OutputEnvVariables ]
+    needs: [ OutputEnvVariables, GenerateTestMatrix ]
+    if: ${{ needs.GenerateTestMatrix.outputs.ec2_linux_china_matrix != '[]' }}
     uses: ./.github/workflows/upload-dependencies.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -195,6 +195,9 @@ jobs:
 
       - name: Generate matrix
         id: set-matrix
+        env:
+          TEST_OS_FILTER: ${{ inputs.test_os_filter }}
+          TEST_DIR_FILTER: ${{ inputs.test_dir_filter }}
         run: |
           go run --tags=generator generator/test_case_generator.go
           
@@ -204,13 +207,13 @@ jobs:
             local matrix_content=$(cat "$matrix_file")
             
             # Apply OS filter if provided
-            if [ -n "${{ inputs.test_os_filter }}" ]; then
-              matrix_content=$(echo "$matrix_content" | jq -c '[.[] | select(.os == "${{ inputs.test_os_filter }}")]')
+            if [ -n "$TEST_OS_FILTER" ]; then
+              matrix_content=$(echo "$matrix_content" | jq -c --arg f "$TEST_OS_FILTER" '[.[] | select(.os == $f)]')
             fi
             
             # Apply test directory filter if provided
-            if [ -n "${{ inputs.test_dir_filter }}" ]; then
-              matrix_content=$(echo "$matrix_content" | jq -c '[.[] | select(.test_dir == "${{ inputs.test_dir_filter }}")]')
+            if [ -n "$TEST_DIR_FILTER" ]; then
+              matrix_content=$(echo "$matrix_content" | jq -c --arg f "$TEST_DIR_FILTER" '[.[] | select(.test_dir == $f)]')
             fi
             
             # Output compact JSON (single line) for GITHUB_OUTPUT compatibility


### PR DESCRIPTION
# Description of the issue
Currently, the `test-artifacts` workflow only differentiates concurrency by the workflow ID and build ID. This means two separate workflow runs cannot happen at the same time for the same build.

# Description of changes
Adds `github.ref_name` (branch) to the concurrency and fixes the filtering. If the partitional test matrix doesn't have any tests after the filter, skips the local stack creation.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Filter for tests `./test/ca_bundle` (before latest commit): https://github.com/aws/amazon-cloudwatch-agent/actions/runs/27980901179
Filter for OS `sles-15`: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/27986690180
Filter for OS `ubuntu-22.04` and tests `./test/cloudwatchlogs`: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/27987644334

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



