### PR TITLE
fix(ci): Use environment variables in workflows

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -35,8 +35,10 @@ jobs:
           filters: .github/config/file-filters.yml
 
       - name: List all updated files
+        env:
+          BUILD_FILES: ${{ steps.filter.outputs.build_files }}
         run: |
-          for file in ${{ steps.filter.outputs.build_files }}; do
+          for file in $BUILD_FILES; do
             echo "$file"
           done
 
@@ -142,7 +144,10 @@ jobs:
 
       - name: Build
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
-        run: make amazon-cloudwatch-agent-${{ matrix.family }}
+        env:
+          MATRIX_FAMILY: ${{ matrix.family }}
+        shell: bash
+        run: make "amazon-cloudwatch-agent-$MATRIX_FAMILY"
 
       - name: Collect binary sizes
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true' && matrix.family != 'darwin' && matrix.os != 'windows-latest' && github.event_name == 'pull_request'
@@ -221,16 +226,15 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - name: Check Job Status
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          # Convert needs context to JSON and process with jq
-          needs_json='${{ toJSON(needs) }}'
-
           failed_jobs=()
           successful_jobs=()
 
           # Loop through all jobs in needs context
-          for job in $(echo "$needs_json" | jq -r 'keys[]'); do
-            result=$(echo "$needs_json" | jq -r ".[\"$job\"].result")
+          for job in $(echo "$NEEDS_JSON" | jq -r 'keys[]'); do
+            result=$(echo "$NEEDS_JSON" | jq -r ".[\"$job\"].result")
 
             if [[ "$result" == "failure" ]]; then
               failed_jobs+=("$job")

--- a/.github/workflows/PR-test.yml
+++ b/.github/workflows/PR-test.yml
@@ -41,14 +41,17 @@ jobs:
       should_run: ${{ steps.check.outputs.has_label }}
     steps:
       - id: check
+        env:
+          PR_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ready for testing') }}
         run: |
           # Fork PRs never receive secrets or id-token permissions, so the
           # integration tests cannot run even if the label is added. Maintainers
           # must push the branch to this repo to run them.
-          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+          if [[ "$PR_FORK" == "true" ]]; then
             echo "Fork PR - integration tests cannot run (no access to secrets)."
             echo "has_label=false" >> $GITHUB_OUTPUT
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'ready for testing') }}" == "true" ]]; then
+          elif [[ "$HAS_LABEL" == "true" ]]; then
             echo "has_label=true" >> $GITHUB_OUTPUT
           else
             echo "has_label=false" >> $GITHUB_OUTPUT
@@ -88,11 +91,16 @@ jobs:
           echo "CWA_GITHUB_TEST_REPO_BRANCH=${CWA_GITHUB_TEST_REPO_BRANCH:-${{ env.CWA_GITHUB_TEST_REPO_BRANCH }}}" >> "$GITHUB_OUTPUT"
 
       - name: Echo test variables
+        env:
+          GITHUB_SHA_VAL: ${{ github.sha }}
+          OUT_REPO_NAME: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+          OUT_REPO_URL: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_URL }}
+          OUT_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
         run: |
-          echo "build_id: ${{ github.sha }}"
-          echo "CWA_GITHUB_TEST_REPO_NAME: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_NAME }}"
-          echo "CWA_GITHUB_TEST_REPO_URL: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_URL }}"
-          echo "CWA_GITHUB_TEST_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}"
+          echo "build_id: $GITHUB_SHA_VAL"
+          echo "CWA_GITHUB_TEST_REPO_NAME: $OUT_REPO_NAME"
+          echo "CWA_GITHUB_TEST_REPO_URL: $OUT_REPO_URL"
+          echo "CWA_GITHUB_TEST_REPO_BRANCH: $OUT_REPO_BRANCH"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -169,9 +177,12 @@ jobs:
         run: |
           # GitHub Actions matrix limit is 256 jobs per workflow run.
           # Use 200 per page for headroom. Up to 5 pages supported (1000 tests).
-          # The ec2_linux_matrix is @json-encoded (double-encoded), so decode first.
+          # Read the filtered matrix from the file written by the "Generate matrix"
+          # step instead of a step-level env var: the matrix can exceed the
+          # kernel's ARG_MAX (~2 MiB) on execve, which would prevent bash from
+          # starting for this step.
           PAGE_SIZE=200
-          FULL_MATRIX=$(echo '${{ steps.set-matrix.outputs.ec2_linux_matrix }}' | jq -r '.')
+          FULL_MATRIX=$(cat filtered_matrix.json)
           TOTAL=$(echo "$FULL_MATRIX" | jq 'length')
           PAGE_COUNT=$(( (TOTAL + PAGE_SIZE - 1) / PAGE_SIZE ))
 
@@ -190,9 +201,12 @@ jobs:
           done
 
       - name: Echo test plan matrix
+        env:
+          EC2_LINUX_PAGE_COUNT: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_page_count }}
+          EC2_SELINUX_MATRIX: ${{ steps.set-matrix.outputs.ec2_selinux_matrix }}
         run: |
-          echo "ec2_linux_matrix pages: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_page_count }}"
-          echo "ec2_selinux_matrix: ${{ steps.set-matrix.outputs.ec2_selinux_matrix }}"
+          echo "ec2_linux_matrix pages: $EC2_LINUX_PAGE_COUNT"
+          echo "ec2_selinux_matrix: $EC2_SELINUX_MATRIX"
 
 
   EC2LinuxIntegrationTest-0:
@@ -355,23 +369,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for ready for testing label
+        env:
+          PR_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          HAS_SKIP_TESTING: ${{ contains(github.event.pull_request.labels.*.name, 'skip testing') }}
+          HAS_READY_FOR_TESTING: ${{ contains(github.event.pull_request.labels.*.name, 'ready for testing') }}
         run: |
-          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+          if [[ "$PR_FORK" == "true" ]]; then
             echo "Fork PR - integration tests skipped (no access to secrets). Push branch to this repo to run them."
             exit 0
           fi
 
-          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+          if [[ "$PR_DRAFT" == "true" ]]; then
             echo "Draft PR - skipping label check."
             exit 0
           fi
 
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip testing') }}" == "true" ]]; then
+          if [[ "$HAS_SKIP_TESTING" == "true" ]]; then
             echo "'skip testing' label found - bypassing integration test requirement."
             exit 0
           fi
 
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ready for testing') }}" != "true" ]]; then
+          if [[ "$HAS_READY_FOR_TESTING" != "true" ]]; then
             echo "Missing 'ready for testing' label. Please add before merging."
             exit 1
           fi
@@ -388,16 +407,15 @@ jobs:
     if: always()
     steps:
       - name: Check Job Status
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          # Convert needs context to JSON and process with jq
-          needs_json='${{ toJSON(needs) }}'
-
           failed_jobs=()
           successful_jobs=()
 
           # Loop through all jobs in needs context
-          for job in $(echo "$needs_json" | jq -r 'keys[]'); do
-            result=$(echo "$needs_json" | jq -r ".[\"$job\"].result")
+          for job in $(echo "$NEEDS_JSON" | jq -r 'keys[]'); do
+            result=$(echo "$NEEDS_JSON" | jq -r ".[\"$job\"].result")
 
             if [[ "$result" == "failure" ]]; then
               failed_jobs+=("$job")

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -40,9 +40,12 @@ jobs:
             echo "Build SHA does not match test SHA"
             exit 1
           fi
-      - run: |
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_BUILD_RUN_ID: ${{ inputs.build_run_id }}
+        run: |
           for i in {1..6}; do
-            conclusion=$(gh run view ${{ inputs.build_run_id }} --repo $GITHUB_REPOSITORY --json conclusion -q '.conclusion')
+            conclusion=$(gh run view "$INPUT_BUILD_RUN_ID" --repo "$GITHUB_REPOSITORY" --json conclusion -q '.conclusion')
             if [[ "$conclusion" == "success" ]]; then
               echo "Run succeeded"
               exit 0
@@ -55,8 +58,6 @@ jobs:
           done
           echo "Timed out waiting for workflow"
           exit 1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   java-eks-e2e-test:
     needs: CheckBuildTestArtifacts

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -128,9 +128,12 @@ jobs:
     permissions:
       actions: write
     steps:
-      - run: gh workflow run integration-test.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_run_id=${{ github.run_id }} -f build_sha=${{ github.sha }}
-        env:
+      - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA_VAL: ${{ github.sha }}
+        run: gh workflow run integration-test.yml --ref "$REF_NAME" --repo "$GITHUB_REPOSITORY" -f "build_run_id=$RUN_ID" -f "build_sha=$GITHUB_SHA_VAL"
 
   StartApplicationSignalsE2ETests:
     needs: [ BuildAndUploadPackages, BuildAndUploadITAR, BuildAndUploadCN, BuildDocker, BuildDistributor ]
@@ -140,9 +143,12 @@ jobs:
     permissions:
       actions: write
     steps:
-      - run: gh workflow run application-signals-e2e-test.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_run_id=${{ github.run_id }} -f build_sha=${{ github.sha }}
-        env:
+      - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA_VAL: ${{ github.sha }}
+        run: gh workflow run application-signals-e2e-test.yml --ref "$REF_NAME" --repo "$GITHUB_REPOSITORY" -f "build_run_id=$RUN_ID" -f "build_sha=$GITHUB_SHA_VAL"
 
   StartEKSE2ETests:
     needs: [ BuildAndUploadPackages, BuildAndUploadITAR, BuildAndUploadCN, BuildDocker, BuildDistributor ]
@@ -151,9 +157,11 @@ jobs:
     permissions:
       actions: write
     steps:
-      - run: gh workflow run e2e-test.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_sha=${{ github.sha }}
-        env:
+      - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          GITHUB_SHA_VAL: ${{ github.sha }}
+        run: gh workflow run e2e-test.yml --ref "$REF_NAME" --repo "$GITHUB_REPOSITORY" -f "build_sha=$GITHUB_SHA_VAL"
 
   StartWorkloadDiscoveryIntegrationTests:
     needs: [ BuildAndUploadPackages, BuildAndUploadITAR, BuildAndUploadCN, BuildDocker, BuildDistributor ]
@@ -162,6 +170,9 @@ jobs:
     permissions:
       actions: write
     steps:
-      - run: gh workflow run wd-integration-test.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_run_id=${{ github.run_id }} -f build_sha=${{ github.sha }}
-        env:
+      - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA_VAL: ${{ github.sha }}
+        run: gh workflow run wd-integration-test.yml --ref "$REF_NAME" --repo "$GITHUB_REPOSITORY" -f "build_run_id=$RUN_ID" -f "build_sha=$GITHUB_SHA_VAL"

--- a/.github/workflows/clean-aws-resources.yml
+++ b/.github/workflows/clean-aws-resources.yml
@@ -138,7 +138,9 @@ jobs:
 
       - name: Clean old host
         working-directory: tool/clean
-        run: go run ./clean_host/clean_host.go ${{ matrix.region }}
+        env:
+          MATRIX_REGION: ${{ matrix.region }}
+        run: go run ./clean_host/clean_host.go "$MATRIX_REGION"
 
   clean-hosts-china:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -123,13 +123,20 @@ jobs:
           echo "::set-output name=ECR_TARGET_ALLOCATOR_REPO::$(echo "${{ vars.ECR_TARGET_ALLOCATOR_STAGING_REPO }}" | awk -F'/' '{print $NF}')"
 
       - name: Echo test variables
+        env:
+          OUT_REPO_NAME: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+          OUT_REPO_URL: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_URL }}
+          OUT_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+          OUT_ECR_INTEGRATION_TEST_REPO: ${{ steps.set-outputs.outputs.ECR_INTEGRATION_TEST_REPO }}
+          OUT_ECR_OPERATOR_REPO: ${{ steps.set-outputs.outputs.ECR_OPERATOR_REPO }}
+          OUT_ECR_TARGET_ALLOCATOR_REPO: ${{ steps.set-outputs.outputs.ECR_TARGET_ALLOCATOR_REPO }}
         run: |
-          echo "CWA_GITHUB_TEST_REPO_NAME: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_NAME }}"
-          echo "CWA_GITHUB_TEST_REPO_URL: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_URL }}"
-          echo "CWA_GITHUB_TEST_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}"
-          echo "ECR_INTEGRATION_TEST_REPO: ${{ steps.set-outputs.outputs.ECR_INTEGRATION_TEST_REPO }}"
-          echo "ECR_OPERATOR_REPO: ${{ steps.set-outputs.outputs.ECR_OPERATOR_REPO }}"
-          echo "ECR_TARGET_ALLOCATOR_REPO: ${{ steps.set-outputs.outputs.ECR_TARGET_ALLOCATOR_REPO }}"
+          echo "CWA_GITHUB_TEST_REPO_NAME: $OUT_REPO_NAME"
+          echo "CWA_GITHUB_TEST_REPO_URL: $OUT_REPO_URL"
+          echo "CWA_GITHUB_TEST_REPO_BRANCH: $OUT_REPO_BRANCH"
+          echo "ECR_INTEGRATION_TEST_REPO: $OUT_ECR_INTEGRATION_TEST_REPO"
+          echo "ECR_OPERATOR_REPO: $OUT_ECR_OPERATOR_REPO"
+          echo "ECR_TARGET_ALLOCATOR_REPO: $OUT_ECR_TARGET_ALLOCATOR_REPO"
 
   GenerateTestMatrix:
     needs: [BuildAgent, BuildOperator]
@@ -156,8 +163,10 @@ jobs:
           echo "::set-output name=eks_e2e_jmx_matrix::$(echo $(cat generator/resources/eks_e2e_jmx_complete_test_matrix.json))"
 
       - name: Echo test plan matrix
+        env:
+          EKS_E2E_JMX_MATRIX: ${{ steps.set-matrix.outputs.eks_e2e_jmx_matrix }}
         run: |
-          echo "eks_e2e_jmx_matrix: ${{ steps.set-matrix.outputs.eks_e2e_jmx_matrix }}"
+          echo "eks_e2e_jmx_matrix: $EKS_E2E_JMX_MATRIX"
 
   EKSE2EJVMTomcatTestHelm:
     needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]

