### PR TITLE
Add orphaned test-VPC reaper and standardize dry-run across cleaners

### DIFF
--- a/.github/workflows/clean-aws-resources.yml
+++ b/.github/workflows/clean-aws-resources.yml
@@ -15,6 +15,7 @@ on:
         default: true
 
 env:
+  TERRAFORM_AWS_ASSUME_ROLE_DURATION: 14400 # 4 hours
   # Scheduled (cron) runs perform real deletions. Any manual (workflow_dispatch)
   # run defaults to a dry run unless dry_run=false is explicitly passed — so a
   # manual trigger, including an API dispatch that omits the input, never deletes
@@ -37,6 +38,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old ami
         working-directory: tool/clean
@@ -56,6 +58,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old file system
         working-directory: tool/clean
@@ -75,6 +78,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old dedicated host
         working-directory: tool/clean
@@ -109,6 +113,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.INTERNAL_AWS_ASSUME_ROLE }}
           aws-region: ${{ matrix.region }}
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old dedicated host
         working-directory: tool/clean
@@ -149,6 +154,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets[matrix.role_secret] }}
           aws-region: ${{ matrix.region }}
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old host
         working-directory: tool/clean
@@ -170,6 +176,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE_CN }}
           aws-region: "cn-north-1"
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old hosts
         working-directory: tool/clean
@@ -189,6 +196,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old ecs resources
         working-directory: tool/clean
@@ -208,6 +216,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old eks cluster
         working-directory: tool/clean
@@ -226,6 +235,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old unused ebs volumes
         working-directory: tool/clean
@@ -245,6 +255,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old asg
         working-directory: tool/clean
@@ -264,6 +275,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old launch configuration
         working-directory: tool/clean
@@ -282,6 +294,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old IAM roles
         working-directory: tool/clean
@@ -300,6 +313,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean old Log Groups
         working-directory: tool/clean
@@ -318,6 +332,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
+          role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Clean Old Security Groups
         working-directory: tool/clean

--- a/.github/workflows/clean-aws-resources.yml
+++ b/.github/workflows/clean-aws-resources.yml
@@ -18,8 +18,8 @@ env:
   # Scheduled (cron) runs perform real deletions. Any manual (workflow_dispatch)
   # run defaults to a dry run unless dry_run=false is explicitly passed — so a
   # manual trigger, including an API dispatch that omits the input, never deletes
-  # by accident. (github.event.inputs does not receive the input's UI default,
-  # hence the explicit event_name gate.)
+  # by accident. UI dispatches include the input's default; an API dispatch that
+  # omits dry_run yields an empty string, which the || falls back to 'true'.
   DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || (github.event.inputs.dry_run || 'true') }}
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
 
       - name: Clean old ami
         working-directory: tool/clean
-        run: go run --tags=clean ./clean_ami/clean_ami.go -dry-run=${DRY_RUN}
+        run: go run --tags=clean ./clean_ami/clean_ami.go -dry-run="${DRY_RUN}"
 
   clean-old-file-systems:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
 
       - name: Clean old file system
         working-directory: tool/clean
-        run: go run --tags=clean ./clean_file_system/clean_file_system.go -dry-run=${DRY_RUN}
+        run: go run --tags=clean ./clean_file_system/clean_file_system.go -dry-run="${DRY_RUN}"
 
   clean-opensource-dedicated-hosts:
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
 
       - name: Clean old dedicated host
         working-directory: tool/clean
-        run: go run --tags=clean ./clean_dedicated_host/clean_dedicated_host.go -dry-run=${DRY_RUN}
+        run: go run --tags=clean ./clean_dedicated_host/clean_dedicated_host.go -dry-run="${DRY_RUN}"
 
   clean-internal-dedicated-hosts:
     runs-on: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
 
       - name: Clean old dedicated host
         working-directory: tool/clean
-        run: go run --tags=clean ./clean_dedicated_host/clean_dedicated_host.go -dry-run=${DRY_RUN}
+        run: go run --tags=clean ./clean_dedicated_host/clean_dedicated_host.go -dry-run="${DRY_RUN}"
 
   clean-hosts:
     runs-on: ubuntu-latest
@@ -154,7 +154,7 @@ jobs:
         working-directory: tool/clean
         env:
           MATRIX_REGION: ${{ matrix.region }}
-        run: go run ./clean_host/clean_host.go -dry-run=${DRY_RUN} "$MATRIX_REGION"
+        run: go run ./clean_host/clean_host.go -dry-run="${DRY_RUN}" "$MATRIX_REGION"
 
   clean-hosts-china:
     runs-on: ubuntu-latest
@@ -173,7 +173,7 @@ jobs:
 
       - name: Clean old hosts
         working-directory: tool/clean
-        run: go run ./clean_host/clean_host.go -dry-run=${DRY_RUN} cn-north-1
+        run: go run ./clean_host/clean_host.go -dry-run="${DRY_RUN}" cn-north-1
 
   clean-ecs-resources:
     runs-on: ubuntu-latest
@@ -192,7 +192,7 @@ jobs:
 
       - name: Clean old ecs resources
         working-directory: tool/clean
-        run: go run --tags=clean ./clean_ecs/clean_ecs.go -dry-run=${DRY_RUN} us-west-2
+        run: go run --tags=clean ./clean_ecs/clean_ecs.go -dry-run="${DRY_RUN}" us-west-2
 
   clean-eks-clusters:
     runs-on: ubuntu-latest
@@ -211,7 +211,7 @@ jobs:
 
       - name: Clean old eks cluster
         working-directory: tool/clean
-        run: go run ./clean_eks/clean_eks.go -dry-run=${DRY_RUN}
+        run: go run ./clean_eks/clean_eks.go -dry-run="${DRY_RUN}"
   clean-ebs-volumes:
     runs-on: ubuntu-latest
     permissions:
@@ -229,7 +229,7 @@ jobs:
 
       - name: Clean old unused ebs volumes
         working-directory: tool/clean
-        run: go run ./clean_ebs/clean_ebs.go -dry-run=${DRY_RUN}
+        run: go run ./clean_ebs/clean_ebs.go -dry-run="${DRY_RUN}"
 
   clean-asg:
     runs-on: ubuntu-latest
@@ -248,7 +248,7 @@ jobs:
 
       - name: Clean old asg
         working-directory: tool/clean
-        run: go run ./clean_auto_scaling_groups/clean_auto_scaling_groups.go -dry-run=${DRY_RUN}
+        run: go run ./clean_auto_scaling_groups/clean_auto_scaling_groups.go -dry-run="${DRY_RUN}"
 
   clean-launch-configs:
     runs-on: ubuntu-latest
@@ -267,7 +267,7 @@ jobs:
 
       - name: Clean old launch configuration
         working-directory: tool/clean
-        run: go run ./clean_launch_configuration/clean_launch_configuration.go -dry-run=${DRY_RUN}
+        run: go run ./clean_launch_configuration/clean_launch_configuration.go -dry-run="${DRY_RUN}"
   clean-iam-roles:
     runs-on: ubuntu-latest
     permissions:
@@ -285,7 +285,7 @@ jobs:
 
       - name: Clean old IAM roles
         working-directory: tool/clean
-        run: go run ./clean_iam_roles/clean_iam_roles.go -dry-run=${DRY_RUN}
+        run: go run ./clean_iam_roles/clean_iam_roles.go -dry-run="${DRY_RUN}"
   clean-log-groups:
     runs-on: ubuntu-latest
     permissions:
@@ -303,7 +303,7 @@ jobs:
 
       - name: Clean old Log Groups
         working-directory: tool/clean
-        run: go run ./clean_log_group/clean_log_group.go -dry-run=${DRY_RUN}
+        run: go run ./clean_log_group/clean_log_group.go -dry-run="${DRY_RUN}"
   clean-security-groups:
     runs-on: ubuntu-latest
     permissions:
@@ -323,5 +323,5 @@ jobs:
         working-directory: tool/clean
         run: |
           set -e
-          go run ./clean_security_group/clean_security_group.go -dry-run=${DRY_RUN} || { echo "Failed to clean security groups"; exit 1; }
+          go run ./clean_security_group/clean_security_group.go -dry-run="${DRY_RUN}" || { echo "Failed to clean security groups"; exit 1; }
 

--- a/.github/workflows/clean-aws-resources.yml
+++ b/.github/workflows/clean-aws-resources.yml
@@ -7,6 +7,20 @@ on:
   schedule:
     - cron: "0 0 * * *" # Run Every Day At Midnight
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: log the resources that would be deleted without deleting them"
+        type: boolean
+        required: false
+        default: true
+
+env:
+  # Scheduled (cron) runs perform real deletions. Any manual (workflow_dispatch)
+  # run defaults to a dry run unless dry_run=false is explicitly passed — so a
+  # manual trigger, including an API dispatch that omits the input, never deletes
+  # by accident. (github.event.inputs does not receive the input's UI default,
+  # hence the explicit event_name gate.)
+  DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || (github.event.inputs.dry_run || 'true') }}
 
 jobs:
   clean-opensource-ami:
@@ -26,7 +40,7 @@ jobs:
 
       - name: Clean old ami
         working-directory: tool/clean
-        run: go run ./clean_ami/clean_ami.go --tags=clean
+        run: go run --tags=clean ./clean_ami/clean_ami.go -dry-run=${DRY_RUN}
 
   clean-old-file-systems:
     runs-on: ubuntu-latest
@@ -45,7 +59,7 @@ jobs:
 
       - name: Clean old file system
         working-directory: tool/clean
-        run: go run ./clean_file_system/clean_file_system.go --tags=clean
+        run: go run --tags=clean ./clean_file_system/clean_file_system.go -dry-run=${DRY_RUN}
 
   clean-opensource-dedicated-hosts:
     runs-on: ubuntu-latest
@@ -64,7 +78,7 @@ jobs:
 
       - name: Clean old dedicated host
         working-directory: tool/clean
-        run: go run ./clean_dedicated_host/clean_dedicated_host.go --tags=clean
+        run: go run --tags=clean ./clean_dedicated_host/clean_dedicated_host.go -dry-run=${DRY_RUN}
 
   clean-internal-dedicated-hosts:
     runs-on: ubuntu-latest
@@ -98,7 +112,7 @@ jobs:
 
       - name: Clean old dedicated host
         working-directory: tool/clean
