### PR TITLE
Bump golangci-lint to support Go version in workflows

### DIFF
--- a/.github/config/file-filters.yml
+++ b/.github/config/file-filters.yml
@@ -2,6 +2,7 @@ lint:
   - '**/*.go'
   - '**/*.sh'
   - '.golangci.yml'
+  - '.github/workflows/PR-build.yml'
   - 'packaging/**'
   - 'go.mod'
   - 'Makefile'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,7 @@ linters:
         - staticcheck
         text: 'ST1005: error strings should not be capitalized'
 issues:
-  new-from-rev: 9af4477
+  new-from-rev: 98e058f9
 formatters:
   enable:
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ install-addlicense:
 install-golangci-lint:
 	#Install from source for golangci-lint is not recommended based on https://golangci-lint.run/usage/install/#install-from-source so using binary
 	#installation
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) v2.4.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) v2.12.2
 
 fmt: install-goimports addlicense
 	go fmt ./...


### PR DESCRIPTION
# Description of the issue
After the https://github.com/aws/amazon-cloudwatch-agent/pull/2186, the lint step in the PR-build workflow began to fail (https://github.com/aws/amazon-cloudwatch-agent/actions/runs/28976695516). This is because the `golangci-lint` version being used was built on Go 1.25 and would not run on Go 1.26. This was not caught in the previous PR because the lint step was skipped.

# Description of changes
- Updates the file filters so if the `PR-build.yml` is changed, it will run the lint step.
- Updates the `golangci-lint` version to 2.12.2 (latest).
- Adjusts `new-from-rev` to the HEAD of main (https://github.com/aws/amazon-cloudwatch-agent/commit/98e058f980d522ed92fc539c82892b987e4d77f9) to prevent noise.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
PR Build: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/28979729440/job/85995392161

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
Set `skip testing` since the changes in this PR does not impact the agent build.