--- a/.github/workflows/ec2-integration-test.yml
+++ b/.github/workflows/ec2-integration-test.yml
@@ -75,9 +75,14 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Echo Test Info
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_LOCALSTACK_HOST: ${{ inputs.localstack_host }}
         run: |
-          echo run cache_if_success os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
-          echo localstack input ${{ inputs.localstack_host }}
+          echo "run cache_if_success os $MATRIX_OS arc $MATRIX_ARC test dir $MATRIX_TEST_DIR"
+          echo "localstack input $INPUT_LOCALSTACK_HOST"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -89,41 +94,65 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 60
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          INPUT_TEST_DIR: ${{ inputs.test_dir }}
+          MATRIX_AGENT_START: ${{ matrix.arrays.agentStartCommand }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_BINARY_NAME: ${{ matrix.arrays.binaryName }}
+          MATRIX_CA_CERT_PATH: ${{ matrix.arrays.caCertPath }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_EXCLUDED_TESTS: ${{ matrix.arrays.excludedTests }}
+          INPUT_TEST_REPO_URL: ${{ inputs.test_repo_url }}
+          INPUT_TEST_REPO_BRANCH: ${{ inputs.test_repo_branch }}
+          MATRIX_INSTALL_AGENT: ${{ matrix.arrays.installAgentCommand }}
+          INPUT_IS_SELINUX_TEST: ${{ inputs.is_selinux_test }}
+          MATRIX_SELINUX_BRANCH: ${{ matrix.arrays.selinux_branch }}
+          INPUT_LOCALSTACK_HOST: ${{ inputs.localstack_host }}
+          INPUT_PLUGINS: ${{ github.event.inputs.plugins }}
+          INPUT_REGION: ${{ inputs.region }}
+          INPUT_S3_BUCKET: ${{ inputs.s3_integration_bucket }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          INPUT_IS_ONPREM_TEST: ${{ inputs.is_onprem_test }}
+          MATRIX_USERNAME: ${{ matrix.arrays.username }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
-            cd ${{inputs.test_dir}}
+            cd "$INPUT_TEST_DIR"
           fi
 
           terraform init
           if terraform apply --auto-approve \
-            -var="agent_start=${{ matrix.arrays.agentStartCommand }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="arc=${{ matrix.arrays.arc }}" \
-            -var="binary_name=${{ matrix.arrays.binaryName }}" \
-            -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
-            -var="cwa_github_sha=${{inputs.build_id}}" \
-            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-            -var="excluded_tests='${{ matrix.arrays.excludedTests }}'" \
-            -var="github_test_repo=${{ inputs.test_repo_url }}" \
-            -var="github_test_repo_branch=${{inputs.test_repo_branch}}" \
-            -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
-            -var="is_selinux_test=${{ inputs.is_selinux_test }}" \
-            -var="selinux_branch=${{ matrix.arrays.selinux_branch }}" \
-            -var="local_stack_host_name=${{ inputs.localstack_host }}" \
-            -var="plugin_tests='${{ github.event.inputs.plugins }}'" \
-            -var="region=${{ inputs.region }}" \
-            -var="s3_bucket=${{ inputs.s3_integration_bucket }}" \
-            -var="ssh_key_name=${{env.KEY_NAME}}" \
-            -var="ssh_key_value=${{env.PRIVATE_KEY}}" \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="test_name=${{ matrix.arrays.os }}" \
-            -var="is_onprem=${{ inputs.is_onprem_test }}" \
-            -var="user=${{ matrix.arrays.username }}"; then
-            terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" -auto-approve
+            -var="agent_start=$MATRIX_AGENT_START" \
+            -var="ami=$MATRIX_AMI" \
+            -var="arc=$MATRIX_ARC" \
+            -var="binary_name=$MATRIX_BINARY_NAME" \
+            -var="ca_cert_path=$MATRIX_CA_CERT_PATH" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID" \
+            -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
+            -var="excluded_tests='$MATRIX_EXCLUDED_TESTS'" \
+            -var="github_test_repo=$INPUT_TEST_REPO_URL" \
+            -var="github_test_repo_branch=$INPUT_TEST_REPO_BRANCH" \
+            -var="install_agent=$MATRIX_INSTALL_AGENT" \
+            -var="is_selinux_test=$INPUT_IS_SELINUX_TEST" \
+            -var="selinux_branch=$MATRIX_SELINUX_BRANCH" \
+            -var="local_stack_host_name=$INPUT_LOCALSTACK_HOST" \
+            -var="plugin_tests='$INPUT_PLUGINS'" \
+            -var="region=$INPUT_REGION" \
+            -var="s3_bucket=$INPUT_S3_BUCKET" \
+            -var="ssh_key_name=$KEY_NAME" \
+            -var="ssh_key_value=$PRIVATE_KEY" \
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="test_name=$MATRIX_OS" \
+            -var="is_onprem=$INPUT_IS_ONPREM_TEST" \
+            -var="user=$MATRIX_USERNAME"; then
+            terraform destroy -var="region=$INPUT_REGION" -var="ami=$MATRIX_AMI" -auto-approve
           else
-            terraform destroy -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" -auto-approve && exit 1
+            terraform destroy -var="region=$INPUT_REGION" -var="ami=$MATRIX_AMI" -auto-approve && exit 1
           fi
       
       - name: "[WIP] ✅ Passed"
@@ -143,16 +172,21 @@ jobs:
       #This is here just in case workflow cancel
       - name: Terraform destroy
         if: ${{ cancelled() || failure() || steps.terraform_apply.outcome == 'failure' }}
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          INPUT_TEST_DIR: ${{ inputs.test_dir }}
+          INPUT_REGION: ${{ inputs.region }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 2
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
-              cd ${{inputs.test_dir}}
+              cd "$INPUT_TEST_DIR"
             fi
 
-            terraform destroy -lock-timeout=5m -var="region=${{ inputs.region }}" -var="ami=${{ matrix.arrays.ami }}" --auto-approve
+            terraform destroy -lock-timeout=5m -var="region=$INPUT_REGION" -var="ami=$MATRIX_AMI" --auto-approve

--- a/.github/workflows/eks-e2e-test.yml
+++ b/.github/workflows/eks-e2e-test.yml
@@ -113,40 +113,60 @@ jobs:
 
       - name: Terraform apply
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          INPUT_TERRAFORM_DIR: ${{ inputs.terraform_dir }}
+          INPUT_REGION: ${{ inputs.region }}
+          MATRIX_K8S_VERSION: ${{ matrix.arrays.k8sVersion }}
+          MATRIX_NODES: ${{ matrix.arrays.nodes }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_HELM_CHARTS_BRANCH: ${{ inputs.helm_charts_branch }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          INPUT_AGENT_REPO: ${{ inputs.cloudwatch_agent_repository }}
+          INPUT_AGENT_TAG: ${{ inputs.cloudwatch_agent_tag }}
+          INPUT_OPERATOR_REPO: ${{ inputs.cloudwatch_agent_operator_repository }}
+          INPUT_OPERATOR_TAG: ${{ inputs.cloudwatch_agent_operator_tag }}
+          INPUT_TA_REPO: ${{ inputs.cloudwatch_agent_target_allocator_repository }}
+          INPUT_AGENT_CONFIG: ${{ inputs.agent_config }}
+          INPUT_PROMETHEUS_CONFIG: ${{ inputs.prometheus_config }}
+          INPUT_OTEL_CONFIG: ${{ inputs.otel_config }}
+          INPUT_SAMPLE_APP: ${{ inputs.sample_app }}
+          INPUT_EKS_INSTALLATION_TYPE: ${{ inputs.eks_installation_type }}
+          INPUT_IP_FAMILY: ${{ inputs.ip_family }}
+          INPUT_VPC_NAME: ${{ inputs.vpc_name }}
         with:
           max_attempts: 3
           timeout_minutes: 60
           retry_wait_seconds: 5
           command: |
-            if [ "${{ inputs.terraform_dir }}" != "" ]; then
-              cd "${{ inputs.terraform_dir }}"
+            if [ -n "$INPUT_TERRAFORM_DIR" ]; then
+              cd "$INPUT_TERRAFORM_DIR"
             else
               cd terraform/eks/e2e
             fi
 
             terraform init
             if terraform apply --auto-approve \
-              -var="region=${{ inputs.region }}" \
-              -var="k8s_version=${{ matrix.arrays.k8sVersion }}" \
-              -var="nodes=${{ matrix.arrays.nodes }}" \
-              -var="helm_charts_branch=${{ inputs.helm_charts_branch }}" \
-              -var="cloudwatch_agent_repository_url=${{ steps.login-ecr.outputs.registry }}" \
-              -var="cloudwatch_agent_repository=${{ inputs.cloudwatch_agent_repository }}" \
-              -var="cloudwatch_agent_tag=${{ inputs.cloudwatch_agent_tag }}" \
-              -var="cloudwatch_agent_operator_repository_url=${{ steps.login-ecr.outputs.registry }}" \
-              -var="cloudwatch_agent_operator_repository=${{ inputs.cloudwatch_agent_operator_repository }}" \
-              -var="cloudwatch_agent_operator_tag=${{ inputs.cloudwatch_agent_operator_tag }}" \
-              -var="cloudwatch_agent_target_allocator_repository_url=${{ steps.login-ecr.outputs.registry }}" \
-              -var="cloudwatch_agent_target_allocator_repository=${{ inputs.cloudwatch_agent_target_allocator_repository }}" \
-              -var="cloudwatch_agent_target_allocator_tag=${{ inputs.cloudwatch_agent_operator_tag }}" \
-              -var="test_dir=${{ matrix.arrays.test_dir }}" \
-              -var="agent_config=${{ inputs.agent_config }}" \
-              -var="prometheus_config=${{ inputs.prometheus_config }}" \
-              -var="otel_config=${{ inputs.otel_config }}" \
-              -var="sample_app=${{ inputs.sample_app }}" \
-              -var="eks_installation_type=${{ inputs.eks_installation_type }}" \
-              -var="ip_family=${{ inputs.ip_family }}" \
-              -var="vpc_name=${{ inputs.vpc_name }}"; then
+              -var="region=$INPUT_REGION" \
+              -var="k8s_version=$MATRIX_K8S_VERSION" \
+              -var="nodes=$MATRIX_NODES" \
+              -var="helm_charts_branch=$INPUT_HELM_CHARTS_BRANCH" \
+              -var="cloudwatch_agent_repository_url=$ECR_REGISTRY" \
+              -var="cloudwatch_agent_repository=$INPUT_AGENT_REPO" \
+              -var="cloudwatch_agent_tag=$INPUT_AGENT_TAG" \
+              -var="cloudwatch_agent_operator_repository_url=$ECR_REGISTRY" \
+              -var="cloudwatch_agent_operator_repository=$INPUT_OPERATOR_REPO" \
+              -var="cloudwatch_agent_operator_tag=$INPUT_OPERATOR_TAG" \
+              -var="cloudwatch_agent_target_allocator_repository_url=$ECR_REGISTRY" \
+              -var="cloudwatch_agent_target_allocator_repository=$INPUT_TA_REPO" \
+              -var="cloudwatch_agent_target_allocator_tag=$INPUT_OPERATOR_TAG" \
+              -var="test_dir=$MATRIX_TEST_DIR" \
+              -var="agent_config=$INPUT_AGENT_CONFIG" \
+              -var="prometheus_config=$INPUT_PROMETHEUS_CONFIG" \
+              -var="otel_config=$INPUT_OTEL_CONFIG" \
+              -var="sample_app=$INPUT_SAMPLE_APP" \
+              -var="eks_installation_type=$INPUT_EKS_INSTALLATION_TYPE" \
+              -var="ip_family=$INPUT_IP_FAMILY" \
+              -var="vpc_name=$INPUT_VPC_NAME"; then
               terraform destroy --auto-approve
             else
               terraform destroy --auto-approve && exit 1
@@ -155,13 +175,15 @@ jobs:
       - name: Terraform destroy
         if: ${{ cancelled() || failure() }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          INPUT_TERRAFORM_DIR: ${{ inputs.terraform_dir }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ inputs.terraform_dir }}" != "" ]; then
-              cd "${{ inputs.terraform_dir }}"
+            if [ -n "$INPUT_TERRAFORM_DIR" ]; then
+              cd "$INPUT_TERRAFORM_DIR"
             else
               cd terraform/eks/e2e
             fi

--- a/.github/workflows/eks-performance-cluster-addon-install.yml
+++ b/.github/workflows/eks-performance-cluster-addon-install.yml
@@ -78,8 +78,10 @@ jobs:
     steps:
       - name: Check trigger type
         id: check-trigger
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+          if [ "$EVENT_NAME" == "workflow_run" ]; then
             echo "Triggered by workflow_run from a scheduled event"
           else
             echo "Triggered manually via workflow_dispatch"

--- a/.github/workflows/eks-performance-cluster-scaling.yml
+++ b/.github/workflows/eks-performance-cluster-scaling.yml
@@ -156,6 +156,8 @@ jobs:
           done
 
       - name: Validate total node count
+        env:
+          EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
           echo "Waiting 30 minutes for scaling operations to complete and stabilize..."
           sleep 1800
@@ -164,7 +166,7 @@ jobs:
           ACTUAL_NODE_COUNT=$(kubectl get nodes --no-headers | wc -l)
           
           # Determine expected count based on trigger type
-          if [ "${{ github.event.schedule }}" = "0 21 * * 1" ]; then
+          if [ "$EVENT_SCHEDULE" = "0 21 * * 1" ]; then
             EXPECTED_NODE_COUNT=0
           else
             EXPECTED_NODE_COUNT=$(($NODE_GROUP_COUNT * $DESIRED_CAPACITY_PER_NODEGROUP + $LEADER_NODE_DESIRED_CAPACITY))

--- a/.github/workflows/eks-performance-cluster-tests.yml
+++ b/.github/workflows/eks-performance-cluster-tests.yml
@@ -70,8 +70,10 @@ jobs:
     steps:
       - name: Check trigger type
         id: check-trigger
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+          if [ "$EVENT_NAME" == "workflow_run" ]; then
             echo "Triggered by workflow_run from a scheduled event"
           else
             echo "Triggered manually via workflow_dispatch"
@@ -162,6 +164,8 @@ jobs:
 
       - name: Run Performance Test
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          PERFORMANCE_METRIC_MAP: ${{ inputs.metric_map || 'base-performance-metrics-map.json' }}
         with:
           max_attempts: 2
           timeout_minutes: 20
@@ -169,7 +173,7 @@ jobs:
             go test -timeout 30m -v $CWA_TEST_DIRECTORY \
               -computeType=EKS \
               -eksClusterName=$CLUSTER_NAME \
-              -performanceMetricMapName=${{ inputs.metric_map || 'base-performance-metrics-map.json' }} \
+              -performanceMetricMapName="$PERFORMANCE_METRIC_MAP" \
               -performanceTestName=EKSPerformanceBaseTest
 
       - name: Cleanup Sample Application

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -56,9 +56,12 @@ jobs:
             echo "Build SHA does not match test SHA"
             exit 1
           fi
-      - run: |
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_BUILD_RUN_ID: ${{ inputs.build_run_id }}
+        run: |
           for i in {1..6}; do
-            conclusion=$(gh run view ${{ inputs.build_run_id }} --repo $GITHUB_REPOSITORY --json conclusion -q '.conclusion')
+            conclusion=$(gh run view "$INPUT_BUILD_RUN_ID" --repo "$GITHUB_REPOSITORY" --json conclusion -q '.conclusion')
             if [[ "$conclusion" == "success" ]]; then
               echo "Run succeeded"
               exit 0
@@ -71,8 +74,6 @@ jobs:
           done
           echo "Timed out waiting for workflow"
           exit 1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   TestArtifacts:
     name: 'TestArtifacts'

--- a/.github/workflows/otel-fork-replace.yml
+++ b/.github/workflows/otel-fork-replace.yml
@@ -22,11 +22,13 @@ jobs:
     steps:
       - name: Get latest commit sha
         id: get-latest-commit
+        env:
+          INPUT_COMMIT_SHA: ${{ inputs.CommitSha }}
         run: |
-          if [ "${{ inputs.CommitSha }}" == "" ]; then
+          if [ -z "$INPUT_COMMIT_SHA" ]; then
             echo "sha=$(git ls-remote ${{ env.UPSTREAM }} ${{ env.UPSTREAM_BRANCH }} | awk '{print $1;}')" >> $GITHUB_OUTPUT
           else
-            echo "sha=${{ inputs.CommitSha }}" >> $GITHUB_OUTPUT
+            echo "sha=$INPUT_COMMIT_SHA" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/record-binary-sizes.yml
+++ b/.github/workflows/record-binary-sizes.yml
@@ -27,10 +27,12 @@ jobs:
         env:
           S3_BUCKET: ${{ vars.S3_INTEGRATION_BUCKET }}
           COMMIT_HASH: ${{ github.sha }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           export COMMIT_DATE=$(git log -1 --format=%ct)
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            export TAG="${{ github.ref_name }}"
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            export TAG="$REF_NAME"
           else
             export TAG=""
           fi

--- a/.github/workflows/release-candidate-test.yml
+++ b/.github/workflows/release-candidate-test.yml
@@ -32,8 +32,10 @@ jobs:
           echo "CWA_GITHUB_TEST_REPO_BRANCH=${CWA_GITHUB_TEST_REPO_BRANCH:-${{ env.CWA_GITHUB_TEST_REPO_BRANCH }}}" >> "$GITHUB_OUTPUT"
 
       - name: Echo test variables
+        env:
+          OUT_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
         run: |
-          echo "CWA_GITHUB_TEST_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}"
+          echo "CWA_GITHUB_TEST_REPO_BRANCH: $OUT_REPO_BRANCH"
 
   RepackageArtifacts:
     name: 'RepackageArtifacts'
@@ -52,6 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Avoid the limit of 5 nested workflows by executing the workflow in this manner
-      - run: gh workflow run test-artifacts.yml --ref ${{ github.ref_name }} --repo $GITHUB_REPOSITORY -f build_id=${{ inputs.build_id }} -f test_repo_branch=${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
-        env:
+      - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          OUT_REPO_BRANCH: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+        run: gh workflow run test-artifacts.yml --ref "$REF_NAME" --repo "$GITHUB_REPOSITORY" -f "build_id=$INPUT_BUILD_ID" -f "test_repo_branch=$OUT_REPO_BRANCH"

--- a/.github/workflows/repackage-release-artifacts.yml
+++ b/.github/workflows/repackage-release-artifacts.yml
@@ -160,8 +160,9 @@ jobs:
         id: pull-image
         env:
           ARTIFACTS_REGISTRY: ${{ steps.login-artifacts-ecr.outputs.registry }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
         run: |
-          docker pull ${{ env.ARTIFACTS_REGISTRY }}/cloudwatch-agent:${{ inputs.build_id }}
+          docker pull "$ARTIFACTS_REGISTRY/cloudwatch-agent:$INPUT_BUILD_ID"
 
       - name: Login to Integ Test Amazon ECR
         id: login-integ-test-ecr
@@ -172,5 +173,6 @@ jobs:
         env:
           ARTIFACTS_REGISTRY: ${{ steps.login-artifacts-ecr.outputs.registry }}
           INTEG_TEST_REGISTRY: ${{ steps.login-integ-test-ecr.outputs.registry }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
         run: |
-          docker buildx imagetools create -t ${{ env.INTEG_TEST_REGISTRY }}/cwagent-integration-test:${{ inputs.build_id }} ${{ env.ARTIFACTS_REGISTRY }}/cloudwatch-agent:${{ inputs.build_id }}
+          docker buildx imagetools create -t "$INTEG_TEST_REGISTRY/cwagent-integration-test:$INPUT_BUILD_ID" "$ARTIFACTS_REGISTRY/cloudwatch-agent:$INPUT_BUILD_ID"

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -86,6 +86,8 @@ jobs:
       # @TODO we can add a matrix in the future but for for now, we will only deploy to AL2.
       - name: Terraform apply
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          GITHUB_SHA_VAL: ${{ github.sha }}
         with:
           max_attempts: 3
           timeout_minutes: 60
@@ -96,7 +98,7 @@ jobs:
             terraform apply --auto-approve \
               -var="github_test_repo=${{ env.CWA_GITHUB_TEST_REPO_URL }}" \
               -var="github_test_repo_branch=${{env.CWA_GITHUB_TEST_REPO_BRANCH}}" \
-              -var="cwa_github_sha=${{ github.sha }}" \
+              -var="cwa_github_sha=$GITHUB_SHA_VAL" \
               -var="user=ec2-user" \
               -var="ami=cloudwatch-agent-integration-test-al2*" \
               -var="arc=amd64" \

--- a/.github/workflows/start-localstack.yml
+++ b/.github/workflows/start-localstack.yml
@@ -63,7 +63,11 @@ jobs:
           aws-region: ${{ inputs.region }}
 
       - name: Echo Localstack Config
-        run: echo repo name ${{inputs.test_repo_name}} repo branch ${{ inputs.test_repo_branch }} region ${{ inputs.region }}
+        env:
+          INPUT_TEST_REPO_NAME: ${{ inputs.test_repo_name }}
+          INPUT_TEST_REPO_BRANCH: ${{ inputs.test_repo_branch }}
+          INPUT_REGION: ${{ inputs.region }}
+        run: echo "repo name $INPUT_TEST_REPO_NAME repo branch $INPUT_TEST_REPO_BRANCH region $INPUT_REGION"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -76,17 +80,23 @@ jobs:
 
       - name: Terraform apply
         id: localstack
+        env:
+          INPUT_TEST_REPO_URL: ${{ inputs.test_repo_url }}
+          INPUT_TEST_REPO_BRANCH: ${{ inputs.test_repo_branch }}
+          INPUT_GITHUB_SHA: ${{ inputs.github_sha }}
+          INPUT_S3_BUCKET: ${{ inputs.s3_integration_bucket }}
+          INPUT_REGION: ${{ inputs.region }}
         run: >
           echo run terraform and execute test code &&
           terraform apply --auto-approve
-          -var="ssh_key_value=${{env.PRIVATE_KEY}}"
-          -var="github_test_repo=${{inputs.test_repo_url}}"
-          -var="github_test_repo_branch=${{inputs.test_repo_branch}}"
-          -var="cwa_github_sha=${{inputs.github_sha}}"
-          -var="s3_bucket=${{inputs.s3_integration_bucket}}"
-          -var="region=${{inputs.region}}"
-          -var="ssh_key_name=${{env.KEY_NAME}}" &&
+          -var="ssh_key_value=$PRIVATE_KEY"
+          -var="github_test_repo=$INPUT_TEST_REPO_URL"
+          -var="github_test_repo_branch=$INPUT_TEST_REPO_BRANCH"
+          -var="cwa_github_sha=$INPUT_GITHUB_SHA"
+          -var="s3_bucket=$INPUT_S3_BUCKET"
+          -var="region=$INPUT_REGION"
+          -var="ssh_key_name=$KEY_NAME" &&
           LOCAL_STACK_HOST_NAME=$(terraform output -raw public_dns) &&
           echo $LOCAL_STACK_HOST_NAME &&
           echo "local_stack_host_name=$LOCAL_STACK_HOST_NAME" >> "$GITHUB_OUTPUT" &&
-          aws s3 cp terraform.tfstate s3://${{inputs.s3_integration_bucket}}/integration-test/local-stack-terraform-state/${{inputs.github_sha}}/terraform.tfstate
+          aws s3 cp terraform.tfstate "s3://$INPUT_S3_BUCKET/integration-test/local-stack-terraform-state/$INPUT_GITHUB_SHA/terraform.tfstate"

--- a/.github/workflows/stop-localstack.yml
+++ b/.github/workflows/stop-localstack.yml
@@ -56,7 +56,10 @@ jobs:
           aws-region: ${{ inputs.region }}
 
       - name: Copy state
-        run: aws s3 cp s3://${{inputs.s3_integration_bucket}}/integration-test/local-stack-terraform-state/${{inputs.github_sha}}/terraform.tfstate .
+        env:
+          INPUT_S3_BUCKET: ${{ inputs.s3_integration_bucket }}
+          INPUT_GITHUB_SHA: ${{ inputs.github_sha }}
+        run: aws s3 cp "s3://$INPUT_S3_BUCKET/integration-test/local-stack-terraform-state/$INPUT_GITHUB_SHA/terraform.tfstate" .
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -68,4 +71,6 @@ jobs:
         run: terraform init
 
       - name: Terraform destroy
-        run: terraform destroy -var="region=${{ inputs.region }}" --auto-approve
+        env:
+          INPUT_REGION: ${{ inputs.region }}
+        run: terraform destroy -var="region=$INPUT_REGION" --auto-approve

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -76,7 +76,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.event.inputs.build_id }}
-        run: echo run identifier ${{ inputs.build_id }}
+        env:
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+        run: echo "run identifier $INPUT_BUILD_ID"
   OutputEnvVariables:
     name: 'OutputEnvVariables'
     runs-on: ubuntu-latest
@@ -138,12 +140,18 @@ jobs:
           fi
 
       - name: Echo test variables
+        env:
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          OUT_REPO_NAME: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+          OUT_REPO_URL: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_URL }}
+          OUT_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+          OUT_COMMIT_DATE: ${{ steps.get-commit-date.outputs.commit_date }}
         run: |
-          echo "build_id: ${{ inputs.build_id }}"
-          echo "CWA_GITHUB_TEST_REPO_NAME: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_NAME }}"
-          echo "CWA_GITHUB_TEST_REPO_URL: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_URL }}"
-          echo "CWA_GITHUB_TEST_REPO_BRANCH: ${{ steps.set-outputs.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}"
-          echo "CWA_COMMIT_DATE: ${{ steps.get-commit-date.outputs.commit_date }}"
+          echo "build_id: $INPUT_BUILD_ID"
+          echo "CWA_GITHUB_TEST_REPO_NAME: $OUT_REPO_NAME"
+          echo "CWA_GITHUB_TEST_REPO_URL: $OUT_REPO_URL"
+          echo "CWA_GITHUB_TEST_REPO_BRANCH: $OUT_REPO_BRANCH"
+          echo "CWA_COMMIT_DATE: $OUT_COMMIT_DATE"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -222,7 +230,11 @@ jobs:
           
           echo "ec2_gpu_matrix=$(apply_filters generator/resources/ec2_gpu_complete_test_matrix.json)" >> "$GITHUB_OUTPUT"
           echo "eks_addon_matrix=$(apply_filters generator/resources/eks_addon_complete_test_matrix.json)" >> "$GITHUB_OUTPUT"
-          echo "ec2_linux_matrix=$(apply_filters generator/resources/ec2_linux_complete_test_matrix.json)" >> "$GITHUB_OUTPUT"
+          # ec2_linux_matrix is large — write to a file so the downstream Paginate
+          # step can read it from disk. Passing it via a step-level env var can
+          # exceed ARG_MAX (~2 MiB) on execve and prevent bash from starting.
+          apply_filters generator/resources/ec2_linux_complete_test_matrix.json > filtered_ec2_linux_matrix.json
+          echo "ec2_linux_matrix=$(cat filtered_ec2_linux_matrix.json)" >> "$GITHUB_OUTPUT"
           echo "ec2_linux_onprem_matrix=$(apply_filters generator/resources/ec2_linux_onprem_complete_test_matrix.json)" >> "$GITHUB_OUTPUT"
           echo "ec2_selinux_matrix=$(apply_filters generator/resources/ec2_selinux_complete_test_matrix.json)" >> "$GITHUB_OUTPUT"
           echo "ec2_windows_matrix=$(apply_filters generator/resources/ec2_windows_complete_test_matrix.json)" >> "$GITHUB_OUTPUT"
@@ -243,8 +255,12 @@ jobs:
         run: |
           # GitHub Actions matrix limit is 256 jobs per workflow run.
           # Use 200 per page for headroom. Up to 5 pages supported (1000 tests).
+          # Read the filtered matrix from the file written by the "Generate matrix"
+          # step instead of a step-level env var: the matrix can exceed the
+          # kernel's ARG_MAX (~2 MiB) on execve, which would prevent bash from
+          # starting for this step.
           PAGE_SIZE=200
-          FULL_MATRIX='${{ steps.set-matrix.outputs.ec2_linux_matrix }}'
+          FULL_MATRIX=$(cat filtered_ec2_linux_matrix.json)
           TOTAL=$(echo "$FULL_MATRIX" | jq 'length')
           PAGE_COUNT=$(( (TOTAL + PAGE_SIZE - 1) / PAGE_SIZE ))
 
@@ -264,36 +280,59 @@ jobs:
           done
 
       - name: Echo test plan matrix
+        env:
+          EC2_GPU_MATRIX: ${{ steps.set-matrix.outputs.ec2_gpu_matrix }}
+          EKS_ADDON_MATRIX: ${{ steps.set-matrix.outputs.eks_addon_matrix }}
+          EC2_LINUX_PAGE_COUNT: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_page_count }}
+          EC2_LINUX_MATRIX_0: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_0 }}
+          EC2_LINUX_MATRIX_1: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_1 }}
+          EC2_LINUX_MATRIX_2: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_2 }}
+          EC2_LINUX_MATRIX_3: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_3 }}
+          EC2_LINUX_MATRIX_4: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_4 }}
+          EC2_LINUX_ONPREM_MATRIX: ${{ steps.set-matrix.outputs.ec2_linux_onprem_matrix }}
+          EC2_SELINUX_MATRIX: ${{ steps.set-matrix.outputs.ec2_selinux_matrix }}
+          EC2_WINDOWS_MATRIX: ${{ steps.set-matrix.outputs.ec2_windows_matrix }}
+          EC2_MAC_MATRIX: ${{ steps.set-matrix.outputs.ec2_mac_matrix }}
+          EC2_PERFORMANCE_MATRIX: ${{ steps.set-matrix.outputs.ec2_performance_matrix }}
+          EC2_WINDOWS_PERFORMANCE_MATRIX: ${{ steps.set-matrix.outputs.ec2_windows_performance_matrix }}
+          EC2_STRESS_MATRIX: ${{ steps.set-matrix.outputs.ec2_stress_matrix }}
+          EC2_WINDOWS_STRESS_MATRIX: ${{ steps.set-matrix.outputs.ec2_windows_stress_matrix }}
+          ECS_EC2_LAUNCH_DAEMON_MATRIX: ${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}
+          ECS_FARGATE_MATRIX: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}
+          EKS_DAEMON_MATRIX: ${{ steps.set-matrix.outputs.eks_daemon_matrix }}
+          EKS_DEPLOYMENT_MATRIX: ${{ steps.set-matrix.outputs.eks_deployment_matrix }}
+          EC2_LINUX_ITAR_MATRIX: ${{ steps.set-matrix.outputs.ec2_linux_itar_matrix }}
+          EC2_LINUX_CHINA_MATRIX: ${{ steps.set-matrix.outputs.ec2_linux_china_matrix }}
         run: |
