### PR TITLE
Add spanmetrics connector to derive RED metrics from traces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.124.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.124.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.124.1
+	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.124.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.124.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.124.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.124.1

--- a/go.sum
+++ b/go.sum
@@ -1279,6 +1279,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnect
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.124.1/go.mod h1:3L7TZSmIPrkKucNXpy3nqoMUURD7x+S81a+Gdh0wD84=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.124.1 h1:/ZG8lfmhi/bixeWzMSTq88sRiFRZvh9Ufpa6cC5AvAE=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.124.1/go.mod h1:gdp9you5kQfb6d9AorQz73H4xUn/rsNL9/p6tEVvKBA=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.124.1 h1:eLVnWAHaqPFw5MM/LOKFH8APVzmfpZt/NfkP29EHWlk=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.124.1/go.mod h1:JPqYKeKCaUk4bn9SoMVg9vT9/si2mo7JitP8SkAQIqI=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.124.1 h1:WMEB86bjqPtbbYLu8vhuy0g9vK+6M5aTy13jwUwQZ1s=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.124.1/go.mod h1:AwoFFkNgtHnOczLkEwlGAPhu54t2LtrOGOg8zxKpPgo=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.124.1 h1:uV7jdTAvpuivYA2w4lGvRf4zSJS5fwhyiLENvVuuTbs=

--- a/service/defaultcomponents/components.go
+++ b/service/defaultcomponents/components.go
@@ -7,6 +7,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
@@ -198,6 +199,7 @@ func Factories() (otelcol.Factories, error) {
 		forwardconnector.NewFactory(),
 		routingconnector.NewFactory(),
 		signaltometricsconnector.NewFactory(),
+		spanmetricsconnector.NewFactory(),
 	); err != nil {
 		return otelcol.Factories{}, err
 	}

--- a/service/defaultcomponents/components_test.go
+++ b/service/defaultcomponents/components_test.go
@@ -107,6 +107,7 @@ func TestComponents(t *testing.T) {
 		"forward",
 		"routing",
 		"signaltometrics",
+		"spanmetrics",
 	}
 	gotConnectors := collections.MapSlice(maps.Keys(factories.Connectors), component.Type.String)
 	assert.Equal(t, len(wantConnectors), len(gotConnectors))

--- a/translator/config/defaults/otel.json
+++ b/translator/config/defaults/otel.json
@@ -7,7 +7,7 @@
   "opentelemetry": {
     "collect": {
       "otlp": {
-        "derive_metrics_from_traces": true
+        "span_metrics_enabled": true
       }
     }
   }

--- a/translator/config/defaults/otel.json
+++ b/translator/config/defaults/otel.json
@@ -6,7 +6,9 @@
   },
   "opentelemetry": {
     "collect": {
-      "otlp": {}
+      "otlp": {
+        "derive_metrics_from_traces": true
+      }
     }
   }
 }

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1902,6 +1902,10 @@
                 "http_endpoint": {
                   "description": "OTLP HTTP receiver endpoint",
                   "type": "string"
+                },
+                "derive_metrics_from_traces": {
+                  "description": "Derive request rate, error, and duration metrics from traces.",
+                  "type": "boolean"
                 }
               },
               "additionalProperties": false

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1903,8 +1903,8 @@
                   "description": "OTLP HTTP receiver endpoint",
                   "type": "string"
                 },
-                "derive_metrics_from_traces": {
-                  "description": "Derive request rate, error, and duration metrics from traces.",
+                "span_metrics_enabled": {
+                  "description": "Enable span metrics connector to derive request, error, and duration metrics from traces.",
                   "type": "boolean"
                 }
               },

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config.yaml
@@ -1,5 +1,28 @@
 connectors:
     forward/opentelemetry: {}
+    spanmetrics/opentelemetry:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+        dimensions:
+            - name: http.response.status_code
+            - name: http.request.method
+            - name: http.route
+            - name: http.status_code
+            - name: http.method
+            - name: rpc.grpc.status_code
+            - name: rpc.response.status_code
+            - name: error.type
+        dimensions_cache_size: 1000
+        events:
+            enabled: false
+        exemplars:
+            enabled: false
+        histogram:
+            disable: false
+            unit: ms
+        metrics_expiration: 0s
+        metrics_flush_interval: 30s
+        namespace: traces.span.metrics
+        resource_metrics_cache_size: 1000
 exporters:
     otlphttp/logs:
         auth:
