### PR TITLE
fix(workflows): Forward test-repo branch to EC2Win

### DIFF
--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -786,6 +786,7 @@ jobs:
             -var="ami=${{ matrix.arrays.ami }}" \
             -var="use_ssm=${{ matrix.arrays.useSSM }}" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
+            -var="github_test_repo_branch=${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}" \
             -var="runner_ip=${{ steps.runner_ip.outputs.ip }}" ; then
             terraform destroy -auto-approve
           else


### PR DESCRIPTION
# Description of the issue
The EC2WinIntegrationTest job's terraform-apply step did not forward CWA_GITHUB_TEST_REPO_BRANCH (the workflow env that selects which test repo branch the EC2 host clones) to terraform. Without it, terraform fell back to its default `var.github_test_repo_branch = "main"`, so the test EC2 host always cloned aws/amazon-cloudwatch-agent-test main even when the workflow ran against a feature branch.

This made it effectively impossible to validate test-repo-only changes via subset/iteration branches: the host code on the EC2 instance was always main while the metric/log expectations rendered on the build runner came from the workflow's target branch.

# Description of changes
Forward CWA_GITHUB_TEST_REPO_BRANCH (already an OutputEnvVariables job output) via a new -var="github_test_repo_branch=..." so the host clones the same test-repo branch the workflow is using.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* https://github.com/aws/amazon-cloudwatch-agent/actions/runs/27989411762

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



