### PR TITLE
Add default OTel config

### DIFF
--- a/tool/downloader/downloader.go
+++ b/tool/downloader/downloader.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/cfg/commonconfig"
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
 	"github.com/aws/amazon-cloudwatch-agent/internal/constants"
-	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util"
 )
 
@@ -82,8 +82,14 @@ func RunDownloader(mode, downloadLocation, outputDir, inputConfig, multiConfig s
 	// Detect agent mode and region
 	mode = util.DetectAgentMode(mode)
 	region, _ := util.DetectRegion(mode, cc.CredentialsMap())
-	if region == "" && downloadLocation != locationDefault {
-		if mode == config.ModeEC2 {
+
+	locationArray := strings.SplitN(downloadLocation, locationSeparator, 2)
+	if locationArray == nil || len(locationArray) < 2 && downloadLocation != locationDefault {
+		return fmt.Errorf("downloadLocation %s is malformed", downloadLocation)
+	}
+
+	if region == "" && locationArray[0] != locationDefault {
+		if mode == translatorconfig.ModeEC2 {
 			return fmt.Errorf("please check if you can access the metadata service. For example, on linux, run 'wget -q -O - http://169.254.169.254/latest/meta-data/instance-id && echo'")
 		}
 		return fmt.Errorf("please make sure the credentials and region set correctly on your hosts")
@@ -94,17 +100,24 @@ func RunDownloader(mode, downloadLocation, outputDir, inputConfig, multiConfig s
 		return fmt.Errorf("failed to clean up output directory: %v", err)
 	}
 
-	locationArray := strings.SplitN(downloadLocation, locationSeparator, 2)
-	if locationArray == nil || len(locationArray) < 2 && downloadLocation != locationDefault {
-		return fmt.Errorf("downloadLocation %s is malformed", downloadLocation)
-	}
-
 	var config, outputFilePath string
 	switch locationArray[0] {
 	case locationDefault:
-		outputFilePath = locationDefault
-		if multiConfig != "remove" {
-			config, err = defaultJSONConfig(mode)
+		if len(locationArray) == 2 {
+			name := locationArray[1]
+			cfg, ok := translatorconfig.DefaultJSONConfigFor(name)
+			if !ok {
+				return fmt.Errorf("unknown default config %q", name)
+			}
+			outputFilePath = locationDefault + "_" + name
+			if multiConfig != "remove" {
+				config = cfg
+			}
+		} else {
+			outputFilePath = locationDefault
+			if multiConfig != "remove" {
+				config, err = defaultJSONConfig(mode)
+			}
 		}
 	case locationSSM:
 		outputFilePath = locationSSM + "_" + EscapeFilePath(locationArray[1])
@@ -141,7 +154,7 @@ func RunDownloader(mode, downloadLocation, outputDir, inputConfig, multiConfig s
 }
 
 func defaultJSONConfig(mode string) (string, error) {
-	return config.DefaultJsonConfig(config.ToValidOs(""), mode), nil
+	return translatorconfig.DefaultJsonConfig(translatorconfig.ToValidOs(""), mode), nil
 }
 
 func downloadFromSSM(region, parameterStoreName, mode string, credsConfig map[string]string) (string, error) {

--- a/tool/downloader/downloader.go
+++ b/tool/downloader/downloader.go
@@ -84,7 +84,7 @@ func RunDownloader(mode, downloadLocation, outputDir, inputConfig, multiConfig s
 	region, _ := util.DetectRegion(mode, cc.CredentialsMap())
 
 	locationArray := strings.SplitN(downloadLocation, locationSeparator, 2)
-	if locationArray == nil || len(locationArray) < 2 && downloadLocation != locationDefault {
+	if len(locationArray) < 2 && downloadLocation != locationDefault {
 		return fmt.Errorf("downloadLocation %s is malformed", downloadLocation)
 	}
 

--- a/tool/downloader/downloader_test.go
+++ b/tool/downloader/downloader_test.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package downloader
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunDownloader_DefaultOtel(t *testing.T) {
+	outputDir := t.TempDir()
+	err := RunDownloader("ec2", "default:otel", outputDir, "", "default", false)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "default_otel.tmp"))
+	require.NoError(t, err)
+
+	expected, err := os.ReadFile("../../translator/config/defaults/otel.json")
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expected), string(content))
+}
+
+func TestRunDownloader_DefaultBare(t *testing.T) {
+	outputDir := t.TempDir()
+	err := RunDownloader("ec2", "default", outputDir, "", "default", false)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "default.tmp"))
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(content, &parsed))
+	assert.Contains(t, parsed, "metrics")
+}
+
+func TestRunDownloader_DefaultUnknown(t *testing.T) {
+	outputDir := t.TempDir()
+	err := RunDownloader("ec2", "default:invalid", outputDir, "", "default", false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown default config "invalid"`)
+}
+
+func TestRunDownloader_DefaultOtelRemove(t *testing.T) {
+	outputDir := t.TempDir()
+	// Pre-create the config file that remove will delete
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "default_otel"), []byte("{}"), 0600))
+
+	err := RunDownloader("ec2", "default:otel", outputDir, "", "remove", false)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(outputDir, "default_otel"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestRunDownloader_DefaultEmptyName(t *testing.T) {
+	outputDir := t.TempDir()
+	err := RunDownloader("ec2", "default:", outputDir, "", "default", false)
+	assert.EqualError(t, err, `unknown default config ""`)
+}
+
+func TestRunDownloader_DefaultExtraColons(t *testing.T) {
+	outputDir := t.TempDir()
+	err := RunDownloader("ec2", "default:otel:extra", outputDir, "", "default", false)
+	assert.EqualError(t, err, `unknown default config "otel:extra"`)
+}

--- a/translator/cmdutil/translatorutil_test.go
+++ b/translator/cmdutil/translatorutil_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aws/amazon-cloudwatch-agent/cfg/envconfig"
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util"
 )
@@ -428,6 +429,16 @@ func TestOpenTelemetryPrometheusSchemaValidation(t *testing.T) {
 
 func TestOpenTelemetryOtlpSchemaValidation(t *testing.T) {
 	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/opentelemetry/validOpenTelemetryOtlp.json", true, map[string]int{})
+}
+
+func TestDefaultOtelConfigSchemaValidation(t *testing.T) {
+	cfg, ok := config.DefaultJSONConfigFor("otel")
+	require.True(t, ok)
+	jsonMap, err := util.GetJsonMapFromJsonBytes([]byte(cfg))
+	require.NoError(t, err)
+	result, err := RunSchemaValidation(jsonMap)
+	require.NoError(t, err)
+	assert.True(t, result.Valid(), "default otel config must pass schema validation: %v", result.Errors())
 }
 
 func TestCombinedV1V2SchemaValidation(t *testing.T) {

--- a/translator/config/defaultConfig.go
+++ b/translator/config/defaultConfig.go
@@ -3,6 +3,21 @@
 
 package config
 
+import _ "embed"
+
+//go:embed defaults/otel.json
+var defaultOtelConfig string
+
+var defaultConfigs = map[string]string{
+	"otel": defaultOtelConfig,
+}
+
+// DefaultJSONConfigFor returns the named default config if it exists.
+func DefaultJSONConfigFor(name string) (string, bool) {
+	cfg, ok := defaultConfigs[name]
+	return cfg, ok
+}
+
 var defaultLinuxOnPremConfig = `
 {
 	"agent": {

--- a/translator/config/defaultConfig_test.go
+++ b/translator/config/defaultConfig_test.go
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultJSONConfigFor_Otel(t *testing.T) {
+	cfg, ok := DefaultJSONConfigFor("otel")
+	require.True(t, ok)
+
+	expected, err := os.ReadFile("defaults/otel.json")
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expected), cfg)
+}
+
+func TestDefaultJSONConfigFor_Unknown(t *testing.T) {
+	_, ok := DefaultJSONConfigFor("unknown")
+	assert.False(t, ok)
+}
+
+func TestDefaultJSONConfigFor_Empty(t *testing.T) {
+	_, ok := DefaultJSONConfigFor("")
+	assert.False(t, ok)
+}

--- a/translator/config/defaults/otel.json
+++ b/translator/config/defaults/otel.json
@@ -1,0 +1,12 @@
+{
+  "agent": {
+    "credentials": {
+      "role_arn": "${CWAGENT_ROLE_ARN}"
+    }
+  },
+  "opentelemetry": {
+    "collect": {
+      "otlp": {}
+    }
+  }
+}

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1427,7 +1427,10 @@
         "role_arn": {
           "description": "The target IAM role with which agent can access aws resources",
           "type": "string",
-          "minLength": 1,
+          "anyOf": [
+            { "minLength": 20 },
+            { "pattern": "^\\$\\{.+\\}$" }
+          ],
           "maxLength": 2048
         }
       },

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1427,7 +1427,7 @@
         "role_arn": {
           "description": "The target IAM role with which agent can access aws resources",
           "type": "string",
-          "minLength": 20,
+          "minLength": 1,
           "maxLength": 2048
         }
       },

--- a/translator/jsonconfig/mergeJsonConfig.go
+++ b/translator/jsonconfig/mergeJsonConfig.go
@@ -19,12 +19,16 @@ import (
 
 func MergeJsonConfigMaps(jsonConfigMapMap map[string]map[string]interface{}, defaultJsonConfigMap map[string]interface{}, multiConfig string) (map[string]interface{}, error) {
 	if len(jsonConfigMapMap) == 0 {
-		if os.Getenv(config.USE_DEFAULT_CONFIG) == config.USE_DEFAULT_CONFIG_TRUE {
+		useDefault := os.Getenv(config.USE_DEFAULT_CONFIG)
+		if useDefault == config.USE_DEFAULT_CONFIG_TRUE {
 			// When USE_DEFAULT_CONFIG is true, ECS and EKS will be supposed to use different default config. EKS default config logic will be added when necessary
 			if ecsutil.GetECSUtilSingleton().IsECS() {
 				log.Println("No json config files found, use the default ecs config")
 				return util.GetJsonMapFromJsonBytes([]byte(config.DefaultECSJsonConfig()))
 			}
+		} else if cfg, ok := config.DefaultJSONConfigFor(useDefault); ok {
+			log.Printf("No json config files found, use the default %s config", useDefault)
+			return util.GetJsonMapFromJsonBytes([]byte(cfg))
 		}
 		if multiConfig == "remove" {
 			os.Exit(constants.ExitCodeNoJSONFile)

--- a/translator/jsonconfig/mergeJsonConfig_test.go
+++ b/translator/jsonconfig/mergeJsonConfig_test.go
@@ -99,3 +99,28 @@ func shouldFail(t *testing.T, testData TestData) {
 	}
 	log.Printf("Test %v %v finished", testData.testId, testData.testName)
 }
+
+func TestMergeJsonConfigMaps_UseDefaultConfigOtel(t *testing.T) {
+	t.Setenv("USE_DEFAULT_CONFIG", "otel")
+	resultMap, err := MergeJsonConfigMaps(nil, nil, "default")
+	assert.NoError(t, err)
+	assert.NotNil(t, resultMap)
+	assert.Contains(t, resultMap, "opentelemetry")
+	assert.Contains(t, resultMap, "agent")
+}
+
+func TestMergeJsonConfigMaps_UseDefaultConfigTrue(t *testing.T) {
+	t.Setenv("USE_DEFAULT_CONFIG", "True")
+	// On non-ECS host, USE_DEFAULT_CONFIG=True falls through to default behavior
+	resultMap, err := MergeJsonConfigMaps(nil, nil, "default")
+	assert.NoError(t, err)
+	assert.Nil(t, resultMap)
+}
+
+func TestMergeJsonConfigMaps_UseDefaultConfigUnknown(t *testing.T) {
+	t.Setenv("USE_DEFAULT_CONFIG", "unknown")
+	resultMap, err := MergeJsonConfigMaps(nil, nil, "default")
+	assert.NoError(t, err)
+	// Unknown value falls through to default behavior
+	assert.Nil(t, resultMap)
+}

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config.conf
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config.conf
@@ -1,0 +1,15 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config.yaml
@@ -1,0 +1,655 @@
+connectors:
+    forward/opentelemetry: {}
+exporters:
+    otlphttp/logs:
+        auth:
+            authenticator: agenthealth/opentelemetry_logs
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: https://logs.us-west-2.amazonaws.com/v1/logs
+        max_idle_conns: 100
+        metrics_endpoint: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
+    otlphttp/metrics:
+        auth:
+            authenticator: agenthealth/opentelemetry_metrics
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: ""
+        max_idle_conns: 100
+        metrics_endpoint: https://monitoring.us-west-2.amazonaws.com/v1/metrics
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
+    otlphttp/traces:
+        auth:
+            authenticator: agenthealth/opentelemetry_traces
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: ""
+        max_idle_conns: 100
+        metrics_endpoint: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: https://xray.us-west-2.amazonaws.com/v1/traces
+        write_buffer_size: 524288
+extensions:
+    agenthealth/opentelemetry_logs:
+        additional_auth: headers_setter/logs
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    agenthealth/opentelemetry_metrics:
+        additional_auth: sigv4auth/monitoring
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    agenthealth/opentelemetry_traces:
+        additional_auth: sigv4auth/xray
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    awscloudwatchlogsprovisioner:
+        additional_auth: sigv4auth/logs
+        imds_retries: 1
+        logs_provision_failure_backoff: 30s
+        max_retries: 2
+        num_workers: 8
+        region: us-west-2
+        request_timeout_seconds: 10
+        role_arn: ${CWAGENT_ROLE_ARN}
+    headers_setter/logs:
+        additional_auth: awscloudwatchlogsprovisioner
+        headers:
+            - action: upsert
+              from_context: aws.log.group.name
+              key: x-aws-log-group
+            - action: upsert
+              from_context: aws.log.stream.name
+              key: x-aws-log-stream
+    sigv4auth/logs:
+        assume_role:
+            arn: ${CWAGENT_ROLE_ARN}
+            sts_region: us-west-2
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-west-2
+        request_timeout_seconds: 30
+        service: logs
+    sigv4auth/monitoring:
+        assume_role:
+            arn: ${CWAGENT_ROLE_ARN}
+            sts_region: us-west-2
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-west-2
+        request_timeout_seconds: 30
+        service: monitoring
+    sigv4auth/xray:
+        assume_role:
+            arn: ${CWAGENT_ROLE_ARN}
+            sts_region: us-west-2
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-west-2
+        request_timeout_seconds: 30
+        service: xray
+processors:
+    attributestocontext/opentelemetry:
+        actions:
+            - from_resource_attribute: aws.log.group.name
+              key: aws.log.group.name
+            - from_resource_attribute: aws.log.stream.name
+              key: aws.log.stream.name
+    batch/opentelemetry_metrics:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 1000
+        send_batch_size: 1000
+        timeout: 30s
+    batch/opentelemetry_traces:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 30s
+    batch/opentelemetry_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys:
+            - aws.log.group.name
+            - aws.log.stream.name
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 30s
+    resourcedetection/opentelemetry:
+        aks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        azure:
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            tags: []
+        consul:
+            address: ""
+            datacenter: ""
+            namespace: ""
+            resource_attributes:
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            token_file: ""
+        detectors:
+            - eks
+            - env
+            - ec2
+        docker:
+            resource_attributes:
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+        ec2:
+            fail_on_missing_metadata: false
+            max_attempts: 3
+            max_backoff: 20s
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+            tags:
+                - ^kubernetes.io/cluster/.*$
+                - ^aws:autoscaling:groupName
+        ecs:
+            resource_attributes:
+                aws.ecs.cluster.arn:
+                    enabled: true
+                aws.ecs.launchtype:
+                    enabled: true
+                aws.ecs.task.arn:
+                    enabled: true
+                aws.ecs.task.family:
+                    enabled: true
+                aws.ecs.task.id:
+                    enabled: true
+                aws.ecs.task.revision:
+                    enabled: true
+                aws.log.group.arns:
+                    enabled: true
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.arns:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+        eks:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: false
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        elasticbeanstalk:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                deployment.environment:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.version:
+                    enabled: true
+        gcp:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.id:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+                gcp.cloud_run.job.execution:
+                    enabled: true
+                gcp.cloud_run.job.task_index:
+                    enabled: true
+                gcp.gce.instance.hostname:
+                    enabled: false
+                gcp.gce.instance.name:
+                    enabled: false
+                gcp.gce.instance_group_manager.name:
+                    enabled: true
+                gcp.gce.instance_group_manager.region:
+                    enabled: true
+                gcp.gce.instance_group_manager.zone:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+        heroku:
+            resource_attributes:
+                cloud.provider:
+                    enabled: true
+                heroku.app.id:
+                    enabled: true
+                heroku.dyno.id:
+                    enabled: true
+                heroku.release.commit:
+                    enabled: true
+                heroku.release.creation_timestamp:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.name:
+                    enabled: true
+                service.version:
+                    enabled: true
+        idle_conn_timeout: 1m30s
+        k8snode:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            node_from_env_var: ""
+            resource_attributes:
+                k8s.node.name:
+                    enabled: true
+                k8s.node.uid:
+                    enabled: true
+        kubeadm:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            resource_attributes:
+                k8s.cluster.name:
+                    enabled: true
+                k8s.cluster.uid:
+                    enabled: true
+        lambda:
+            resource_attributes:
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.max_memory:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+        max_idle_conns: 100
+        openshift:
+            address: ""
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+            tls: {}
+            token: ""
+        override: true
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.cpu.cache.l2.size:
+                    enabled: false
+                host.cpu.family:
+                    enabled: false
+                host.cpu.model.id:
+                    enabled: false
+                host.cpu.model.name:
+                    enabled: false
+                host.cpu.stepping:
+                    enabled: false
+                host.cpu.vendor.id:
+                    enabled: false
+                host.id:
+                    enabled: false
+                host.ip:
+                    enabled: false
+                host.mac:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: false
+                os.type:
+                    enabled: true
+                os.version:
+                    enabled: false
+        timeout: 2s
+    transform/identity:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+        metric_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+        trace_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+    transform/logs_cleanup:
+        error_mode: propagate
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: propagate
+              statements:
+                - delete_key(resource.attributes, "aws.log.group.name")
+                - delete_key(resource.attributes, "aws.log.stream.name")
+                - delete_key(resource.attributes, "aws.log.source")
+        metric_statements: []
+        trace_statements: []
+    transform/logs_routing:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["aws.log.group.name"], Concat(["/aws/cwagent", resource.attributes["aws.log.source"]], "/")) where resource.attributes["aws.log.group.name"] == nil and resource.attributes["aws.log.source"] != nil
+                - set(resource.attributes["aws.log.group.name"], "/aws/cwagent/default") where resource.attributes["aws.log.group.name"] == nil
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], resource.attributes["host.id"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil
+                - set(resource.attributes["aws.log.stream.name"], resource.attributes["host.name"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil
+                - set(resource.attributes["aws.log.stream.name"], "default") where resource.attributes["aws.log.stream.name"] == nil
+        metric_statements: []
+        trace_statements: []
+    transform/otlp_log_source:
+        error_mode: propagate
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: propagate
+              statements:
+                - set(resource.attributes["aws.log.source"], "otlp") where resource.attributes["aws.log.source"] == nil
+        metric_statements: []
+        trace_statements: []
+    transform/otlp_scope:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "otel-otlp")
+        metric_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "otel-otlp")
+        trace_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "otel-otlp")
+receivers:
+    otlp/grpc_127_0_0_1_4317:
+        protocols:
+            grpc:
+                endpoint: 127.0.0.1:4317
+                keepalive:
+                    enforcement_policy: {}
+                    server_parameters: {}
+                read_buffer_size: 524288
+                transport: tcp
+    otlp/http_127_0_0_1_4318:
+        protocols:
+            http:
+                cors: {}
+                endpoint: 127.0.0.1:4318
+                idle_timeout: 0s
+                logs_url_path: /v1/logs
+                metrics_url_path: /v1/metrics
+                read_header_timeout: 0s
+                traces_url_path: /v1/traces
+                write_timeout: 0s
+service:
+    extensions:
+        - sigv4auth/monitoring
+        - agenthealth/opentelemetry_metrics
+        - sigv4auth/logs
+        - awscloudwatchlogsprovisioner
+        - headers_setter/logs
+        - agenthealth/opentelemetry_logs
+        - sigv4auth/xray
+        - agenthealth/opentelemetry_traces
+    pipelines:
+        logs/opentelemetry:
+            exporters:
+                - otlphttp/logs
+            processors:
+                - resourcedetection/opentelemetry
+                - transform/identity
+                - transform/logs_routing
+                - attributestocontext/opentelemetry
+                - transform/logs_cleanup
+                - batch/opentelemetry_logs
+            receivers:
+                - forward/opentelemetry
+        logs/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/otlp_scope
+                - transform/otlp_log_source
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+        metrics/opentelemetry:
+            exporters:
+                - otlphttp/metrics
+            processors:
+                - resourcedetection/opentelemetry
+                - transform/identity
+                - batch/opentelemetry_metrics
+            receivers:
+                - forward/opentelemetry
+        metrics/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/otlp_scope
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+        traces/opentelemetry:
+            exporters:
+                - otlphttp/traces
+            processors:
+                - resourcedetection/opentelemetry
+                - transform/identity
+                - batch/opentelemetry_traces
+            receivers:
+                - forward/opentelemetry
+        traces/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/otlp_scope
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -427,6 +427,23 @@ func TestOtlpOtelConfig(t *testing.T) {
 	checkTranslation(t, "opentelemetry/otlp_otel_config", "linux", nil, "")
 }
 
+func TestDefaultOtelConfigTranslation(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	agent.Global_Config.Region = "us-west-2"
+	agent.Global_Config.RegionType = config.RegionTypeCredsMap
+
+	cfg, ok := config.DefaultJSONConfigFor("otel")
+	require.True(t, ok)
+
+	var input any
+	require.NoError(t, json.Unmarshal([]byte(cfg), &input))
+
+	translator.SetTargetPlatform("linux")
+	verifyToTomlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config.conf")
+	verifyToYamlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config.yaml")
+}
+
 func TestOtlpOtelEKSConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetMode(config.ModeEC2)


### PR DESCRIPTION
# Description of changes
Adds support for named default configurations. Leverages the existing `default` and `USE_DEFAULT_CONFIG` patterns. Allows for simple enablement of a default OTel configuration. Can be used with the control script with `-c default:otel` or as an environment variable with `USE_DEFAULT_CONFIG=otel`.

The control script leverages the downloader to write the JSON configuration to the agent's configuration directory. Maintains backwards compatibility and still supports `-c default` and `USE_DEFAULT_CONFIG=True` (on ECS).

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests. Built the agent and deployed to an EC2 instance.
```
sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -c default:otel
sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -c file:/tmp/debug.json -s
```

```
-rw-r--r--. 1 root root 154 Jun 26 20:48 default_otel
-rw-r--r--. 1 root root  27 Jun 26 20:48 file_debug.json
=== default_otel ===
{
  "agent": {
    "credentials": {
      "role_arn": "${CWAGENT_ROLE_ARN}"
    }
  },
  "opentelemetry": {
    "collect": {
      "otlp": {}
    }
  }
}
=== file_debug.json ===
{"agent": {"debug": true}}
```
YAML includes environment variable for each of the sigv4auth extensions
```
sigv4auth/monitoring:
    assume_role:
        arn: ${CWAGENT_ROLE_ARN}
        sts_region: us-east-1
```
Still works even when the environment variable isn't set
```
2026-06-26T20:58:31Z D! {"caller":"otlphttpexporter@v0.124.0/otlp.go:177","msg":"Preparing to make HTTP request","url":"https://xray.us-east-1.amazonaws.com/v1/traces"}
2026-06-26T20:58:31Z D! {"caller":"otlphttpexporter@v0.124.0/otlp.go:177","msg":"Preparing to make HTTP request","url":"https://monitoring.us-east-1.amazonaws.com/v1/metrics"}
```
Setting the environment variable in `env-config.json` results in
```
2026-06-26T21:05:54Z E! Error running agent: failed to build extensions: failed to create extension "sigv4auth/monitoring": could not retrieve credential provider: failed to refresh cached credentials, operation error STS: AssumeRole, https
    response error StatusCode: 403, RequestID: <snip>, api error AccessDenied: User: arn:aws:sts::<snip>:assumed-role/CloudWatchAgentTestRole/<snip> is not authorized to perform: sts:AssumeRole on
    resource: arn:aws:iam::<snip>:role/CloudWatchAgentTestRole
```
which shows that it tries to assume it (even if the base IAM role doesn't have permissions to assume it in this case).

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



