### PR TITLE
Add windows events logs for opentelemetry section

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,6 +203,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.124.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.124.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.124.1
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.124.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.124.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1387,6 +1387,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceive
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.124.1/go.mod h1:cVf9mR1NQUOSxKaG68d1f6J1R1gD+es8N4KlfXzMrzY=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.124.1 h1:ViSLfZ+rwltr/cJyUzxwH7+Ew/qDs4KyQpMFsDbRd/g=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.124.1/go.mod h1:mEiB1YGSaguEyYsq803/QgBiJVofgknWgJ3eqgvlj7I=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.124.1 h1:4gVuHekKmzaLU1tZvIAntbkJhpThoCkZEwJCdL7SrOs=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.124.1/go.mod h1:BcBDxsZysvBLwjGhjLP62QY9Db6uXqvhSIQJkhVfEz0=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.124.1 h1:XkxqUEoukMWXF+EpEWeM9itXKt62yKi13Lzd8ZEASP4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.124.1/go.mod h1:CuCZVPz+yn88b5vhZPAlxaMrVuhAVexUV6f8b07lpUc=
 github.com/openconfig/gnmi v0.0.0-20180912164834-33a1865c3029 h1:lXQqyLroROhwR2Yq/kXbLzVecgmVeZh2TFLg6OxCd+w=

--- a/service/defaultcomponents/components.go
+++ b/service/defaultcomponents/components.go
@@ -60,6 +60,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/connector/forwardconnector"
@@ -123,6 +124,7 @@ func Factories() (otelcol.Factories, error) {
 		systemmetricsreceiver.NewFactory(),
 		tcplogreceiver.NewFactory(),
 		udplogreceiver.NewFactory(),
+		windowseventlogreceiver.NewFactory(),
 		zipkinreceiver.NewFactory(),
 	); err != nil {
 		return otelcol.Factories{}, err

--- a/service/defaultcomponents/components_test.go
+++ b/service/defaultcomponents/components_test.go
@@ -40,6 +40,7 @@ func TestComponents(t *testing.T) {
 		"systemmetrics",
 		"tcplog",
 		"udplog",
+		"windowseventlog",
 		"zipkin",
 	}
 	gotReceivers := collections.MapSlice(maps.Keys(factories.Receivers), component.Type.String)

--- a/tool/downloader/downloader_test.go
+++ b/tool/downloader/downloader_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 )
 
 func TestRunDownloader_DefaultOtel(t *testing.T) {
@@ -21,9 +23,9 @@ func TestRunDownloader_DefaultOtel(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(outputDir, "default_otel.tmp"))
 	require.NoError(t, err)
 
-	expected, err := os.ReadFile("../../translator/config/defaults/otel.json")
-	require.NoError(t, err)
-	assert.JSONEq(t, string(expected), string(content))
+	expected, ok := config.DefaultJSONConfigFor("otel")
+	require.True(t, ok)
+	assert.JSONEq(t, expected, string(content))
 }
 
 func TestRunDownloader_DefaultBare(t *testing.T) {

--- a/translator/cmdutil/translatorutil_test.go
+++ b/translator/cmdutil/translatorutil_test.go
@@ -441,6 +441,16 @@ func TestDefaultOtelConfigSchemaValidation(t *testing.T) {
 	assert.True(t, result.Valid(), "default otel config must pass schema validation: %v", result.Errors())
 }
 
+func TestOpenTelemetryWindowsEventsSchemaValidation(t *testing.T) {
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/opentelemetry/validOpenTelemetryWindowsEvents.json", true, map[string]int{})
+}
+
+func TestOpenTelemetryWindowsEventsInvalidSchemaValidation(t *testing.T) {
+	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/opentelemetry/invalidOpenTelemetryWindowsEvents.json", false, map[string]int{
+		"enum": 1,
+	})
+}
+
 func TestCombinedV1V2SchemaValidation(t *testing.T) {
 	checkIfSchemaValidateAsExpected(t, "../../translator/config/sampleSchema/opentelemetry/validCombinedV1V2Config.json", true, map[string]int{})
 }

--- a/translator/config/defaultConfig.go
+++ b/translator/config/defaultConfig.go
@@ -3,11 +3,6 @@
 
 package config
 
-import _ "embed"
-
-//go:embed defaults/otel.json
-var defaultOtelConfig string
-
 var defaultConfigs = map[string]string{
 	"otel": defaultOtelConfig,
 }