-          echo "ec2_gpu_matrix: ${{ steps.set-matrix.outputs.ec2_gpu_matrix }}"
-          echo "eks_addon_matrix: ${{ steps.set-matrix.outputs.eks_addon_matrix }}"
-          echo "ec2_linux_matrix pages: ${{ steps.paginate-matrix.outputs.ec2_linux_matrix_page_count }}"
+          echo "ec2_gpu_matrix: $EC2_GPU_MATRIX"
+          echo "eks_addon_matrix: $EKS_ADDON_MATRIX"
+          echo "ec2_linux_matrix pages: $EC2_LINUX_PAGE_COUNT"
           for i in 0 1 2 3 4; do
-            page='${{ steps.paginate-matrix.outputs.ec2_linux_matrix_0 }}'
+            page="$EC2_LINUX_MATRIX_0"
             case $i in
-              1) page='${{ steps.paginate-matrix.outputs.ec2_linux_matrix_1 }}' ;;
-              2) page='${{ steps.paginate-matrix.outputs.ec2_linux_matrix_2 }}' ;;
-              3) page='${{ steps.paginate-matrix.outputs.ec2_linux_matrix_3 }}' ;;
-              4) page='${{ steps.paginate-matrix.outputs.ec2_linux_matrix_4 }}' ;;
+              1) page="$EC2_LINUX_MATRIX_1" ;;
+              2) page="$EC2_LINUX_MATRIX_2" ;;
+              3) page="$EC2_LINUX_MATRIX_3" ;;
+              4) page="$EC2_LINUX_MATRIX_4" ;;
             esac
             if [ -n "$page" ]; then
               echo "ec2_linux_matrix_$i: $(echo "$page" | jq 'length') entries"
             fi
           done