-        run: go run ./clean_dedicated_host/clean_dedicated_host.go --tags=clean
+        run: go run --tags=clean ./clean_dedicated_host/clean_dedicated_host.go -dry-run=${DRY_RUN}
 
   clean-hosts:
     runs-on: ubuntu-latest
@@ -140,7 +154,7 @@ jobs:
         working-directory: tool/clean
         env:
           MATRIX_REGION: ${{ matrix.region }}
-        run: go run ./clean_host/clean_host.go "$MATRIX_REGION"
+        run: go run ./clean_host/clean_host.go -dry-run=${DRY_RUN} "$MATRIX_REGION"
 
   clean-hosts-china:
     runs-on: ubuntu-latest
@@ -159,7 +173,7 @@ jobs:
 
       - name: Clean old hosts
         working-directory: tool/clean
-        run: go run ./clean_host/clean_host.go cn-north-1
+        run: go run ./clean_host/clean_host.go -dry-run=${DRY_RUN} cn-north-1
 
   clean-ecs-resources:
     runs-on: ubuntu-latest
@@ -178,7 +192,7 @@ jobs:
 
       - name: Clean old ecs resources
         working-directory: tool/clean
-        run: go run --tags=clean ./clean_ecs/clean_ecs.go us-west-2
+        run: go run --tags=clean ./clean_ecs/clean_ecs.go -dry-run=${DRY_RUN} us-west-2
 
   clean-eks-clusters:
     runs-on: ubuntu-latest
@@ -197,7 +211,7 @@ jobs:
 
       - name: Clean old eks cluster
         working-directory: tool/clean
-        run: go run ./clean_eks/clean_eks.go --tags=clean
+        run: go run ./clean_eks/clean_eks.go -dry-run=${DRY_RUN}
   clean-ebs-volumes:
     runs-on: ubuntu-latest
     permissions:
@@ -215,7 +229,7 @@ jobs:
 
       - name: Clean old unused ebs volumes
         working-directory: tool/clean
-        run: go run ./clean_ebs/clean_ebs.go --tags=clean
+        run: go run ./clean_ebs/clean_ebs.go -dry-run=${DRY_RUN}
 
   clean-asg:
     runs-on: ubuntu-latest
@@ -234,7 +248,7 @@ jobs:
 
       - name: Clean old asg
         working-directory: tool/clean
-        run: go run ./clean_auto_scaling_groups/clean_auto_scaling_groups.go --tags=clean
+        run: go run ./clean_auto_scaling_groups/clean_auto_scaling_groups.go -dry-run=${DRY_RUN}
 
   clean-launch-configs:
     runs-on: ubuntu-latest
@@ -253,7 +267,7 @@ jobs:
 
       - name: Clean old launch configuration
         working-directory: tool/clean
-        run: go run ./clean_launch_configuration/clean_launch_configuration.go --tags=clean
+        run: go run ./clean_launch_configuration/clean_launch_configuration.go -dry-run=${DRY_RUN}
   clean-iam-roles:
     runs-on: ubuntu-latest
     permissions:
@@ -271,7 +285,7 @@ jobs:
 
       - name: Clean old IAM roles
         working-directory: tool/clean
-        run: go run ./clean_iam_roles/clean_iam_roles.go --tags=clean
+        run: go run ./clean_iam_roles/clean_iam_roles.go -dry-run=${DRY_RUN}
   clean-log-groups:
     runs-on: ubuntu-latest
     permissions:
@@ -289,7 +303,7 @@ jobs:
 
       - name: Clean old Log Groups
         working-directory: tool/clean
-        run: go run ./clean_log_group/clean_log_group.go 
+        run: go run ./clean_log_group/clean_log_group.go -dry-run=${DRY_RUN}
   clean-security-groups:
     runs-on: ubuntu-latest
     permissions:
@@ -309,5 +323,5 @@ jobs:
         working-directory: tool/clean
         run: |
           set -e