@@ -165,6 +188,14 @@ processors:
               key: aws.log.group.name
             - from_resource_attribute: aws.log.stream.name
               key: aws.log.stream.name
+    batch/opentelemetry_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys:
+            - aws.log.group.name
+            - aws.log.stream.name
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 30s
     batch/opentelemetry_metrics:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 1000
@@ -172,14 +203,6 @@ processors:
         timeout: 30s
     batch/opentelemetry_traces:
         metadata_cardinality_limit: 1000
-        send_batch_max_size: 10000
-        send_batch_size: 10000
-        timeout: 30s
-    batch/opentelemetry_logs:
-        metadata_cardinality_limit: 1000
-        metadata_keys:
-            - aws.log.group.name
-            - aws.log.stream.name
         send_batch_max_size: 10000
         send_batch_size: 10000
         timeout: 30s
@@ -613,6 +636,7 @@ service:
                 - batch/opentelemetry_metrics
             receivers:
                 - forward/opentelemetry
+                - spanmetrics/opentelemetry
         metrics/otlp:
             exporters:
                 - forward/opentelemetry
@@ -624,6 +648,7 @@ service:
         traces/opentelemetry:
             exporters:
                 - otlphttp/traces
+                - spanmetrics/opentelemetry
             processors:
                 - resourcedetection/opentelemetry
                 - transform/identity

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -159,6 +159,8 @@ const (
 var (
 	DatabaseInsightsConfigKey   = ConfigKey(OpenTelemetryKey, CollectKey, DatabaseInsightsKey)
 	DatabaseInsightsPostgresKey = ConfigKey(OpenTelemetryKey, CollectKey, DatabaseInsightsKey, PostgreSQLKey)
+	OtelCollectLogsConfigKey    = ConfigKey(OpenTelemetryKey, CollectKey, LogsKey)
+	OtelSpanMetricsEnabledKey   = ConfigKey(OpenTelemetryKey, CollectKey, OtlpKey, "span_metrics_enabled")
 )
 
 const (
@@ -187,7 +189,6 @@ var (
 	MetricsAggregationDimensionsKey = ConfigKey(MetricsKey, AggregationDimensionsKey)
 	OTLPLogsKey                     = ConfigKey(LogsKey, MetricsCollectedKey, OtlpKey)
 	OTLPMetricsKey                  = ConfigKey(MetricsKey, MetricsCollectedKey, OtlpKey)
-	OtelCollectLogsConfigKey        = ConfigKey(OpenTelemetryKey, CollectKey, LogsKey)
 )
 
 type TranslatorID interface {

--- a/translator/translate/otel/connector/spanmetrics/config.yaml
+++ b/translator/translate/otel/connector/spanmetrics/config.yaml
@@ -1,0 +1,11 @@
+namespace: traces.span.metrics
+metrics_flush_interval: 30s
+dimensions:
+  - name: http.response.status_code
+  - name: http.request.method
+  - name: http.route
+  - name: http.status_code
+  - name: http.method
+  - name: rpc.grpc.status_code
+  - name: rpc.response.status_code
+  - name: error.type

--- a/translator/translate/otel/connector/spanmetrics/translator.go
+++ b/translator/translate/otel/connector/spanmetrics/translator.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package spanmetrics
+
+import (
+	_ "embed"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/connector"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+//go:embed config.yaml
+var defaultConfig string
+
+const spanMetricsKey = "derive_metrics_from_traces"
+
+type translator struct {
+	name    string
+	factory connector.Factory
+}
+
+var _ common.ComponentTranslator = (*translator)(nil)
+
+func NewTranslator(name string) common.ComponentTranslator {
+	return &translator{
+		name:    name,
+		factory: spanmetricsconnector.NewFactory(),
+	}
+}
+
+func (t *translator) ID() component.ID {
+	return component.NewIDWithName(t.factory.Type(), t.name)
+}
+
+func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
+	cfg := t.factory.CreateDefaultConfig()
+	return common.GetYamlFileToYamlConfig(cfg, defaultConfig)
+}
+
+// IsEnabled checks if derive_metrics_from_traces is enabled in the config.
+func IsEnabled(conf *confmap.Conf) bool {
+	if conf == nil {
+		return false
+	}
+	key := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey, spanMetricsKey)
+	val := conf.Get(key)
+	enabled, ok := val.(bool)
+	return ok && enabled
+}

--- a/translator/translate/otel/connector/spanmetrics/translator.go
+++ b/translator/translate/otel/connector/spanmetrics/translator.go
@@ -17,8 +17,6 @@ import (
 //go:embed config.yaml
 var defaultConfig string
 
-const spanMetricsKey = "span_metrics_enabled"
-
 type translator struct {
 	name    string
 	factory connector.Factory
@@ -40,15 +38,4 @@ func (t *translator) ID() component.ID {
 func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig()
 	return common.GetYamlFileToYamlConfig(cfg, defaultConfig)
-}
-
-// IsEnabled checks if span_metrics_enabled is enabled in the config.
-func IsEnabled(conf *confmap.Conf) bool {
-	if conf == nil {
-		return false
-	}
-	key := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey, spanMetricsKey)
-	val := conf.Get(key)
-	enabled, ok := val.(bool)
-	return ok && enabled
 }

--- a/translator/translate/otel/connector/spanmetrics/translator.go
+++ b/translator/translate/otel/connector/spanmetrics/translator.go
@@ -17,7 +17,7 @@ import (
 //go:embed config.yaml
 var defaultConfig string
 
-const spanMetricsKey = "derive_metrics_from_traces"
+const spanMetricsKey = "span_metrics_enabled"
 
 type translator struct {
 	name    string
@@ -42,7 +42,7 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	return common.GetYamlFileToYamlConfig(cfg, defaultConfig)
 }
 
-// IsEnabled checks if derive_metrics_from_traces is enabled in the config.
+// IsEnabled checks if span_metrics_enabled is enabled in the config.
 func IsEnabled(conf *confmap.Conf) bool {
 	if conf == nil {
 		return false

--- a/translator/translate/otel/connector/spanmetrics/translator_test.go
+++ b/translator/translate/otel/connector/spanmetrics/translator_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap"
 )
 
 func TestTranslator_ID(t *testing.T) {
@@ -21,39 +20,4 @@ func TestTranslator_Translate(t *testing.T) {
 	cfg, err := tr.Translate(nil)
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
-}
-
-func TestIsEnabled(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    map[string]any
-		expected bool
-	}{
-		{
-			name:     "enabled",
-			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{"span_metrics_enabled": true}}}},
-			expected: true,
-		},
-		{
-			name:     "disabled",
-			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{"span_metrics_enabled": false}}}},
-			expected: false,
-		},
-		{
-			name:     "absent",
-			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{}}}},
-			expected: false,
-		},
-		{
-			name:     "no otlp",
-			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{}}},
-			expected: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			conf := confmap.NewFromStringMap(tt.input)
-			assert.Equal(t, tt.expected, IsEnabled(conf))
-		})
-	}
 }