-          echo "ec2_linux_onprem_matrix: ${{ steps.set-matrix.outputs.ec2_linux_onprem_matrix }}"
-          echo "ec2_selinux_matrix: ${{ steps.set-matrix.outputs.ec2_selinux_matrix }}"
-          echo "ec2_windows_matrix: ${{ steps.set-matrix.outputs.ec2_windows_matrix }}"
-          echo "ec2_mac_matrix: ${{ steps.set-matrix.outputs.ec2_mac_matrix }}"
-          echo "ec2_performance_matrix: ${{ steps.set-matrix.outputs.ec2_performance_matrix}}"
-          echo "ec2_windows_performance_matrix: ${{ steps.set-matrix.outputs.ec2_windows_performance_matrix}}"
-          echo "ec2_stress_matrix: ${{ steps.set-matrix.outputs.ec2_stress_matrix}}"
-          echo "ec2_windows_stress_matrix: ${{ steps.set-matrix.outputs.ec2_windows_stress_matrix}}"
-          echo "ecs_ec2_launch_daemon_matrix: ${{ steps.set-matrix.outputs.ecs_ec2_launch_daemon_matrix }}"
-          echo "ecs_fargate_matrix: ${{ steps.set-matrix.outputs.ecs_fargate_matrix }}"
-          echo "eks_daemon_matrix: ${{ steps.set-matrix.outputs.eks_daemon_matrix }}"
-          echo "eks_deployment_matrix: ${{ steps.set-matrix.outputs.eks_deployment_matrix }}"
-          echo "ec2_linux_itar_matrix: ${{ steps.set-matrix.outputs.ec2_linux_itar_matrix }}"
-          echo "ec2_linux_china_matrix: ${{ steps.set-matrix.outputs.ec2_linux_china_matrix }}"
+          echo "ec2_linux_onprem_matrix: $EC2_LINUX_ONPREM_MATRIX"
+          echo "ec2_selinux_matrix: $EC2_SELINUX_MATRIX"
+          echo "ec2_windows_matrix: $EC2_WINDOWS_MATRIX"
+          echo "ec2_mac_matrix: $EC2_MAC_MATRIX"
+          echo "ec2_performance_matrix: $EC2_PERFORMANCE_MATRIX"
+          echo "ec2_windows_performance_matrix: $EC2_WINDOWS_PERFORMANCE_MATRIX"
+          echo "ec2_stress_matrix: $EC2_STRESS_MATRIX"
+          echo "ec2_windows_stress_matrix: $EC2_WINDOWS_STRESS_MATRIX"
+          echo "ecs_ec2_launch_daemon_matrix: $ECS_EC2_LAUNCH_DAEMON_MATRIX"
+          echo "ecs_fargate_matrix: $ECS_FARGATE_MATRIX"
+          echo "eks_daemon_matrix: $EKS_DAEMON_MATRIX"
+          echo "eks_deployment_matrix: $EKS_DEPLOYMENT_MATRIX"
+          echo "ec2_linux_itar_matrix: $EC2_LINUX_ITAR_MATRIX"
+          echo "ec2_linux_china_matrix: $EC2_LINUX_CHINA_MATRIX"
 
   CloudformationTest:
     needs: [OutputEnvVariables, GenerateTestMatrix]
@@ -324,9 +363,11 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Test cf
+        env:
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
         run: |
           cd test/test/cloudformation
-          go test -timeout 1h -package_path=s3://${S3_INTEGRATION_BUCKET}/integration-test/binary/${{ inputs.build_id }}/linux/amd64/amazon-cloudwatch-agent.rpm -iam_role=${CF_IAM_ROLE} -key_name=${CF_KEY_NAME} -metric_name=mem_used_percent
+          go test -timeout 1h "-package_path=s3://${S3_INTEGRATION_BUCKET}/integration-test/binary/${INPUT_BUILD_ID}/linux/amd64/amazon-cloudwatch-agent.rpm" "-iam_role=${CF_IAM_ROLE}" "-key_name=${CF_KEY_NAME}" -metric_name=mem_used_percent
 
   StartLocalStack:
     name: 'StartLocalStack'
@@ -427,7 +468,11 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+        run: echo "run on ec2 instance os $MATRIX_OS arc $MATRIX_ARC test dir $MATRIX_TEST_DIR"
 
 
       - name: Get Runner IP