-          go run ./clean_security_group/clean_security_group.go || { echo "Failed to clean security groups"; exit 1; }
+          go run ./clean_security_group/clean_security_group.go -dry-run=${DRY_RUN} || { echo "Failed to clean security groups"; exit 1; }
 

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"sort"
@@ -56,6 +57,8 @@ var imagePrefixes = []string{
 }
 
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
 	err := cleanAMIs()
 	if err != nil {
 		log.Fatalf("errors cleaning %v", err)
@@ -88,6 +91,9 @@ func deregisterAMIs(ctx context.Context, ec2client *ec2.Client, images []types.I
 	for _, image := range images {
 		if image.Name != nil && image.ImageId != nil && image.CreationDate != nil {
 			log.Printf("Try to delete ami %v tags %v image id %v image creation date raw %v", *image.Name, image.Tags, *image.ImageId, *image.CreationDate)
+			if clean.Skip("deregister ami %v (%v)", *image.Name, *image.ImageId) {
+				continue
+			}
 			deregisterImageInput := &ec2.DeregisterImageInput{ImageId: image.ImageId}
 			_, err := ec2client.DeregisterImage(ctx, deregisterImageInput)
 

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"sort"
@@ -59,6 +60,8 @@ var imagePrefixes = []string{
 }
 
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
 	err := cleanAMIs()
 	if err != nil {
 		log.Fatalf("errors cleaning %v", err)
@@ -91,6 +94,9 @@ func deregisterAMIs(ctx context.Context, ec2client *ec2.Client, images []types.I
 	for _, image := range images {
 		if image.Name != nil && image.ImageId != nil && image.CreationDate != nil {
 			log.Printf("Try to delete ami %v tags %v image id %v image creation date raw %v", *image.Name, image.Tags, *image.ImageId, *image.CreationDate)
+			if clean.Skip("deregister ami %v (%v)", *image.Name, *image.ImageId) {
+				continue
+			}
 			deregisterImageInput := &ec2.DeregisterImageInput{ImageId: image.ImageId}
 			_, err := ec2client.DeregisterImage(ctx, deregisterImageInput)
 

--- a/tool/clean/clean_auto_scaling_groups/clean_auto_scaling_groups.go
+++ b/tool/clean/clean_auto_scaling_groups/clean_auto_scaling_groups.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 
 // Clean eks clusters if they have been open longer than 7 day
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
 	err := cleanAutoScalingGroups()
 	if err != nil {
 		log.Fatalf("errors cleaning %v", err)
@@ -60,6 +63,9 @@ func terminateAutoScaling(ctx context.Context, client *autoscaling.Client, filte
 	for _, group := range describeAutoScalingGroupsOutput.AutoScalingGroups {
 		if expirationDateCluster.After(*group.CreatedTime) {
 			log.Printf("try to delete auto scaling group %s", *group.AutoScalingGroupName)
+			if clean.Skip("delete auto scaling group %s", *group.AutoScalingGroupName) {
+				continue
+			}
 			deleteAutoScalingGroupInput := autoscaling.DeleteAutoScalingGroupInput{
 				AutoScalingGroupName: group.AutoScalingGroupName,
 				ForceDelete:          aws.Bool(true),

--- a/tool/clean/clean_dedicated_host/clean_dedicated_host.go
+++ b/tool/clean/clean_dedicated_host/clean_dedicated_host.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"time"
 
@@ -24,6 +25,8 @@ const tagName = "tag:Name"
 const tagValue = "IntegrationTestMacDedicatedHost"
 
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
 	err := cleanDedicatedHost()
 	if err != nil {
 		log.Fatalf("errors cleaning %v", err)
@@ -62,6 +65,9 @@ func cleanDedicatedHost() error {
 	}
 
 	log.Printf("Dedicated hosts to release %v", dedicatedHostIds)
+	if clean.Skip("release dedicated hosts %v", dedicatedHostIds) {
+		return nil
+	}
 	releaseDedicatedHost := ec2.ReleaseHostsInput{HostIds: dedicatedHostIds}
 	_, err = ec2client.ReleaseHosts(cxt, &releaseDedicatedHost)
 	return err

--- a/tool/clean/clean_ebs/clean_ebs.go
+++ b/tool/clean/clean_ebs/clean_ebs.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 
 // Clean ebs volumes if they have been open longer than 7 day and unused
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
 	err := cleanVolumes()
 	if err != nil {
 		log.Fatalf("errors cleaning %v", err)
@@ -39,6 +42,10 @@ func cleanVolumes() error {
 
 func deleteUnusedVolumes(ctx context.Context, client *ec2.Client) error {
 
+	// KeepDurationOneWeek is negative, so expirationDate is "now minus one week".
+	// A volume created before that is older than the retention window.
+	expirationDate := time.Now().UTC().Add(clean.KeepDurationOneWeek)
+
 	input := &ec2.DescribeVolumesInput{
 		Filters: []types.Filter{
 			{
@@ -54,14 +61,17 @@ func deleteUnusedVolumes(ctx context.Context, client *ec2.Client) error {
 		return err
 	}
 	for _, volume := range volumes.Volumes {
-		if time.Since(*volume.CreateTime) > clean.KeepDurationOneWeek && len(volume.Attachments) == 0 {
+		if expirationDate.After(*volume.CreateTime) && len(volume.Attachments) == 0 {
+			if clean.Skip("delete unused volume %s", *volume.VolumeId) {
+				continue
+			}
 			log.Printf("Deleting unused volume %s", *volume.VolumeId)
 			_, err = client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{
 				VolumeId: volume.VolumeId,
 			})
-		}
-		if err != nil {
-			log.Printf("Error deleting volume %s: %v", *volume.VolumeId, err)
+			if err != nil {
+				log.Printf("Error deleting volume %s: %v", *volume.VolumeId, err)
+			}
 		}
 	}
 	return nil

--- a/tool/clean/clean_ecs/clean_ecs.go
+++ b/tool/clean/clean_ecs/clean_ecs.go
@@ -8,8 +8,8 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
-	"os"
 	"strings"
 	"time"
 
@@ -23,15 +23,23 @@ import (
 
 // Clean ECS clusters if they have been running longer than 7 days
 
-var expirationTimeOneWeek = time.Now().UTC().Add(-clean.KeepDurationOneWeek)
+// KeepDurationOneWeek is negative, so this is "now minus one week"; a task that
+// started after this cutoff is younger than a week and keeps its cluster alive.
+var expirationTimeOneWeek = time.Now().UTC().Add(clean.KeepDurationOneWeek)
 
 const clusterPrefix = "cwagent-integ-test-cluster-"
 
 var taskdefPrefixes = []string{"cwagent-integ-test-", "extra-apps-family-", "cwagent-task-family-"}
 
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
+	region := flag.Arg(0)
+	if region == "" {
+		log.Fatal("Region argument is required, e.g. clean_ecs.go <region>")
+	}
 	ctx := context.Background()
-	defaultConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(os.Args[1]))
+	defaultConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		log.Fatalf("Error loading AWS config for ECS cleanup: %v", err)
 	}
@@ -98,6 +106,9 @@ func terminateClusters(ctx context.Context, client *ecs.Client) {
 	// Deletion Logic
 	for _, clusterId := range clusterIds {
 		log.Printf("Cluster to terminate: %s", *clusterId)
+		if clean.Skip("delete ECS cluster %s (scale down and delete its services, deregister container instances)", *clusterId) {
+			continue
+		}
 
 		// Delete cluster services
 		serviceInput := ecs.ListServicesInput{Cluster: clusterId}
@@ -189,6 +200,10 @@ func deleteInactiveTaskDefinitions(ctx context.Context, client *ecs.Client) {
 	}
 
 	log.Printf("Found %d inactive task definitions to delete", len(taskDefsToDelete))
+
+	if clean.Skip("delete %d inactive task definitions", len(taskDefsToDelete)) {
+		return
+	}
 
 	// Batch delete task definitions (API supports up to 10 at a time)
 	const batchSize = 10

--- a/tool/clean/clean_eks/clean_eks.go
+++ b/tool/clean/clean_eks/clean_eks.go
@@ -5,12 +5,16 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 
 	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
@@ -19,7 +23,14 @@ import (
 // make this configurable or construct based on some configs?
 const betaEksEndpoint = "https://api.beta.us-west-2.wesley.amazonaws.com"
 
+// reapingTagKey marks a VPC the reaper has begun tearing down. It lets a later
+// run resume teardown of a VPC whose NAT gateways/endpoints (the age signals)
+// were already deleted, instead of skipping it as "age cannot be determined".
+const reapingTagKey = "cleaner:reaping"
+
 var (
+	// ClustersToClean is the allowlist of EKS cluster name prefixes the cleaner
+	// is permitted to delete.
 	ClustersToClean = []string{
 		"cwagent-eks-integ-",
 		"cwagent-operator-helm-integ-",
@@ -28,19 +39,42 @@ var (
 		"cwagent-monitoring-config-e2e-eks-",
 		"cwagent-addon-eks-integ-",
 	}
+
+	// testVpcNamePrefixes are the tag:Name prefixes of the dedicated VPCs that
+	// some tests stand up (private subnets + NAT gateway + interface/gateway VPC
+	// endpoints). A partially-failed `terraform destroy` strands the whole stack
+	// — leaking the VPC, NAT gateway, Elastic IP and the quota-limited S3 gateway
+	// endpoint — so the reaper below reclaims the entire orphaned stack.
+	testVpcNamePrefixes = []string{
+		"efa-test-vpc-",
+	}
+
+	// Poll budgets for resources that delete asynchronously and whose ENIs must
+	// clear before dependents (subnets, security groups, VPC) can be removed.
+	endpointDeleteTimeout = 3 * time.Minute
+	natDeleteTimeout      = 6 * time.Minute
+	pollInterval          = 15 * time.Second
 )
 
-// Clean eks clusters if they have been open longer than 7 day
+// Clean eks clusters if they have been open longer than the keep-duration, then
+// reap any orphaned test VPCs left behind by failed terraform destroys.
 func main() {
-	err := cleanCluster()
-	if err != nil {
+	clean.RegisterCommonFlags()
+	flag.Parse()
+
+	ctx := context.Background()
+	if err := cleanCluster(ctx); err != nil {
 		log.Fatalf("errors cleaning %v", err)
+	}
+	// Orphaned-VPC reaping is best-effort: a failure here must not mask a
+	// successful cluster clean, and the next daily run will retry.
+	if err := cleanOrphanedVpcResources(ctx); err != nil {
+		log.Printf("errors cleaning orphaned vpc resources %v", err)
 	}
 }
 
-func cleanCluster() error {
+func cleanCluster(ctx context.Context) error {
 	log.Print("Begin to clean EKS Clusters")
-	ctx := context.Background()
 	defaultConfig, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return err
@@ -80,52 +114,717 @@ func clusterNameMatchesClustersToClean(clusterName string, clustersToClean []str
 }
 
 func terminateClusters(ctx context.Context, client *eks.Client) {
-	listClusterInput := eks.ListClustersInput{}
 	expirationDateCluster := time.Now().UTC().Add(clean.KeepDurationOneDay)
 
-	clusters, err := client.ListClusters(ctx, &listClusterInput)
-	if err != nil {
-		log.Fatalf("could not get cluster list")
-	}
-	for _, cluster := range clusters.Clusters {
-		describeClusterInput := eks.DescribeClusterInput{Name: aws.String(cluster)}
-		describeClusterOutput, err := client.DescribeCluster(ctx, &describeClusterInput)
+	var nextToken *string
+	for {
+		clusters, err := client.ListClusters(ctx, &eks.ListClustersInput{NextToken: nextToken})
 		if err != nil {
+			// Non-fatal: a beta-endpoint outage should not abort the whole run.
+			log.Printf("could not get cluster list: %v", err)
 			return
 		}
-		if !expirationDateCluster.After(*describeClusterOutput.Cluster.CreatedAt) {
-			log.Printf("Ignoring cluster %s with a launch-date %s since it was created in the last %s", cluster, *describeClusterOutput.Cluster.CreatedAt, clean.KeepDurationOneDay)
-			continue
-		}
-		if !clusterNameMatchesClustersToClean(*describeClusterOutput.Cluster.Name, ClustersToClean) {
-			log.Printf("Ignoring cluster %s since it doesnt match any of the clean regexes", cluster)
-			continue
-		}
-		log.Printf("Try to delete cluster %s launch-date %s", cluster, *describeClusterOutput.Cluster.CreatedAt)
-		describeNodegroupInput := eks.ListNodegroupsInput{ClusterName: aws.String(cluster)}
-		nodeGroupOutput, err := client.ListNodegroups(ctx, &describeNodegroupInput)
-		if err != nil {
-			log.Printf("could not query node groups cluster %s err %v", cluster, err)
-		}
-		// it takes about 5 minutes to delete node groups
-		// it will fail to delete cluster if we need to delete node groups
-		// this will delete the cluster on next run the next day
-		// I do not want to wait for node groups to be deleted
-		// as it will increase the runtime of this cleaner
-		for _, nodegroup := range nodeGroupOutput.Nodegroups {
-			deleteNodegroupInput := eks.DeleteNodegroupInput{
-				ClusterName:   aws.String(cluster),
-				NodegroupName: aws.String(nodegroup),
-			}
-			_, err := client.DeleteNodegroup(ctx, &deleteNodegroupInput)
+		for _, cluster := range clusters.Clusters {
+			describeClusterOutput, err := client.DescribeCluster(ctx, &eks.DescribeClusterInput{Name: aws.String(cluster)})
 			if err != nil {
-				log.Printf("could not delete node groups %s cluster %s err %v", nodegroup, cluster, err)
+				log.Printf("could not describe cluster %s err %v", cluster, err)
+				continue
+			}
+			if describeClusterOutput.Cluster == nil || describeClusterOutput.Cluster.CreatedAt == nil {
+				log.Printf("Ignoring cluster %s: missing cluster metadata", cluster)
+				continue
+			}
+			if !expirationDateCluster.After(*describeClusterOutput.Cluster.CreatedAt) {
+				log.Printf("Ignoring cluster %s with a launch-date %s since it was created in the last %s", cluster, *describeClusterOutput.Cluster.CreatedAt, clean.KeepDurationOneDay)
+				continue
+			}
+			if !clusterNameMatchesClustersToClean(*describeClusterOutput.Cluster.Name, ClustersToClean) {
+				log.Printf("Ignoring cluster %s since it doesnt match any of the clean regexes", cluster)
+				continue
+			}
+			if clean.Skip("delete cluster %s launch-date %s", cluster, *describeClusterOutput.Cluster.CreatedAt) {
+				continue
+			}
+			log.Printf("Try to delete cluster %s launch-date %s", cluster, *describeClusterOutput.Cluster.CreatedAt)
+			nodeGroupOutput, err := client.ListNodegroups(ctx, &eks.ListNodegroupsInput{ClusterName: aws.String(cluster)})
+			if err != nil {
+				log.Printf("could not query node groups cluster %s err %v", cluster, err)
+			} else {
+				// it takes about 5 minutes to delete node groups
+				// it will fail to delete cluster if we need to delete node groups
+				// this will delete the cluster on next run the next day
+				// I do not want to wait for node groups to be deleted
+				// as it will increase the runtime of this cleaner
+				for _, nodegroup := range nodeGroupOutput.Nodegroups {
+					deleteNodegroupInput := eks.DeleteNodegroupInput{
+						ClusterName:   aws.String(cluster),
+						NodegroupName: aws.String(nodegroup),
+					}
+					if _, err := client.DeleteNodegroup(ctx, &deleteNodegroupInput); err != nil {
+						log.Printf("could not delete node groups %s cluster %s err %v", nodegroup, cluster, err)
+					}
+				}
+			}
+			deleteClusterInput := eks.DeleteClusterInput{Name: aws.String(cluster)}
+			if _, err := client.DeleteCluster(ctx, &deleteClusterInput); err != nil {
+				log.Printf("could not delete cluster %s err %v", cluster, err)
 			}
 		}
-		deleteClusterInput := eks.DeleteClusterInput{Name: aws.String(cluster)}
-		_, err = client.DeleteCluster(ctx, &deleteClusterInput)
-		if err != nil {
-			log.Printf("could not delete cluster %s err %v", cluster, err)
+		if clusters.NextToken == nil {
+			return
+		}
+		nextToken = clusters.NextToken
+	}
+}
+
+// cleanOrphanedVpcResources finds the dedicated test VPCs named by
+// testVpcNamePrefixes that are no longer backing any live EKS cluster and tears
+// the entire VPC stack down: VPC endpoints, NAT gateways, Elastic IPs, internet
+// gateways, subnets, route tables, security groups and finally the VPC itself.
+func cleanOrphanedVpcResources(ctx context.Context) error {
+	log.Print("Begin to clean orphaned test VPCs")
+	defaultConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	ec2Client := ec2.NewFromConfig(defaultConfig)
+	eksClient := eks.NewFromConfig(defaultConfig)
+
+	betaConfig, err := config.LoadDefaultConfig(ctx, config.WithEndpointResolverWithOptions(eksBetaEndpointResolver()))
+	if err != nil {
+		return err
+	}
+	betaEksClient := eks.NewFromConfig(betaConfig)
+
+	// A VPC that still backs a live EKS cluster must be left alone. Build the
+	// in-use set from BOTH the prod and beta EKS endpoints (mirroring
+	// terminateClusters). If we cannot build a complete in-use set (e.g. a
+	// DescribeCluster call fails), we abort the VPC pass rather than risk
+	// deleting a VPC that a cluster we failed to inspect still depends on.
+	// Fail closed: the next daily run retries.
+	inUse, err := vpcsInUseByClusters(ctx, eksClient)
+	if err != nil {
+		return fmt.Errorf("determining in-use VPCs (prod): %w", err)
+	}
+	// Beta enumeration is best-effort: the beta endpoint is internal and may be
+	// unreachable from the runner. A failure here must not disable the whole
+	// (prod) VPC pass. EFA test VPCs back prod clusters, so the residual risk of
+	// skipping beta is negligible; prod enumeration above stays fail-closed.
+	if betaInUse, err := vpcsInUseByClusters(ctx, betaEksClient); err != nil {
+		log.Printf("could not determine beta in-use VPCs (continuing with prod only): %v", err)
+	} else {
+		for vpcID := range betaInUse {
+			inUse[vpcID] = true
 		}
 	}
+
+	nameFilters := make([]string, 0, len(testVpcNamePrefixes))
+	for _, p := range testVpcNamePrefixes {
+		nameFilters = append(nameFilters, p+"*")
+	}
+	var vpcs []ec2types.Vpc
+	var vpcNextToken *string
+	for {
+		vpcsOut, err := ec2Client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+			Filters:   []ec2types.Filter{{Name: aws.String("tag:Name"), Values: nameFilters}},
+			NextToken: vpcNextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("describing test VPCs: %w", err)
+		}
+		vpcs = append(vpcs, vpcsOut.Vpcs...)
+		if vpcsOut.NextToken == nil {
+			break
+		}
+		vpcNextToken = vpcsOut.NextToken
+	}
+
+	for _, vpc := range vpcs {
+		vpcID := aws.ToString(vpc.VpcId)
+		name := vpcNameTag(vpc)
+
+		// Gate 1: never touch a VPC backing a live cluster.
+		if inUse[vpcID] {
+			log.Printf("Ignoring VPC %s (%s): still backs a live EKS cluster", vpcID, name)
+			continue
+		}
+		// Gate 2: never touch a VPC that still has instances in any
+		// non-terminated state (running/pending/stopping/stopped/shutting-down).
+		active, err := vpcHasActiveInstances(ctx, ec2Client, vpcID)
+		if err != nil {
+			log.Printf("could not check instances for VPC %s: %v", vpcID, err)
+			continue
+		}
+		if active {
+			log.Printf("Ignoring VPC %s (%s): has active (non-terminated) instances", vpcID, name)
+			continue
+		}
+		// Gate 3: only reap a VPC we can prove is old enough. VPCs carry no
+		// creation timestamp, so age is derived from the newest NAT gateway or
+		// VPC endpoint in the VPC. If neither exists we cannot determine age and
+		// fail safe (skip) — this prevents deleting a stack mid-terraform-apply
+		// whose NAT gateway/endpoints have not been created yet.
+		//
+		// Exception: if the VPC already carries a reaping marker WITH a valid
+		// timestamp (written by this reaper at teardown start), a prior run
+		// approved it and began teardown — which deletes the NAT/endpoint age
+		// signals — so we resume rather than strand a partially-torn-down VPC.
+		// A malformed value is ignored so an unrelated/hand-set tag cannot
+		// silently disable the age gate.
+		reaping := false
+		if ts := vpcTag(vpc, reapingTagKey); ts != "" {
+			if _, perr := time.Parse(time.RFC3339, ts); perr == nil {
+				reaping = true
+			} else {
+				log.Printf("VPC %s has malformed %s tag %q; ignoring it", vpcID, reapingTagKey, ts)
+			}
+		}
+		if !reaping {
+			eligible, err := vpcReapEligibleByAge(ctx, ec2Client, vpcID)
+			if err != nil {
+				log.Printf("could not determine age for VPC %s: %v", vpcID, err)
+				continue
+			}
+			if !eligible {
+				log.Printf("Ignoring VPC %s (%s): too new or age cannot be determined", vpcID, name)
+				continue
+			}
+		}
+
+		if err := deleteVpcAndDependencies(ctx, ec2Client, vpcID, name); err != nil {
+			log.Printf("could not fully tear down VPC %s (%s): %v", vpcID, name, err)
+		}
+	}
+	return nil
+}
+
+// deleteVpcAndDependencies removes an orphaned VPC's resources in dependency
+// order. Each step is best-effort: a failure is logged and the teardown
+// proceeds, so the next daily run can retry whatever remains.
+func deleteVpcAndDependencies(ctx context.Context, ec2Client *ec2.Client, vpcID, name string) error {
+	if clean.DryRun {
+		return dryRunDescribeVpc(ctx, ec2Client, vpcID, name)
+	}
+	log.Printf("Tearing down orphaned VPC %s (%s)", vpcID, name)
+
+	// 0. Mark the VPC as being reaped. If a later step fails and the VPC
+	//    survives, the next run resumes teardown (via the reaping-tag gate)
+	//    even though the NAT gateways/endpoints it derives age from are gone.
+	//    Best-effort.
+	if _, err := ec2Client.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{vpcID},
+		Tags:      []ec2types.Tag{{Key: aws.String(reapingTagKey), Value: aws.String(time.Now().UTC().Format(time.RFC3339))}},
+	}); err != nil {
+		log.Printf("could not tag VPC %s as reaping: %v", vpcID, err)
+	}
+
+	// 1. VPC endpoints (interface endpoints own ENIs that block subnet/SG/VPC
+	//    deletion; the S3 gateway endpoint is the quota-limited resource).
+	deleteVpcEndpoints(ctx, ec2Client, vpcID)
+	waitVpcEndpointsGone(ctx, ec2Client, vpcID)
+
+	// 2. NAT gateways (own ENIs + hold the Elastic IPs). Collect the allocation
+	//    IDs so we can release the EIPs once the gateways are gone.
+	allocationIDs := deleteNatGateways(ctx, ec2Client, vpcID)
+	waitNatGatewaysGone(ctx, ec2Client, vpcID)
+
+	// 3. Release the Elastic IPs the NAT gateways were using.
+	releaseAddresses(ctx, ec2Client, allocationIDs)
+
+	// 4. Internet gateways must be detached before deletion.
+	deleteInternetGateways(ctx, ec2Client, vpcID)
+
+	// 5. Delete leftover 'available' (detached) ENIs. These are the usual reason
+	//    a terraform destroy stalls on these VPCs, and they block subnet
+	//    deletion. Only detached interfaces are removed.
+	deleteAvailableNetworkInterfaces(ctx, ec2Client, vpcID)
+
+	// Re-check for active instances before deleting subnets — the gates ran
+	// before the multi-minute endpoint/NAT waits above, so this closes the
+	// TOCTOU window where a workload began launching into the VPC meanwhile.
+	// The VPC keeps its reaping tag, so a later run resumes if we abort here.
+	if active, err := vpcHasActiveInstances(ctx, ec2Client, vpcID); err != nil {
+		return fmt.Errorf("re-checking instances for VPC %s: %w", vpcID, err)
+	} else if active {
+		return fmt.Errorf("aborting teardown of VPC %s: active instances appeared during teardown", vpcID)
+	}
+
+	// 6. Subnets (deleting a subnet also drops its route-table associations).
+	deleteSubnets(ctx, ec2Client, vpcID)
+
+	// 7. Non-main route tables.
+	deleteRouteTables(ctx, ec2Client, vpcID)
+
+	// 8. Non-default security groups.
+	deleteSecurityGroups(ctx, ec2Client, vpcID)
+
+	// 9. Finally the VPC itself.
+	if _, err := ec2Client.DeleteVpc(ctx, &ec2.DeleteVpcInput{VpcId: aws.String(vpcID)}); err != nil {
+		return fmt.Errorf("deleting VPC %s: %w", vpcID, err)
+	}
+	log.Printf("Deleted orphaned VPC %s (%s)", vpcID, name)
+	return nil
+}
+
+func deleteVpcEndpoints(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
+	out, err := ec2Client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		log.Printf("could not describe endpoints for VPC %s: %v", vpcID, err)
+		return
+	}
+	ids := make([]string, 0, len(out.VpcEndpoints))
+	for _, ep := range out.VpcEndpoints {
+		if ep.State == ec2types.StateDeleted || ep.State == ec2types.StateDeleting {
+			continue
+		}
+		ids = append(ids, aws.ToString(ep.VpcEndpointId))
+	}
+	if len(ids) == 0 {
+		return
+	}
+	log.Printf("Deleting %d endpoint(s) %v in VPC %s", len(ids), ids, vpcID)
+	res, err := ec2Client.DeleteVpcEndpoints(ctx, &ec2.DeleteVpcEndpointsInput{VpcEndpointIds: ids})
+	if err != nil {
+		log.Printf("could not delete endpoints in VPC %s: %v", vpcID, err)
+		return
+	}
+	for _, un := range res.Unsuccessful {
+		msg := ""
+		if un.Error != nil {
+			msg = aws.ToString(un.Error.Message)
+		}
+		log.Printf("failed to delete endpoint %s in VPC %s: %s", aws.ToString(un.ResourceId), vpcID, msg)
+	}
+}
+
+func deleteNatGateways(ctx context.Context, ec2Client *ec2.Client, vpcID string) []string {
+	out, err := ec2Client.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		log.Printf("could not describe NAT gateways for VPC %s: %v", vpcID, err)
+		return nil
+	}
+	var allocationIDs []string
+	for _, gw := range out.NatGateways {
+		// Collect EIP allocation IDs from every NAT gateway that still reports
+		// them — including ones already deleting/deleted (AWS lists a deleted
+		// NAT for ~1h). This lets a later run still release the EIP when NAT
+		// deletion outlasted this run's wait budget.
+		for _, addr := range gw.NatGatewayAddresses {
+			if id := aws.ToString(addr.AllocationId); id != "" {
+				allocationIDs = append(allocationIDs, id)
+			}
+		}
+		if gw.State == ec2types.NatGatewayStateDeleted || gw.State == ec2types.NatGatewayStateDeleting {
+			continue
+		}
+		id := aws.ToString(gw.NatGatewayId)
+		log.Printf("Deleting NAT gateway %s in VPC %s", id, vpcID)
+		if _, err := ec2Client.DeleteNatGateway(ctx, &ec2.DeleteNatGatewayInput{NatGatewayId: aws.String(id)}); err != nil {
+			log.Printf("could not delete NAT gateway %s: %v", id, err)
+		}
+	}
+	return allocationIDs
+}
+
+func releaseAddresses(ctx context.Context, ec2Client *ec2.Client, allocationIDs []string) {
+	for _, id := range allocationIDs {
+		log.Printf("Releasing Elastic IP %s", id)
+		if _, err := ec2Client.ReleaseAddress(ctx, &ec2.ReleaseAddressInput{AllocationId: aws.String(id)}); err != nil {
+			log.Printf("could not release Elastic IP %s: %v", id, err)
+		}
+	}
+}
+
+func deleteInternetGateways(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
+	out, err := ec2Client.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+		Filters: []ec2types.Filter{{Name: aws.String("attachment.vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		log.Printf("could not describe internet gateways for VPC %s: %v", vpcID, err)
+		return
+	}
+	for _, igw := range out.InternetGateways {
+		id := aws.ToString(igw.InternetGatewayId)
+		if _, err := ec2Client.DetachInternetGateway(ctx, &ec2.DetachInternetGatewayInput{
+			InternetGatewayId: aws.String(id),
+			VpcId:             aws.String(vpcID),
+		}); err != nil {
+			log.Printf("could not detach internet gateway %s from VPC %s: %v", id, vpcID, err)
+		}
+		log.Printf("Deleting internet gateway %s", id)
+		if _, err := ec2Client.DeleteInternetGateway(ctx, &ec2.DeleteInternetGatewayInput{InternetGatewayId: aws.String(id)}); err != nil {
+			log.Printf("could not delete internet gateway %s: %v", id, err)
+		}
+	}
+}
+
+func deleteAvailableNetworkInterfaces(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
+	out, err := ec2Client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+			{Name: aws.String("status"), Values: []string{"available"}},
+		},
+	})
+	if err != nil {
+		log.Printf("could not describe network interfaces for VPC %s: %v", vpcID, err)
+		return
+	}
+	for _, eni := range out.NetworkInterfaces {
+		id := aws.ToString(eni.NetworkInterfaceId)
+		log.Printf("Deleting leftover network interface %s", id)
+		if _, err := ec2Client.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String(id)}); err != nil {
+			log.Printf("could not delete network interface %s: %v", id, err)
+		}
+	}
+}
+
+func deleteSubnets(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
+	out, err := ec2Client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		log.Printf("could not describe subnets for VPC %s: %v", vpcID, err)
+		return
+	}
+	for _, sn := range out.Subnets {
+		id := aws.ToString(sn.SubnetId)
+		log.Printf("Deleting subnet %s", id)
+		if _, err := ec2Client.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{SubnetId: aws.String(id)}); err != nil {
+			log.Printf("could not delete subnet %s: %v", id, err)
+		}
+	}
+}
+
+func deleteRouteTables(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
+	out, err := ec2Client.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		log.Printf("could not describe route tables for VPC %s: %v", vpcID, err)
+		return
+	}
+	for _, rt := range out.RouteTables {
+		id := aws.ToString(rt.RouteTableId)
+		main := false
+		for _, assoc := range rt.Associations {
+			if aws.ToBool(assoc.Main) {
+				main = true
+				continue
+			}
+			if aid := aws.ToString(assoc.RouteTableAssociationId); aid != "" {
+				if _, err := ec2Client.DisassociateRouteTable(ctx, &ec2.DisassociateRouteTableInput{AssociationId: aws.String(aid)}); err != nil {
+					log.Printf("could not disassociate route table %s (assoc %s): %v", id, aid, err)
+				}
+			}
+		}
+		// The main route table is deleted implicitly with the VPC.
+		if main {
+			continue
+		}
+		log.Printf("Deleting route table %s", id)
+		if _, err := ec2Client.DeleteRouteTable(ctx, &ec2.DeleteRouteTableInput{RouteTableId: aws.String(id)}); err != nil {
+			log.Printf("could not delete route table %s: %v", id, err)
+		}
+	}
+}
+
+func deleteSecurityGroups(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
+	out, err := ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		log.Printf("could not describe security groups for VPC %s: %v", vpcID, err)
+		return
+	}
+
+	// Two passes: first revoke all ingress/egress rules on every non-default SG,
+	// then delete them. A single pass fails with DependencyViolation when SGs
+	// reference each other — an SG cannot be deleted while another SG's rule
+	// still references it — which would leave the VPC un-reapable.
+	var deletable []ec2types.SecurityGroup
+	for _, sg := range out.SecurityGroups {
+		// The default security group cannot be deleted; it goes with the VPC.
+		if aws.ToString(sg.GroupName) == "default" {
+			continue
+		}
+		id := aws.ToString(sg.GroupId)
+		if len(sg.IpPermissions) > 0 {
+			if _, err := ec2Client.RevokeSecurityGroupIngress(ctx, &ec2.RevokeSecurityGroupIngressInput{
+				GroupId:       aws.String(id),
+				IpPermissions: sg.IpPermissions,
+			}); err != nil {
+				log.Printf("could not revoke ingress on security group %s: %v", id, err)
+			}
+		}
+		if len(sg.IpPermissionsEgress) > 0 {
+			if _, err := ec2Client.RevokeSecurityGroupEgress(ctx, &ec2.RevokeSecurityGroupEgressInput{
+				GroupId:       aws.String(id),
+				IpPermissions: sg.IpPermissionsEgress,
+			}); err != nil {
+				log.Printf("could not revoke egress on security group %s: %v", id, err)
+			}
+		}
+		deletable = append(deletable, sg)
+	}
+	for _, sg := range deletable {
+		id := aws.ToString(sg.GroupId)
+		log.Printf("Deleting security group %s (%s)", id, aws.ToString(sg.GroupName))
+		if _, err := ec2Client.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{GroupId: aws.String(id)}); err != nil {
+			log.Printf("could not delete security group %s: %v", id, err)
+		}
+	}
+}
+
+func waitVpcEndpointsGone(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
+	deadline := time.Now().Add(endpointDeleteTimeout)
+	for {
+		out, err := ec2Client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		})
+		if err != nil {
+			log.Printf("could not poll endpoints for VPC %s: %v", vpcID, err)
+			return
+		}
+		remaining := 0
+		for _, ep := range out.VpcEndpoints {
+			if ep.State != ec2types.StateDeleted {
+				remaining++
+			}
+		}
+		if remaining == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			log.Printf("timed out waiting for %d endpoint(s) in VPC %s to delete", remaining, vpcID)
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+func waitNatGatewaysGone(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
+	deadline := time.Now().Add(natDeleteTimeout)
+	for {
+		out, err := ec2Client.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+			Filter: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+		})
+		if err != nil {
+			log.Printf("could not poll NAT gateways for VPC %s: %v", vpcID, err)
+			return
+		}
+		remaining := 0
+		for _, gw := range out.NatGateways {
+			if gw.State != ec2types.NatGatewayStateDeleted {
+				remaining++
+			}
+		}
+		if remaining == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			log.Printf("timed out waiting for %d NAT gateway(s) in VPC %s to delete", remaining, vpcID)
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+func dryRunDescribeVpc(ctx context.Context, ec2Client *ec2.Client, vpcID, name string) error {
+	log.Printf("Dry-Run: would tear down orphaned VPC %s (%s):", vpcID, name)
+
+	if out, err := ec2Client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	}); err == nil {
+		for _, ep := range out.VpcEndpoints {
+			log.Printf("  - endpoint %s (%s)", aws.ToString(ep.VpcEndpointId), aws.ToString(ep.ServiceName))
+		}
+	}
+	if out, err := ec2Client.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	}); err == nil {
+		for _, gw := range out.NatGateways {
+			if gw.State == ec2types.NatGatewayStateDeleted {
+				continue
+			}
+			for _, addr := range gw.NatGatewayAddresses {
+				if id := aws.ToString(addr.AllocationId); id != "" {
+					log.Printf("  - Elastic IP %s (via NAT %s)", id, aws.ToString(gw.NatGatewayId))
+				}
+			}
+			log.Printf("  - NAT gateway %s", aws.ToString(gw.NatGatewayId))
+		}
+	}
+	if out, err := ec2Client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+			{Name: aws.String("status"), Values: []string{"available"}},
+		},
+	}); err == nil {
+		for _, eni := range out.NetworkInterfaces {
+			log.Printf("  - network interface %s", aws.ToString(eni.NetworkInterfaceId))
+		}
+	}
+	if out, err := ec2Client.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+		Filters: []ec2types.Filter{{Name: aws.String("attachment.vpc-id"), Values: []string{vpcID}}},
+	}); err == nil {
+		for _, igw := range out.InternetGateways {
+			log.Printf("  - internet gateway %s", aws.ToString(igw.InternetGatewayId))
+		}
+	}
+	if out, err := ec2Client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	}); err == nil {
+		for _, sn := range out.Subnets {
+			log.Printf("  - subnet %s", aws.ToString(sn.SubnetId))
+		}
+	}
+	if out, err := ec2Client.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	}); err == nil {
+		for _, rt := range out.RouteTables {
+			isMain := false
+			for _, assoc := range rt.Associations {
+				if aws.ToBool(assoc.Main) {
+					isMain = true
+				}
+			}
+			if !isMain {
+				log.Printf("  - route table %s", aws.ToString(rt.RouteTableId))
+			}
+		}
+	}
+	if out, err := ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	}); err == nil {
+		for _, sg := range out.SecurityGroups {
+			if aws.ToString(sg.GroupName) != "default" {
+				log.Printf("  - security group %s (%s)", aws.ToString(sg.GroupId), aws.ToString(sg.GroupName))
+			}
+		}
+	}
+	log.Printf("  - VPC %s", vpcID)
+	return nil
+}
+
+func vpcsInUseByClusters(ctx context.Context, client *eks.Client) (map[string]bool, error) {
+	inUse := make(map[string]bool)
+	var nextToken *string
+	for {
+		out, err := client.ListClusters(ctx, &eks.ListClustersInput{NextToken: nextToken})
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range out.Clusters {
+			desc, err := client.DescribeCluster(ctx, &eks.DescribeClusterInput{Name: aws.String(name)})
+			if err != nil {
+				return nil, fmt.Errorf("describing cluster %s: %w", name, err)
+			}
+			if desc.Cluster != nil && desc.Cluster.ResourcesVpcConfig != nil {
+				if vpcID := aws.ToString(desc.Cluster.ResourcesVpcConfig.VpcId); vpcID != "" {
+					inUse[vpcID] = true
+				}
+			}
+		}
+		if out.NextToken == nil {
+			return inUse, nil
+		}
+		nextToken = out.NextToken
+	}
+}
+
+// vpcHasActiveInstances reports whether the VPC contains any instance that is
+// not fully terminated. Stopped/stopping/shutting-down instances still occupy
+// the VPC (ENIs, subnets) and signal the stack is not truly orphaned.
+func vpcHasActiveInstances(ctx context.Context, client *ec2.Client, vpcID string) (bool, error) {
+	var nextToken *string
+	for {
+		out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+			Filters: []ec2types.Filter{
+				{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+				{Name: aws.String("instance-state-name"), Values: []string{"running", "pending", "stopping", "stopped", "shutting-down"}},
+			},
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, r := range out.Reservations {
+			if len(r.Instances) > 0 {
+				return true, nil
+			}
+		}
+		if out.NextToken == nil {
+			return false, nil
+		}
+		nextToken = out.NextToken
+	}
+}
+
+// vpcReapEligibleByAge reports whether the VPC is old enough to reap. VPCs have
+// no creation timestamp, so age is derived from the newest non-deleted NAT
+// gateway or VPC endpoint in the VPC. The VPC is eligible only if that newest
+// signal is older than the keep-duration. When no age signal exists the
+// function returns false (fail safe): a VPC we cannot age — e.g. one still
+// mid-`terraform apply` before its NAT gateway/endpoints exist — is never
+// reaped.
+func vpcReapEligibleByAge(ctx context.Context, client *ec2.Client, vpcID string) (bool, error) {
+	// KeepDurationOneDay is negative, so expiration is "now minus one day".
+	expiration := time.Now().UTC().Add(clean.KeepDurationOneDay)
+	var newest *time.Time
+	consider := func(t *time.Time) {
+		if t == nil {
+			return
+		}
+		if newest == nil || t.After(*newest) {
+			newest = t
+		}
+	}
+
+	natOut, err := client.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, gw := range natOut.NatGateways {
+		if gw.State == ec2types.NatGatewayStateDeleted {
+			continue
+		}
+		consider(gw.CreateTime)
+	}
+
+	epOut, err := client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, ep := range epOut.VpcEndpoints {
+		if ep.State == ec2types.StateDeleted {
+			continue
+		}
+		consider(ep.CreationTimestamp)
+	}
+
+	if newest == nil {
+		return false, nil // no age signal — fail safe
+	}
+	return !newest.After(expiration), nil
+}
+
+func vpcTag(vpc ec2types.Vpc, key string) string {
+	for _, tag := range vpc.Tags {
+		if aws.ToString(tag.Key) == key {
+			return aws.ToString(tag.Value)
+		}
+	}
+	return ""
+}
+
+func vpcNameTag(vpc ec2types.Vpc) string {
+	return vpcTag(vpc, "Name")
 }

--- a/tool/clean/clean_eks/clean_eks.go
+++ b/tool/clean/clean_eks/clean_eks.go
@@ -30,6 +30,11 @@ const betaEksEndpoint = "https://api.beta.us-west-2.wesley.amazonaws.com"
 // were already deleted, instead of skipping it as "age cannot be determined".
 const reapingTagKey = "cleaner:reaping"
 
+// firstSeenTagKey records when the reaper first observed a VPC that has no NAT
+// gateway / endpoint age signal (e.g. a prior partial terraform destroy stripped
+// them). It lets such shells age in and be reaped instead of being stranded.
+const firstSeenTagKey = "cleaner:first-seen"
+
 var (
 	// clustersToClean is the allowlist of EKS cluster name prefixes the cleaner
 	// is permitted to delete.
@@ -53,7 +58,7 @@ var (
 
 	// Poll budgets for resources that delete asynchronously and whose ENIs must
 	// clear before dependents (subnets, security groups, VPC) can be removed.
-	endpointDeleteTimeout = 3 * time.Minute
+	endpointDeleteTimeout = 5 * time.Minute
 	natDeleteTimeout      = 6 * time.Minute
 	pollInterval          = 15 * time.Second
 )
@@ -282,14 +287,29 @@ func cleanOrphanedVpcResources(ctx context.Context) error {
 			}
 		}
 		if !reaping {
-			eligible, err := vpcReapEligibleByAge(ctx, ec2Client, vpcID)
+			eligible, hasSignal, err := vpcReapEligibleByAge(ctx, ec2Client, vpcID)
 			if err != nil {
 				log.Printf("could not determine age for VPC %s: %v", vpcID, err)
 				continue
 			}
 			if !eligible {
-				log.Printf("Ignoring VPC %s (%s): too new or age cannot be determined", vpcID, name)
-				continue
+				if hasSignal {
+					log.Printf("Ignoring VPC %s (%s): too new", vpcID, name)
+					continue
+				}
+				// No NAT/endpoint age signal (e.g. a prior partial terraform
+				// destroy stripped them). Fall back to a first-seen marker so a
+				// genuinely-old shell is not stranded forever: tag on first sight,
+				// reap once the marker is older than the keep-duration.
+				old, ferr := vpcFirstSeenEligible(ctx, ec2Client, vpc)
+				if ferr != nil {
+					log.Printf("could not evaluate first-seen marker for VPC %s: %v", vpcID, ferr)
+					continue
+				}
+				if !old {
+					log.Printf("Ignoring VPC %s (%s): no age signal yet; recorded first-seen marker", vpcID, name)
+					continue
+				}
 			}
 		}
 
@@ -550,29 +570,18 @@ func deleteSecurityGroups(ctx context.Context, ec2Client *ec2.Client, vpcID stri
 	// then delete them. A single pass fails with DependencyViolation when SGs
 	// reference each other — an SG cannot be deleted while another SG's rule
 	// still references it — which would leave the VPC un-reapable.
+	//
+	// Revoke by SecurityGroupRuleId, NOT by the IpPermissions returned from
+	// DescribeSecurityGroups: those carry Description fields (and peer-SG
+	// UserIdGroupPairs) that Revoke* rejects with InvalidRequest, so replaying
+	// them verbatim silently revokes nothing and the mutual references persist.
 	var deletable []ec2types.SecurityGroup
 	for _, sg := range out.SecurityGroups {
 		// The default security group cannot be deleted; it goes with the VPC.
 		if aws.ToString(sg.GroupName) == "default" {
 			continue
 		}
-		id := aws.ToString(sg.GroupId)
-		if len(sg.IpPermissions) > 0 {
-			if _, err := ec2Client.RevokeSecurityGroupIngress(ctx, &ec2.RevokeSecurityGroupIngressInput{
-				GroupId:       aws.String(id),
-				IpPermissions: sg.IpPermissions,
-			}); err != nil {
-				log.Printf("could not revoke ingress on security group %s: %v", id, err)
-			}
-		}
-		if len(sg.IpPermissionsEgress) > 0 {
-			if _, err := ec2Client.RevokeSecurityGroupEgress(ctx, &ec2.RevokeSecurityGroupEgressInput{
-				GroupId:       aws.String(id),
-				IpPermissions: sg.IpPermissionsEgress,
-			}); err != nil {
-				log.Printf("could not revoke egress on security group %s: %v", id, err)
-			}
-		}
+		revokeSecurityGroupRules(ctx, ec2Client, aws.ToString(sg.GroupId))
 		deletable = append(deletable, sg)
 	}
 	for _, sg := range deletable {
@@ -580,6 +589,43 @@ func deleteSecurityGroups(ctx context.Context, ec2Client *ec2.Client, vpcID stri
 		log.Printf("Deleting security group %s (%s)", id, aws.ToString(sg.GroupName))
 		if _, err := ec2Client.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{GroupId: aws.String(id)}); err != nil {
 			log.Printf("could not delete security group %s: %v", id, err)
+		}
+	}
+}
+
+// revokeSecurityGroupRules removes every ingress and egress rule from a security
+// group by rule ID. Revoking by ID sidesteps the InvalidRequest that Revoke*
+// returns when handed the Description-bearing IpPermissions from a Describe call.
+func revokeSecurityGroupRules(ctx context.Context, ec2Client *ec2.Client, groupID string) {
+	out, err := ec2Client.DescribeSecurityGroupRules(ctx, &ec2.DescribeSecurityGroupRulesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("group-id"), Values: []string{groupID}}},
+	})
+	if err != nil {
+		log.Printf("could not describe rules for security group %s: %v", groupID, err)
+		return
+	}
+	var ingress, egress []string
+	for _, rule := range out.SecurityGroupRules {
+		if aws.ToBool(rule.IsEgress) {
+			egress = append(egress, aws.ToString(rule.SecurityGroupRuleId))
+		} else {
+			ingress = append(ingress, aws.ToString(rule.SecurityGroupRuleId))
+		}
+	}
+	if len(ingress) > 0 {
+		if _, err := ec2Client.RevokeSecurityGroupIngress(ctx, &ec2.RevokeSecurityGroupIngressInput{
+			GroupId:              aws.String(groupID),
+			SecurityGroupRuleIds: ingress,
+		}); err != nil {
+			log.Printf("could not revoke ingress on security group %s: %v", groupID, err)
+		}
+	}
+	if len(egress) > 0 {
+		if _, err := ec2Client.RevokeSecurityGroupEgress(ctx, &ec2.RevokeSecurityGroupEgressInput{
+			GroupId:              aws.String(groupID),
+			SecurityGroupRuleIds: egress,
+		}); err != nil {
+			log.Printf("could not revoke egress on security group %s: %v", groupID, err)
 		}
 	}
 }