--- a/translator/translate/otel/connector/spanmetrics/translator_test.go
+++ b/translator/translate/otel/connector/spanmetrics/translator_test.go
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package spanmetrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestTranslator_ID(t *testing.T) {
+	tr := NewTranslator("opentelemetry")
+	assert.Equal(t, "spanmetrics/opentelemetry", tr.ID().String())
+}
+
+func TestTranslator_Translate(t *testing.T) {
+	tr := NewTranslator("opentelemetry")
+	cfg, err := tr.Translate(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+}
+
+func TestIsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]any
+		expected bool
+	}{
+		{
+			name:     "enabled",
+			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{"derive_metrics_from_traces": true}}}},
+			expected: true,
+		},
+		{
+			name:     "disabled",
+			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{"derive_metrics_from_traces": false}}}},
+			expected: false,
+		},
+		{
+			name:     "absent",
+			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{}}}},
+			expected: false,
+		},
+		{
+			name:     "no otlp",
+			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{}}},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := confmap.NewFromStringMap(tt.input)
+			assert.Equal(t, tt.expected, IsEnabled(conf))
+		})
+	}
+}

--- a/translator/translate/otel/connector/spanmetrics/translator_test.go
+++ b/translator/translate/otel/connector/spanmetrics/translator_test.go
@@ -31,12 +31,12 @@ func TestIsEnabled(t *testing.T) {
 	}{
 		{
 			name:     "enabled",
-			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{"derive_metrics_from_traces": true}}}},
+			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{"span_metrics_enabled": true}}}},
 			expected: true,
 		},
 		{
 			name:     "disabled",
-			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{"derive_metrics_from_traces": false}}}},
+			input:    map[string]any{"opentelemetry": map[string]any{"collect": map[string]any{"otlp": map[string]any{"span_metrics_enabled": false}}}},
 			expected: false,
 		},
 		{

--- a/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
@@ -66,7 +66,7 @@ func (t *baseMetricsTranslator) Translate(conf *confmap.Conf) (*common.Component
 	receivers := common.NewTranslatorMap[component.Config, component.ID](fwdConnector)
 	connectors := common.NewTranslatorMap[component.Config, component.ID](fwdConnector)
 
-	if spanmetrics.IsEnabled(conf) {
+	if common.GetOrDefaultBool(conf, common.OtelSpanMetricsEnabledKey, false) {
 		sm := spanmetrics.NewTranslator(common.OpenTelemetryKey)
 		receivers.Set(sm)
 		connectors.Set(sm)

--- a/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/spanmetrics"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/otlphttp"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
@@ -62,11 +63,20 @@ func (t *baseMetricsTranslator) Translate(conf *confmap.Conf) (*common.Component
 	processors.Set(transformprocessor.NewTranslatorWithName(common.Identity))
 	processors.Set(batchprocessor.NewTranslator(common.WithName("opentelemetry_metrics"), batchprocessor.WithSendBatchSize(common.MaxMetricsPerRequest), batchprocessor.WithSendBatchMaxSize(common.MaxMetricsPerRequest), batchprocessor.WithTimeout(common.BatchTimeout)))
 
+	receivers := common.NewTranslatorMap[component.Config, component.ID](fwdConnector)
+	connectors := common.NewTranslatorMap[component.Config, component.ID](fwdConnector)
+
+	if spanmetrics.IsEnabled(conf) {
+		sm := spanmetrics.NewTranslator(common.OpenTelemetryKey)
+		receivers.Set(sm)
+		connectors.Set(sm)
+	}
+
 	return &common.ComponentTranslators{
-		Receivers:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+		Receivers:  receivers,
 		Processors: processors,
 		Exporters:  common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("metrics", otlphttp.EndpointConfig{MetricsEndpoint: metricsEndpoint}, otlphttp.WithAuthenticator(agentHealthExt.ID()))),
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](sigv4Ext, agentHealthExt),
-		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+		Connectors: connectors,
 	}, nil
 }

--- a/translator/translate/otel/pipeline/opentelemetry/translator_traces.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_traces.go
@@ -64,7 +64,7 @@ func (t *baseTracesTranslator) Translate(conf *confmap.Conf) (*common.ComponentT
 	exporters := common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("traces", otlphttp.EndpointConfig{TracesEndpoint: tracesEndpoint}, otlphttp.WithAuthenticator(agentHealthExt.ID())))
 	connectors := common.NewTranslatorMap[component.Config, component.ID](fwdConnector)
 
-	if spanmetrics.IsEnabled(conf) {
+	if common.GetOrDefaultBool(conf, common.OtelSpanMetricsEnabledKey, false) {
 		sm := spanmetrics.NewTranslator(common.OpenTelemetryKey)
 		exporters.Set(sm)
 		connectors.Set(sm)

--- a/translator/translate/otel/pipeline/opentelemetry/translator_traces.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_traces.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/spanmetrics"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter/otlphttp"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/agenthealth"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
@@ -60,11 +61,20 @@ func (t *baseTracesTranslator) Translate(conf *confmap.Conf) (*common.ComponentT
 	processors.Set(transformprocessor.NewTranslatorWithName(common.Identity))
 	processors.Set(batchprocessor.NewTranslator(common.WithName("opentelemetry_traces"), batchprocessor.WithSendBatchSize(common.MaxSpansPerRequest), batchprocessor.WithSendBatchMaxSize(common.MaxSpansPerRequest), batchprocessor.WithTimeout(common.BatchTimeout)))
 
+	exporters := common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("traces", otlphttp.EndpointConfig{TracesEndpoint: tracesEndpoint}, otlphttp.WithAuthenticator(agentHealthExt.ID())))
+	connectors := common.NewTranslatorMap[component.Config, component.ID](fwdConnector)
+
+	if spanmetrics.IsEnabled(conf) {
+		sm := spanmetrics.NewTranslator(common.OpenTelemetryKey)
+		exporters.Set(sm)
+		connectors.Set(sm)
+	}
+
 	return &common.ComponentTranslators{
 		Receivers:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
 		Processors: processors,
-		Exporters:  common.NewTranslatorMap[component.Config, component.ID](otlphttp.NewTranslatorWithName("traces", otlphttp.EndpointConfig{TracesEndpoint: tracesEndpoint}, otlphttp.WithAuthenticator(agentHealthExt.ID()))),
+		Exporters:  exporters,
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](sigv4Ext, agentHealthExt),
-		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+		Connectors: connectors,
 	}, nil
 }


### PR DESCRIPTION
# Description of changes
Adds the spanmetrics connector (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.124.x/connector/spanmetricsconnector/README.md) to derive Request, Error, and Duration (RED) metrics from OTLP traces. 

Enabled via the following configuration:
```json
{
  "opentelemetry": {
    "collect": {
      "otlp": {
        "span_metrics_enabled": true
      }
    }
  }
}
```

The connector is wired as an exporter in the OTLP traces pipeline and a receiver in the shared OTLP export metrics pipeline. When enabled, every span produces:
- `traces.span.metrics.calls` (counter)
- `traces.span.metrics.duration` (histogram, unit: ms)

Configured dimensions are carried over from span attributes onto the generated datapoint attributes: `http.request.method`, `http.response.status_code`, `http.route`, `rpc.grpc.status_code`, `error.type` (plus legacy semconv equivalents). The connector also auto-adds `service.name`, `span.name`, `span.kind`, and `status.code`.

`span_metrics_enabled` is enabled by default in the `default:otel` config.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit tests. Built the agent and deployed to an EC2 instance with `default:otel`.

Sent OTLP traces via HTTP/JSON:
```json
[
  {"service.name": "e2e-test", "span.name": "GET /verify", "kind": "SERVER", "status": "OK", "duration": "50ms", "attributes": {"http.request.method": "GET", "http.response.status_code": 200}},
  {"service.name": "e2e-test", "span.name": "POST /checkout", "kind": "SERVER", "status": "ERROR", "duration": "150ms", "attributes": {"http.request.method": "POST", "http.response.status_code": 500, "error.type": "InternalError"}}
]
```

Spanmetrics connector starts:
```
2026-06-29T22:02:52Z I! {"caller":"spanmetricsconnector@v0.124.1/connector.go:110","msg":"Building spanmetrics connector"}
2026-06-29T22:02:52Z I! {"caller":"spanmetricsconnector@v0.124.1/connector.go:204","msg":"Starting spanmetrics connector"}
2026-06-29T22:02:52Z I! {"caller":"service@v0.124.0/service.go:289","msg":"Everything is ready. Begin running and processing data."}
```

Can see the metrics in CloudWatch Query Studio
<img width="2527" height="925" alt="image" src="https://github.com/user-attachments/assets/afe57f03-5d4e-4436-b0b8-e0436e65561a" />
<img width="2524" height="863" alt="image" src="https://github.com/user-attachments/assets/688d550c-b926-432a-95a1-86b43bc19b9e" />


# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