--- a/translator/config/defaultConfig_test.go
+++ b/translator/config/defaultConfig_test.go
@@ -4,7 +4,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,10 +13,7 @@ import (
 func TestDefaultJSONConfigFor_Otel(t *testing.T) {
 	cfg, ok := DefaultJSONConfigFor("otel")
 	require.True(t, ok)
-
-	expected, err := os.ReadFile("defaults/otel.json")
-	require.NoError(t, err)
-	assert.JSONEq(t, string(expected), cfg)
+	assert.JSONEq(t, defaultOtelConfig, cfg)
 }
 
 func TestDefaultJSONConfigFor_Unknown(t *testing.T) {

--- a/translator/config/defaultConfig_unix.go
+++ b/translator/config/defaultConfig_unix.go
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package config
+
+import _ "embed"
+
+//go:embed defaults/otel.json
+var defaultOtelConfig string

--- a/translator/config/defaultConfig_windows.go
+++ b/translator/config/defaultConfig_windows.go
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package config
+
+import _ "embed"
+
+//go:embed defaults/otel_windows.json
+var defaultOtelConfig string

--- a/translator/config/defaults/otel_windows.json
+++ b/translator/config/defaults/otel_windows.json
@@ -1,0 +1,24 @@
+{
+  "agent": {
+    "credentials": {
+      "role_arn": "${CWAGENT_ROLE_ARN}"
+    }
+  },
+  "opentelemetry": {
+    "collect": {
+      "otlp": {},
+      "windows_events": {
+        "collect_list": [
+          {
+            "event_name": "System",
+            "event_levels": ["ERROR", "WARNING"]
+          },
+          {
+            "event_name": "Application",
+            "event_levels": ["ERROR", "WARNING"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/config/sampleSchema/opentelemetry/invalidOpenTelemetryWindowsEvents.json
+++ b/translator/config/sampleSchema/opentelemetry/invalidOpenTelemetryWindowsEvents.json
@@ -1,0 +1,17 @@
+{
+  "agent": {
+    "region": "us-east-1"
+  },
+  "opentelemetry": {
+    "collect": {
+      "windows_events": {
+        "collect_list": [
+          {
+            "event_name": "System",
+            "event_format": "invalid_format"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/config/sampleSchema/opentelemetry/validOpenTelemetryWindowsEvents.json
+++ b/translator/config/sampleSchema/opentelemetry/validOpenTelemetryWindowsEvents.json
@@ -1,0 +1,29 @@
+{
+  "agent": {
+    "region": "us-east-1"
+  },
+  "opentelemetry": {
+    "collect": {
+      "windows_events": {
+        "collect_list": [
+          {
+            "event_name": "System",
+            "event_levels": ["ERROR", "WARNING"],
+            "event_format": "xml",
+            "log_group_name": "/aws/windows/System"
+          },
+          {
+            "event_name": "Application",
+            "event_levels": ["INFORMATION"],
+            "log_group_name": "/aws/windows/Application",
+            "log_stream_name": "my-stream"
+          },
+          {
+            "event_name": "Security",
+            "event_ids": [4624, 4625]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1909,6 +1909,68 @@
                 }
               },
               "additionalProperties": false
+            },
+            "windows_events": {
+              "type": "object",
+              "properties": {
+                "collect_list": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "event_name": {
+                        "description": "The Windows Event Log channel to collect from",
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                      },
+                      "event_levels": {
+                        "description": "Event severity levels to collect",
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["CRITICAL", "ERROR", "WARNING", "INFORMATION", "VERBOSE"]
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                      },
+                      "event_ids": {
+                        "description": "Specific event IDs to collect",
+                        "type": "array",
+                        "items": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 65535
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                      },
+                      "event_format": {
+                        "description": "Output format: xml (raw XML) or text (structured)",
+                        "type": "string",
+                        "enum": ["text", "xml"]
+                      },
+                      "log_group_name": {
+                        "description": "CloudWatch Logs group name override",
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 512
+                      },
+                      "log_stream_name": {
+                        "description": "CloudWatch Logs stream name override",
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 512
+                      }
+                    },
+                    "required": ["event_name"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": ["collect_list"],
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.conf
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.conf
@@ -1,0 +1,15 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.yaml
@@ -1,0 +1,747 @@
+connectors:
+    forward/opentelemetry: {}
+exporters:
+    otlphttp/logs:
+        auth:
+            authenticator: agenthealth/opentelemetry_logs
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: https://logs.us-west-2.amazonaws.com/v1/logs
+        max_idle_conns: 100
+        metrics_endpoint: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
+    otlphttp/metrics:
+        auth:
+            authenticator: agenthealth/opentelemetry_metrics
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: ""
+        max_idle_conns: 100
+        metrics_endpoint: https://monitoring.us-west-2.amazonaws.com/v1/metrics
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
+    otlphttp/traces:
+        auth:
+            authenticator: agenthealth/opentelemetry_traces
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: ""
+        max_idle_conns: 100
+        metrics_endpoint: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: https://xray.us-west-2.amazonaws.com/v1/traces
+        write_buffer_size: 524288
+extensions:
+    agenthealth/opentelemetry_logs:
+        additional_auth: headers_setter/logs
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    agenthealth/opentelemetry_metrics:
+        additional_auth: sigv4auth/monitoring
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    agenthealth/opentelemetry_traces:
+        additional_auth: sigv4auth/xray
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    awscloudwatchlogsprovisioner:
+        additional_auth: sigv4auth/logs
+        imds_retries: 1
+        logs_provision_failure_backoff: 30s
+        max_retries: 2
+        num_workers: 8
+        region: us-west-2
+        request_timeout_seconds: 10
+        role_arn: ${CWAGENT_ROLE_ARN}
+    file_storage/opentelemetry:
+        compaction:
+            check_interval: 5s
+            directory: c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\state\otel
+            max_transaction_size: 65536
+            rebound_needed_threshold_mib: 100
+            rebound_trigger_threshold_mib: 10
+        create_directory: true
+        directory: c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\state\otel
+        directory_permissions: "0750"
+        timeout: 1s
+    headers_setter/logs:
+        additional_auth: awscloudwatchlogsprovisioner
+        headers:
+            - action: upsert
+              from_context: aws.log.group.name
+              key: x-aws-log-group
+            - action: upsert
+              from_context: aws.log.stream.name
+              key: x-aws-log-stream
+    sigv4auth/logs:
+        assume_role:
+            arn: ${CWAGENT_ROLE_ARN}
+            sts_region: us-west-2
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-west-2
+        request_timeout_seconds: 30
+        service: logs
+    sigv4auth/monitoring:
+        assume_role:
+            arn: ${CWAGENT_ROLE_ARN}
+            sts_region: us-west-2
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-west-2
+        request_timeout_seconds: 30
+        service: monitoring
+    sigv4auth/xray:
+        assume_role:
+            arn: ${CWAGENT_ROLE_ARN}
+            sts_region: us-west-2
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-west-2
+        request_timeout_seconds: 30
+        service: xray
+processors:
+    attributestocontext/opentelemetry:
+        actions:
+            - from_resource_attribute: aws.log.group.name
+              key: aws.log.group.name
+            - from_resource_attribute: aws.log.stream.name
+              key: aws.log.stream.name
+    batch/opentelemetry_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys:
+            - aws.log.group.name
+            - aws.log.stream.name
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 30s
+    batch/opentelemetry_metrics:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 1000
+        send_batch_size: 1000
+        timeout: 30s
+    batch/opentelemetry_traces:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 30s
+    filter/windows_events_application:
+        error_mode: ignore
+        logs:
+            log_record:
+                - not((severity_number == 17 or severity_number == 13))
+        metrics: {}
+        spans: {}
+        traces: {}
+    filter/windows_events_system:
+        error_mode: ignore
+        logs:
+            log_record:
+                - not((severity_number == 17 or severity_number == 13))
+        metrics: {}
+        spans: {}
+        traces: {}
+    resourcedetection/opentelemetry:
+        aks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        azure:
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            tags: []
+        consul:
+            address: ""
+            datacenter: ""
+            namespace: ""
+            resource_attributes:
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            token_file: ""
+        detectors:
+            - eks
+            - env
+            - ec2
+        docker:
+            resource_attributes:
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+        ec2:
+            fail_on_missing_metadata: false
+            max_attempts: 3
+            max_backoff: 20s
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+            tags:
+                - ^kubernetes.io/cluster/.*$
+                - ^aws:autoscaling:groupName
+        ecs:
+            resource_attributes:
+                aws.ecs.cluster.arn:
+                    enabled: true
+                aws.ecs.launchtype:
+                    enabled: true
+                aws.ecs.task.arn:
+                    enabled: true
+                aws.ecs.task.family:
+                    enabled: true
+                aws.ecs.task.id:
+                    enabled: true
+                aws.ecs.task.revision:
+                    enabled: true
+                aws.log.group.arns:
+                    enabled: true
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.arns:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+        eks:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: false
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        elasticbeanstalk:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                deployment.environment:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.version:
+                    enabled: true
+        gcp:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.id:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+                gcp.cloud_run.job.execution:
+                    enabled: true
+                gcp.cloud_run.job.task_index:
+                    enabled: true
+                gcp.gce.instance.hostname:
+                    enabled: false
+                gcp.gce.instance.name:
+                    enabled: false
+                gcp.gce.instance_group_manager.name:
+                    enabled: true
+                gcp.gce.instance_group_manager.region:
+                    enabled: true
+                gcp.gce.instance_group_manager.zone:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+        heroku:
+            resource_attributes:
+                cloud.provider:
+                    enabled: true
+                heroku.app.id:
+                    enabled: true
+                heroku.dyno.id:
+                    enabled: true
+                heroku.release.commit:
+                    enabled: true
+                heroku.release.creation_timestamp:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.name:
+                    enabled: true
+                service.version:
+                    enabled: true
+        idle_conn_timeout: 1m30s
+        k8snode:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            node_from_env_var: ""
+            resource_attributes:
+                k8s.node.name:
+                    enabled: true
+                k8s.node.uid:
+                    enabled: true
+        kubeadm:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            resource_attributes:
+                k8s.cluster.name:
+                    enabled: true
+                k8s.cluster.uid:
+                    enabled: true
+        lambda:
+            resource_attributes:
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.max_memory:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+        max_idle_conns: 100
+        openshift:
+            address: ""
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+            tls: {}
+            token: ""
+        override: true
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.cpu.cache.l2.size:
+                    enabled: false
+                host.cpu.family:
+                    enabled: false
+                host.cpu.model.id:
+                    enabled: false
+                host.cpu.model.name:
+                    enabled: false
+                host.cpu.stepping:
+                    enabled: false
+                host.cpu.vendor.id:
+                    enabled: false
+                host.id:
+                    enabled: false
+                host.ip:
+                    enabled: false
+                host.mac:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: false
+                os.type:
+                    enabled: true
+                os.version:
+                    enabled: false
+        timeout: 2s
+    transform/identity:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil and resource.attributes["cloud.platform"] == "aws_ec2"
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+        metric_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil and resource.attributes["cloud.platform"] == "aws_ec2"
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+        trace_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil and resource.attributes["cloud.platform"] == "aws_ec2"
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+    transform/logs_cleanup:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - delete_key(resource.attributes, "aws.log.group.name")
+                - delete_key(resource.attributes, "aws.log.stream.name")
+                - delete_key(resource.attributes, "aws.log.source")
+                - delete_key(resource.attributes, "aws.log.channel")
+        metric_statements: []
+        trace_statements: []
+    transform/logs_routing:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["aws.log.group.name"], Concat(["/aws/cwagent", resource.attributes["aws.log.source"]], "/")) where resource.attributes["aws.log.group.name"] == nil and resource.attributes["aws.log.source"] != nil
+                - set(resource.attributes["aws.log.group.name"], "/aws/cwagent/default") where resource.attributes["aws.log.group.name"] == nil
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["aws.log.channel"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["aws.log.channel"] != nil
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["aws.log.channel"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["aws.log.channel"] != nil
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], resource.attributes["host.id"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil
+                - set(resource.attributes["aws.log.stream.name"], resource.attributes["host.name"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil
+                - set(resource.attributes["aws.log.stream.name"], "default") where resource.attributes["aws.log.stream.name"] == nil
+        metric_statements: []
+        trace_statements: []
+    transform/otlp_log_source:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["aws.log.source"], "otlp") where resource.attributes["aws.log.source"] == nil
+        metric_statements: []
+        trace_statements: []
+    transform/otlp_scope:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(scope.attributes["cloudwatch.solution"], "otel-otlp")
+        metric_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(scope.attributes["cloudwatch.solution"], "otel-otlp")
+        trace_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(scope.attributes["cloudwatch.solution"], "otel-otlp")
+    transform/windows_events_scope:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(scope.attributes["cloudwatch.solution"], "otel-windows-events")
+        metric_statements: []
+        trace_statements: []
+receivers:
+    otlp/grpc_127_0_0_1_4317:
+        protocols:
+            grpc:
+                endpoint: 127.0.0.1:4317
+                keepalive:
+                    enforcement_policy: {}
+                    server_parameters: {}
+                read_buffer_size: 524288
+                transport: tcp
+    otlp/http_127_0_0_1_4318:
+        protocols:
+            http:
+                cors: {}
+                endpoint: 127.0.0.1:4318
+                idle_timeout: 0s
+                logs_url_path: /v1/logs
+                metrics_url_path: /v1/metrics
+                read_header_timeout: 0s
+                traces_url_path: /v1/traces
+                write_timeout: 0s
+    windowseventlog/application:
+        channel: Application
+        id: windows_eventlog_input
+        max_reads: 100
+        operators: []
+        poll_interval: 1s
+        resource:
+            aws.log.channel: Application
+            aws.log.source: windows_events
+        retry_on_failure:
+            enabled: false
+            initial_interval: 1s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+        start_at: end
+        storage: file_storage/opentelemetry
+        type: windows_eventlog_input
+    windowseventlog/system:
+        channel: System
+        id: windows_eventlog_input
+        max_reads: 100
+        operators: []
+        poll_interval: 1s
+        resource:
+            aws.log.channel: System
+            aws.log.source: windows_events
+        retry_on_failure:
+            enabled: false
+            initial_interval: 1s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+        start_at: end
+        storage: file_storage/opentelemetry
+        type: windows_eventlog_input
+service:
+    extensions:
+        - sigv4auth/monitoring
+        - agenthealth/opentelemetry_metrics
+        - sigv4auth/logs
+        - awscloudwatchlogsprovisioner
+        - headers_setter/logs
+        - agenthealth/opentelemetry_logs
+        - sigv4auth/xray
+        - agenthealth/opentelemetry_traces
+        - file_storage/opentelemetry
+    pipelines:
+        logs/opentelemetry:
+            exporters:
+                - otlphttp/logs
+            processors:
+                - resourcedetection/opentelemetry
+                - transform/identity
+                - transform/logs_routing
+                - attributestocontext/opentelemetry
+                - transform/logs_cleanup
+                - batch/opentelemetry_logs
+            receivers:
+                - forward/opentelemetry
+        logs/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/otlp_scope
+                - transform/otlp_log_source
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+        logs/windows_events_application:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/windows_events_scope
+                - filter/windows_events_application
+            receivers:
+                - windowseventlog/application
+        logs/windows_events_system:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/windows_events_scope
+                - filter/windows_events_system
+            receivers:
+                - windowseventlog/system
+        metrics/opentelemetry:
+            exporters:
+                - otlphttp/metrics
+            processors:
+                - resourcedetection/opentelemetry
+                - transform/identity
+                - batch/opentelemetry_metrics
+            receivers:
+                - forward/opentelemetry
+        metrics/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/otlp_scope
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+        traces/opentelemetry:
+            exporters:
+                - otlphttp/traces
+            processors:
+                - resourcedetection/opentelemetry
+                - transform/identity
+                - batch/opentelemetry_traces
+            receivers:
+                - forward/opentelemetry
+        traces/otlp:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/otlp_scope
+            receivers:
+                - otlp/grpc_127_0_0_1_4317
+                - otlp/http_127_0_0_1_4318
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            output_paths:
+                - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.yaml
@@ -684,16 +684,16 @@ service:
             exporters:
                 - forward/opentelemetry
             processors:
-                - transform/windows_events_scope
                 - filter/windows_events_application
+                - transform/windows_events_scope
             receivers:
                 - windowseventlog/application
         logs/windows_events_system:
             exporters:
                 - forward/opentelemetry
             processors:
-                - transform/windows_events_scope
                 - filter/windows_events_system
+                - transform/windows_events_scope
             receivers:
                 - windowseventlog/system
         metrics/opentelemetry:

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.yaml
@@ -140,34 +140,31 @@ extensions:
               from_context: aws.log.stream.name
               key: x-aws-log-stream
     sigv4auth/logs:
-        assume_role:
-            arn: ${CWAGENT_ROLE_ARN}
-            sts_region: us-west-2
+        assume_role: {}
         imds_retries: 1
         max_retries: 2
         num_workers: 8
         region: us-west-2
         request_timeout_seconds: 30
+        role_arn: ${CWAGENT_ROLE_ARN}
         service: logs
     sigv4auth/monitoring:
-        assume_role:
-            arn: ${CWAGENT_ROLE_ARN}
-            sts_region: us-west-2
+        assume_role: {}
         imds_retries: 1
         max_retries: 2
         num_workers: 8
         region: us-west-2
         request_timeout_seconds: 30
+        role_arn: ${CWAGENT_ROLE_ARN}
         service: monitoring
     sigv4auth/xray:
-        assume_role:
-            arn: ${CWAGENT_ROLE_ARN}
-            sts_region: us-west-2
+        assume_role: {}
         imds_retries: 1
         max_retries: 2
         num_workers: 8
         region: us-west-2
         request_timeout_seconds: 30
+        role_arn: ${CWAGENT_ROLE_ARN}
         service: xray
 processors:
     attributestocontext/opentelemetry:
@@ -194,7 +191,7 @@ processors:
         send_batch_max_size: 10000
         send_batch_size: 10000
         timeout: 30s
-    filter/windows_events_application:
+    filter/windows_events_application_1:
         error_mode: ignore
         logs:
             log_record:
@@ -202,7 +199,7 @@ processors:
         metrics: {}
         spans: {}
         traces: {}
-    filter/windows_events_system:
+    filter/windows_events_system_0:
         error_mode: ignore
         logs:
             log_record:
@@ -613,7 +610,7 @@ receivers:
                 read_header_timeout: 0s
                 traces_url_path: /v1/traces
                 write_timeout: 0s
-    windowseventlog/application:
+    windowseventlog/application_2122316671:
         channel: Application
         id: windows_eventlog_input
         max_reads: 100
@@ -630,7 +627,7 @@ receivers:
         start_at: end
         storage: file_storage/opentelemetry
         type: windows_eventlog_input
-    windowseventlog/system:
+    windowseventlog/system_653521908:
         channel: System
         id: windows_eventlog_input
         max_reads: 100
@@ -680,22 +677,22 @@ service:
             receivers:
                 - otlp/grpc_127_0_0_1_4317
                 - otlp/http_127_0_0_1_4318
-        logs/windows_events_application:
+        logs/windows_events_application_1:
             exporters:
                 - forward/opentelemetry
             processors:
-                - filter/windows_events_application
+                - filter/windows_events_application_1
                 - transform/windows_events_scope
             receivers:
-                - windowseventlog/application
-        logs/windows_events_system:
+                - windowseventlog/application_2122316671
+        logs/windows_events_system_0:
             exporters:
                 - forward/opentelemetry
             processors:
-                - filter/windows_events_system
+                - filter/windows_events_system_0
                 - transform/windows_events_scope
             receivers:
-                - windowseventlog/system
+                - windowseventlog/system_653521908
         metrics/opentelemetry:
             exporters:
                 - otlphttp/metrics

--- a/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.conf
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.conf
@@ -1,0 +1,15 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false

--- a/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.json
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.json
@@ -1,0 +1,22 @@
+{
+  "agent": {
+    "region": "us-east-1"
+  },
+  "opentelemetry": {
+    "collect": {
+      "windows_events": {
+        "collect_list": [
+          {
+            "event_name": "System",
+            "event_levels": ["ERROR", "WARNING", "INFORMATION"],
+            "log_group_name": "/aws/cwagent/windows-events/System"
+          },
+          {
+            "event_name": "Application",
+            "event_levels": ["ERROR", "WARNING"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.yaml
@@ -1,0 +1,545 @@
+connectors:
+    forward/opentelemetry: {}
+exporters:
+    otlphttp/logs:
+        auth:
+            authenticator: agenthealth/opentelemetry_logs
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: https://logs.us-east-1.amazonaws.com/v1/logs
+        max_idle_conns: 100
+        metrics_endpoint: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
+extensions:
+    agenthealth/opentelemetry_logs:
+        additional_auth: headers_setter/logs
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EC2
+                region_type: ACJ
+    awscloudwatchlogsprovisioner:
+        additional_auth: sigv4auth/logs
+        imds_retries: 1
+        logs_provision_failure_backoff: 30s
+        max_retries: 2
+        num_workers: 8
+        region: us-east-1
+        request_timeout_seconds: 10
+    file_storage/opentelemetry:
+        compaction:
+            check_interval: 5s
+            directory: c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\state\otel
+            max_transaction_size: 65536
+            rebound_needed_threshold_mib: 100
+            rebound_trigger_threshold_mib: 10
+        create_directory: true
+        directory: c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\state\otel
+        directory_permissions: "0750"
+        timeout: 1s
+    headers_setter/logs:
+        additional_auth: awscloudwatchlogsprovisioner
+        headers:
+            - action: upsert
+              from_context: aws.log.group.name
+              key: x-aws-log-group
+            - action: upsert
+              from_context: aws.log.stream.name
+              key: x-aws-log-stream
+    sigv4auth/logs:
+        assume_role: {}
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-east-1
+        request_timeout_seconds: 30
+        service: logs
+processors:
+    attributestocontext/opentelemetry:
+        actions:
+            - from_resource_attribute: aws.log.group.name
+              key: aws.log.group.name
+            - from_resource_attribute: aws.log.stream.name
+              key: aws.log.stream.name
+    batch/opentelemetry_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys:
+            - aws.log.group.name
+            - aws.log.stream.name
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 30s
+    filter/windows_events_application:
+        error_mode: ignore
+        logs:
+            log_record:
+                - not((severity_number == 17 or severity_number == 13))
+        metrics: {}
+        spans: {}
+        traces: {}
+    filter/windows_events_system:
+        error_mode: ignore
+        logs:
+            log_record:
+                - not((severity_number == 17 or severity_number == 13 or severity_number == 9))
+        metrics: {}
+        spans: {}
+        traces: {}
+    resourcedetection/opentelemetry:
+        aks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        azure:
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            tags: []
+        consul:
+            address: ""
+            datacenter: ""
+            namespace: ""
+            resource_attributes:
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            token_file: ""
+        detectors:
+            - eks
+            - env
+            - ec2
+        docker:
+            resource_attributes:
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+        ec2:
+            fail_on_missing_metadata: false
+            max_attempts: 3
+            max_backoff: 20s
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+            tags:
+                - ^kubernetes.io/cluster/.*$
+                - ^aws:autoscaling:groupName
+        ecs:
+            resource_attributes:
+                aws.ecs.cluster.arn:
+                    enabled: true
+                aws.ecs.launchtype:
+                    enabled: true
+                aws.ecs.task.arn:
+                    enabled: true
+                aws.ecs.task.family:
+                    enabled: true
+                aws.ecs.task.id:
+                    enabled: true
+                aws.ecs.task.revision:
+                    enabled: true
+                aws.log.group.arns:
+                    enabled: true
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.arns:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+        eks:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: false
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        elasticbeanstalk:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                deployment.environment:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.version:
+                    enabled: true
+        gcp:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.id:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+                gcp.cloud_run.job.execution:
+                    enabled: true
+                gcp.cloud_run.job.task_index:
+                    enabled: true
+                gcp.gce.instance.hostname:
+                    enabled: false
+                gcp.gce.instance.name:
+                    enabled: false
+                gcp.gce.instance_group_manager.name:
+                    enabled: true
+                gcp.gce.instance_group_manager.region:
+                    enabled: true
+                gcp.gce.instance_group_manager.zone:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+        heroku:
+            resource_attributes:
+                cloud.provider:
+                    enabled: true
+                heroku.app.id:
+                    enabled: true
+                heroku.dyno.id:
+                    enabled: true
+                heroku.release.commit:
+                    enabled: true
+                heroku.release.creation_timestamp:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.name:
+                    enabled: true
+                service.version:
+                    enabled: true
+        idle_conn_timeout: 1m30s
+        k8snode:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            node_from_env_var: ""
+            resource_attributes:
+                k8s.node.name:
+                    enabled: true
+                k8s.node.uid:
+                    enabled: true
+        kubeadm:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            resource_attributes:
+                k8s.cluster.name:
+                    enabled: true
+                k8s.cluster.uid:
+                    enabled: true
+        lambda:
+            resource_attributes:
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.max_memory:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+        max_idle_conns: 100
+        openshift:
+            address: ""
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+            tls: {}
+            token: ""
+        override: true
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.cpu.cache.l2.size:
+                    enabled: false
+                host.cpu.family:
+                    enabled: false
+                host.cpu.model.id:
+                    enabled: false
+                host.cpu.model.name:
+                    enabled: false
+                host.cpu.stepping:
+                    enabled: false
+                host.cpu.vendor.id:
+                    enabled: false
+                host.id:
+                    enabled: false
+                host.ip:
+                    enabled: false
+                host.mac:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: false
+                os.type:
+                    enabled: true
+                os.version:
+                    enabled: false
+        timeout: 2s
+    transform/identity:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil and resource.attributes["cloud.platform"] == "aws_ec2"
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+        metric_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil and resource.attributes["cloud.platform"] == "aws_ec2"
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+        trace_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:ec2", resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], Concat(["instance", resource.attributes["host.id"]], "/")], ":")) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["host.id"] != nil and resource.attributes["cloud.platform"] == "aws_ec2"
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["ec2.tag.aws:autoscaling:groupName"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["ec2.tag.aws:autoscaling:groupName"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
+    transform/logs_cleanup:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - delete_key(resource.attributes, "aws.log.group.name")
+                - delete_key(resource.attributes, "aws.log.stream.name")
+                - delete_key(resource.attributes, "aws.log.source")
+                - delete_key(resource.attributes, "aws.log.channel")
+        metric_statements: []
+        trace_statements: []
+    transform/logs_routing:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["aws.log.group.name"], Concat(["/aws/cwagent", resource.attributes["aws.log.source"]], "/")) where resource.attributes["aws.log.group.name"] == nil and resource.attributes["aws.log.source"] != nil
+                - set(resource.attributes["aws.log.group.name"], "/aws/cwagent/default") where resource.attributes["aws.log.group.name"] == nil
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["aws.log.channel"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["aws.log.channel"] != nil
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["aws.log.channel"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["aws.log.channel"] != nil
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], resource.attributes["host.id"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil
+                - set(resource.attributes["aws.log.stream.name"], resource.attributes["host.name"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil
+                - set(resource.attributes["aws.log.stream.name"], "default") where resource.attributes["aws.log.stream.name"] == nil
+        metric_statements: []
+        trace_statements: []
+    transform/windows_events_scope:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(scope.attributes["cloudwatch.solution"], "otel-windows-events")
+        metric_statements: []
+        trace_statements: []
+receivers:
+    windowseventlog/application:
+        channel: Application
+        id: windows_eventlog_input
+        max_reads: 100
+        operators: []
+        poll_interval: 1s
+        resource:
+            aws.log.channel: Application
+            aws.log.source: windows_events
+        retry_on_failure:
+            enabled: false
+            initial_interval: 1s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+        start_at: end
+        storage: file_storage/opentelemetry
+        type: windows_eventlog_input
+    windowseventlog/system:
+        channel: System
+        id: windows_eventlog_input
+        max_reads: 100
+        operators: []
+        poll_interval: 1s
+        resource:
+            aws.log.channel: System
+            aws.log.group.name: /aws/cwagent/windows-events/System
+            aws.log.source: windows_events
+        retry_on_failure:
+            enabled: false
+            initial_interval: 1s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+        start_at: end
+        storage: file_storage/opentelemetry
+        type: windows_eventlog_input
+service:
+    extensions:
+        - sigv4auth/logs
+        - awscloudwatchlogsprovisioner
+        - headers_setter/logs
+        - agenthealth/opentelemetry_logs
+        - file_storage/opentelemetry
+    pipelines:
+        logs/opentelemetry:
+            exporters:
+                - otlphttp/logs
+            processors:
+                - resourcedetection/opentelemetry
+                - transform/identity
+                - transform/logs_routing
+                - attributestocontext/opentelemetry
+                - transform/logs_cleanup
+                - batch/opentelemetry_logs
+            receivers:
+                - forward/opentelemetry
+        logs/windows_events_application:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/windows_events_scope
+                - filter/windows_events_application
+            receivers:
+                - windowseventlog/application
+        logs/windows_events_system:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/windows_events_scope
+                - filter/windows_events_system
+            receivers:
+                - windowseventlog/system
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            output_paths:
+                - c:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs\amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.yaml
@@ -105,6 +105,15 @@ processors:
         metrics: {}
         spans: {}
         traces: {}
+    resource/windows_events_system:
+        attributes:
+            - action: upsert
+              converted_type: ""
+              from_attribute: ""
+              from_context: ""
+              key: aws.log.group.name
+              pattern: ""
+              value: /aws/cwagent/windows-events/System
     resourcedetection/opentelemetry:
         aks:
             resource_attributes:
@@ -482,7 +491,6 @@ receivers:
         poll_interval: 1s
         resource:
             aws.log.channel: System
-            aws.log.group.name: /aws/cwagent/windows-events/System
             aws.log.source: windows_events
         retry_on_failure:
             enabled: false
@@ -516,16 +524,17 @@ service:
             exporters:
                 - forward/opentelemetry
             processors:
-                - transform/windows_events_scope
                 - filter/windows_events_application
+                - transform/windows_events_scope
             receivers:
                 - windowseventlog/application
         logs/windows_events_system:
             exporters:
                 - forward/opentelemetry
             processors:
-                - transform/windows_events_scope
                 - filter/windows_events_system
+                - resource/windows_events_system
+                - transform/windows_events_scope
             receivers:
                 - windowseventlog/system
     telemetry:

--- a/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/windows_events_config.yaml
@@ -89,7 +89,7 @@ processors:
         send_batch_max_size: 10000
         send_batch_size: 10000
         timeout: 30s
-    filter/windows_events_application:
+    filter/windows_events_application_1:
         error_mode: ignore
         logs:
             log_record:
@@ -97,7 +97,7 @@ processors:
         metrics: {}
         spans: {}
         traces: {}
-    filter/windows_events_system:
+    filter/windows_events_system_0:
         error_mode: ignore
         logs:
             log_record:
@@ -105,7 +105,7 @@ processors:
         metrics: {}
         spans: {}
         traces: {}
-    resource/windows_events_system:
+    resource/windows_events_system_0:
         attributes:
             - action: upsert
               converted_type: ""
@@ -466,7 +466,7 @@ processors:
         metric_statements: []
         trace_statements: []
 receivers:
-    windowseventlog/application:
+    windowseventlog/application_2122316671:
         channel: Application
         id: windows_eventlog_input
         max_reads: 100
@@ -483,7 +483,7 @@ receivers:
         start_at: end
         storage: file_storage/opentelemetry
         type: windows_eventlog_input
-    windowseventlog/system:
+    windowseventlog/system_653521908:
         channel: System
         id: windows_eventlog_input
         max_reads: 100
@@ -520,23 +520,23 @@ service:
                 - batch/opentelemetry_logs
             receivers:
                 - forward/opentelemetry
-        logs/windows_events_application:
+        logs/windows_events_application_1:
             exporters:
                 - forward/opentelemetry
             processors:
-                - filter/windows_events_application
+                - filter/windows_events_application_1
                 - transform/windows_events_scope
             receivers:
-                - windowseventlog/application
-        logs/windows_events_system:
+                - windowseventlog/application_2122316671
+        logs/windows_events_system_0:
             exporters:
                 - forward/opentelemetry
             processors:
-                - filter/windows_events_system
-                - resource/windows_events_system
+                - filter/windows_events_system_0
+                - resource/windows_events_system_0
                 - transform/windows_events_scope
             receivers:
-                - windowseventlog/system
+                - windowseventlog/system_653521908
     telemetry:
         logs:
             encoding: console

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -427,23 +427,6 @@ func TestOtlpOtelConfig(t *testing.T) {
 	checkTranslation(t, "opentelemetry/otlp_otel_config", "linux", nil, "")
 }
 
-func TestDefaultOtelConfigTranslation(t *testing.T) {
-	resetContext(t)
-	context.CurrentContext().SetMode(config.ModeEC2)
-	agent.Global_Config.Region = "us-west-2"
-	agent.Global_Config.RegionType = config.RegionTypeCredsMap
-
-	cfg, ok := config.DefaultJSONConfigFor("otel")
-	require.True(t, ok)
-
-	var input any
-	require.NoError(t, json.Unmarshal([]byte(cfg), &input))
-
-	translator.SetTargetPlatform("linux")
-	verifyToTomlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config.conf")
-	verifyToYamlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config.yaml")
-}
-
 func TestOtlpOtelEKSConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetMode(config.ModeEC2)

--- a/translator/tocwconfig/tocwconfig_unix_test.go
+++ b/translator/tocwconfig/tocwconfig_unix_test.go
@@ -202,6 +202,23 @@ func TestDefaultOtelConfigAzureVMTranslation(t *testing.T) {
 	verifyToYamlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config_azurevm.yaml")
 }
 
+func TestDefaultOtelConfigTranslation(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	agent.Global_Config.Region = "us-west-2"
+	agent.Global_Config.RegionType = config.RegionTypeCredsMap
+
+	cfg, ok := config.DefaultJSONConfigFor("otel")
+	require.True(t, ok)
+
+	var input any
+	require.NoError(t, json.Unmarshal([]byte(cfg), &input))
+
+	translator.SetTargetPlatform("linux")
+	verifyToTomlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config.conf")
+	verifyToYamlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config.yaml")
+}
+
 func TestAzureVMHostMetricsConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetMode(config.ModeAzureVM)

--- a/translator/tocwconfig/tocwconfig_windows_test.go
+++ b/translator/tocwconfig/tocwconfig_windows_test.go
@@ -7,10 +7,15 @@
 package tocwconfig
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
 	"github.com/aws/amazon-cloudwatch-agent/translator/context"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 )
 
 func TestCompleteConfigWindows(t *testing.T) {
@@ -25,4 +30,27 @@ func TestCompleteConfigWindows(t *testing.T) {
 	// The translation needs to use the runtime.GOOS value in order to generate the proper configuration YAML,
 	// so this is separate
 	checkTranslation(t, "complete_windows_config", "windows", expectedEnvVars, "")
+}
+
+func TestWindowsEventsOtelConfig(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	checkTranslation(t, "opentelemetry/windows_events_config", "windows", nil, "")
+}
+
+func TestDefaultOtelConfigWindowsTranslation(t *testing.T) {
+	resetContext(t)
+	context.CurrentContext().SetMode(config.ModeEC2)
+	agent.Global_Config.Region = "us-west-2"
+	agent.Global_Config.RegionType = config.RegionTypeCredsMap
+
+	cfg, ok := config.DefaultJSONConfigFor("otel")
+	require.True(t, ok)
+
+	var input any
+	require.NoError(t, json.Unmarshal([]byte(cfg), &input))
+
+	translator.SetTargetPlatform("windows")
+	verifyToTomlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config_windows.conf")
+	verifyToYamlTranslation(t, input, "./sampleConfig/opentelemetry/default_otel_config_windows.yaml")
 }

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -136,6 +136,8 @@ const (
 	AppSignalsRules                  = "rules"
 )
 
+const WindowsEventsKey = "windows_events"
+
 // DBI (Database Insights) constants
 const (
 	DatabaseInsightsKey = "database_insights"
@@ -161,6 +163,7 @@ var (
 	DatabaseInsightsPostgresKey = ConfigKey(OpenTelemetryKey, CollectKey, DatabaseInsightsKey, PostgreSQLKey)
 	OtelCollectLogsConfigKey    = ConfigKey(OpenTelemetryKey, CollectKey, LogsKey)
 	OtelSpanMetricsEnabledKey   = ConfigKey(OpenTelemetryKey, CollectKey, OtlpKey, "span_metrics_enabled")
+	WindowsEventsConfigKey      = ConfigKey(OpenTelemetryKey, CollectKey, WindowsEventsKey)
 )
 
 const (
@@ -524,6 +527,14 @@ func IsAnySet(conf *confmap.Conf, keys []string) bool {
 		}
 	}
 	return false
+}
+
+// ValidateAnySet returns a MissingKeyError if none of the keys are set in the config.
+func ValidateAnySet(conf *confmap.Conf, id ID, keys []string) error {
+	if conf != nil && IsAnySet(conf, keys) {
+		return nil
+	}
+	return &MissingKeyError{ID: id, JsonKey: strings.Join(keys, " or ")}
 }
 
 func KueueContainerInsightsEnabled(conf *confmap.Conf) bool {

--- a/translator/translate/otel/common/common_test.go
+++ b/translator/translate/otel/common/common_test.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
 )
 
 type testTranslator struct {
@@ -383,4 +385,35 @@ func TestIsAnySet(t *testing.T) {
 			assert.Equal(t, testCase.want, IsAnySet(conf, testCase.keys))
 		})
 	}
+}
+
+func TestValidateAnySet(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"otlp": map[string]any{},
+			},
+		},
+	})
+	id := pipeline.NewIDWithName(pipeline.SignalLogs, "test")
+	keys := []string{"opentelemetry::collect::logs", "opentelemetry::collect::otlp", "opentelemetry::collect::windows_events"}
+
+	t.Run("NilConf", func(t *testing.T) {
+		err := ValidateAnySet(nil, id, keys)
+		var missingErr *MissingKeyError
+		require.ErrorAs(t, err, &missingErr)
+		assert.Equal(t, id, missingErr.ID)
+		assert.Equal(t, strings.Join(keys, " or "), missingErr.JsonKey)
+	})
+	t.Run("NoneSet", func(t *testing.T) {
+		empty := confmap.NewFromStringMap(map[string]any{})
+		err := ValidateAnySet(empty, id, keys)
+		var missingErr *MissingKeyError
+		require.ErrorAs(t, err, &missingErr)
+		assert.Equal(t, id, missingErr.ID)
+	})
+	t.Run("OneSet", func(t *testing.T) {
+		err := ValidateAnySet(conf, id, keys)
+		assert.NoError(t, err)
+	})
 }

--- a/translator/translate/otel/common/ottl.go
+++ b/translator/translate/otel/common/ottl.go
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package common
+
+// OTTL error modes control how processors handle statement evaluation failures.
+// See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor#config
+const (
+	OTTLErrorModeIgnore    = "ignore"
+	OTTLErrorModePropagate = "propagate"
+)

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator.go
@@ -177,7 +177,7 @@ func (t *dbiTranslator) pgReceiver(name string, extraOpts ...postgresql.Option) 
 func (t *dbiTranslator) excludeMonitorFilter() common.ComponentTranslator {
 	idx := strconv.Itoa(t.instanceIndex)
 	condition := fmt.Sprintf(`attributes["user.name"] == "%s" or attributes["postgresql.rolname"] == "%s"`, t.cfg.username, t.cfg.username)
-	return filterprocessor.NewTranslatorWithLogCondition(common.DbiFilterExcludeMonitor+"_"+idx, condition)
+	return filterprocessor.NewTranslatorWithLogCondition(common.DbiFilterExcludeMonitor+"_"+idx, condition, common.OTTLErrorModePropagate)
 }
 
 func (t *dbiTranslator) scopeTransform() common.ComponentTranslator {

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
@@ -5,6 +5,7 @@ package opentelemetry
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
 	"go.opentelemetry.io/collector/component"
@@ -39,10 +40,17 @@ func (t *baseLogsTranslator) ID() pipeline.ID {
 	return pipeline.NewIDWithName(pipeline.SignalLogs, common.OpenTelemetryKey)
 }
 
+// otelLogsKeys are the config keys that activate the base opentelemetry logs pipeline.
+var otelLogsKeys = []string{
+	common.OtelCollectLogsConfigKey,
+	common.DatabaseInsightsConfigKey,
+	common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey),
+	common.WindowsEventsConfigKey,
+}
+
 func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
-	otlpKey := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)
-	if conf == nil || (!conf.IsSet(common.OtelCollectLogsConfigKey) && !conf.IsSet(common.DatabaseInsightsConfigKey) && !conf.IsSet(otlpKey)) {
-		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey + " or " + otlpKey}
+	if err := common.ValidateAnySet(conf, t.ID(), otelLogsKeys); err != nil {
+		return nil, err
 	}
 
 	region := agent.Global_Config.Region
@@ -74,12 +82,16 @@ func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTra
 		{Key: "aws.log.group.name", FromResourceAttribute: "aws.log.group.name"},
 		{Key: "aws.log.stream.name", FromResourceAttribute: "aws.log.stream.name"},
 	})
+	cleanupStmts := []string{
+		`delete_key(resource.attributes, "aws.log.group.name")`,
+		`delete_key(resource.attributes, "aws.log.stream.name")`,
+		`delete_key(resource.attributes, "aws.log.source")`,
+	}
+	if runtime.GOOS == "windows" && conf != nil && conf.IsSet(common.WindowsEventsConfigKey) {
+		cleanupStmts = append(cleanupStmts, `delete_key(resource.attributes, "aws.log.channel")`)
+	}
 	logsCleanup := transformprocessor.NewTranslatorWithName("logs_cleanup",
-		transformprocessor.WithLogResourceStatements([]string{
-			`delete_key(resource.attributes, "aws.log.group.name")`,
-			`delete_key(resource.attributes, "aws.log.stream.name")`,
-			`delete_key(resource.attributes, "aws.log.source")`,
-		}),
+		transformprocessor.WithLogResourceStatements(cleanupStmts),
 	)
 	batch := batchprocessor.NewTranslator(
 		common.WithName("opentelemetry_logs"),

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
@@ -45,11 +45,14 @@ var otelLogsKeys = []string{
 	common.OtelCollectLogsConfigKey,
 	common.DatabaseInsightsConfigKey,
 	common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey),
-	common.WindowsEventsConfigKey,
 }
 
 func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
-	if err := common.ValidateAnySet(conf, t.ID(), otelLogsKeys); err != nil {
+	keys := otelLogsKeys
+	if runtime.GOOS == "windows" {
+		keys = append(keys, common.WindowsEventsConfigKey)
+	}
+	if err := common.ValidateAnySet(conf, t.ID(), keys); err != nil {
 		return nil, err
 	}
 

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
@@ -4,6 +4,7 @@
 package opentelemetry
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -19,7 +20,11 @@ func TestBaseLogsTranslator(t *testing.T) {
 	tt := NewBaseLogsTranslator()
 	assert.EqualValues(t, "logs/opentelemetry", tt.ID().String())
 
-	missingErr := &common.MissingKeyError{ID: tt.ID(), JsonKey: strings.Join(otelLogsKeys, " or ")}
+	keys := otelLogsKeys
+	if runtime.GOOS == "windows" {
+		keys = append(keys, common.WindowsEventsConfigKey)
+	}
+	missingErr := &common.MissingKeyError{ID: tt.ID(), JsonKey: strings.Join(keys, " or ")}
 	testCases := map[string]struct {
 		input   map[string]interface{}
 		wantErr error

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs_test.go
@@ -4,6 +4,7 @@
 package opentelemetry
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,17 +19,18 @@ func TestBaseLogsTranslator(t *testing.T) {
 	tt := NewBaseLogsTranslator()
 	assert.EqualValues(t, "logs/opentelemetry", tt.ID().String())
 
+	missingErr := &common.MissingKeyError{ID: tt.ID(), JsonKey: strings.Join(otelLogsKeys, " or ")}
 	testCases := map[string]struct {
 		input   map[string]interface{}
 		wantErr error
 	}{
 		"WithNilConf": {
 			input:   nil,
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey + " or " + common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)},
+			wantErr: missingErr,
 		},
 		"WithoutCollectKey": {
 			input:   map[string]interface{}{},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey + " or " + common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)},
+			wantErr: missingErr,
 		},
 		"WithCollectKeyButNoLogs": {
 			input: map[string]interface{}{
@@ -36,7 +38,7 @@ func TestBaseLogsTranslator(t *testing.T) {
 					"collect": map[string]interface{}{},
 				},
 			},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: common.OtelCollectLogsConfigKey + " or " + common.DatabaseInsightsConfigKey + " or " + common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey)},
+			wantErr: missingErr,
 		},
 		"WithCollectLogsKey": {
 			input: map[string]interface{}{

--- a/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_metrics.go
@@ -24,7 +24,13 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/transformprocessor"
 )
 
-var otelCollectKey = common.ConfigKey(common.OpenTelemetryKey, common.CollectKey)
+var otelMetricsKeys = []string{
+	common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtlpKey),
+	common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.HostMetricsKey),
+	common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.PrometheusKey),
+	common.DatabaseInsightsConfigKey,
+	common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtelContainerInsightsKey),
+}
 
 type baseMetricsTranslator struct{}
 
@@ -38,12 +44,9 @@ func (t *baseMetricsTranslator) ID() pipeline.ID {
 	return pipeline.NewIDWithName(pipeline.SignalMetrics, common.OpenTelemetryKey)
 }
 
-// Translate creates the shared metrics export pipeline. It activates when any
-// collect sub-section is present; it receives data via the forward connector
-// from feature pipelines (host_metrics, otlp, span_metrics).
 func (t *baseMetricsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
-	if conf == nil || !conf.IsSet(otelCollectKey) {
-		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: otelCollectKey}
+	if err := common.ValidateAnySet(conf, t.ID(), otelMetricsKeys); err != nil {
+		return nil, err
 	}
 
 	region := agent.Global_Config.Region

--- a/translator/translate/otel/pipeline/opentelemetry/translator_metrics_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_metrics_test.go
@@ -4,6 +4,7 @@
 package opentelemetry
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,16 +25,40 @@ func TestBaseMetricsTranslator(t *testing.T) {
 	}{
 		"WithNilConf": {
 			input:   nil,
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: strings.Join(otelMetricsKeys, " or ")},
 		},
 		"WithoutCollectKey": {
 			input:   map[string]interface{}{},
-			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: otelCollectKey},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: strings.Join(otelMetricsKeys, " or ")},
 		},
-		"WithCollectKey": {
+		"WithCollectKeyButNoMetricsSource": {
 			input: map[string]interface{}{
 				"opentelemetry": map[string]interface{}{
 					"collect": map[string]interface{}{},
+				},
+			},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: strings.Join(otelMetricsKeys, " or ")},
+		},
+		"WithWindowsEventsOnlyNoMetrics": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"windows_events": map[string]interface{}{
+							"collect_list": []interface{}{
+								map[string]interface{}{"event_name": "System"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: &common.MissingKeyError{ID: tt.ID(), JsonKey: strings.Join(otelMetricsKeys, " or ")},
+		},
+		"WithOtlpKey": {
+			input: map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"otlp": map[string]interface{}{},
+					},
 				},
 			},
 		},
@@ -75,7 +100,9 @@ func TestBaseMetricsTranslatorEmptyRegion(t *testing.T) {
 	tt := NewBaseMetricsTranslator()
 	conf := confmap.NewFromStringMap(map[string]interface{}{
 		"opentelemetry": map[string]interface{}{
-			"collect": map[string]interface{}{},
+			"collect": map[string]interface{}{
+				"otlp": map[string]interface{}{},
+			},
 		},
 	})
 	got, err := tt.Translate(conf)

--- a/translator/translate/otel/pipeline/opentelemetry/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translators.go
@@ -13,6 +13,7 @@ import (
 	hi "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/hostmetrics"
 	otelotlp "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/otlp"
 	prom "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/prometheus"
+	we "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/windowsevents"
 )
 
 func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
@@ -25,5 +26,6 @@ func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
 	translators.Merge(dbi.NewTranslators(conf))
 	translators.Merge(ci.NewTranslators(conf))
 	translators.Merge(otelotlp.NewTranslators(conf))
+	translators.Merge(we.NewTranslators(conf))
 	return translators
 }

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translator.go
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package windowsevents
+
+import (
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/filestorage"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/filterprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/transformprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/windowseventlog"
+)
+
+// severityNumbers maps config level names to OTel severity numbers.
+// Derived from pkg/stanza/operator/input/windows/xml.go parseSeverity():
+//
+//	Level "1"/Critical → Fatal(21), "2"/Error → Error(17),
+//	"3"/Warning → Warn(13), "4"/Information → Info(9), default → Default(0)
+//
+// TODO: Replace with upstream Query XML filtering when collector is bumped past v0.124.
+var severityNumbers = map[string]int{
+	"CRITICAL":    21,
+	"ERROR":       17,
+	"WARNING":     13,
+	"INFORMATION": 9,
+	"VERBOSE":     0,
+}
+
+type eventEntry struct {
+	name         string
+	receiverName string
+	channel      string
+	raw          bool
+	resource     map[string]string
+	eventLevels  []string
+	eventIDs     []int
+}
+
+// filterCondition builds an OTTL drop condition. When both levels and IDs are present, they are ANDed.
+func (e eventEntry) filterCondition() string {
+	var parts []string
+
+	if len(e.eventLevels) > 0 {
+		var severityChecks []string
+		for _, level := range e.eventLevels {
+			if sev, ok := severityNumbers[level]; ok {
+				severityChecks = append(severityChecks, fmt.Sprintf("severity_number == %d", sev))
+			}
+		}
+		if len(severityChecks) > 0 {
+			parts = append(parts, "("+strings.Join(severityChecks, " or ")+")")
+		}
+	}
+
+	if len(e.eventIDs) > 0 {
+		var idChecks []string
+		for _, id := range e.eventIDs {
+			idChecks = append(idChecks, fmt.Sprintf("body[\"event_id\"][\"id\"] == %d", id))
+		}
+		if len(idChecks) > 0 {
+			parts = append(parts, "("+strings.Join(idChecks, " or ")+")")
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	// Drop records that DON'T match the filter (filter processor drops when condition is true)
+	return "not(" + strings.Join(parts, " and ") + ")"
+}
+
+type windowsEventsPipelineTranslator struct {
+	entry eventEntry
+}
+
+var _ common.PipelineTranslator = (*windowsEventsPipelineTranslator)(nil)
+
+func (t *windowsEventsPipelineTranslator) ID() pipeline.ID {
+	return pipeline.NewIDWithName(pipeline.SignalLogs, "windows_events_"+t.entry.name)
+}
+
+func (t *windowsEventsPipelineTranslator) Translate(_ *confmap.Conf) (*common.ComponentTranslators, error) {
+	if t.entry.raw && len(t.entry.eventIDs) > 0 {
+		return nil, fmt.Errorf("event_ids filtering is not supported with event_format \"xml\" for channel %q", t.entry.channel)
+	}
+
+	fwdConnector := forward.NewTranslator(common.OpenTelemetryKey)
+
+	receivers := common.NewTranslatorMap[component.Config, component.ID]()
+	receivers.Set(windowseventlog.NewTranslator(t.entry.receiverName, t.entry.channel, t.entry.raw, t.entry.resource))
+
+	processors := common.NewTranslatorMap[component.Config, component.ID]()
+	processors.Set(transformprocessor.NewTranslatorWithName("windows_events_scope",
+		transformprocessor.WithErrorMode(common.OTTLErrorModeIgnore),
+		transformprocessor.WithLogScopeStatements(common.ScopeStatementsForSolution("otel-windows-events")),
+	))
+
+	// TODO: Replace with upstream Query XML filtering when collector is bumped past v0.124.
+	condition := t.entry.filterCondition()
+	if condition != "" {
+		processors.Set(filterprocessor.NewTranslatorWithLogCondition("windows_events_"+t.entry.name, condition, common.OTTLErrorModeIgnore))
+	}
+
+	return &common.ComponentTranslators{
+		Receivers:  receivers,
+		Processors: processors,
+		Exporters:  common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+		Extensions: common.NewTranslatorMap[component.Config, component.ID](filestorage.NewTranslator()),
+		Connectors: common.NewTranslatorMap[component.Config, component.ID](fwdConnector),
+	}, nil
+}

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/connector/forward"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/filestorage"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/filterprocessor"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/resourceprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/transformprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver/windowseventlog"
 )
@@ -35,13 +36,26 @@ var severityNumbers = map[string]int{
 }
 
 type eventEntry struct {
-	name         string
-	receiverName string
-	channel      string
-	raw          bool
-	resource     map[string]string
-	eventLevels  []string
-	eventIDs     []int
+	name          string
+	receiverName  string
+	channel       string
+	raw           bool
+	resource      map[string]string
+	logGroupName  string
+	logStreamName string
+	eventLevels   []string
+	eventIDs      []int
+}
+
+func (e eventEntry) routingAttributes() map[string]string {
+	attrs := make(map[string]string)
+	if e.logGroupName != "" {
+		attrs["aws.log.group.name"] = e.logGroupName
+	}
+	if e.logStreamName != "" {
+		attrs["aws.log.stream.name"] = e.logStreamName
+	}
+	return attrs
 }
 
 // filterCondition builds an OTTL drop condition. When both levels and IDs are present, they are ANDed.
@@ -99,16 +113,23 @@ func (t *windowsEventsPipelineTranslator) Translate(_ *confmap.Conf) (*common.Co
 	receivers.Set(windowseventlog.NewTranslator(t.entry.receiverName, t.entry.channel, t.entry.raw, t.entry.resource))
 
 	processors := common.NewTranslatorMap[component.Config, component.ID]()
-	processors.Set(transformprocessor.NewTranslatorWithName("windows_events_scope",
-		transformprocessor.WithErrorMode(common.OTTLErrorModeIgnore),
-		transformprocessor.WithLogScopeStatements(common.ScopeStatementsForSolution("otel-windows-events")),
-	))
 
 	// TODO: Replace with upstream Query XML filtering when collector is bumped past v0.124.
 	condition := t.entry.filterCondition()
 	if condition != "" {
 		processors.Set(filterprocessor.NewTranslatorWithLogCondition("windows_events_"+t.entry.name, condition, common.OTTLErrorModeIgnore))
 	}
+
+	if attrs := t.entry.routingAttributes(); len(attrs) > 0 {
+		processors.Set(resourceprocessor.NewTranslator(
+			common.WithName("windows_events_"+t.entry.name),
+			resourceprocessor.WithAttributes(attrs),
+		))
+	}
+	processors.Set(transformprocessor.NewTranslatorWithName("windows_events_scope",
+		transformprocessor.WithErrorMode(common.OTTLErrorModeIgnore),
+		transformprocessor.WithLogScopeStatements(common.ScopeStatementsForSolution("otel-windows-events")),
+	))
 
 	return &common.ComponentTranslators{
 		Receivers:  receivers,

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translator_test.go
@@ -8,57 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/pipeline"
-
-	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
-	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
 )
-
-func TestNewTranslators_Disabled(t *testing.T) {
-	conf := confmap.NewFromStringMap(map[string]any{
-		"opentelemetry": map[string]any{"collect": map[string]any{}},
-	})
-	translators := NewTranslators(conf)
-	assert.Equal(t, 0, translators.Len())
-}
-
-func TestNewTranslators_TwoEntries(t *testing.T) {
-	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_WINDOWS)
-	defer translatorcontext.CurrentContext().SetOs("")
-	conf := confmap.NewFromStringMap(map[string]any{
-		"opentelemetry": map[string]any{
-			"collect": map[string]any{
-				"windows_events": map[string]any{
-					"collect_list": []any{
-						map[string]any{"event_name": "System"},
-						map[string]any{"event_name": "Application"},
-					},
-				},
-			},
-		},
-	})
-	translators := NewTranslators(conf)
-	assert.Equal(t, 2, translators.Len())
-}
-
-func TestNewTranslators_NonWindows(t *testing.T) {
-	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
-	defer translatorcontext.CurrentContext().SetOs("")
-	conf := confmap.NewFromStringMap(map[string]any{
-		"opentelemetry": map[string]any{
-			"collect": map[string]any{
-				"windows_events": map[string]any{
-					"collect_list": []any{
-						map[string]any{"event_name": "System"},
-					},
-				},
-			},
-		},
-	})
-	translators := NewTranslators(conf)
-	assert.Equal(t, 0, translators.Len())
-}
 
 func TestPipelineTranslator_ID(t *testing.T) {
 	pt := &windowsEventsPipelineTranslator{entry: eventEntry{name: "system_0"}}
@@ -101,37 +52,19 @@ func TestPipelineTranslator_Translate_WithFilter(t *testing.T) {
 	assert.Equal(t, 2, result.Processors.Len())
 }
 
-func TestParseEntries(t *testing.T) {
-	conf := confmap.NewFromStringMap(map[string]any{
-		"opentelemetry": map[string]any{
-			"collect": map[string]any{
-				"windows_events": map[string]any{
-					"collect_list": []any{
-						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}, "event_format": "xml", "log_group_name": "/custom/system"},
-						map[string]any{"event_name": "Application", "event_ids": []any{float64(1001)}},
-						map[string]any{"event_name": "Microsoft-Windows-PowerShell/Operational", "event_levels": []any{"WARNING"}},
-					},
-				},
-			},
-		},
-	})
-	entries := parseEntries(conf)
-	require.Len(t, entries, 3)
+func TestPipelineTranslator_Translate_WithRoutingAttrs(t *testing.T) {
+	pt := &windowsEventsPipelineTranslator{entry: eventEntry{
+		name:         "system",
+		receiverName: "system",
+		channel:      "System",
+		resource:     map[string]string{"aws.log.source": "windows_events", "aws.log.channel": "System"},
+		logGroupName: "/custom/group",
+	}}
+	result, err := pt.Translate(nil)
+	require.NoError(t, err)
 
-	assert.Equal(t, "system", entries[0].name)
-	assert.Equal(t, "System", entries[0].channel)
-	assert.True(t, entries[0].raw)
-	assert.Equal(t, "/custom/system", entries[0].resource["aws.log.group.name"])
-	assert.Equal(t, []string{"ERROR"}, entries[0].eventLevels)
-
-	assert.Equal(t, "application", entries[1].name)
-	assert.Equal(t, "Application", entries[1].channel)
-	assert.False(t, entries[1].raw)
-	assert.Equal(t, []int{1001}, entries[1].eventIDs)
-
-	assert.Equal(t, "microsoft-windows-powershell_operational", entries[2].name)
-	assert.Equal(t, "Microsoft-Windows-PowerShell/Operational", entries[2].channel)
-	assert.Equal(t, []string{"WARNING"}, entries[2].eventLevels)
+	// resource processor + scope transform = 2 processors
+	assert.Equal(t, 2, result.Processors.Len())
 }
 
 func TestPipelineTranslator_DuplicateChannels_SharedReceiver(t *testing.T) {
@@ -160,32 +93,6 @@ func TestPipelineTranslator_DuplicateChannels_SharedReceiver(t *testing.T) {
 
 	// Same receiver ID (shared checkpoint)
 	assert.Equal(t, r1.Receivers.Keys(), r2.Receivers.Keys())
-}
-
-func TestParseEntries_DuplicateChannels(t *testing.T) {
-	conf := confmap.NewFromStringMap(map[string]any{
-		"opentelemetry": map[string]any{
-			"collect": map[string]any{
-				"windows_events": map[string]any{
-					"collect_list": []any{
-						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}},
-						map[string]any{"event_name": "System", "event_levels": []any{"WARNING"}},
-						map[string]any{"event_name": "System", "event_ids": []any{float64(1001)}},
-					},
-				},
-			},
-		},
-	})
-	entries := parseEntries(conf)
-	require.Len(t, entries, 3)
-	assert.Equal(t, "system", entries[0].name)
-	assert.Equal(t, "system_1", entries[1].name)
-	assert.Equal(t, "system_2", entries[2].name)
-
-	// All entries share the same receiver (same channel = same checkpoint)
-	assert.Equal(t, "system", entries[0].receiverName)
-	assert.Equal(t, "system", entries[1].receiverName)
-	assert.Equal(t, "system", entries[2].receiverName)
 }
 
 func TestPipelineTranslator_Translate_XmlWithEventIDs_Error(t *testing.T) {
@@ -234,6 +141,35 @@ func TestBuildFilterCondition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.entry.filterCondition())
+		})
+	}
+}
+
+func TestRoutingAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    eventEntry
+		expected map[string]string
+	}{
+		{
+			name:     "no routing attrs",
+			entry:    eventEntry{name: "system"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "log group only",
+			entry:    eventEntry{name: "system", logGroupName: "/custom/group"},
+			expected: map[string]string{"aws.log.group.name": "/custom/group"},
+		},
+		{
+			name:     "both",
+			entry:    eventEntry{name: "system", logGroupName: "/custom/group", logStreamName: "my-stream"},
+			expected: map[string]string{"aws.log.group.name": "/custom/group", "aws.log.stream.name": "my-stream"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.entry.routingAttributes())
 		})
 	}
 }

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translator_test.go
@@ -1,0 +1,239 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package windowsevents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+
+	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
+	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
+)
+
+func TestNewTranslators_Disabled(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{"collect": map[string]any{}},
+	})
+	translators := NewTranslators(conf)
+	assert.Equal(t, 0, translators.Len())
+}
+
+func TestNewTranslators_TwoEntries(t *testing.T) {
+	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_WINDOWS)
+	defer translatorcontext.CurrentContext().SetOs("")
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System"},
+						map[string]any{"event_name": "Application"},
+					},
+				},
+			},
+		},
+	})
+	translators := NewTranslators(conf)
+	assert.Equal(t, 2, translators.Len())
+}
+
+func TestNewTranslators_NonWindows(t *testing.T) {
+	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
+	defer translatorcontext.CurrentContext().SetOs("")
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System"},
+					},
+				},
+			},
+		},
+	})
+	translators := NewTranslators(conf)
+	assert.Equal(t, 0, translators.Len())
+}
+
+func TestPipelineTranslator_ID(t *testing.T) {
+	pt := &windowsEventsPipelineTranslator{entry: eventEntry{name: "system_0"}}
+	assert.Equal(t, pipeline.NewIDWithName(pipeline.SignalLogs, "windows_events_system_0"), pt.ID())
+}
+
+func TestPipelineTranslator_Translate_NoFilter(t *testing.T) {
+	pt := &windowsEventsPipelineTranslator{entry: eventEntry{
+		name:         "system",
+		receiverName: "system",
+		channel:      "System",
+		raw:          false,
+		resource:     map[string]string{"aws.log.source": "windows_events"},
+	}}
+	result, err := pt.Translate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.Receivers.Len())
+	assert.Equal(t, 1, result.Processors.Len())
+	assert.Equal(t, 1, result.Exporters.Len())
+	assert.Equal(t, 1, result.Extensions.Len())
+	assert.Equal(t, 1, result.Connectors.Len())
+}
+
+func TestPipelineTranslator_Translate_WithFilter(t *testing.T) {
+	pt := &windowsEventsPipelineTranslator{entry: eventEntry{
+		name:         "system",
+		receiverName: "system",
+		channel:      "System",
+		raw:          false,
+		resource:     map[string]string{"aws.log.source": "windows_events"},
+		eventLevels:  []string{"ERROR", "WARNING"},
+	}}
+	result, err := pt.Translate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.Extensions.Len())
+	assert.Equal(t, 2, result.Processors.Len())
+}
+
+func TestParseEntries(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}, "event_format": "xml", "log_group_name": "/custom/system"},
+						map[string]any{"event_name": "Application", "event_ids": []any{float64(1001)}},
+						map[string]any{"event_name": "Microsoft-Windows-PowerShell/Operational", "event_levels": []any{"WARNING"}},
+					},
+				},
+			},
+		},
+	})
+	entries := parseEntries(conf)
+	require.Len(t, entries, 3)
+
+	assert.Equal(t, "system", entries[0].name)
+	assert.Equal(t, "System", entries[0].channel)
+	assert.True(t, entries[0].raw)
+	assert.Equal(t, "/custom/system", entries[0].resource["aws.log.group.name"])
+	assert.Equal(t, []string{"ERROR"}, entries[0].eventLevels)
+
+	assert.Equal(t, "application", entries[1].name)
+	assert.Equal(t, "Application", entries[1].channel)
+	assert.False(t, entries[1].raw)
+	assert.Equal(t, []int{1001}, entries[1].eventIDs)
+
+	assert.Equal(t, "microsoft-windows-powershell_operational", entries[2].name)
+	assert.Equal(t, "Microsoft-Windows-PowerShell/Operational", entries[2].channel)
+	assert.Equal(t, []string{"WARNING"}, entries[2].eventLevels)
+}
+
+func TestPipelineTranslator_DuplicateChannels_SharedReceiver(t *testing.T) {
+	pt1 := &windowsEventsPipelineTranslator{entry: eventEntry{
+		name:         "system",
+		receiverName: "system",
+		channel:      "System",
+		resource:     map[string]string{"aws.log.source": "windows_events", "aws.log.channel": "System"},
+		eventLevels:  []string{"ERROR"},
+	}}
+	pt2 := &windowsEventsPipelineTranslator{entry: eventEntry{
+		name:         "system_1",
+		receiverName: "system",
+		channel:      "System",
+		resource:     map[string]string{"aws.log.source": "windows_events", "aws.log.channel": "System"},
+		eventLevels:  []string{"WARNING"},
+	}}
+
+	r1, err := pt1.Translate(nil)
+	require.NoError(t, err)
+	r2, err := pt2.Translate(nil)
+	require.NoError(t, err)
+
+	// Different pipeline IDs
+	assert.NotEqual(t, pt1.ID(), pt2.ID())
+
+	// Same receiver ID (shared checkpoint)
+	assert.Equal(t, r1.Receivers.Keys(), r2.Receivers.Keys())
+}
+
+func TestParseEntries_DuplicateChannels(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}},
+						map[string]any{"event_name": "System", "event_levels": []any{"WARNING"}},
+						map[string]any{"event_name": "System", "event_ids": []any{float64(1001)}},
+					},
+				},
+			},
+		},
+	})
+	entries := parseEntries(conf)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "system", entries[0].name)
+	assert.Equal(t, "system_1", entries[1].name)
+	assert.Equal(t, "system_2", entries[2].name)
+
+	// All entries share the same receiver (same channel = same checkpoint)
+	assert.Equal(t, "system", entries[0].receiverName)
+	assert.Equal(t, "system", entries[1].receiverName)
+	assert.Equal(t, "system", entries[2].receiverName)
+}
+
+func TestPipelineTranslator_Translate_XmlWithEventIDs_Error(t *testing.T) {
+	pt := &windowsEventsPipelineTranslator{entry: eventEntry{
+		name:     "security",
+		channel:  "Security",
+		raw:      true,
+		eventIDs: []int{4624},
+	}}
+	_, err := pt.Translate(nil)
+	assert.EqualError(t, err, `event_ids filtering is not supported with event_format "xml" for channel "Security"`)
+}
+
+func TestBuildFilterCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    eventEntry
+		expected string
+	}{
+		{
+			name:     "no filter",
+			entry:    eventEntry{name: "system_0", channel: "System"},
+			expected: "",
+		},
+		{
+			name:     "levels only",
+			entry:    eventEntry{name: "system_0", eventLevels: []string{"ERROR", "WARNING"}},
+			expected: `not((severity_number == 17 or severity_number == 13))`,
+		},
+		{
+			name:     "ids only",
+			entry:    eventEntry{name: "security_0", eventIDs: []int{4624, 4625}},
+			expected: `not((body["event_id"]["id"] == 4624 or body["event_id"]["id"] == 4625))`,
+		},
+		{
+			name:     "verbose only",
+			entry:    eventEntry{name: "system_0", eventLevels: []string{"VERBOSE"}},
+			expected: `not((severity_number == 0))`,
+		},
+		{
+			name:     "levels and ids",
+			entry:    eventEntry{name: "system_0", eventLevels: []string{"ERROR"}, eventIDs: []int{1001}},
+			expected: `not((severity_number == 17) and (body["event_id"]["id"] == 1001))`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.entry.filterCondition())
+		})
+	}
+}

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators.go
@@ -53,6 +53,7 @@ func parseEntries(conf *confmap.Conf) []eventEntry {
 
 	var entries []eventEntry
 	seen := map[string]int{}
+	channelReceiver := map[string]string{}
 	for _, item := range list {
 		m, ok := item.(map[string]any)
 		if !ok {
@@ -70,12 +71,9 @@ func parseEntries(conf *confmap.Conf) []eventEntry {
 			"aws.log.source":  common.WindowsEventsKey,
 			"aws.log.channel": channel,
 		}
-		if logGroup, ok := m[logGroupNameKey].(string); ok && logGroup != "" {
-			resource["aws.log.group.name"] = logGroup
-		}
-		if logStream, ok := m[logStreamNameKey].(string); ok && logStream != "" {
-			resource["aws.log.stream.name"] = logStream
-		}
+
+		logGroupName, _ := m[logGroupNameKey].(string)
+		logStreamName, _ := m[logStreamNameKey].(string)
 
 		var levels []string
 		if rawLevels, ok := m[eventLevelsKey].([]any); ok {
@@ -105,14 +103,23 @@ func parseEntries(conf *confmap.Conf) []eventEntry {
 		}
 		seen[sanitized]++
 
+		receiverName := name
+		if rn, ok := channelReceiver[channel]; ok {
+			receiverName = rn
+		} else {
+			channelReceiver[channel] = name
+		}
+
 		entries = append(entries, eventEntry{
-			name:         name,
-			receiverName: sanitized,
-			channel:      channel,
-			raw:          raw,
-			resource:     resource,
-			eventLevels:  levels,
-			eventIDs:     ids,
+			name:          name,
+			receiverName:  receiverName,
+			channel:       channel,
+			raw:           raw,
+			resource:      resource,
+			logGroupName:  logGroupName,
+			logStreamName: logStreamName,
+			eventLevels:   levels,
+			eventIDs:      ids,
 		})
 	}
 	return entries

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/pipeline"
 
+	"github.com/aws/amazon-cloudwatch-agent/internal/util/hash"
 	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
 	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
@@ -52,9 +53,7 @@ func parseEntries(conf *confmap.Conf) []eventEntry {
 	}
 
 	var entries []eventEntry
-	seen := map[string]int{}
-	channelReceiver := map[string]string{}
-	for _, item := range list {
+	for i, item := range list {
 		m, ok := item.(map[string]any)
 		if !ok {
 			continue
@@ -97,22 +96,9 @@ func parseEntries(conf *confmap.Conf) []eventEntry {
 		}
 
 		sanitized := sanitizeName(channel)
-		name := sanitized
-		if n := seen[sanitized]; n > 0 {
-			name = fmt.Sprintf("%s_%d", sanitized, n)
-		}
-		seen[sanitized]++
-
-		receiverName := name
-		if rn, ok := channelReceiver[channel]; ok {
-			receiverName = rn
-		} else {
-			channelReceiver[channel] = name
-		}
-
 		entries = append(entries, eventEntry{
-			name:          name,
-			receiverName:  receiverName,
+			name:          fmt.Sprintf("%s_%d", sanitized, i),
+			receiverName:  fmt.Sprintf("%s_%s", sanitized, receiverHash(channel, format)),
 			channel:       channel,
 			raw:           raw,
 			resource:      resource,
@@ -123,6 +109,10 @@ func parseEntries(conf *confmap.Conf) []eventEntry {
 		})
 	}
 	return entries
+}
+
+func receiverHash(channel, format string) string {
+	return hash.HashName(channel + "\x00" + format)
 }
 
 func sanitizeName(channel string) string {

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators.go
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package windowsevents
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pipeline"
+
+	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
+	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+const (
+	collectListKey   = "collect_list"
+	eventNameKey     = "event_name"
+	eventLevelsKey   = "event_levels"
+	eventIDsKey      = "event_ids"
+	eventFormatKey   = "event_format"
+	logGroupNameKey  = "log_group_name"
+	logStreamNameKey = "log_stream_name"
+)
+
+var configKey = common.WindowsEventsConfigKey
+
+func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
+	translators := common.NewTranslatorMap[*common.ComponentTranslators, pipeline.ID]()
+	if conf == nil || !conf.IsSet(configKey) {
+		return translators
+	}
+	if translatorcontext.CurrentContext().Os() != translatorconfig.OS_TYPE_WINDOWS {
+		log.Printf("W! windows_events is only supported on Windows, ignoring on %s", translatorcontext.CurrentContext().Os())
+		return translators
+	}
+	for _, entry := range parseEntries(conf) {
+		translators.Set(&windowsEventsPipelineTranslator{entry: entry})
+	}
+	return translators
+}
+
+func parseEntries(conf *confmap.Conf) []eventEntry {
+	key := common.ConfigKey(configKey, collectListKey)
+	val := conf.Get(key)
+	list, ok := val.([]any)
+	if !ok || len(list) == 0 {
+		return nil
+	}
+
+	var entries []eventEntry
+	seen := map[string]int{}
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		channel, _ := m[eventNameKey].(string)
+		if channel == "" {
+			continue
+		}
+
+		format, _ := m[eventFormatKey].(string)
+		raw := format == "xml"
+
+		resource := map[string]string{
+			"aws.log.source":  common.WindowsEventsKey,
+			"aws.log.channel": channel,
+		}
+		if logGroup, ok := m[logGroupNameKey].(string); ok && logGroup != "" {
+			resource["aws.log.group.name"] = logGroup
+		}
+		if logStream, ok := m[logStreamNameKey].(string); ok && logStream != "" {
+			resource["aws.log.stream.name"] = logStream
+		}
+
+		var levels []string
+		if rawLevels, ok := m[eventLevelsKey].([]any); ok {
+			for _, l := range rawLevels {
+				if s, ok := l.(string); ok {
+					levels = append(levels, s)
+				}
+			}
+		}
+
+		var ids []int
+		if rawIDs, ok := m[eventIDsKey].([]any); ok {
+			for _, id := range rawIDs {
+				switch v := id.(type) {
+				case float64:
+					ids = append(ids, int(v))
+				case int:
+					ids = append(ids, v)
+				}
+			}
+		}
+
+		sanitized := sanitizeName(channel)
+		name := sanitized
+		if n := seen[sanitized]; n > 0 {
+			name = fmt.Sprintf("%s_%d", sanitized, n)
+		}
+		seen[sanitized]++
+
+		entries = append(entries, eventEntry{
+			name:         name,
+			receiverName: sanitized,
+			channel:      channel,
+			raw:          raw,
+			resource:     resource,
+			eventLevels:  levels,
+			eventIDs:     ids,
+		})
+	}
+	return entries
+}
+
+func sanitizeName(channel string) string {
+	return strings.Map(func(r rune) rune {
+		if 'a' <= r && r <= 'z' || '0' <= r && r <= '9' || r == '-' {
+			return r
+		}
+		return '_'
+	}, strings.ToLower(channel))
+}

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators_test.go
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package windowsevents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+
+	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
+	translatorcontext "github.com/aws/amazon-cloudwatch-agent/translator/context"
+)
+
+func TestNewTranslators_Disabled(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{"collect": map[string]any{}},
+	})
+	translators := NewTranslators(conf)
+	assert.Equal(t, 0, translators.Len())
+}
+
+func TestNewTranslators_TwoEntries(t *testing.T) {
+	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_WINDOWS)
+	defer translatorcontext.CurrentContext().SetOs("")
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System"},
+						map[string]any{"event_name": "Application"},
+					},
+				},
+			},
+		},
+	})
+	translators := NewTranslators(conf)
+	assert.Equal(t, 2, translators.Len())
+}
+
+func TestNewTranslators_NonWindows(t *testing.T) {
+	translatorcontext.CurrentContext().SetOs(translatorconfig.OS_TYPE_LINUX)
+	defer translatorcontext.CurrentContext().SetOs("")
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System"},
+					},
+				},
+			},
+		},
+	})
+	translators := NewTranslators(conf)
+	assert.Equal(t, 0, translators.Len())
+}
+
+func TestParseEntries(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}, "event_format": "xml", "log_group_name": "/custom/system"},
+						map[string]any{"event_name": "Application", "event_ids": []any{float64(1001)}},
+						map[string]any{"event_name": "Microsoft-Windows-PowerShell/Operational", "event_levels": []any{"WARNING"}},
+					},
+				},
+			},
+		},
+	})
+	entries := parseEntries(conf)
+	require.Len(t, entries, 3)
+
+	assert.Equal(t, "system", entries[0].name)
+	assert.Equal(t, "System", entries[0].channel)
+	assert.True(t, entries[0].raw)
+	assert.Equal(t, "/custom/system", entries[0].logGroupName)
+	assert.Equal(t, []string{"ERROR"}, entries[0].eventLevels)
+
+	assert.Equal(t, "application", entries[1].name)
+	assert.Equal(t, "Application", entries[1].channel)
+	assert.False(t, entries[1].raw)
+	assert.Equal(t, []int{1001}, entries[1].eventIDs)
+
+	assert.Equal(t, "microsoft-windows-powershell_operational", entries[2].name)
+	assert.Equal(t, "Microsoft-Windows-PowerShell/Operational", entries[2].channel)
+	assert.Equal(t, []string{"WARNING"}, entries[2].eventLevels)
+}
+
+func TestParseEntries_DuplicateChannels(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}},
+						map[string]any{"event_name": "System", "event_levels": []any{"WARNING"}},
+						map[string]any{"event_name": "System", "event_ids": []any{float64(1001)}},
+					},
+				},
+			},
+		},
+	})
+	entries := parseEntries(conf)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "system", entries[0].name)
+	assert.Equal(t, "system_1", entries[1].name)
+	assert.Equal(t, "system_2", entries[2].name)
+
+	// All entries share the same receiver (same channel = same checkpoint)
+	assert.Equal(t, "system", entries[0].receiverName)
+	assert.Equal(t, "system", entries[1].receiverName)
+	assert.Equal(t, "system", entries[2].receiverName)
+}
+
+func TestParseEntries_DifferentChannelsSanitizeCollision(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "A/B", "event_levels": []any{"ERROR"}},
+						map[string]any{"event_name": "A_B", "event_levels": []any{"WARNING"}},
+					},
+				},
+			},
+		},
+	})
+	entries := parseEntries(conf)
+	require.Len(t, entries, 2)
+
+	// Different channels get different receiver names even if they collide after sanitization
+	assert.NotEqual(t, entries[0].receiverName, entries[1].receiverName)
+	assert.Equal(t, "a_b", entries[0].receiverName)
+	assert.Equal(t, "a_b_1", entries[1].receiverName)
+}