@@ -791,7 +837,7 @@ func vpcHasActiveInstances(ctx context.Context, client *ec2.Client, vpcID string
 // function returns false (fail safe): a VPC we cannot age — e.g. one still
 // mid-`terraform apply` before its NAT gateway/endpoints exist — is never
 // reaped.
-func vpcReapEligibleByAge(ctx context.Context, client *ec2.Client, vpcID string) (bool, error) {
+func vpcReapEligibleByAge(ctx context.Context, client *ec2.Client, vpcID string) (eligible bool, hasSignal bool, err error) {
 	// KeepDurationOneDay is negative, so expiration is "now minus one day".
 	expiration := time.Now().UTC().Add(clean.KeepDurationOneDay)
 	var newest *time.Time
@@ -808,7 +854,7 @@ func vpcReapEligibleByAge(ctx context.Context, client *ec2.Client, vpcID string)
 		Filter: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
 	})
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	for _, gw := range natOut.NatGateways {
 		if gw.State == ec2types.NatGatewayStateDeleted {
@@ -821,7 +867,7 @@ func vpcReapEligibleByAge(ctx context.Context, client *ec2.Client, vpcID string)
 		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
 	})
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	for _, ep := range epOut.VpcEndpoints {
 		if ep.State == ec2types.StateDeleted {
@@ -831,9 +877,33 @@ func vpcReapEligibleByAge(ctx context.Context, client *ec2.Client, vpcID string)
 	}
 
 	if newest == nil {
-		return false, nil // no age signal — fail safe
+		return false, false, nil // no age signal
 	}
-	return !newest.After(expiration), nil
+	return !newest.After(expiration), true, nil
+}
+
+// vpcFirstSeenEligible handles VPCs with no NAT/endpoint age signal. It reports
+// whether the VPC has carried a first-seen marker longer than the keep-duration.
+// On first sight (or a malformed marker) it records the marker and reports false;
+// in dry-run the write is skipped (logged) and it reports false.
+func vpcFirstSeenEligible(ctx context.Context, ec2Client *ec2.Client, vpc ec2types.Vpc) (bool, error) {
+	vpcID := aws.ToString(vpc.VpcId)
+	// KeepDurationOneDay is negative, so expiration is "now minus one day".
+	expiration := time.Now().UTC().Add(clean.KeepDurationOneDay)
+	if ts := vpcTag(vpc, firstSeenTagKey); ts != "" {
+		if seen, perr := time.Parse(time.RFC3339, ts); perr == nil {
+			return seen.Before(expiration), nil
+		}
+		log.Printf("VPC %s has malformed %s tag %q; re-recording it", vpcID, firstSeenTagKey, ts)
+	}
+	if clean.Skip("tag VPC %s with a %s marker", vpcID, firstSeenTagKey) {
+		return false, nil
+	}
+	_, err := ec2Client.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{vpcID},
+		Tags:      []ec2types.Tag{{Key: aws.String(firstSeenTagKey), Value: aws.String(time.Now().UTC().Format(time.RFC3339))}},
+	})
+	return false, err
 }
 
 func vpcTag(vpc ec2types.Vpc, key string) string {

--- a/tool/clean/clean_eks/clean_eks.go
+++ b/tool/clean/clean_eks/clean_eks.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -16,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 
 	"github.com/aws/amazon-cloudwatch-agent/tool/clean"
 )
