### PR TITLE
Update file_storage to write state to subdirectory

### DIFF
--- a/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
+++ b/translator/tocwconfig/sampleConfig/complete_linux_config.yaml
@@ -184,15 +184,15 @@ extensions:
     entitystore:
         mode: ec2
         region: us-west-2
-    file_storage/journald:
+    file_storage/opentelemetry:
         compaction:
             check_interval: 5s
-            directory: /var/lib/otelcol/file_storage
+            directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
             max_transaction_size: 65536
             rebound_needed_threshold_mib: 100
             rebound_trigger_threshold_mib: 10
         create_directory: true
-        directory: /opt/aws/amazon-cloudwatch-agent/logs/state
+        directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
         directory_permissions: "0750"
         timeout: 1s
 processors:
@@ -452,7 +452,7 @@ receivers:
             max_elapsed_time: 5m0s
             max_interval: 30s
         start_at: end
-        storage: file_storage/journald
+        storage: file_storage/opentelemetry
         type: journald_input
         units:
             - systemd
@@ -467,7 +467,7 @@ receivers:
             max_elapsed_time: 5m0s
             max_interval: 30s
         start_at: end
-        storage: file_storage/journald
+        storage: file_storage/opentelemetry
         type: journald_input
         units:
             - nginx
@@ -558,7 +558,7 @@ service:
         - agenthealth/statuscode
         - agenthealth/logs
         - agenthealth/traces
-        - file_storage/journald
+        - file_storage/opentelemetry
         - entitystore
     pipelines:
         logs/emf_logs:

--- a/translator/tocwconfig/sampleConfig/journaldlogs_filters.yaml
+++ b/translator/tocwconfig/sampleConfig/journaldlogs_filters.yaml
@@ -86,15 +86,15 @@ extensions:
     entitystore:
         mode: ec2
         region: us-west-2
-    file_storage/journald:
+    file_storage/opentelemetry:
         compaction:
             check_interval: 5s
-            directory: /var/lib/otelcol/file_storage
+            directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
             max_transaction_size: 65536
             rebound_needed_threshold_mib: 100
             rebound_trigger_threshold_mib: 10
         create_directory: true
-        directory: /opt/aws/amazon-cloudwatch-agent/logs/state
+        directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
         directory_permissions: "0750"
         timeout: 1s
 processors:
@@ -136,7 +136,7 @@ receivers:
             max_elapsed_time: 5m0s
             max_interval: 30s
         start_at: end
-        storage: file_storage/journald
+        storage: file_storage/opentelemetry
         type: journald_input
     journald/journald_1:
         id: journald_input
@@ -148,13 +148,13 @@ receivers:
             max_elapsed_time: 5m0s
             max_interval: 30s
         start_at: end
-        storage: file_storage/journald
+        storage: file_storage/opentelemetry
         type: journald_input
 service:
     extensions:
         - agenthealth/logs
         - agenthealth/statuscode
-        - file_storage/journald
+        - file_storage/opentelemetry
         - entitystore
     pipelines:
         logs/journald/0:

--- a/translator/tocwconfig/sampleConfig/journaldlogs_matches.yaml
+++ b/translator/tocwconfig/sampleConfig/journaldlogs_matches.yaml
@@ -52,15 +52,15 @@ extensions:
     entitystore:
         mode: ec2
         region: us-west-2
-    file_storage/journald:
+    file_storage/opentelemetry:
         compaction:
             check_interval: 5s
-            directory: /var/lib/otelcol/file_storage
+            directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
             max_transaction_size: 65536
             rebound_needed_threshold_mib: 100
             rebound_trigger_threshold_mib: 10
         create_directory: true
-        directory: /opt/aws/amazon-cloudwatch-agent/logs/state
+        directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
         directory_permissions: "0750"
         timeout: 1s
 processors:
@@ -83,13 +83,13 @@ receivers:
             max_elapsed_time: 5m0s
             max_interval: 30s
         start_at: end
-        storage: file_storage/journald
+        storage: file_storage/opentelemetry
         type: journald_input
 service:
     extensions:
         - agenthealth/logs
         - agenthealth/statuscode
-        - file_storage/journald
+        - file_storage/opentelemetry
         - entitystore
     pipelines:
         logs/journald/0:

--- a/translator/tocwconfig/sampleConfig/journaldlogs_priority.yaml
+++ b/translator/tocwconfig/sampleConfig/journaldlogs_priority.yaml
@@ -52,15 +52,15 @@ extensions:
     entitystore:
         mode: ec2
         region: us-west-2
-    file_storage/journald:
+    file_storage/opentelemetry:
         compaction:
             check_interval: 5s
-            directory: /var/lib/otelcol/file_storage
+            directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
             max_transaction_size: 65536
             rebound_needed_threshold_mib: 100
             rebound_trigger_threshold_mib: 10
         create_directory: true
