### PR TITLE
Bump Go version to 1.26.4

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -49,7 +49,7 @@ jobs:
         if: needs.changes.outputs.lint == 'true'
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
           cache: false
 
       - name: Check out code
@@ -106,7 +106,7 @@ jobs:
         if: needs.changes.outputs.build == 'true'
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
           cache: false
 
       - name: Check out code
@@ -153,7 +153,7 @@ jobs:
         if: needs.changes.outputs.build == 'true'
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
           cache: false
 
       - name: Check out code

--- a/.github/workflows/PR-test.yml
+++ b/.github/workflows/PR-test.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
   StartLocalStack:
     name: 'StartLocalStack'
@@ -139,7 +139,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - name: Install jq
         run: sudo apt-get install -y jq

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - name: SetOutputs
         id: set-outputs
@@ -147,7 +147,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - name: Generate matrix
         id: set-matrix

--- a/.github/workflows/eks-performance-cluster-tests.yml
+++ b/.github/workflows/eks-performance-cluster-tests.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
           cache: false
       - name: Get old commit sha from go.mod
         id: get-old-commit

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
   GenerateTestMatrix:
     name: 'GenerateTestMatrix'
@@ -191,7 +191,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - name: Generate matrix
         id: set-matrix
@@ -314,7 +314,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1

--- a/.github/workflows/test-build-packages.yml
+++ b/.github/workflows/test-build-packages.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - name: Free up disk space
         working-directory: cwa

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
           cache: false
 
       - name: Free up disk space

--- a/.github/workflows/upload-dependencies.yml
+++ b/.github/workflows/upload-dependencies.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.4
 
       - name: Upload Dependencies and Test Repo
         env:

--- a/.github/workflows/wd-integration-test.yml
+++ b/.github/workflows/wd-integration-test.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: ~1.22.2
+          go-version: ~1.26.4
 
       - name: Generate matrix
         id: set-matrix


### PR DESCRIPTION
# Description of the issue
The CloudWatch agent release is currently built with a newer version of Go (1.26.4).

# Description of changes
Bumps the Go version used in the workflows to match the build version.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/28886437229/job/85687794827

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