@@ -29,9 +31,9 @@ const betaEksEndpoint = "https://api.beta.us-west-2.wesley.amazonaws.com"
 const reapingTagKey = "cleaner:reaping"
 
 var (
-	// ClustersToClean is the allowlist of EKS cluster name prefixes the cleaner
+	// clustersToClean is the allowlist of EKS cluster name prefixes the cleaner
 	// is permitted to delete.
-	ClustersToClean = []string{
+	clustersToClean = []string{
 		"cwagent-eks-integ-",
 		"cwagent-operator-helm-integ-",
 		"cwagent-helm-chart-integ-",
@@ -138,7 +140,7 @@ func terminateClusters(ctx context.Context, client *eks.Client) {
 				log.Printf("Ignoring cluster %s with a launch-date %s since it was created in the last %s", cluster, *describeClusterOutput.Cluster.CreatedAt, clean.KeepDurationOneDay)
 				continue
 			}
-			if !clusterNameMatchesClustersToClean(*describeClusterOutput.Cluster.Name, ClustersToClean) {
+			if !clusterNameMatchesClustersToClean(*describeClusterOutput.Cluster.Name, clustersToClean) {
 				log.Printf("Ignoring cluster %s since it doesnt match any of the clean regexes", cluster)
 				continue
 			}
@@ -366,6 +368,9 @@ func deleteVpcAndDependencies(ctx context.Context, ec2Client *ec2.Client, vpcID,
 	return nil
 }
 
+// The per-VPC delete helpers below each issue a single (unpaginated) Describe.
+// Orphaned test VPCs hold only a handful of each resource, so one page always
+// suffices; add pagination if that assumption ever changes.
 func deleteVpcEndpoints(ctx context.Context, ec2Client *ec2.Client, vpcID string) {
 	out, err := ec2Client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
 		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
@@ -602,7 +607,11 @@ func waitVpcEndpointsGone(ctx context.Context, ec2Client *ec2.Client, vpcID stri
 			log.Printf("timed out waiting for %d endpoint(s) in VPC %s to delete", remaining, vpcID)
 			return
 		}
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(pollInterval):
+		}
 	}
 }
 
@@ -629,7 +638,11 @@ func waitNatGatewaysGone(ctx context.Context, ec2Client *ec2.Client, vpcID strin
 			log.Printf("timed out waiting for %d NAT gateway(s) in VPC %s to delete", remaining, vpcID)
 			return
 		}
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(pollInterval):
+		}
 	}
 }
 