--- a/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/windowsevents/translators_test.go
@@ -76,20 +76,41 @@ func TestParseEntries(t *testing.T) {
 	entries := parseEntries(conf)
 	require.Len(t, entries, 3)
 
-	assert.Equal(t, "system", entries[0].name)
+	assert.Equal(t, "system_0", entries[0].name)
 	assert.Equal(t, "System", entries[0].channel)
 	assert.True(t, entries[0].raw)
 	assert.Equal(t, "/custom/system", entries[0].logGroupName)
 	assert.Equal(t, []string{"ERROR"}, entries[0].eventLevels)
 
-	assert.Equal(t, "application", entries[1].name)
+	assert.Equal(t, "application_1", entries[1].name)
 	assert.Equal(t, "Application", entries[1].channel)
 	assert.False(t, entries[1].raw)
 	assert.Equal(t, []int{1001}, entries[1].eventIDs)
 
-	assert.Equal(t, "microsoft-windows-powershell_operational", entries[2].name)
+	assert.Equal(t, "microsoft-windows-powershell_operational_2", entries[2].name)
 	assert.Equal(t, "Microsoft-Windows-PowerShell/Operational", entries[2].channel)
 	assert.Equal(t, []string{"WARNING"}, entries[2].eventLevels)
+}
+
+func TestParseEntries_ReceiverNames(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System", "event_levels": []any{"ERROR", "WARNING", "INFORMATION"}, "log_group_name": "/aws/cwagent/windows-events/System"},
+						map[string]any{"event_name": "Application", "event_levels": []any{"ERROR", "WARNING"}},
+					},
+				},
+			},
+		},
+	})
+	entries := parseEntries(conf)
+	require.Len(t, entries, 2)
+
+	// Receiver names are hash-based on (channel, format) and stable
+	assert.Equal(t, "system_653521908", entries[0].receiverName)
+	assert.Equal(t, "application_2122316671", entries[1].receiverName)
 }
 
 func TestParseEntries_DuplicateChannels(t *testing.T) {
@@ -108,14 +129,91 @@ func TestParseEntries_DuplicateChannels(t *testing.T) {
 	})
 	entries := parseEntries(conf)
 	require.Len(t, entries, 3)