-        directory: /opt/aws/amazon-cloudwatch-agent/logs/state
+        directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
         directory_permissions: "0750"
         timeout: 1s
 processors:
@@ -80,13 +80,13 @@ receivers:
             max_elapsed_time: 5m0s
             max_interval: 30s
         start_at: end
-        storage: file_storage/journald
+        storage: file_storage/opentelemetry
         type: journald_input
 service:
     extensions:
         - agenthealth/logs
         - agenthealth/statuscode
-        - file_storage/journald
+        - file_storage/opentelemetry
         - entitystore
     pipelines:
         logs/journald/0:

--- a/translator/tocwconfig/sampleConfig/journaldlogs_units.yaml
+++ b/translator/tocwconfig/sampleConfig/journaldlogs_units.yaml
@@ -52,15 +52,15 @@ extensions:
     entitystore:
         mode: ec2
         region: us-west-2
-    file_storage/journald:
+    file_storage/opentelemetry:
         compaction:
             check_interval: 5s
-            directory: /var/lib/otelcol/file_storage
+            directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
             max_transaction_size: 65536
             rebound_needed_threshold_mib: 100
             rebound_trigger_threshold_mib: 10
         create_directory: true
-        directory: /opt/aws/amazon-cloudwatch-agent/logs/state
+        directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
         directory_permissions: "0750"
         timeout: 1s
 processors:
@@ -80,7 +80,7 @@ receivers:
             max_elapsed_time: 5m0s
             max_interval: 30s
         start_at: end
-        storage: file_storage/journald
+        storage: file_storage/opentelemetry
         type: journald_input
         units:
             - sshd
@@ -88,7 +88,7 @@ service:
     extensions:
         - agenthealth/logs
         - agenthealth/statuscode
-        - file_storage/journald
+        - file_storage/opentelemetry
         - entitystore
     pipelines:
         logs/journald/0:

--- a/translator/tocwconfig/sampleConfig/journaldlogs_units_and_priority.yaml
+++ b/translator/tocwconfig/sampleConfig/journaldlogs_units_and_priority.yaml
@@ -52,15 +52,15 @@ extensions:
     entitystore:
         mode: ec2
         region: us-west-2
-    file_storage/journald:
+    file_storage/opentelemetry:
         compaction:
             check_interval: 5s
-            directory: /var/lib/otelcol/file_storage
+            directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
             max_transaction_size: 65536
             rebound_needed_threshold_mib: 100
             rebound_trigger_threshold_mib: 10
         create_directory: true
-        directory: /opt/aws/amazon-cloudwatch-agent/logs/state
+        directory: /opt/aws/amazon-cloudwatch-agent/logs/state/otel
         directory_permissions: "0750"
         timeout: 1s
 processors:
@@ -80,7 +80,7 @@ receivers:
             max_elapsed_time: 5m0s
             max_interval: 30s
         start_at: end
-        storage: file_storage/journald
+        storage: file_storage/opentelemetry
         type: journald_input
         units:
             - sshd
@@ -89,7 +89,7 @@ service:
     extensions:
         - agenthealth/logs
         - agenthealth/statuscode
-        - file_storage/journald
+        - file_storage/opentelemetry
         - entitystore
     pipelines:
         logs/journald/0:

--- a/translator/translate/otel/extension/filestorage/translator.go
+++ b/translator/translate/otel/extension/filestorage/translator.go
@@ -11,12 +11,8 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension"
 