@@ -721,6 +734,13 @@ func vpcsInUseByClusters(ctx context.Context, client *eks.Client) (map[string]bo
 		for _, name := range out.Clusters {
 			desc, err := client.DescribeCluster(ctx, &eks.DescribeClusterInput{Name: aws.String(name)})
 			if err != nil {
+				var notFound *ekstypes.ResourceNotFoundException
+				if errors.As(err, &notFound) {
+					// Cluster is being deleted (e.g. by terminateClusters, which ran just
+					// before) — it no longer holds a VPC, so skip it rather than aborting
+					// the whole reap pass. Genuine errors still fail closed below.
+					continue
+				}
 				return nil, fmt.Errorf("describing cluster %s: %w", name, err)
 			}
 			if desc.Cluster != nil && desc.Cluster.ResourcesVpcConfig != nil {

--- a/tool/clean/clean_file_system/clean_file_system.go
+++ b/tool/clean/clean_file_system/clean_file_system.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 )
 
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
 	log.Printf("Begin to clean EFS resources")
 	expirationDate := time.Now().UTC().Add(clean.KeepDurationOneDay)
 	cxt := context.Background()
@@ -39,14 +42,15 @@ func main() {
 		for _, fileSystem := range describeFileSystemsOutput.FileSystems {
 			if expirationDate.After(*fileSystem.CreationTime) {
 				log.Printf("Trying to delete file system %s launch-date %v", *fileSystem.FileSystemId, fileSystem.CreationTime)
+				var mtErr error
 				if fileSystem.NumberOfMountTargets > 0 {
-					err = deleteMountTargets(cxt, efsclient, fileSystem.FileSystemId)
+					mtErr = deleteMountTargets(cxt, efsclient, fileSystem.FileSystemId)
 				}
 
-				if err == nil {
+				if mtErr == nil {
 					fileSystemIdSlice = append(fileSystemIdSlice, fileSystem.FileSystemId)
 				} else {
-					log.Printf("Unable to delete all the mount targets for %s due to %v", *fileSystem.FileSystemId, err)
+					log.Printf("Unable to delete all the mount targets for %s due to %v", *fileSystem.FileSystemId, mtErr)
 				}
 			}
 		}
@@ -56,6 +60,9 @@ func main() {
 		nextToken = describeFileSystemsOutput.NextMarker
 	}
 	for _, fileSystemId := range fileSystemIdSlice {
+		if clean.Skip("delete file system %s", *fileSystemId) {
+			continue
+		}
 		terminateFileSystemsInput := efs.DeleteFileSystemInput{FileSystemId: fileSystemId}
 		if _, err = efsclient.DeleteFileSystem(cxt, &terminateFileSystemsInput); err != nil {
 			log.Printf("Unable to delete file system %s due to %v", *fileSystemId, err)
@@ -74,6 +81,9 @@ func deleteMountTargets(cxt context.Context, client *efs.Client, fileSystemId *s
 			return err
 		}
 		for _, mountTarget := range dmto.MountTargets {
+			if clean.Skip("delete mount target %s for %s", *mountTarget.MountTargetId, *fileSystemId) {
+				continue
+			}
 			dlmti := &efs.DeleteMountTargetInput{MountTargetId: mountTarget.MountTargetId}
 			if _, err = client.DeleteMountTarget(cxt, dlmti); err != nil {
 				return err

--- a/tool/clean/clean_flags.go
+++ b/tool/clean/clean_flags.go
@@ -5,6 +5,7 @@ package clean
 
 import (
 	"flag"
+	"fmt"
 	"log"
 )
 
@@ -38,7 +39,10 @@ func RegisterCommonFlags() {
 //	// ... perform the real deletion ...
 func Skip(action string, args ...any) bool {
 	if DryRun {
-		log.Printf("[dry-run] would "+action, args...)
+		// Forward action as the format string (rather than concatenating a prefix
+		// into it) so `go vet` recognizes Skip as a printf wrapper and validates
+		// format/arg mismatches at every call site.
+		log.Print("[dry-run] would ", fmt.Sprintf(action, args...))
 		return true
 	}
 	return false

--- a/tool/clean/clean_flags.go
+++ b/tool/clean/clean_flags.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package clean
+
+import (
+	"flag"
+	"log"
+)
+
+// DryRun reports whether cleaners should only log the resources they would
+// delete instead of deleting them. It is populated by RegisterCommonFlags once
+// flag.Parse has run.
+var DryRun bool
+
+// RegisterCommonFlags registers the flags shared by every cleaner on the
+// default flag.CommandLine set. Call it from main before flag.Parse. Callers
+// may register additional flags of their own before parsing.
+//
+//	-dry-run  when true, no resource is deleted; intended deletions are logged.
+//	-tags     accepted and ignored. The clean-aws-resources workflow passes
+//	          -tags as a go *build* flag (before the package path), so programs
+//	          never receive it. This is defensive for manual/legacy invocations
+//	          like `clean_x.go --tags=clean` that would otherwise pass it as a
+//	          program argument and make flag.Parse reject the unknown flag.
+func RegisterCommonFlags() {
+	flag.BoolVar(&DryRun, "dry-run", false, "log the resources that would be deleted without deleting them")
+	_ = flag.String("tags", "", "ignored; defensive for manual `--tags=clean` invocations")
+}
+
+// Skip logs an intended mutating action and reports whether it should be
+// skipped because dry-run mode is enabled. Use it to gate every mutating call
+// (delete/terminate/release/revoke/detach), for example:
+//
+//	if clean.Skip("delete volume %s", id) {
+//		continue
+//	}
+//	// ... perform the real deletion ...
+func Skip(action string, args ...any) bool {
+	if DryRun {
+		log.Printf("[dry-run] would "+action, args...)
+		return true
+	}
+	return false
+}

--- a/tool/clean/clean_host/clean_host.go
+++ b/tool/clean/clean_host/clean_host.go
@@ -4,8 +4,8 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
-	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -18,17 +18,22 @@ import (
 
 // Clean integration hosts if they have been open longer than 1 day
 func main() {
-	err := cleanHost()
-	if err != nil {
+	clean.RegisterCommonFlags()
+	flag.Parse()
+	region := flag.Arg(0)
+	if region == "" {
+		log.Fatal("Region argument is required, e.g. clean_host.go <region>")
+	}
+	if err := cleanHost(region); err != nil {
 		log.Fatalf("errors cleaning %v", err)
 	}
 }
 
-func cleanHost() error {
+func cleanHost(region string) error {
 	log.Print("Begin to clean EC2 Host")
 
 	cxt := context.Background()
-	defaultConfig, err := config.LoadDefaultConfig(cxt, config.WithRegion(os.Args[1]))
+	defaultConfig, err := config.LoadDefaultConfig(cxt, config.WithRegion(region))
 	if err != nil {
 		return err
 	}
@@ -83,10 +88,12 @@ func terminateInstances(cxt context.Context, ec2client *ec2.Client) {
 		}
 
 		log.Printf("instances to terminate %v", instanceIds)
-		terminateInstance := ec2.TerminateInstancesInput{InstanceIds: instanceIds}
-		_, err := ec2client.TerminateInstances(cxt, &terminateInstance)
-		if err != nil {
-			log.Printf("Error %v terminating instances %v", err, instanceIds)
+		if !clean.Skip("terminate instances %v", instanceIds) {
+			terminateInstance := ec2.TerminateInstancesInput{InstanceIds: instanceIds}
+			_, err := ec2client.TerminateInstances(cxt, &terminateInstance)
+			if err != nil {
+				log.Printf("Error %v terminating instances %v", err, instanceIds)
+			}
 		}
 		if describeInstanceOutput.NextToken == nil {
 			break

--- a/tool/clean/clean_iam_roles/clean_iam_roles.go
+++ b/tool/clean/clean_iam_roles/clean_iam_roles.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"strings"
@@ -48,6 +49,8 @@ type iamClient interface {
 }
 
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
 	log.Print("Begin to clean IAM Roles")
 	ctx := context.Background()
 	cfg, err := config.LoadDefaultConfig(ctx)
@@ -99,6 +102,9 @@ func deleteRole(ctx context.Context, client iamClient, role types.Role) error {
 		lastUsed = fmt.Sprintf("%d days ago", int(time.Since(*role.RoleLastUsed.LastUsedDate).Hours()/24))
 	}
 	log.Printf("Trying to delete role (%q) last used %s", *role.RoleName, lastUsed)
+	if clean.Skip("delete IAM role %q (detach policies, delete inline policies, remove instance profiles)", *role.RoleName) {
+		return nil
+	}
 	if err := detachPolicies(ctx, client, role); err != nil {
 		return err
 	}

--- a/tool/clean/clean_launch_configuration/clean_launch_configuration.go
+++ b/tool/clean/clean_launch_configuration/clean_launch_configuration.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"log"
 	"strings"
 	"time"
@@ -16,6 +17,8 @@ import (
 )
 
 func main() {
+	clean.RegisterCommonFlags()
+	flag.Parse()
 	err := cleanLaunchConfiguration()
 	if err != nil {
 		log.Fatalf("errors cleaning %v", err)
@@ -46,6 +49,9 @@ func cleanLaunchConfiguration() error {
 		}
 		if expirationDate.After(*launchConfig.CreatedTime) {
 			log.Printf("Try to delete %s", *launchConfig.LaunchConfigurationName)
+			if clean.Skip("delete launch configuration %s", *launchConfig.LaunchConfigurationName) {
+				continue
+			}
 			_, err := autoScalingClient.DeleteLaunchConfiguration(ctx, &autoscaling.DeleteLaunchConfigurationInput{
 				LaunchConfigurationName: launchConfig.LaunchConfigurationName,
 			})

--- a/tool/clean/clean_log_group/clean_log_group.go
+++ b/tool/clean/clean_log_group/clean_log_group.go
@@ -52,7 +52,6 @@ func init() {
 		inactiveThreshold: 1 * clean.KeepDurationOneDay,
 		numWorkers:        15,
 		exceptionList:     []string{"lambda"},
-		dryRun:            true,
 	}
 
 }
@@ -61,8 +60,9 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 	// Parse command line flags
-	flag.BoolVar(&cfg.dryRun, "dry-run", false, "Enable dry-run mode (no actual deletion)")
+	clean.RegisterCommonFlags()
 	flag.Parse()
+	cfg.dryRun = clean.DryRun
 	// Load AWS configuration
 	awsCfg, err := loadAWSConfig(ctx)
 	if err != nil {

--- a/tool/clean/clean_security_group/clean_security_group.go
+++ b/tool/clean/clean_security_group/clean_security_group.go
@@ -53,7 +53,6 @@ func init() {
 		ageThreshold:  1 * clean.KeepDurationOneDay,
 		numWorkers:    30,
 		exceptionList: []string{"default"},
-		dryRun:        true,
 		skipVpcSGs:    false,
 		skipWithRules: false,
 	}
@@ -64,11 +63,12 @@ func main() {
 	defer cancel()
 
 	// Parse command line flags
-	flag.BoolVar(&cfg.dryRun, "dry-run", false, "Enable dry-run mode (no actual deletion)")
+	clean.RegisterCommonFlags()
 	flag.DurationVar(&cfg.ageThreshold, "age", 1*clean.KeepDurationOneDay, "Age threshold for security groups (e.g. 24h)")
 	flag.BoolVar(&cfg.skipVpcSGs, "skip-vpc", false, "Skip security groups associated with VPCs")
 	flag.BoolVar(&cfg.skipWithRules, "skip-with-rules", false, "Skip security groups that have ingress or egress rules")
 	flag.Parse()
+	cfg.dryRun = clean.DryRun
 
 	// Load AWS configuration
 	awsCfg, err := loadAWSConfig(ctx)
@@ -325,35 +325,36 @@ func fetchAndProcessSecurityGroups(ctx context.Context, client ec2Client,
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			output, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
-				MaxResults: aws.Int32(maxResults),
-				NextToken:  nextToken,
-			})
-			if err != nil {
-				return fmt.Errorf("describing security groups: %w", err)
-			}
-
-			log.Printf("🔍 Described %d times | Found %d security groups\n", describeCount, len(output.SecurityGroups))
-
-			// Process in batches with context awareness
-			for _, securityGroup := range output.SecurityGroups {
-				select {
-				case securityGroupChan <- securityGroup:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
-			}
-
-			if output.NextToken == nil {
-				break
-			}
-
-			nextToken = output.NextToken
-			describeCount++
 		}
-	}
 
-	return nil
+		output, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			MaxResults: aws.Int32(maxResults),
+			NextToken:  nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("describing security groups: %w", err)
+		}
+
+		log.Printf("🔍 Described %d times | Found %d security groups\n", describeCount, len(output.SecurityGroups))
+
+		// Process in batches with context awareness
+		for _, securityGroup := range output.SecurityGroups {
+			select {
+			case securityGroupChan <- securityGroup:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		// A bare break here would only exit the select, spinning the loop on the
+		// same page forever; return when there are no more pages.
+		if output.NextToken == nil {
+			return nil
+		}
+
+		nextToken = output.NextToken
+		describeCount++
+	}
 }
 
 func isSecurityGroupInUse(ctx context.Context, client ec2Client, securityGroupID string) (bool, error) {


### PR DESCRIPTION
# Description of changes
clean_eks: after the cluster pass, reap dedicated EFA test VPCs (tag:Name efa-test-vpc-*) left behind by failed terraform destroys. Tears the stack down in dependency order — VPC endpoints, NAT gateways, Elastic IPs, leftover ENIs, internet gateways, subnets, route tables, security groups (revoke-then-delete), then the VPC — behind three safety gates: not backing a live EKS cluster (prod + best-effort beta), no active EC2 instances (re-checked before subnet deletion), and an age gate from the newest NAT gateway/VPC endpoint. A cleaner:reaping tag lets a partially-torn-down VPC resume on a later run instead of being stranded once its age signals are gone.

Shared dry-run: add tool/clean/clean_flags.go (clean.DryRun, RegisterCommonFlags, Skip) and gate every mutating call across all 12 cleaners. Add a -dry-run flag to each tool and a workflow_dispatch dry_run input (DRY_RUN env: scheduled runs stay live, manual defaults to dry-run). Normalize --tags=clean to build-flag position and move ecs/host region args to flag.Arg(0).

Also fix pre-existing bugs surfaced while touching these files:
- clean_ecs: inverted-sign expiration deleted clusters with active tasks
- clean_security_group: break-in-select spun pagination to timeout
- clean_ebs / clean_file_system: age no-op and stale-error under-deletion

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* https://github.com/aws/amazon-cloudwatch-agent/actions/runs/29632783157/job/88049627003

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