@@ -444,9 +489,23 @@ jobs:
         continue-on-error: true
         if: ${{ matrix.arrays.family == 'linux' }}
         timeout-minutes: 30
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_INSTALL_AGENT: ${{ matrix.arrays.installAgentCommand }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_USERNAME: ${{ matrix.arrays.username }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_CA_CERT_PATH: ${{ matrix.arrays.caCertPath }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_BINARY_NAME: ${{ matrix.arrays.binaryName }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          OUT_REPO_BRANCH: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+          LOCALSTACK_HOST: ${{ needs.StartLocalStack.outputs.local_stack_host_name }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/ec2/linux
           fi
@@ -455,20 +514,20 @@ jobs:
           if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}" \
             -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-            -var="test_name=${{ matrix.arrays.os }}" \
-            -var="cwa_github_sha=${{ inputs.build_id }}" \
-            -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
-            -var="github_test_repo_branch=${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}" \
-            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-            -var="user=${{ matrix.arrays.username }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
-            -var="arc=${{ matrix.arrays.arc }}" \
-            -var="binary_name=${{ matrix.arrays.binaryName }}" \
-            -var="local_stack_host_name=${{ needs.StartLocalStack.outputs.local_stack_host_name }}" \
+            -var="test_name=$MATRIX_OS" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID" \
+            -var="install_agent=$MATRIX_INSTALL_AGENT" \
+            -var="github_test_repo_branch=$OUT_REPO_BRANCH" \
+            -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
+            -var="user=$MATRIX_USERNAME" \
+            -var="ami=$MATRIX_AMI" \
+            -var="ca_cert_path=$MATRIX_CA_CERT_PATH" \
+            -var="arc=$MATRIX_ARC" \
+            -var="binary_name=$MATRIX_BINARY_NAME" \
+            -var="local_stack_host_name=$LOCALSTACK_HOST" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
             -var="ssh_key_name=${KEY_NAME}" \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" ; then terraform destroy -auto-approve
+            -var="test_dir=$MATRIX_TEST_DIR" ; then terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
           fi
@@ -492,9 +551,17 @@ jobs:
         continue-on-error: true
         if: ${{ matrix.arrays.family == 'window' }}
         timeout-minutes: 30
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          OUT_REPO_BRANCH: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+          RUNNER_IP: ${{ steps.runner_ip.outputs.ip }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/ec2/win
           fi
@@ -504,14 +571,14 @@ jobs:
             -var="ssh_key_value=${PRIVATE_KEY}" \
             -var="ssh_key_name=${KEY_NAME}" \
             -var="github_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-            -var="cwa_github_sha=${{ inputs.build_id }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID" \
+            -var="ami=$MATRIX_AMI" \
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
             -var="github_test_repo=${{env.CWA_GITHUB_TEST_REPO_URL}}" \
-            -var="github_test_repo_branch=${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}" \
+            -var="github_test_repo_branch=$OUT_REPO_BRANCH" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
-            -var="runner_ip=${{ steps.runner_ip.outputs.ip }}" ; then terraform destroy -auto-approve
+            -var="runner_ip=$RUNNER_IP" ; then terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
           fi
@@ -532,14 +599,17 @@ jobs:
       - name: Terraform destroy
         if: ${{ cancelled() || failure() || steps.terraform_apply.outcome == 'failure' || steps.terraform_apply_windows.outcome == 'failure' }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_FAMILY: ${{ matrix.arrays.family }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
-            elif if "${{ matrix.arrays.os }}" == window; then
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
+            elif [ "$MATRIX_FAMILY" = "window" ]; then
               cd terraform/ec2/win
             else
               cd terraform/ec2/linux
@@ -754,7 +824,11 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} use ssm ${{ matrix.arrays.useSSM }} test ${{ matrix.arrays.test_dir }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_USE_SSM: ${{ matrix.arrays.useSSM }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+        run: echo "run on ec2 instance os $MATRIX_OS use ssm $MATRIX_USE_SSM test $MATRIX_TEST_DIR"
 
       - name: Get Runner IP
         id: runner_ip
@@ -770,26 +844,36 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 60
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_USE_SSM: ${{ matrix.arrays.useSSM }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          OUT_REPO_BRANCH: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+          RUNNER_IP: ${{ steps.runner_ip.outputs.ip }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/ec2/win
           fi
 
           terraform init
           if terraform apply --auto-approve \
-            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+            -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
             -var="ssh_key_value=${PRIVATE_KEY}" \
             -var="ssh_key_name=${KEY_NAME}" \
-            -var="test_name=${{ matrix.arrays.os }}" \
-            -var="cwa_github_sha=${{ inputs.build_id }}"  \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="use_ssm=${{ matrix.arrays.useSSM }}" \
+            -var="test_name=$MATRIX_OS" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID"  \
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="ami=$MATRIX_AMI" \
+            -var="use_ssm=$MATRIX_USE_SSM" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
-            -var="github_test_repo_branch=${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}" \
-            -var="runner_ip=${{ steps.runner_ip.outputs.ip }}" ; then
+            -var="github_test_repo_branch=$OUT_REPO_BRANCH" \
+            -var="runner_ip=$RUNNER_IP" ; then
             terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
@@ -812,13 +896,15 @@ jobs:
       - name: Terraform destroy
         if: ${{ cancelled() || failure() || steps.terraform_apply.outcome == 'failure' }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/win
             fi
@@ -848,7 +934,9 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Echo OS
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+        run: echo "run on ec2 instance os $MATRIX_OS"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -860,9 +948,16 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 60
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/ec2/mac
           fi
@@ -871,11 +966,11 @@ jobs:
           if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}" \
             -var="ssh_key_name=${KEY_NAME}"  \
-            -var="arc=${{ matrix.arrays.arc }}" \
-            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-            -var="cwa_github_sha=${{ inputs.build_id }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
+            -var="arc=$MATRIX_ARC" \
+            -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID" \
+            -var="ami=$MATRIX_AMI" \
+            -var="test_dir=$MATRIX_TEST_DIR" \
             -var="license_manager_arn=${{ env.LICENSE_MANAGER_ARN }}" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}"; then
             terraform destroy -auto-approve
@@ -900,13 +995,15 @@ jobs:
       - name: Terraform destroy
         if: ${{ cancelled() || failure() || steps.terraform_apply.outcome == 'failure' }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/mac
             fi
@@ -1005,21 +1102,29 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 30
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_METADATA_ENABLED: ${{ matrix.arrays.metadataEnabled }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/ecs_ec2/daemon
           fi
 
           terraform init
           if terraform apply --auto-approve \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-            -var="cwagent_image_tag=${{ inputs.build_id }}" \
-            -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-            -var="metadataEnabled=${{ matrix.arrays.metadataEnabled }}" \
-            -var="ami=${{ matrix.arrays.ami }}"; then
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="cwagent_image_repo=$ECR_REGISTRY/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
+            -var="cwagent_image_tag=$INPUT_BUILD_ID" \
+            -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
+            -var="metadataEnabled=$MATRIX_METADATA_ENABLED" \
+            -var="ami=$MATRIX_AMI"; then
             terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
@@ -1042,13 +1147,15 @@ jobs:
       - name: Terraform destroy
         if: ${{ cancelled() || failure() || steps.terraform_apply.outcome == 'failure' }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ecs_ec2/daemon
             fi
@@ -1092,18 +1199,23 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 30
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/ecs_fargate/linux
           fi
 
           terraform init
           if terraform apply --auto-approve \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-            -var="cwagent_image_tag=${{ inputs.build_id }}"; then
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="cwagent_image_repo=$ECR_REGISTRY/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
+            -var="cwagent_image_tag=$INPUT_BUILD_ID"; then
             terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
@@ -1126,13 +1238,15 @@ jobs:
       - name: Terraform destroy
         if: ${{ cancelled() || failure() || steps.terraform_apply.outcome == 'failure' }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ecs_fargate/linux
             fi
@@ -1178,9 +1292,16 @@ jobs:
         timeout-minutes: 90 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
         env:
           HELM_CHART_BRANCH_INPUT: ${{ inputs.helm_chart_branch }}
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_K8S_VERSION: ${{ matrix.arrays.k8sVersion }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/eks/daemon
           fi
@@ -1205,12 +1326,12 @@ jobs:
           fi
 
           if terraform apply --auto-approve \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-            -var="cwagent_image_tag=${{ inputs.build_id }}" \
-            -var="ami_type=${{ matrix.arrays.ami }}" \
-            -var="instance_type=${{ matrix.arrays.instanceType }}" \
-            -var="k8s_version=${{ matrix.arrays.k8sVersion }}" \
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="cwagent_image_repo=$ECR_REGISTRY/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
+            -var="cwagent_image_tag=$INPUT_BUILD_ID" \
+            -var="ami_type=$MATRIX_AMI" \
+            -var="instance_type=$MATRIX_INSTANCE_TYPE" \
+            -var="k8s_version=$MATRIX_K8S_VERSION" \
             $HELM_VAR; then
             terraform destroy -auto-approve
           else
@@ -1234,13 +1355,15 @@ jobs:
       - name: Terraform destroy
         if: ${{ cancelled() || failure() || steps.terraform_apply.outcome == 'failure' }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/eks/daemon
             fi
@@ -1284,19 +1407,25 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_K8S_VERSION: ${{ matrix.arrays.k8sVersion }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/eks/deployment
           fi
 
           terraform init
           if terraform apply --auto-approve \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-            -var="cwagent_image_tag=${{ inputs.build_id }}" \
-            -var="k8s_version=${{ matrix.arrays.k8sVersion }}"; then
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="cwagent_image_repo=$ECR_REGISTRY/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
+            -var="cwagent_image_tag=$INPUT_BUILD_ID" \
+            -var="k8s_version=$MATRIX_K8S_VERSION"; then
             terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
@@ -1318,13 +1447,15 @@ jobs:
       - name: Terraform destroy
         if: ${{ cancelled() || failure() || steps.terraform_apply.outcome == 'failure' }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/eks/deployment
             fi
@@ -1368,21 +1499,30 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 60
+        env:
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          COMMIT_DATE: ${{ needs.OutputEnvVariables.outputs.CWA_COMMIT_DATE }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_VALUES_PER_MINUTE: ${{ matrix.arrays.values_per_minute }}
+          MATRIX_FAMILY: ${{ matrix.arrays.family }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          RUNNER_IP: ${{ steps.runner_ip.outputs.ip }}
         run: |
           cd terraform/performance
           terraform init
           if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}"  \
-            -var="cwa_github_sha=${{ inputs.build_id }}" \
-            -var="cwa_github_sha_date=${{ needs.OutputEnvVariables.outputs.CWA_COMMIT_DATE }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="arc=${{ matrix.arrays.arc }}" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID" \
+            -var="cwa_github_sha_date=$COMMIT_DATE" \
+            -var="ami=$MATRIX_AMI" \
+            -var="arc=$MATRIX_ARC" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
             -var="ssh_key_name=${KEY_NAME}" \
-            -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
-            -var="family=${{ matrix.arrays.family}}"\
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="runner_ip=${{ steps.runner_ip.outputs.ip }}" ; then terraform destroy -auto-approve
+            -var="values_per_minute=$MATRIX_VALUES_PER_MINUTE"\
+            -var="family=$MATRIX_FAMILY"\
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="runner_ip=$RUNNER_IP" ; then terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
           fi
@@ -1448,21 +1588,30 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 60
+        env:
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          COMMIT_DATE: ${{ needs.OutputEnvVariables.outputs.CWA_COMMIT_DATE }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_VALUES_PER_MINUTE: ${{ matrix.arrays.values_per_minute }}
+          MATRIX_FAMILY: ${{ matrix.arrays.family }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          RUNNER_IP: ${{ steps.runner_ip.outputs.ip }}
         run: |
           cd terraform/performance
           terraform init
           if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}"  \
-            -var="cwa_github_sha=${{ inputs.build_id }}" \
-            -var="cwa_github_sha_date=${{ needs.OutputEnvVariables.outputs.CWA_COMMIT_DATE }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="arc=${{ matrix.arrays.arc }}" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID" \
+            -var="cwa_github_sha_date=$COMMIT_DATE" \
+            -var="ami=$MATRIX_AMI" \
+            -var="arc=$MATRIX_ARC" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
             -var="ssh_key_name=${KEY_NAME}" \
-            -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
-            -var="family=${{ matrix.arrays.family}}"\
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="runner_ip=${{ steps.runner_ip.outputs.ip }}" ; then terraform destroy -auto-approve
+            -var="values_per_minute=$MATRIX_VALUES_PER_MINUTE"\
+            -var="family=$MATRIX_FAMILY"\
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="runner_ip=$RUNNER_IP" ; then terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
           fi
@@ -1525,25 +1674,37 @@ jobs:
         run: terraform --version
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }} values per minute ${{ matrix.arrays.values_per_minute }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_VALUES_PER_MINUTE: ${{ matrix.arrays.values_per_minute }}
+        run: echo "run on ec2 instance os $MATRIX_OS arc $MATRIX_ARC test dir $MATRIX_TEST_DIR values per minute $MATRIX_VALUES_PER_MINUTE"
 
       - name: Terraform apply
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 60
+        env:
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_VALUES_PER_MINUTE: ${{ matrix.arrays.values_per_minute }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          RUNNER_IP: ${{ steps.runner_ip.outputs.ip }}
         run: |
           cd terraform/stress
           terraform init
           if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}"  \
-            -var="cwa_github_sha=${{ inputs.build_id }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="arc=${{ matrix.arrays.arc }}" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID" \
+            -var="ami=$MATRIX_AMI" \
+            -var="arc=$MATRIX_ARC" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
             -var="ssh_key_name=${KEY_NAME}" \
-            -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="runner_ip=${{ steps.runner_ip.outputs.ip }}" ; then terraform destroy -auto-approve
+            -var="values_per_minute=$MATRIX_VALUES_PER_MINUTE"\
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="runner_ip=$RUNNER_IP" ; then terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
           fi
@@ -1606,26 +1767,39 @@ jobs:
         run: terraform --version
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }} values per minute ${{ matrix.arrays.values_per_minute }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_VALUES_PER_MINUTE: ${{ matrix.arrays.values_per_minute }}
+        run: echo "run on ec2 instance os $MATRIX_OS arc $MATRIX_ARC test dir $MATRIX_TEST_DIR values per minute $MATRIX_VALUES_PER_MINUTE"
 
       - name: Terraform apply
         id: terraform_apply
         continue-on-error: true
         timeout-minutes: 60
+        env:
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_VALUES_PER_MINUTE: ${{ matrix.arrays.values_per_minute }}
+          MATRIX_FAMILY: ${{ matrix.arrays.family }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          RUNNER_IP: ${{ steps.runner_ip.outputs.ip }}
         run: |
           cd terraform/stress
           terraform init
           if terraform apply --auto-approve \
             -var="ssh_key_value=${PRIVATE_KEY}"  \
-            -var="cwa_github_sha=${{ inputs.build_id }}" \
-            -var="ami=${{ matrix.arrays.ami }}" \
-            -var="arc=${{ matrix.arrays.arc }}" \
+            -var="cwa_github_sha=$INPUT_BUILD_ID" \
+            -var="ami=$MATRIX_AMI" \
+            -var="arc=$MATRIX_ARC" \
             -var="s3_bucket=${S3_INTEGRATION_BUCKET}" \
             -var="ssh_key_name=${KEY_NAME}" \
-            -var="values_per_minute=${{ matrix.arrays.values_per_minute}}"\
-            -var="family=${{ matrix.arrays.family}}"\
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="runner_ip=${{ steps.runner_ip.outputs.ip }}" ; then terraform destroy -auto-approve
+            -var="values_per_minute=$MATRIX_VALUES_PER_MINUTE"\
+            -var="family=$MATRIX_FAMILY"\
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="runner_ip=$RUNNER_IP" ; then terraform destroy -auto-approve
           else
             terraform destroy -auto-approve && exit 1
           fi
@@ -1690,21 +1864,29 @@ jobs:
       - name: Terraform apply and setup
         id: terraform_apply
         continue-on-error: true
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_K8S_VERSION: ${{ matrix.arrays.k8sVersion }}
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-            cd "${{ matrix.arrays.terraform_dir }}"
+          if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+            cd "$MATRIX_TERRAFORM_DIR"
           else
             cd terraform/eks/addon/gpu
           fi
 
           terraform init
           if terraform apply --auto-approve \
-            -var="test_dir=${{ matrix.arrays.test_dir }}" \
-            -var="cwagent_image_repo=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
-            -var="cwagent_image_tag=${{ inputs.build_id }}" \
-            -var="ami_type=${{ matrix.arrays.ami }}" \
-            -var="instance_type=${{ matrix.arrays.instanceType }}" \
-            -var="k8s_version=${{ matrix.arrays.k8sVersion }}"; then
+            -var="test_dir=$MATRIX_TEST_DIR" \
+            -var="cwagent_image_repo=$ECR_REGISTRY/${{ env.ECR_INTEGRATION_TEST_REPO }}" \
+            -var="cwagent_image_tag=$INPUT_BUILD_ID" \
+            -var="ami_type=$MATRIX_AMI" \
+            -var="instance_type=$MATRIX_INSTANCE_TYPE" \
+            -var="k8s_version=$MATRIX_K8S_VERSION"; then
             echo "Terraform apply successful."
           else
             terraform destroy -auto-approve && exit 1
@@ -1727,13 +1909,15 @@ jobs:
       - name: Terraform destroy
         if: always()
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/eks/addon/gpu
             fi

--- a/.github/workflows/test-build-distributor.yml
+++ b/.github/workflows/test-build-distributor.yml
@@ -92,22 +92,29 @@ jobs:
 
       - name: Agent Version
         id: version
+        env:
+          INPUT_BUCKET: ${{ inputs.Bucket }}
+          INPUT_BUCKET_KEY: ${{ inputs.BucketKey }}
         run: |
-          aws s3 cp s3://${{ inputs.Bucket }}/${{ inputs.BucketKey }}/CWAGENT_VERSION .
+          aws s3 cp "s3://$INPUT_BUCKET/$INPUT_BUCKET_KEY/CWAGENT_VERSION" .
           echo "version=$(cat CWAGENT_VERSION)" >> "$GITHUB_OUTPUT"
 
       - name: Check if SSM distributor version already exists
         id: check
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          INPUT_REGION: ${{ inputs.Region }}
+          AGENT_VERSION: ${{ steps.version.outputs.version }}
         run: |
           VERSION_EXISTS=$(aws ssm list-document-versions \
-            --name "${{ inputs.DistributorName }}" \
-            --region ${{ inputs.Region }} \
+            --name "$INPUT_DISTRIBUTOR_NAME" \
+            --region "$INPUT_REGION" \
             --no-paginate \
-            --query "DocumentVersions[?VersionName=='${{ steps.version.outputs.version }}']" \
+            --query "DocumentVersions[?VersionName=='$AGENT_VERSION']" \
             --output text 2>/dev/null)
           if [ -n "$VERSION_EXISTS" ]; then
             echo "should-build=false" >> "$GITHUB_OUTPUT"
-            echo "Version ${{ steps.version.outputs.version }} already exists, skipping build"
+            echo "Version $AGENT_VERSION already exists, skipping build"
           else
             echo "should-build=true" >> "$GITHUB_OUTPUT"
           fi
@@ -142,35 +149,39 @@ jobs:
 
       - name: Prepare Linux package
         run: |
-          mkdir -p ${{ env.WORKING_DIRECTORY }}
-          aws s3 cp ${{ env.SOURCE_S3_PATH }}/amazon-cloudwatch-agent.rpm ${{ env.WORKING_DIRECTORY }}/
-          aws s3 cp ${{ env.SOURCE_S3_PATH }}/amazon-cloudwatch-agent.deb ${{ env.WORKING_DIRECTORY }}/
-          cp ${{ env.CHECKOUT_ROOT_DIR }}/packaging/linux/install.sh ${{ env.WORKING_DIRECTORY }}/
-          cp ${{ env.CHECKOUT_ROOT_DIR }}/packaging/linux/uninstall.sh ${{ env.WORKING_DIRECTORY }}/
-          cp ${{ env.CHECKOUT_ROOT_DIR }}/packaging/linux/detect-system.sh ${{ env.WORKING_DIRECTORY }}/
+          mkdir -p "$WORKING_DIRECTORY"
+          aws s3 cp "$SOURCE_S3_PATH/amazon-cloudwatch-agent.rpm" "$WORKING_DIRECTORY/"
+          aws s3 cp "$SOURCE_S3_PATH/amazon-cloudwatch-agent.deb" "$WORKING_DIRECTORY/"
+          cp "${{ env.CHECKOUT_ROOT_DIR }}/packaging/linux/install.sh" "$WORKING_DIRECTORY/"
+          cp "${{ env.CHECKOUT_ROOT_DIR }}/packaging/linux/uninstall.sh" "$WORKING_DIRECTORY/"
+          cp "${{ env.CHECKOUT_ROOT_DIR }}/packaging/linux/detect-system.sh" "$WORKING_DIRECTORY/"
 
       - name: Create manifest JSON
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          AGENT_VERSION: ${{ needs.AgentVersion.outputs.agent-version }}
         run: |
-          cat > ${{ env.WORKING_DIRECTORY }}/manifest.json << EOF
+          cat > "$WORKING_DIRECTORY/manifest.json" << EOF
           {
-            "name": "${{ inputs.DistributorName }}",
+            "name": "$INPUT_DISTRIBUTOR_NAME",
             "platform": "linux",
-            "architecture": "${{ matrix.arch }}",
-            "version": "${{ needs.AgentVersion.outputs.agent-version }}"
+            "architecture": "$MATRIX_ARCH",
+            "version": "$AGENT_VERSION"
           }
           EOF
 
       - name: Zip
-        run: zip -j AmazonCloudWatchAgent.zip ${{ env.WORKING_DIRECTORY }}/*
+        run: zip -j AmazonCloudWatchAgent.zip "$WORKING_DIRECTORY"/*
 
       - name: Upload zip
-        run: aws s3 cp AmazonCloudWatchAgent.zip ${{ env.DESTINATION_S3_PATH }}/AmazonCloudWatchAgent.zip
+        run: aws s3 cp AmazonCloudWatchAgent.zip "$DESTINATION_S3_PATH/AmazonCloudWatchAgent.zip"
 
       - name: Calculate checksum
         run: echo "$(sha256sum AmazonCloudWatchAgent.zip | cut -d' ' -f1)" > checksum.txt
 
       - name: Upload checksum
-        run: aws s3 cp checksum.txt ${{ env.DESTINATION_S3_PATH }}/checksum.txt
+        run: aws s3 cp checksum.txt "$DESTINATION_S3_PATH/checksum.txt"
 
   PackageDarwin:
     name: 'PackageDarwin'
@@ -202,33 +213,37 @@ jobs:
 
       - name: Prepare macOS package
         run: |
-          mkdir -p ${{ env.WORKING_DIRECTORY }}
-          aws s3 cp ${{ env.SOURCE_S3_PATH }}/amazon-cloudwatch-agent.pkg ${{ env.WORKING_DIRECTORY }}/
-          cp ${{ env.CHECKOUT_ROOT_DIR }}/packaging/darwin/install.sh ${{ env.WORKING_DIRECTORY }}/
-          cp ${{ env.CHECKOUT_ROOT_DIR }}/packaging/darwin/uninstall.sh ${{ env.WORKING_DIRECTORY }}/
+          mkdir -p "$WORKING_DIRECTORY"
+          aws s3 cp "$SOURCE_S3_PATH/amazon-cloudwatch-agent.pkg" "$WORKING_DIRECTORY/"
+          cp "${{ env.CHECKOUT_ROOT_DIR }}/packaging/darwin/install.sh" "$WORKING_DIRECTORY/"
+          cp "${{ env.CHECKOUT_ROOT_DIR }}/packaging/darwin/uninstall.sh" "$WORKING_DIRECTORY/"
 
       - name: Create manifest JSON
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          AGENT_VERSION: ${{ needs.AgentVersion.outputs.agent-version }}
         run: |
-          cat > ${{ env.WORKING_DIRECTORY }}/manifest.json << EOF
+          cat > "$WORKING_DIRECTORY/manifest.json" << EOF
           {
-            "name": "${{ inputs.DistributorName }}",
+            "name": "$INPUT_DISTRIBUTOR_NAME",
             "platform": "mac_os_x",
-            "architecture": "${{ matrix.arch }}",
-            "version": "${{ needs.AgentVersion.outputs.agent-version }}"
+            "architecture": "$MATRIX_ARCH",
+            "version": "$AGENT_VERSION"
           }
           EOF
 
       - name: Zip
-        run: zip -j AmazonCloudWatchAgent.zip ${{ env.WORKING_DIRECTORY }}/*
+        run: zip -j AmazonCloudWatchAgent.zip "$WORKING_DIRECTORY"/*
 
       - name: Upload zip
-        run: aws s3 cp AmazonCloudWatchAgent.zip ${{ env.DESTINATION_S3_PATH }}/AmazonCloudWatchAgent.zip
+        run: aws s3 cp AmazonCloudWatchAgent.zip "$DESTINATION_S3_PATH/AmazonCloudWatchAgent.zip"
 
       - name: Calculate checksum
         run: echo "$(sha256sum AmazonCloudWatchAgent.zip | cut -d' ' -f1)" > checksum.txt
 
       - name: Upload checksum
-        run: aws s3 cp checksum.txt ${{ env.DESTINATION_S3_PATH }}/checksum.txt
+        run: aws s3 cp checksum.txt "$DESTINATION_S3_PATH/checksum.txt"
 
   PackageWindows:
     name: 'PackageWindows'
@@ -257,33 +272,36 @@ jobs:
 
       - name: Prepare Windows package
         run: |
-          mkdir -p ${{ env.WORKING_DIRECTORY }}
-          aws s3 cp ${{ env.SOURCE_S3_PATH }}/amazon-cloudwatch-agent.msi ${{ env.WORKING_DIRECTORY }}/
-          cp ${{ env.CHECKOUT_ROOT_DIR }}/packaging/windows/install.ps1 ${{ env.WORKING_DIRECTORY }}/
-          cp ${{ env.CHECKOUT_ROOT_DIR }}/packaging/windows/uninstall.ps1 ${{ env.WORKING_DIRECTORY }}/
+          mkdir -p "$WORKING_DIRECTORY"
+          aws s3 cp "$SOURCE_S3_PATH/amazon-cloudwatch-agent.msi" "$WORKING_DIRECTORY/"
+          cp "${{ env.CHECKOUT_ROOT_DIR }}/packaging/windows/install.ps1" "$WORKING_DIRECTORY/"
+          cp "${{ env.CHECKOUT_ROOT_DIR }}/packaging/windows/uninstall.ps1" "$WORKING_DIRECTORY/"
 
       - name: Create manifest JSON
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          AGENT_VERSION: ${{ needs.AgentVersion.outputs.agent-version }}
         run: |
-          cat > ${{ env.WORKING_DIRECTORY }}/manifest.json << EOF
+          cat > "$WORKING_DIRECTORY/manifest.json" << EOF
           {
-            "name": "${{ inputs.DistributorName }}",
+            "name": "$INPUT_DISTRIBUTOR_NAME",
             "platform": "windows",
             "architecture": "amd64",
-            "version": "${{ needs.AgentVersion.outputs.agent-version }}"
+            "version": "$AGENT_VERSION"
           }
           EOF
 
       - name: Zip
-        run: zip -j AmazonCloudWatchAgent.zip ${{ env.WORKING_DIRECTORY }}/*
+        run: zip -j AmazonCloudWatchAgent.zip "$WORKING_DIRECTORY"/*
 
       - name: Upload zip
-        run: aws s3 cp AmazonCloudWatchAgent.zip ${{ env.DESTINATION_S3_PATH }}/AmazonCloudWatchAgent.zip
+        run: aws s3 cp AmazonCloudWatchAgent.zip "$DESTINATION_S3_PATH/AmazonCloudWatchAgent.zip"
 
       - name: Calculate checksum
         run: echo "$(sha256sum AmazonCloudWatchAgent.zip | cut -d' ' -f1)" > checksum.txt
 
       - name: Upload checksum
-        run: aws s3 cp checksum.txt ${{ env.DESTINATION_S3_PATH }}/checksum.txt
+        run: aws s3 cp checksum.txt "$DESTINATION_S3_PATH/checksum.txt"
 
   UploadDistributor:
     name: 'UploadDistributor'
@@ -312,11 +330,11 @@ jobs:
       - name: Download checksums
         run: |
           mkdir -p checksum/{windows/amd64,linux/{amd64,arm64},darwin/{amd64,arm64}}
-          aws s3 cp ${{ env.S3_PATH }}/windows/amd64/${{ env.AGENT_VERSION }}/checksum.txt checksum/windows/amd64/
-          aws s3 cp ${{ env.S3_PATH }}/linux/amd64/${{ env.AGENT_VERSION }}/checksum.txt checksum/linux/amd64/
-          aws s3 cp ${{ env.S3_PATH }}/linux/arm64/${{ env.AGENT_VERSION }}/checksum.txt checksum/linux/arm64/
-          aws s3 cp ${{ env.S3_PATH }}/darwin/amd64/${{ env.AGENT_VERSION }}/checksum.txt checksum/darwin/amd64/
-          aws s3 cp ${{ env.S3_PATH }}/darwin/arm64/${{ env.AGENT_VERSION }}/checksum.txt checksum/darwin/arm64/
+          aws s3 cp "$S3_PATH/windows/amd64/$AGENT_VERSION/checksum.txt" checksum/windows/amd64/
+          aws s3 cp "$S3_PATH/linux/amd64/$AGENT_VERSION/checksum.txt" checksum/linux/amd64/
+          aws s3 cp "$S3_PATH/linux/arm64/$AGENT_VERSION/checksum.txt" checksum/linux/arm64/
+          aws s3 cp "$S3_PATH/darwin/amd64/$AGENT_VERSION/checksum.txt" checksum/darwin/amd64/
+          aws s3 cp "$S3_PATH/darwin/arm64/$AGENT_VERSION/checksum.txt" checksum/darwin/arm64/
 
       - name: Create manifest JSON
         run: |
@@ -326,15 +344,18 @@ jobs:
           export DARWIN_AMD64_SHA=$(cat checksum/darwin/amd64/checksum.txt)
           export DARWIN_ARM64_SHA=$(cat checksum/darwin/arm64/checksum.txt)
           
-          envsubst < ${{ env.CHECKOUT_ROOT_DIR }}/packaging/manifest.json > manifest.json
+          envsubst < "${{ env.CHECKOUT_ROOT_DIR }}/packaging/manifest.json" > manifest.json
 
       - name: Upload manifest JSON to S3
-        run: aws s3 cp manifest.json ${{ env.S3_PATH }}/manifest.json
+        run: aws s3 cp manifest.json "$S3_PATH/manifest.json"
 
       - name: Check if distributor exists
         id: check-distributor
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          INPUT_REGION: ${{ inputs.Region }}
         run: |
-          if aws ssm describe-document --name "${{ inputs.DistributorName }}" --region ${{ inputs.Region }} 2>/dev/null; then
+          if aws ssm describe-document --name "$INPUT_DISTRIBUTOR_NAME" --region "$INPUT_REGION" 2>/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -342,44 +363,58 @@ jobs:
 
       - name: Create distributor
         if: steps.check-distributor.outputs.exists == 'false'
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          INPUT_REGION: ${{ inputs.Region }}
+          AGENT_VERSION: ${{ needs.AgentVersion.outputs.agent-version }}
         run: |
           aws ssm create-document \
-            --name "${{ inputs.DistributorName }}" \
+            --name "$INPUT_DISTRIBUTOR_NAME" \
             --content file://manifest.json \
-            --attachments Key="SourceUrl",Values="${{ env.S3_PATH }}" \
-            --version-name "${{ needs.AgentVersion.outputs.agent-version }}" \
+            --attachments Key="SourceUrl",Values="$S3_PATH" \
+            --version-name "$AGENT_VERSION" \
             --document-type Package \
-            --region ${{ inputs.Region }}
+            --region "$INPUT_REGION"
 
       - name: Remove oldest if limit hit
         if: steps.check-distributor.outputs.exists == 'true'
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          INPUT_REGION: ${{ inputs.Region }}
         run: |
-          VERSION_COUNT=$(aws ssm list-document-versions --name "${{ inputs.DistributorName }}" --region ${{ inputs.Region }} --no-paginate --query 'length(DocumentVersions)' --output text)
-          if [ "$VERSION_COUNT" -ge ${{ env.SSM_DISTRIBUTOR_VERSION_LIMIT }} ]; then
-            OLDEST_VERSION=$(aws ssm list-document-versions --name "${{ inputs.DistributorName }}" --region ${{ inputs.Region }} --no-paginate --query 'DocumentVersions[-1].DocumentVersion' --output text)
+          VERSION_COUNT=$(aws ssm list-document-versions --name "$INPUT_DISTRIBUTOR_NAME" --region "$INPUT_REGION" --no-paginate --query 'length(DocumentVersions)' --output text)
+          if [ "$VERSION_COUNT" -ge "${{ env.SSM_DISTRIBUTOR_VERSION_LIMIT }}" ]; then
+            OLDEST_VERSION=$(aws ssm list-document-versions --name "$INPUT_DISTRIBUTOR_NAME" --region "$INPUT_REGION" --no-paginate --query 'DocumentVersions[-1].DocumentVersion' --output text)
             echo "Deleting oldest version: $OLDEST_VERSION"
-            aws ssm delete-document --name "${{ inputs.DistributorName }}" --document-version "$OLDEST_VERSION" --region ${{ inputs.Region }}
+            aws ssm delete-document --name "$INPUT_DISTRIBUTOR_NAME" --document-version "$OLDEST_VERSION" --region "$INPUT_REGION"
           fi
 
       - name: Update distributor
         if: steps.check-distributor.outputs.exists == 'true'
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          INPUT_REGION: ${{ inputs.Region }}
+          AGENT_VERSION: ${{ needs.AgentVersion.outputs.agent-version }}
         run: |
           aws ssm update-document \
-            --name "${{ inputs.DistributorName }}" \
+            --name "$INPUT_DISTRIBUTOR_NAME" \
             --content file://manifest.json \
-            --attachments Key="SourceUrl",Values="${{ env.S3_PATH }}" \
-            --version-name "${{ needs.AgentVersion.outputs.agent-version }}" \
+            --attachments Key="SourceUrl",Values="$S3_PATH" \
+            --version-name "$AGENT_VERSION" \
             --document-version "\$LATEST" \
-            --region ${{ inputs.Region }}
+            --region "$INPUT_REGION"
 
       - name: Verify distributor
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          INPUT_REGION: ${{ inputs.Region }}
         with:
           max_attempts: 6
           timeout_minutes: 5
           retry_wait_seconds: 10
           command: |
-            STATUS=$(aws ssm describe-document --name "${{ inputs.DistributorName }}" --region ${{ inputs.Region }} --query 'Document.Status' --output text)
+            STATUS=$(aws ssm describe-document --name "$INPUT_DISTRIBUTOR_NAME" --region "$INPUT_REGION" --query 'Document.Status' --output text)
             if [ "$STATUS" != "Active" ]; then
               echo "Error: Document status is $STATUS, expected Active"
               exit 1
@@ -387,14 +422,17 @@ jobs:
             echo "Document is Active"
 
       - name: Update default version
+        env:
+          INPUT_DISTRIBUTOR_NAME: ${{ inputs.DistributorName }}
+          INPUT_REGION: ${{ inputs.Region }}
         run: |
-          CURRENT_DEFAULT=$(aws ssm describe-document --name "${{ inputs.DistributorName }}" --region ${{ inputs.Region }} --query 'Document.DefaultVersion' --output text)
-          LATEST_VERSION=$(aws ssm describe-document --name "${{ inputs.DistributorName }}" --region ${{ inputs.Region }} --query 'Document.LatestVersion' --output text)
-          if [ "$CURRENT_DEFAULT" != "$LATEST_DEFAULT" ]; then
+          CURRENT_DEFAULT=$(aws ssm describe-document --name "$INPUT_DISTRIBUTOR_NAME" --region "$INPUT_REGION" --query 'Document.DefaultVersion' --output text)
+          LATEST_VERSION=$(aws ssm describe-document --name "$INPUT_DISTRIBUTOR_NAME" --region "$INPUT_REGION" --query 'Document.LatestVersion' --output text)
+          if [ "$CURRENT_DEFAULT" != "$LATEST_VERSION" ]; then
             aws ssm update-document-default-version \
-              --name "${{ inputs.DistributorName }}" \
+              --name "$INPUT_DISTRIBUTOR_NAME" \
               --document-version "$LATEST_VERSION" \
-              --region ${{ inputs.Region }}
+              --region "$INPUT_REGION"
           else
             echo "Default version already matches latest version"
           fi

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -91,11 +91,13 @@ jobs:
       # Build dir is ignored in our .dockerignore thus need to copy to another dir.
       - name: Copy Binary For Agent Image Build
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_container.outputs.cache-hit == false
+        env:
+          INPUT_BUCKET_KEY: ${{ inputs.BucketKey }}
         run: |
           mkdir amd64
           mkdir arm64
-          aws s3 cp s3://${{ vars.S3_INTEGRATION_BUCKET }}/${{ inputs.BucketKey }}/linux/amd64/amazon-cloudwatch-agent.rpm amd64/amazon-cloudwatch-agent.rpm
-          aws s3 cp s3://${{ vars.S3_INTEGRATION_BUCKET }}/${{ inputs.BucketKey }}/linux/arm64/amazon-cloudwatch-agent.rpm arm64/amazon-cloudwatch-agent.rpm
+          aws s3 cp "s3://${{ vars.S3_INTEGRATION_BUCKET }}/$INPUT_BUCKET_KEY/linux/amd64/amazon-cloudwatch-agent.rpm" amd64/amazon-cloudwatch-agent.rpm
+          aws s3 cp "s3://${{ vars.S3_INTEGRATION_BUCKET }}/$INPUT_BUCKET_KEY/linux/arm64/amazon-cloudwatch-agent.rpm" arm64/amazon-cloudwatch-agent.rpm
 
       - name: Get ECR Repo name
         id: repo_name
@@ -160,8 +162,10 @@ jobs:
 
       - name: Copy binary
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_win_zip.outputs.cache-hit == false
+        env:
+          INPUT_BUCKET_KEY: ${{ inputs.BucketKey }}
         run: |
-          aws s3 cp s3://${{ vars.S3_INTEGRATION_BUCKET }}/${{ inputs.BucketKey }} . --recursive
+          aws s3 cp "s3://${{ vars.S3_INTEGRATION_BUCKET }}/$INPUT_BUCKET_KEY" . --recursive
       - name: Unzip
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_win_zip.outputs.cache-hit == false
         run: |
@@ -186,7 +190,9 @@ jobs:
 
       - name: Upload zip
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_win_zip.outputs.cache-hit == false
-        run: aws s3 cp buildMSI.zip s3://${{ vars.S3_INTEGRATION_BUCKET }}/${{ inputs.BucketKey }}/buildMSI.zip
+        env:
+          INPUT_BUCKET_KEY: ${{ inputs.BucketKey }}
+        run: aws s3 cp buildMSI.zip "s3://${{ vars.S3_INTEGRATION_BUCKET }}/$INPUT_BUCKET_KEY/buildMSI.zip"
 
   BuildMSI-2022:
     name: 'BuildMSI-2022'
@@ -214,10 +220,14 @@ jobs:
       # Using the env variable returns "" for bucket name thus use the secret
       - name: Copy msi
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_msi.outputs.cache-hit == false
-        run: aws s3 cp s3://${{ vars.S3_INTEGRATION_BUCKET }}/${{ inputs.BucketKey }}/buildMSI.zip .
+        env:
+          INPUT_BUCKET_KEY: ${{ inputs.BucketKey }}
+        run: aws s3 cp "s3://${{ vars.S3_INTEGRATION_BUCKET }}/$env:INPUT_BUCKET_KEY/buildMSI.zip" .
 
       - name: Create msi
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_msi.outputs.cache-hit == false
+        env:
+          INPUT_PACKAGE_BUCKET_KEY: ${{ inputs.PackageBucketKey }}
         run: |
           curl -OLS https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314.exe
           .\wix314.exe /install /quiet /norestart
@@ -225,7 +235,7 @@ jobs:
           $env:PATH = $env:PATH + $wixToolsetBinPath
           Expand-Archive buildMSI.zip -Force
           cd buildMSI/msi_dep
-          .\create_msi.ps1 "nosha" ${{ vars.S3_INTEGRATION_BUCKET }}/${{ inputs.PackageBucketKey }}
+          .\create_msi.ps1 "nosha" "${{ vars.S3_INTEGRATION_BUCKET }}/$env:INPUT_PACKAGE_BUCKET_KEY"
 
       - name: clean ecr login credential cache
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_msi.outputs.cache-hit == false
@@ -345,10 +355,12 @@ jobs:
 
       - name: Download from s3
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_sig.outputs.cache-hit == false
+        env:
+          INPUT_PACKAGE_BUCKET_KEY: ${{ inputs.PackageBucketKey }}
         run: |
           mkdir -p packages/amd64
           mkdir packages/arm64
-          aws s3 cp s3://${{ vars.S3_INTEGRATION_BUCKET }}/${{ inputs.PackageBucketKey }}/amazon-cloudwatch-agent.msi ./packages/amazon-cloudwatch-agent.msi
+          aws s3 cp "s3://${{ vars.S3_INTEGRATION_BUCKET }}/$INPUT_PACKAGE_BUCKET_KEY/amazon-cloudwatch-agent.msi" ./packages/amazon-cloudwatch-agent.msi
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@d6f3f49f3345e29369fe57596a3ca8f94c4d2ca7 # v5.4.0
         with:
@@ -360,5 +372,7 @@ jobs:
 
       - name: Upload to s3
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_sig.outputs.cache-hit == false
+        env:
+          INPUT_PACKAGE_BUCKET_KEY: ${{ inputs.PackageBucketKey }}
         run: |
-          aws s3 cp packages/amazon-cloudwatch-agent.msi.sig s3://${{ vars.S3_INTEGRATION_BUCKET }}/${{ inputs.PackageBucketKey }}/amazon-cloudwatch-agent.msi.sig
+          aws s3 cp packages/amazon-cloudwatch-agent.msi.sig "s3://${{ vars.S3_INTEGRATION_BUCKET }}/$INPUT_PACKAGE_BUCKET_KEY/amazon-cloudwatch-agent.msi.sig"

--- a/.github/workflows/test-build-packages.yml
+++ b/.github/workflows/test-build-packages.yml
@@ -132,12 +132,15 @@ jobs:
       - name: Build And Upload PKG
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_binaries.outputs.cache-hit == false
         working-directory: /tmp/
+        env:
+          INPUT_BUCKET: ${{ inputs.Bucket }}
+          INPUT_PACKAGE_BUCKET_KEY: ${{ inputs.PackageBucketKey }}
         run: |
           chmod +x create_pkg.sh
           chmod +x arm64/create_pkg.sh
-          ./create_pkg.sh ${{ inputs.Bucket }}/${{ inputs.PackageBucketKey }} "nosha" amd64
+          ./create_pkg.sh "$INPUT_BUCKET/$INPUT_PACKAGE_BUCKET_KEY" "nosha" amd64
           cd arm64
-          ./create_pkg.sh ${{ inputs.Bucket }}/${{ inputs.PackageBucketKey }} "nosha" arm64
+          ./create_pkg.sh "$INPUT_BUCKET/$INPUT_PACKAGE_BUCKET_KEY" "nosha" arm64
 
   #GH actions set up gpg only works on ubuntu as of this commit date
   GPGSignMacPackage:
@@ -165,11 +168,14 @@ jobs:
 
       - name: Download from s3
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_sig.outputs.cache-hit == false
+        env:
+          INPUT_BUCKET: ${{ inputs.Bucket }}
+          INPUT_PACKAGE_BUCKET_KEY: ${{ inputs.PackageBucketKey }}
         run: |
           mkdir -p packages/amd64
           mkdir packages/arm64
-          aws s3 cp s3://${{ inputs.Bucket }}/${{ inputs.PackageBucketKey }}/amd64/amazon-cloudwatch-agent.pkg ./packages/amd64/amazon-cloudwatch-agent.pkg
-          aws s3 cp s3://${{ inputs.Bucket }}/${{ inputs.PackageBucketKey }}/arm64/amazon-cloudwatch-agent.pkg ./packages/arm64/amazon-cloudwatch-agent.pkg
+          aws s3 cp "s3://$INPUT_BUCKET/$INPUT_PACKAGE_BUCKET_KEY/amd64/amazon-cloudwatch-agent.pkg" ./packages/amd64/amazon-cloudwatch-agent.pkg
+          aws s3 cp "s3://$INPUT_BUCKET/$INPUT_PACKAGE_BUCKET_KEY/arm64/amazon-cloudwatch-agent.pkg" ./packages/arm64/amazon-cloudwatch-agent.pkg
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@d6f3f49f3345e29369fe57596a3ca8f94c4d2ca7 # v5.4.0
         with:
@@ -181,6 +187,9 @@ jobs:
 
       - name: Upload to s3
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_sig.outputs.cache-hit == false
+        env:
+          INPUT_BUCKET: ${{ inputs.Bucket }}
+          INPUT_PACKAGE_BUCKET_KEY: ${{ inputs.PackageBucketKey }}
         run: |
-          aws s3 cp packages/amd64/amazon-cloudwatch-agent.pkg.sig s3://${{ inputs.Bucket }}/${{ inputs.PackageBucketKey }}/amd64/amazon-cloudwatch-agent.pkg.sig
-          aws s3 cp packages/arm64/amazon-cloudwatch-agent.pkg.sig s3://${{ inputs.Bucket }}/${{ inputs.PackageBucketKey }}/arm64/amazon-cloudwatch-agent.pkg.sig
+          aws s3 cp packages/amd64/amazon-cloudwatch-agent.pkg.sig "s3://$INPUT_BUCKET/$INPUT_PACKAGE_BUCKET_KEY/amd64/amazon-cloudwatch-agent.pkg.sig"
+          aws s3 cp packages/arm64/amazon-cloudwatch-agent.pkg.sig "s3://$INPUT_BUCKET/$INPUT_PACKAGE_BUCKET_KEY/arm64/amazon-cloudwatch-agent.pkg.sig"

--- a/.github/workflows/wd-integration-test.yml
+++ b/.github/workflows/wd-integration-test.yml
@@ -41,9 +41,12 @@ jobs:
             echo "Build SHA does not match test SHA"
             exit 1
           fi
-      - run: |-
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_BUILD_RUN_ID: ${{ inputs.build_run_id }}
+        run: |-
           for i in {1..6}; do
-            conclusion=$(gh run view ${{ inputs.build_run_id }} --repo $GITHUB_REPOSITORY --json conclusion -q '.conclusion')
+            conclusion=$(gh run view "$INPUT_BUILD_RUN_ID" --repo "$GITHUB_REPOSITORY" --json conclusion -q '.conclusion')
             if [[ "$conclusion" == "success" ]]; then
               echo "Run succeeded"
               exit 0
@@ -56,8 +59,6 @@ jobs:
           done
           echo "Timed out waiting for workflow"
           exit 1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   GenerateTestMatrix:
     name: 'GenerateTestMatrix'
@@ -113,7 +114,11 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+        run: echo "run on ec2 instance os $MATRIX_OS arc $MATRIX_ARC test dir $MATRIX_TEST_DIR"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -125,35 +130,49 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_BINARY_NAME: ${{ matrix.arrays.binaryName }}
+          MATRIX_CA_CERT_PATH: ${{ matrix.arrays.caCertPath }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_USERNAME: ${{ matrix.arrays.username }}
+          MATRIX_INSTALL_AGENT: ${{ matrix.arrays.installAgentCommand }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_BUILD_SHA: ${{ inputs.build_sha }}
+          INPUT_TEST_REPO_BRANCH: ${{ inputs.test_repo_branch || env.CWA_GITHUB_TEST_REPO_BRANCH }}
+          LOCALSTACK_HOST: ${{ needs.StartWorkloadDiscoveryIntegrationTests.outputs.local_stack_host_name }}
         with:
           max_attempts: 3
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |-
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/linux
             fi
 
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${{env.PRIVATE_KEY}}" \
+              -var="ssh_key_value=$PRIVATE_KEY" \
               -var="github_test_repo=${{ env.CWA_GITHUB_TEST_REPO_URL }}" \
-              -var="test_name=${{ matrix.arrays.os }}" \
-              -var="cwa_github_sha=${{inputs.build_sha}}" \
-              -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
-              -var="github_test_repo_branch=${{ inputs.test_repo_branch || env.CWA_GITHUB_TEST_REPO_BRANCH }}" \
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-              -var="user=${{ matrix.arrays.username }}" \
-              -var="ami=${{ matrix.arrays.ami }}" \
-              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
-              -var="arc=${{ matrix.arrays.arc }}" \
-              -var="binary_name=${{ matrix.arrays.binaryName }}" \
-              -var="local_stack_host_name=${{ needs.StartWorkloadDiscoveryIntegrationTests.outputs.local_stack_host_name }}" \
+              -var="test_name=$MATRIX_OS" \
+              -var="cwa_github_sha=$INPUT_BUILD_SHA" \
+              -var="install_agent=$MATRIX_INSTALL_AGENT" \
+              -var="github_test_repo_branch=$INPUT_TEST_REPO_BRANCH" \
+              -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
+              -var="user=$MATRIX_USERNAME" \
+              -var="ami=$MATRIX_AMI" \
+              -var="ca_cert_path=$MATRIX_CA_CERT_PATH" \
+              -var="arc=$MATRIX_ARC" \
+              -var="binary_name=$MATRIX_BINARY_NAME" \
+              -var="local_stack_host_name=$LOCALSTACK_HOST" \
               -var="s3_bucket=${{ vars.S3_INTEGRATION_BUCKET }}" \
-              -var="ssh_key_name=${{env.KEY_NAME}}" \
-              -var="test_dir=${{ matrix.arrays.test_dir }}"; then terraform destroy -auto-approve
+              -var="ssh_key_name=$KEY_NAME" \
+              -var="test_dir=$MATRIX_TEST_DIR"; then terraform destroy -auto-approve
             else
               terraform destroy -auto-approve && exit 1
             fi
@@ -175,18 +194,21 @@ jobs:
       - name: Terraform destroy
         if: ${{ (cancelled() || failure()) }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |-
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/linux
             fi
 
-            terraform destroy -lock-timeout=5m -var="ami=${{ matrix.arrays.ami }}" --auto-approve
+            terraform destroy -lock-timeout=5m -var="ami=$MATRIX_AMI" --auto-approve
 
   EC2WindowsWorkloadDiscoveryIntegrationTest:
     needs: [ GenerateTestMatrix ]
@@ -213,7 +235,11 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+        run: echo "run on ec2 instance os $MATRIX_OS arc $MATRIX_ARC test dir $MATRIX_TEST_DIR"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -225,26 +251,33 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_BUILD_SHA: ${{ inputs.build_sha }}
         with:
           max_attempts: 3
           timeout_minutes: 60
           retry_wait_seconds: 5
           command: |-
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/win
             fi
 
             terraform init
             if terraform apply --auto-approve \
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
               -var="ssh_key_value=${PRIVATE_KEY}" \
               -var="ssh_key_name=${KEY_NAME}" \
-              -var="test_name=${{ matrix.arrays.os }}" \
-              -var="cwa_github_sha=${{ inputs.build_sha }}"  \
-              -var="test_dir=${{ matrix.arrays.test_dir }}" \
-              -var="ami=${{ matrix.arrays.ami }}" \
+              -var="test_name=$MATRIX_OS" \
+              -var="cwa_github_sha=$INPUT_BUILD_SHA"  \
+              -var="test_dir=$MATRIX_TEST_DIR" \
+              -var="ami=$MATRIX_AMI" \
               -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
               terraform destroy -auto-approve
             else
@@ -268,18 +301,21 @@ jobs:
       - name: Terraform destroy
         if: ${{ (cancelled() || failure()) }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |-
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/win
             fi
 
-            terraform destroy -lock-timeout=5m -var="ami=${{ matrix.arrays.ami }}" --auto-approve
+            terraform destroy -lock-timeout=5m -var="ami=$MATRIX_AMI" --auto-approve
 
   EC2NvidiaLinuxWorkloadDiscoveryIntegrationTest:
     needs: [ GenerateTestMatrix ]
@@ -306,7 +342,11 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+        run: echo "run on ec2 instance os $MATRIX_OS arc $MATRIX_ARC test dir $MATRIX_TEST_DIR"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -318,35 +358,49 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_BINARY_NAME: ${{ matrix.arrays.binaryName }}
+          MATRIX_CA_CERT_PATH: ${{ matrix.arrays.caCertPath }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_USERNAME: ${{ matrix.arrays.username }}
+          MATRIX_INSTALL_AGENT: ${{ matrix.arrays.installAgentCommand }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_BUILD_SHA: ${{ inputs.build_sha }}
+          INPUT_TEST_REPO_BRANCH: ${{ inputs.test_repo_branch || env.CWA_GITHUB_TEST_REPO_BRANCH }}
+          LOCALSTACK_HOST: ${{ needs.StartWorkloadDiscoveryIntegrationTests.outputs.local_stack_host_name }}
         with:
           max_attempts: 3
           timeout_minutes: 30
           retry_wait_seconds: 5
           command: |-
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/linux
             fi
 
             terraform init
             if terraform apply --auto-approve \
-              -var="ssh_key_value=${{env.PRIVATE_KEY}}" \
+              -var="ssh_key_value=$PRIVATE_KEY" \
               -var="github_test_repo=${{ env.CWA_GITHUB_TEST_REPO_URL }}" \
-              -var="test_name=${{ matrix.arrays.os }}" \
-              -var="cwa_github_sha=${{inputs.build_sha}}" \
-              -var="install_agent=${{ matrix.arrays.installAgentCommand }}" \
-              -var="github_test_repo_branch=${{ inputs.test_repo_branch || env.CWA_GITHUB_TEST_REPO_BRANCH }}" \
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
-              -var="user=${{ matrix.arrays.username }}" \
-              -var="ami=${{ matrix.arrays.ami }}" \
-              -var="ca_cert_path=${{ matrix.arrays.caCertPath }}" \
-              -var="arc=${{ matrix.arrays.arc }}" \
-              -var="binary_name=${{ matrix.arrays.binaryName }}" \
-              -var="local_stack_host_name=${{ needs.StartWorkloadDiscoveryIntegrationTests.outputs.local_stack_host_name }}" \
+              -var="test_name=$MATRIX_OS" \
+              -var="cwa_github_sha=$INPUT_BUILD_SHA" \
+              -var="install_agent=$MATRIX_INSTALL_AGENT" \
+              -var="github_test_repo_branch=$INPUT_TEST_REPO_BRANCH" \
+              -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
+              -var="user=$MATRIX_USERNAME" \
+              -var="ami=$MATRIX_AMI" \
+              -var="ca_cert_path=$MATRIX_CA_CERT_PATH" \
+              -var="arc=$MATRIX_ARC" \
+              -var="binary_name=$MATRIX_BINARY_NAME" \
+              -var="local_stack_host_name=$LOCALSTACK_HOST" \
               -var="s3_bucket=${{ vars.S3_INTEGRATION_BUCKET }}" \
-              -var="ssh_key_name=${{env.KEY_NAME}}" \
-              -var="test_dir=${{ matrix.arrays.test_dir }}"; then terraform destroy -auto-approve
+              -var="ssh_key_name=$KEY_NAME" \
+              -var="test_dir=$MATRIX_TEST_DIR"; then terraform destroy -auto-approve
             else
               terraform destroy -auto-approve && exit 1
             fi
@@ -368,18 +422,21 @@ jobs:
       - name: Terraform destroy
         if: ${{ (cancelled() || failure()) }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |-
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/linux
             fi
 
-            terraform destroy -lock-timeout=5m -var="ami=${{ matrix.arrays.ami }}" --auto-approve
+            terraform destroy -lock-timeout=5m -var="ami=$MATRIX_AMI" --auto-approve
 
   EC2NvidiaWindowsWorkloadDiscoveryIntegrationTest:
     needs: [ GenerateTestMatrix ]
@@ -406,7 +463,11 @@ jobs:
           role-duration-seconds: ${{ env.TERRAFORM_AWS_ASSUME_ROLE_DURATION }}
 
       - name: Echo Test Info
-        run: echo run on ec2 instance os ${{ matrix.arrays.os }} arc ${{ matrix.arrays.arc }} test dir ${{ matrix.arrays.test_dir }}
+        env:
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_ARC: ${{ matrix.arrays.arc }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+        run: echo "run on ec2 instance os $MATRIX_OS arc $MATRIX_ARC test dir $MATRIX_TEST_DIR"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -418,26 +479,33 @@ jobs:
         id: terraform_apply
         continue-on-error: true
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_OS: ${{ matrix.arrays.os }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
+          MATRIX_INSTANCE_TYPE: ${{ matrix.arrays.instanceType }}
+          MATRIX_TEST_DIR: ${{ matrix.arrays.test_dir }}
+          INPUT_BUILD_SHA: ${{ inputs.build_sha }}
         with:
           max_attempts: 3
           timeout_minutes: 60
           retry_wait_seconds: 5
           command: |-
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/win
             fi
 
             terraform init
             if terraform apply --auto-approve \
-              -var="ec2_instance_type=${{ matrix.arrays.instanceType }}" \
+              -var="ec2_instance_type=$MATRIX_INSTANCE_TYPE" \
               -var="ssh_key_value=${PRIVATE_KEY}" \
               -var="ssh_key_name=${KEY_NAME}" \
-              -var="test_name=${{ matrix.arrays.os }}" \
-              -var="cwa_github_sha=${{ inputs.build_sha }}"  \
-              -var="test_dir=${{ matrix.arrays.test_dir }}" \
-              -var="ami=${{ matrix.arrays.ami }}" \
+              -var="test_name=$MATRIX_OS" \
+              -var="cwa_github_sha=$INPUT_BUILD_SHA"  \
+              -var="test_dir=$MATRIX_TEST_DIR" \
+              -var="ami=$MATRIX_AMI" \
               -var="s3_bucket=${S3_INTEGRATION_BUCKET}" ; then
               terraform destroy -auto-approve
             else
@@ -461,15 +529,18 @@ jobs:
       - name: Terraform destroy
         if: ${{ (cancelled() || failure()) }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        env:
+          MATRIX_TERRAFORM_DIR: ${{ matrix.arrays.terraform_dir }}
+          MATRIX_AMI: ${{ matrix.arrays.ami }}
         with:
           max_attempts: 3
           timeout_minutes: 8
           retry_wait_seconds: 5
           command: |-
-            if [ "${{ matrix.arrays.terraform_dir }}" != "" ]; then
-              cd "${{ matrix.arrays.terraform_dir }}"
+            if [ -n "$MATRIX_TERRAFORM_DIR" ]; then
+              cd "$MATRIX_TERRAFORM_DIR"
             else
               cd terraform/ec2/win
             fi
 
-            terraform destroy -lock-timeout=5m -var="ami=${{ matrix.arrays.ami }}" --auto-approve
+            terraform destroy -lock-timeout=5m -var="ami=$MATRIX_AMI" --auto-approve


### PR DESCRIPTION
# Description of changes

Move user-controlled context interpolations (`inputs.*`, `matrix.*`, `github.event.*`, `needs.*.outputs.*`, `steps.*.outputs.*`, `toJSON`, `contains`) out of shell `run:` and `nick-fields/retry` `command:` blocks into step-level `env:` bindings, then reference them as shell variables. This mirrors the pattern established in #1971.

Direct fixes across 23 workflows plus two indirect cases:
- `test-build-distributor.yml`: job-level `env:` values derived from user inputs were referenced via `${{ env.X }}` in `run:` blocks, which GitHub Actions expands at parse-time. Converted to shell-variable references (`"$X"`).
- `test-build-docker.yml`: `Copy msi` step runs on `windows-2022` (PowerShell default); use `$env:VARNAME` instead of bash-style `$VARNAME`.

Also fixes three pre-existing correctness bugs surfaced during review:
- `test-artifacts.yml`: `elif if` syntax error changed to valid `elif [ ... ]`.
- `test-artifacts.yml`: `Terraform destroy` retry fallback previously branched on `matrix.arrays.os`, but the corresponding apply steps branch on `matrix.arrays.family`. Aligned the destroy check to `matrix.arrays.family` so Windows-family cleanup `cd`'s to `terraform/ec2/win` rather than falling through to the Linux path.
- `test-build-distributor.yml`: `LATEST_DEFAULT` undefined variable typo changed to `LATEST_VERSION`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
N/A

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.