-	assert.Equal(t, "system", entries[0].name)
+	assert.Equal(t, "system_0", entries[0].name)
 	assert.Equal(t, "system_1", entries[1].name)
 	assert.Equal(t, "system_2", entries[2].name)
 
-	// All entries share the same receiver (same channel = same checkpoint)
-	assert.Equal(t, "system", entries[0].receiverName)
-	assert.Equal(t, "system", entries[1].receiverName)
-	assert.Equal(t, "system", entries[2].receiverName)
+	// All entries share the same receiver (same channel + same format = same checkpoint)
+	assert.Equal(t, entries[0].receiverName, entries[1].receiverName)
+	assert.Equal(t, entries[1].receiverName, entries[2].receiverName)
+}
+
+func TestParseEntries_ReceiverNameStableAcrossReorder(t *testing.T) {
+	confAB := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}},
+						map[string]any{"event_name": "Application"},
+					},
+				},
+			},
+		},
+	})
+	confBA := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "Application"},
+						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}},
+					},
+				},
+			},
+		},
+	})
+
+	entriesAB := parseEntries(confAB)
+	entriesBA := parseEntries(confBA)
+	require.Len(t, entriesAB, 2)
+	require.Len(t, entriesBA, 2)
+
+	// Receiver name is order-independent (hash-based)
+	assert.Equal(t, entriesAB[0].receiverName, entriesBA[1].receiverName)
+	assert.Equal(t, entriesAB[1].receiverName, entriesBA[0].receiverName)
+}
+
+func TestParseEntries_DuplicateChannelsDifferentFormat(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System", "event_format": "xml"},
+						map[string]any{"event_name": "System", "event_levels": []any{"ERROR"}},
+					},
+				},
+			},
+		},
+	})
+	entries := parseEntries(conf)
+	require.Len(t, entries, 2)
+
+	// Different formats get separate receivers even for the same channel
+	assert.NotEqual(t, entries[0].receiverName, entries[1].receiverName)
+	assert.True(t, entries[0].raw)
+	assert.False(t, entries[1].raw)
+}
+
+func TestParseEntries_DuplicateChannelsSameFormatShareReceiver(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"opentelemetry": map[string]any{
+			"collect": map[string]any{
+				"windows_events": map[string]any{
+					"collect_list": []any{
+						map[string]any{"event_name": "System", "event_format": "xml"},
+						map[string]any{"event_name": "System", "event_format": "xml"},
+					},
+				},
+			},
+		},
+	})
+	entries := parseEntries(conf)
+	require.Len(t, entries, 2)
+
+	// Same format + same channel still share a receiver
+	assert.Equal(t, entries[0].receiverName, entries[1].receiverName)
 }
 
 func TestParseEntries_DifferentChannelsSanitizeCollision(t *testing.T) {
@@ -136,6 +234,4 @@ func TestParseEntries_DifferentChannelsSanitizeCollision(t *testing.T) {
 
 	// Different channels get different receiver names even if they collide after sanitization
 	assert.NotEqual(t, entries[0].receiverName, entries[1].receiverName)
-	assert.Equal(t, "a_b", entries[0].receiverName)
-	assert.Equal(t, "a_b_1", entries[1].receiverName)
 }

--- a/translator/translate/otel/processor/filterprocessor/translator.go
+++ b/translator/translate/otel/processor/filterprocessor/translator.go
@@ -7,7 +7,6 @@ import (
 	_ "embed"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"go.opentelemetry.io/collector/component"
@@ -32,6 +31,7 @@ type translator struct {
 	common.IndexProvider
 	factory            processor.Factory
 	logRecordCondition string
+	errorMode          string
 }
 
 var _ common.ComponentTranslator = (*translator)(nil)
@@ -49,8 +49,8 @@ func NewTranslator(opts ...common.TranslatorOption) common.ComponentTranslator {
 }
 
 // NewTranslatorWithLogCondition creates a filter translator that drops logs matching the given OTTL condition.
-func NewTranslatorWithLogCondition(name string, condition string) common.ComponentTranslator {
-	t := &translator{factory: filterprocessor.NewFactory(), logRecordCondition: condition}
+func NewTranslatorWithLogCondition(name, condition, errorMode string) common.ComponentTranslator {
+	t := &translator{factory: filterprocessor.NewFactory(), logRecordCondition: condition, errorMode: errorMode}
 	t.SetName(name)
 	return t
 }
@@ -62,11 +62,10 @@ func (t *translator) ID() component.ID {
 // Translate creates a processor config based on the fields in the
 // Metrics section of the JSON config.
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
-	// DBI: filter log records by OTTL condition
-	if strings.HasPrefix(t.Name(), common.DbiFilterExcludeMonitor) {
+	if t.logRecordCondition != "" {
 		cfg := &filterprocessor.Config{}
 		if err := confmap.NewFromStringMap(map[string]interface{}{
-			"error_mode": "propagate",
+			"error_mode": t.errorMode,
 			"logs": map[string]interface{}{
 				"log_record": []interface{}{t.logRecordCondition},
 			},

--- a/translator/translate/otel/processor/filterprocessor/translator_test.go
+++ b/translator/translate/otel/processor/filterprocessor/translator_test.go
@@ -161,7 +161,7 @@ func TestContainerInsights(t *testing.T) {
 
 func TestDbiExcludeMonitor(t *testing.T) {
 	condition := `attributes["user.name"] == "cw_monitor" or attributes["postgresql.rolname"] == "cw_monitor"`
-	tr := NewTranslatorWithLogCondition(common.DbiFilterExcludeMonitor+"_0", condition)
+	tr := NewTranslatorWithLogCondition(common.DbiFilterExcludeMonitor+"_0", condition, "propagate")
 	assert.Equal(t, "filter/dbi_exclude_monitor_0", tr.ID().String())
 
 	cfg, err := tr.Translate(nil)

--- a/translator/translate/otel/processor/resourceprocessor/translator.go
+++ b/translator/translate/otel/processor/resourceprocessor/translator.go
@@ -19,15 +19,22 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 )
 
+func WithAttributes(attrs map[string]string) common.TranslatorOption {
+	return func(target any) {
+		if t, ok := target.(*translator); ok {
+			t.attributes = attrs
+		}
+	}
+}
+
 type translator struct {
 	common.NameProvider
 	common.IndexProvider
-	factory processor.Factory
+	factory    processor.Factory
+	attributes map[string]string
 }
 
-var (
-	_ common.ComponentTranslator = (*translator)(nil)
-)
+var _ common.ComponentTranslator = (*translator)(nil)
 
 func NewTranslator(opts ...common.TranslatorOption) common.ComponentTranslator {
 	t := &translator{factory: resourceprocessor.NewFactory()}
@@ -41,15 +48,35 @@ func NewTranslator(opts ...common.TranslatorOption) common.ComponentTranslator {
 	return t
 }
 
-var _ common.ComponentTranslator = (*translator)(nil)
-
 func (t *translator) ID() component.ID {
 	return component.NewIDWithName(t.factory.Type(), t.Name())
 }
 
-// Translate creates a processor config based on the fields in the
-// Metrics section of the JSON config.
 func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
+	if len(t.attributes) > 0 {
+		return t.translateStaticAttributes()
+	}
+	return t.translateJMX(conf)
+}
+
+func (t *translator) translateStaticAttributes() (component.Config, error) {
+	cfg := t.factory.CreateDefaultConfig().(*resourceprocessor.Config)
+	attrs := make([]any, 0, len(t.attributes))
+	for k, v := range t.attributes {
+		attrs = append(attrs, map[string]any{
+			"action": "upsert",
+			"key":    k,
+			"value":  v,
+		})
+	}
+	c := confmap.NewFromStringMap(map[string]any{"attributes": attrs})
+	if err := c.Unmarshal(&cfg); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal resource processor: %w", err)
+	}
+	return cfg, nil
+}
+
+func (t *translator) translateJMX(conf *confmap.Conf) (component.Config, error) {
 	if conf == nil || (!conf.IsSet(common.JmxConfigKey) && t.Name() != common.PipelineNameContainerInsightsJmx) {
 		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: common.JmxConfigKey}
 	}

--- a/translator/translate/otel/processor/resourceprocessor/translator_test.go
+++ b/translator/translate/otel/processor/resourceprocessor/translator_test.go
@@ -191,6 +191,43 @@ func TestTranslator(t *testing.T) {
 	}
 }
 
+func TestTranslateStaticAttributes(t *testing.T) {
+	tt := NewTranslator(
+		common.WithName("test_single"),
+		WithAttributes(map[string]string{
+			"key1": "value1",
+		}),
+	)
+	assert.Equal(t, "resource/test_single", tt.ID().String())
+
+	got, err := tt.Translate(nil)
+	require.NoError(t, err)
+
+	gotCfg, ok := got.(*resourceprocessor.Config)
+	require.True(t, ok)
+	require.Len(t, gotCfg.AttributesActions, 1)
+	assert.Equal(t, "key1", gotCfg.AttributesActions[0].Key)
+	assert.Equal(t, "value1", gotCfg.AttributesActions[0].Value)
+	assert.Equal(t, "upsert", string(gotCfg.AttributesActions[0].Action))
+}
+
+func TestTranslateStaticAttributes_MultipleKeys(t *testing.T) {
+	tt := NewTranslator(
+		common.WithName("test_multi"),
+		WithAttributes(map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		}),
+	)
+
+	got, err := tt.Translate(nil)
+	require.NoError(t, err)
+
+	gotCfg, ok := got.(*resourceprocessor.Config)
+	require.True(t, ok)
+	assert.Len(t, gotCfg.AttributesActions, 2)
+}
+
 func TestContainerInsightsJmx(t *testing.T) {
 	transl := NewTranslator(common.WithName(common.PipelineNameContainerInsightsJmx)).(*translator)
 	expectedCfg := transl.factory.CreateDefaultConfig().(*resourceprocessor.Config)

--- a/translator/translate/otel/processor/transformprocessor/transform_logs_routing_host_windows.yaml
+++ b/translator/translate/otel/processor/transformprocessor/transform_logs_routing_host_windows.yaml
@@ -1,0 +1,19 @@
+error_mode: ignore
+log_statements:
+  - error_mode: ignore
+    context: resource
+    statements:
+      # Log group: /aws/cwagent/{source} or /aws/cwagent/default
+      - set(resource.attributes["aws.log.group.name"], Concat(["/aws/cwagent", resource.attributes["aws.log.source"]], "/")) where resource.attributes["aws.log.group.name"] == nil and resource.attributes["aws.log.source"] != nil
+      - set(resource.attributes["aws.log.group.name"], "/aws/cwagent/default") where resource.attributes["aws.log.group.name"] == nil
+      # Log stream: host.{id,name}/{channel} for windows events
+      - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["aws.log.channel"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["aws.log.channel"] != nil
+      - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["aws.log.channel"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["aws.log.channel"] != nil
+      # Log stream: host.{id,name}/service.namespace/service.name (first match wins)
+      - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+      - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.id"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+      - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+      - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["host.name"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+      - set(resource.attributes["aws.log.stream.name"], resource.attributes["host.id"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.id"] != nil
+      - set(resource.attributes["aws.log.stream.name"], resource.attributes["host.name"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["host.name"] != nil
+      - set(resource.attributes["aws.log.stream.name"], "default") where resource.attributes["aws.log.stream.name"] == nil

--- a/translator/translate/otel/processor/transformprocessor/translator.go
+++ b/translator/translate/otel/processor/transformprocessor/translator.go
@@ -6,6 +6,7 @@ package transformprocessor
 import (
 	_ "embed"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
@@ -118,7 +119,7 @@ func (t *translator) hasDynamicStatements() bool {
 		len(t.metricScopeStatements) > 0
 }
 
-func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
+func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig().(*transformprocessor.Config)
 
 	if t.hasDynamicStatements() {
@@ -175,6 +176,9 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	if t.name == common.LogsRouting {
 		if context.CurrentContext().KubernetesMode() != "" {
 			return common.GetYamlFileToYamlConfig(cfg, transformLogsRoutingK8sConfig)
+		}
+		if runtime.GOOS == "windows" && conf != nil && conf.IsSet(common.WindowsEventsConfigKey) {
+			return common.GetYamlFileToYamlConfig(cfg, transformLogsRoutingHostWindowsConfig)
 		}
 		return common.GetYamlFileToYamlConfig(cfg, transformLogsRoutingHostConfig)
 	}

--- a/translator/translate/otel/processor/transformprocessor/translator_test.go
+++ b/translator/translate/otel/processor/transformprocessor/translator_test.go
@@ -5,14 +5,17 @@ package transformprocessor
 
 import (
 	_ "embed"
+	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
+	"gopkg.in/yaml.v3"
 
 	"github.com/aws/amazon-cloudwatch-agent/internal/util/testutil"
 	translatorconfig "github.com/aws/amazon-cloudwatch-agent/translator/config"
@@ -199,4 +202,42 @@ func TestScopeStatementsAllSignals(t *testing.T) {
 	assert.Equal(t, "scope", string(actualCfg.LogStatements[0].Context))
 	require.Len(t, actualCfg.TraceStatements, 1)
 	assert.Equal(t, "scope", string(actualCfg.TraceStatements[0].Context))
+}
+
+func TestLogsRoutingWindowsSync(t *testing.T) {
+	type routingConfig struct {
+		LogStatements []struct {
+			Statements []string `yaml:"statements"`
+		} `yaml:"log_statements"`
+	}
+
+	baseBytes, err := os.ReadFile("transform_logs_routing_host.yaml")
+	require.NoError(t, err)
+	winBytes, err := os.ReadFile("transform_logs_routing_host_windows.yaml")
+	require.NoError(t, err)
+
+	var base, win routingConfig
+	require.NoError(t, yaml.Unmarshal(baseBytes, &base))
+	require.NoError(t, yaml.Unmarshal(winBytes, &win))
+
+	require.Len(t, base.LogStatements, 1)
+	require.Len(t, win.LogStatements, 1)
+
+	baseStmts := base.LogStatements[0].Statements
+	winStmts := win.LogStatements[0].Statements
+
+	// Partition Windows statements into channel-routing and shared
+	var channelStmts, sharedStmts []string
+	for _, stmt := range winStmts {
+		if strings.Contains(stmt, "aws.log.channel") {
+			channelStmts = append(channelStmts, stmt)
+		} else {
+			sharedStmts = append(sharedStmts, stmt)
+		}
+	}
+
+	assert.Equal(t, 2, len(channelStmts),
+		"Windows routing YAML must have exactly 2 channel-routing statements")
+	assert.Equal(t, baseStmts, sharedStmts,
+		"Windows routing YAML shared statements must match base")
 }

--- a/translator/translate/otel/processor/transformprocessor/translator_unix.go
+++ b/translator/translate/otel/processor/transformprocessor/translator_unix.go
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package transformprocessor
+
+var transformLogsRoutingHostWindowsConfig string

--- a/translator/translate/otel/processor/transformprocessor/translator_windows.go
+++ b/translator/translate/otel/processor/transformprocessor/translator_windows.go
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package transformprocessor
+
+import _ "embed"
+
+//go:embed transform_logs_routing_host_windows.yaml
+var transformLogsRoutingHostWindowsConfig string

--- a/translator/translate/otel/receiver/windowseventlog/translator.go
+++ b/translator/translate/otel/receiver/windowseventlog/translator.go
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package windowseventlog
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/filestorage"
+)
+
+type translator struct {
+	name     string
+	channel  string
+	raw      bool
+	resource map[string]string
+	factory  receiver.Factory
+}
+
+var _ common.ComponentTranslator = (*translator)(nil)
+
+func NewTranslator(name, channel string, raw bool, resource map[string]string) common.ComponentTranslator {
+	return &translator{
+		name:     name,
+		channel:  channel,
+		raw:      raw,
+		resource: resource,
+		factory:  windowseventlogreceiver.NewFactory(),
+	}
+}
+
+func (t *translator) ID() component.ID {
+	return component.NewIDWithName(t.factory.Type(), t.name)
+}
+
+func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
+	cfg := t.factory.CreateDefaultConfig().(*windowseventlogreceiver.WindowsLogConfig)
+	cfg.InputConfig.Channel = t.channel
+	cfg.InputConfig.Raw = t.raw
+	cfg.InputConfig.StartAt = "end"
+	storageID := filestorage.ComponentID()
+	cfg.StorageID = &storageID
+	if len(t.resource) > 0 {
+		cfg.InputConfig.Resource = make(map[string]helper.ExprStringConfig, len(t.resource))
+		for k, v := range t.resource {
+			cfg.InputConfig.Resource[k] = helper.ExprStringConfig(v)
+		}
+	}
+	return cfg, nil
+}

--- a/translator/translate/otel/receiver/windowseventlog/translator_test.go
+++ b/translator/translate/otel/receiver/windowseventlog/translator_test.go
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package windowseventlog
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/filestorage"
+)
+
+func TestTranslator_Translate(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		channel  string
+		raw      bool
+		resource map[string]string
+	}{
+		{
+			name:    "Structured",
+			id:      "system_0",
+			channel: "System",
+			raw:     false,
+			resource: map[string]string{
+				"aws.log.source":     "windows_events",
+				"aws.log.group.name": "/aws/windows/System",
+			},
+		},
+		{
+			name:    "Raw",
+			id:      "system_0",
+			channel: "System",
+			raw:     true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewTranslator(tc.id, tc.channel, tc.raw, tc.resource)
+			assert.Equal(t, "windowseventlog/"+tc.id, tr.ID().String())
+
+			cfg, err := tr.Translate(nil)
+			require.NoError(t, err)
+
+			got, ok := cfg.(*windowseventlogreceiver.WindowsLogConfig)
+			require.True(t, ok)
+			assert.Equal(t, tc.channel, got.InputConfig.Channel)
+			assert.Equal(t, "end", got.InputConfig.StartAt)
+			assert.Equal(t, tc.raw, got.InputConfig.Raw)
+			assert.NotNil(t, got.StorageID)
+			assert.Equal(t, filestorage.ComponentID(), *got.StorageID)
+			if len(tc.resource) > 0 {
+				for k, v := range tc.resource {
+					assert.Equal(t, helper.ExprStringConfig(v), got.InputConfig.Resource[k])
+				}
+			} else {
+				assert.Empty(t, got.InputConfig.Resource)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description of changes
- Adds `opentelemetry.collect.windows_events` with:
  - Per-channel OTel pipelines using the upstream `windowseventlogreceiver`
    - Channel names are sanitized for OTel component IDs (allowlist `[a-z0-9-]`)
    - Stable naming based on channel name (not array index) to prevent checkpoint orphaning on config reorder
  - OTTL-based severity level and event ID filtering
    - `event_ids` + `event_format: "xml"` is rejected at translation time (OTTL body filter can't work on raw XML)
    - Once the `windowseventlogreceiver` is bumped past v0.124 to include Query XML support for native channel-level filtering, can swap out the `filterprocessor` with a `query` (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.150.0/receiver/windowseventlogreceiver/README.md#xml-queries) similar to `logs/logs_collected/windows_events`.
  - Log group/stream routing via resource attributes (`aws.log.source`, `aws.log.channel`)
    - Default log group: `/aws/cwagent/windows_events`
    - Default log stream: `{host.id}/{channel}`
  - Platform-split default config (`default:otel` includes System + Application on Windows)
  - JSON schema validation for the new config section
  - Scope tagging (`cloudwatch.solution: "otel-windows-events"`)
  - Shared file_storage extension for checkpoint persistence
- Metrics pipeline is not activated by windows_events-only configs
- Generalizes `filterprocessor.NewTranslatorWithLogCondition` to accept an error mode parameter (was DBI-only, now shared with windows_events).

## Unsupported fields compared to `logs/logs_collected/windows_events`
- `filters` (regex-based include/exclude filtering)
- `log_group_class` (STANDARD/INFREQUENT_ACCESS)
- `retention_in_days`

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
- Unit tests: schema validation (valid + invalid), receiver translator, pipeline translator (parse entries, filter conditions, duplicate channels, channel sanitization), metrics pipeline guard, routing YAML sync test
- Sample file translation test (`windows_events_config.json` → `.yaml`, `default_otel_config.json` → `.yaml`)
- E2E verified on Windows:
  - OTel-only: logs delivered to CWL, state files created with stable names
  - V1-only: logs delivered to CWL via existing telegraf path
  - Combined (v1 + OTel in same config): both pipelines run in parallel, no conflicts
- E2E verified on Linux: agent starts without errors (windows_events ignored on non-Windows)

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