-	"github.com/aws/amazon-cloudwatch-agent/tool/paths"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/logs/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
-)
-
-const (
-	name = "journald"
 )
 
 type translator struct {
@@ -25,9 +21,8 @@ type translator struct {
 
 var _ common.ComponentTranslator = (*translator)(nil)
 
-// StorageComponentID returns the component.ID for the file_storage/journald extension.
-func StorageComponentID() component.ID {
-	return component.NewIDWithName(filestorage.NewFactory().Type(), name)
+func ComponentID() component.ID {
+	return component.NewIDWithName(filestorage.NewFactory().Type(), common.OpenTelemetryKey)
 }
 
 func NewTranslator() common.ComponentTranslator {
@@ -37,12 +32,14 @@ func NewTranslator() common.ComponentTranslator {
 }
 
 func (t *translator) ID() component.ID {
-	return component.NewIDWithName(t.factory.Type(), name)
+	return component.NewIDWithName(t.factory.Type(), common.OpenTelemetryKey)
 }
 
 func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*filestorage.Config)
-	cfg.Directory = filepath.Join(paths.AgentDir, "logs", "state")
+	dir := filepath.Join(util.GetFileStateFolder(), "otel")
+	cfg.Directory = dir
+	cfg.Compaction.Directory = dir
 	cfg.CreateDirectory = true
 	return cfg, nil
 }

--- a/translator/translate/otel/extension/filestorage/translator_test.go
+++ b/translator/translate/otel/extension/filestorage/translator_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestTranslator(t *testing.T) {
 	tt := NewTranslator()
-	assert.Equal(t, "file_storage/journald", tt.ID().String())
+	assert.Equal(t, "file_storage/opentelemetry", tt.ID().String())
 
 	conf := confmap.NewFromStringMap(map[string]interface{}{})
 	got, err := tt.Translate(conf)
@@ -25,6 +25,7 @@ func TestTranslator(t *testing.T) {
 
 	gotCfg, ok := got.(*filestorage.Config)
 	require.True(t, ok)
-	assert.Equal(t, "/opt/aws/amazon-cloudwatch-agent/logs/state", gotCfg.Directory)
+	assert.Equal(t, "/opt/aws/amazon-cloudwatch-agent/logs/state/otel", gotCfg.Directory)
+	assert.Equal(t, "/opt/aws/amazon-cloudwatch-agent/logs/state/otel", gotCfg.Compaction.Directory)
 	assert.True(t, gotCfg.CreateDirectory)
 }

--- a/translator/translate/otel/pipeline/journald/translator.go
+++ b/translator/translate/otel/pipeline/journald/translator.go
@@ -200,7 +200,6 @@ func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators
 	translators.Extensions.Set(agenthealth.NewTranslator(agenthealth.LogsName, []string{agenthealth.OperationPutLogEvents}))
 	translators.Extensions.Set(agenthealth.NewTranslatorWithStatusCode(agenthealth.StatusCodeName, nil, true))
 
-	// Add file storage extension for journald cursor persistence
 	translators.Extensions.Set(filestorage.NewTranslator())
 
 	return &translators, nil

--- a/translator/translate/otel/receiver/journald/translator.go
+++ b/translator/translate/otel/receiver/journald/translator.go
@@ -57,7 +57,7 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 		copy(cfg.InputConfig.Matches, t.matches)
 	}
 
-	storageID := filestorage.StorageComponentID()
+	storageID := filestorage.ComponentID()
 	cfg.StorageID = &storageID
 
 	return cfg, nil

--- a/translator/translate/otel/receiver/journald/translator_test.go
+++ b/translator/translate/otel/receiver/journald/translator_test.go
@@ -69,7 +69,7 @@ func TestTranslatorWithConfig(t *testing.T) {
 			assert.Equal(t, tc.want.InputConfig.Priority, gotCfg.InputConfig.Priority)
 			assert.Equal(t, tc.want.InputConfig.Matches, gotCfg.InputConfig.Matches)
 			assert.NotNil(t, gotCfg.StorageID)
-			assert.Equal(t, filestorage.StorageComponentID(), *gotCfg.StorageID)
+			assert.Equal(t, filestorage.ComponentID(), *gotCfg.StorageID)
 		})
 	}
 }


### PR DESCRIPTION
# Description of the issue
The `logfile` plugin's `cleanupStateFolder()` globs the state directory (`logs/state/*`) and deletes any file it cannot parse as its expected two-line offset format. When the `journald` receiver uses the `file_storage` extension to persist state in the same directory, the BoltDB files end up being deleted by the state directory cleanup.

# Description of changes
Moves the `file_storage` directory to `logs/state/otel` to prevent this conflict. Sets the `Compaction.Directory` to match the storage directory for consistency.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested on EC2 with both `logfile` and `journald` configured. The cleanup is non-deterministic, but is possible if the `journald` receiver is delayed during startup.

```json
  {
    "agent": {
      "debug": true
    },
    "logs": {
      "logs_collected": {
        "files": {
          "collect_list": [
            {
              "file_path": "/var/log/messages",
              "log_group_name": "/test/v1-logs"
            }
          ]
        },
        "journald": {
          "collect_list": [
            {
              "log_group_name": "/test/journald",
              "units": ["sshd"]
            }
          ]
        }
      }
    }
  }
```

Before
```
$ ls -la /opt/aws/amazon-cloudwatch-agent/logs/state/
total 20
drwxr-xr-x. 2 root root    42 Jul  2 19:50 .
drwxr-xr-x. 3 root root    90 Jul  2 19:50 ..
-rw-------. 1 root root 32768 Jul  2 19:50 receiver_journald_journald_0
```

After
```
$ sudo find /opt/aws/amazon-cloudwatch-agent/logs/state/ -ls
 41944463   0 drwxr-xr-x   3 root root   18 Jul  2 20:07 /opt/aws/amazon-cloudwatch-agent/logs/state/
   491122   0 drwxr-x---   2 root root   42 Jul  2 20:07 /opt/aws/amazon-cloudwatch-agent/logs/state/otel
   671148  20 -rw-------   1 root root 32768 Jul  2 20:07 /opt/aws/amazon-cloudwatch-agent/logs/state/otel/receiver_journald_journald_0
```
# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



