### PR TITLE
Add comparison workflow for binary size

### DIFF
--- a/.github/scripts/collect-binary-sizes.sh
+++ b/.github/scripts/collect-binary-sizes.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Collect local binary sizes and write a JSON artifact.
+# The report job handles baseline comparison.
+#
+# Required env: RUNNER_OS
+
+set -euo pipefail
+
+RUNNER_OS="${RUNNER_OS:-unknown}"
+
+echo "Collecting local binary sizes..."
+
+python3 - "$RUNNER_OS" <<'PYEOF'
+import json, os, sys
+
+runner_os = sys.argv[1]
+skip_ext = ('.sig', '.jar', '.rpm', '.deb', '.pkg', '.msi', '.tar.gz', '.gz', '.zip')
+skip_names = ('CWAGENT_VERSION', 'buildMSI.zip')
+
+binaries = {}
+for root, dirs, files in os.walk("build/bin"):
+    for fname in files:
+        filepath = os.path.join(root, fname)
+        rel_path = os.path.relpath(filepath, "build/bin")
+        segments = rel_path.replace("\\", "/").split("/")
+        if len(segments) != 2:
+            continue
+        if any(fname.endswith(ext) for ext in skip_ext):
+            continue
+        if fname in skip_names:
+            continue
+        key = "/".join(segments)
+        binaries[key] = os.path.getsize(filepath)
+
+output_file = f"size-report-{runner_os}.json"
+with open(output_file, "w") as f:
+    json.dump({"binaries": binaries}, f, indent=2)
+
+print(f"Wrote {output_file} ({len(binaries)} binaries)")
+PYEOF

--- a/.github/scripts/record-binary-sizes.sh
+++ b/.github/scripts/record-binary-sizes.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Record binary sizes to DynamoDB after a main merge.
+# Reads sizes from S3 (binaries already uploaded by BuildAndUpload job).
+#
+# Required env: S3_BUCKET, COMMIT_HASH, COMMIT_DATE, TAG (optional)
+
+set -euo pipefail
+
+TABLE_NAME="CWABinarySizes"
+S3_BUCKET="${S3_BUCKET:?S3_BUCKET is required}"
+COMMIT_HASH="${COMMIT_HASH:?COMMIT_HASH is required}"
+COMMIT_DATE="${COMMIT_DATE:?COMMIT_DATE is required}"
+TAG="${TAG:-}"
+REGION="us-west-2"
+
+S3_PREFIX="integration-test/binary/${COMMIT_HASH}/"
+
+echo "Collecting binary sizes from S3 (${COMMIT_HASH:0:12})..."
+
+ITEM_JSON=$(
+     aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}" --recursive --region "$REGION" |
+          awk '{print $3, $4}' |
+          python3 - "$S3_PREFIX" "$COMMIT_HASH" "$COMMIT_DATE" "$TAG" <<'PYEOF'
+import sys, json
+
+prefix = sys.argv[1]
+commit_hash = sys.argv[2]
+commit_date = sys.argv[3]
+tag = sys.argv[4]
+
+skip_ext = ('.sig', '.jar', '.rpm', '.deb', '.pkg', '.msi', '.tar.gz', '.gz', '.zip')
+skip_names = ('CWAGENT_VERSION', 'buildMSI.zip')
+
+binaries = {}
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    parts = line.split(' ', 1)
+    if len(parts) != 2:
+        continue
+    size, key = int(parts[0]), parts[1]
+    rel_path = key[len(prefix):] if key.startswith(prefix) else key
+    segments = rel_path.split('/')
+    if len(segments) != 2:
+        continue
+    filename = segments[1]
+    if any(filename.endswith(ext) for ext in skip_ext):
+        continue
+    if filename in skip_names:
+        continue
+    binaries[rel_path] = {"N": str(size)}
+
+if not binaries:
+    sys.exit(1)
+
+record_type = "release" if tag else "commit"
+item = {
+    "CommitHash": {"S": commit_hash},
+    "CommitDate": {"N": commit_date},
+    "Branch": {"S": "main"},
+    "RecordType": {"S": record_type},
+    "Binaries": {"M": binaries},
+}
+if tag:
+    item["Tag"] = {"S": tag}
+
+print(json.dumps(item))
+PYEOF
+) || {
+     echo "No binaries found in S3, skipping."
+     exit 0
+}
+
+RECORD_TYPE=$(echo "$ITEM_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['RecordType']['S'])")
+
+if [[ "$RECORD_TYPE" == "release" ]]; then
+     aws dynamodb put-item \
+          --table-name "$TABLE_NAME" \
+          --item "$ITEM_JSON" \
+          --region "$REGION"
+else
+     err=$(aws dynamodb put-item \
+          --table-name "$TABLE_NAME" \
+          --item "$ITEM_JSON" \
+          --condition-expression "attribute_not_exists(CommitHash) OR RecordType <> :release" \
+          --expression-attribute-values '{":release": {"S": "release"}}' \
+          --region "$REGION" 2>&1) || {
+          if echo "$err" | grep -q "ConditionalCheckFailedException"; then
+               echo "Skipped (existing release entry)"
+          else
+               echo "$err" >&2
+               exit 1
+          fi
+     }
+fi
+
+echo "Recorded binary sizes for ${COMMIT_HASH:0:12} (type=${RECORD_TYPE}, tag=${TAG:-none})"

--- a/.github/scripts/report-binary-sizes.sh
+++ b/.github/scripts/report-binary-sizes.sh
@@ -1,0 +1,351 @@
+#!/bin/bash
+# Merge size artifacts, query DynamoDB baselines, compute deltas, post PR comment.
+#
+# Required env: GH_TOKEN, PR_NUMBER
+# Usage: report-binary-sizes.sh <reports-dir>
+
+set -euo pipefail
+
+REPORTS_DIR="${1:-.}"
+PR_NUMBER="${PR_NUMBER:?PR_NUMBER is required}"
+TABLE_NAME="CWABinarySizes"
+REGION="us-west-2"
+MARKER="<!-- binary-size-report -->"
+
+# Check if there are any reports to process
+if ! ls "$REPORTS_DIR"/size-report-*.json &>/dev/null; then
+     echo "No size report artifacts found."
+     exit 0
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Querying DynamoDB for recent main commits..."
+aws dynamodb query \
+     --table-name "$TABLE_NAME" \
+     --index-name BranchDateIndex \
+     --key-condition-expression "Branch = :b" \
+     --expression-attribute-values '{":b": {"S": "main"}}' \
+     --no-scan-index-forward \
+     --max-items 9 \
+     --region "$REGION" \
+     --output json >"$WORK_DIR/main_baseline.json" 2>/dev/null || echo '{"Items":[]}' >"$WORK_DIR/main_baseline.json"
+
+echo "Querying DynamoDB for latest release baseline..."
+aws dynamodb query \
+     --table-name "$TABLE_NAME" \
+     --index-name ReleaseDateIndex \
+     --key-condition-expression "RecordType = :rt" \
+     --expression-attribute-values '{":rt": {"S": "release"}}' \
+     --no-scan-index-forward \
+     --max-items 1 \
+     --region "$REGION" \
+     --output json >"$WORK_DIR/release_baseline.json" 2>/dev/null || echo '{"Items":[]}' >"$WORK_DIR/release_baseline.json"
+
+echo "Generating report..."
+COMMENT_BODY=$(
+     python3 - "$REPORTS_DIR" "$WORK_DIR/main_baseline.json" "$WORK_DIR/release_baseline.json" <<'EOF'
+import json, glob, os, sys
+
+reports_dir, main_path, release_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Merge all runner artifacts
+files = glob.glob(os.path.join(reports_dir, "size-report-*.json"))
+if not files:
+    exit(0)
+
+pr_sizes = {}
+for f in files:
+    with open(f) as fh:
+        data = json.load(fh)
+    for key, size in data.get("binaries", {}).items():
+        pr_sizes[key] = size
+
+if not pr_sizes:
+    exit(0)
+
+# Parse DynamoDB baselines
+def parse_dynamo_items(path):
+    with open(path) as f:
+        data = json.load(f)
+    return data.get("Items", [])
+
+def parse_item(item):
+    commit = item.get("CommitHash", {}).get("S", "")
+    tag = item.get("Tag", {}).get("S", "")
+    binaries = {}
+    for key, val in item.get("Binaries", {}).get("M", {}).items():
+        binaries[key] = int(val.get("N", 0))
+    return binaries, commit, tag
+
+main_items = parse_dynamo_items(main_path)
+release_items = parse_dynamo_items(release_path)
+
+main_sizes, main_commit, _ = parse_item(main_items[0]) if main_items else ({}, "", "")
+release_sizes, release_commit, release_tag = parse_item(release_items[0]) if release_items else ({}, "", "")
+
+# Formatting helpers
+def fmt_size(b):
+    if b >= 1_000_000:
+        return f"{b / 1_000_000:.1f} MB"
+    elif b >= 1_000:
+        return f"{b / 1_000:.1f} KB"
+    return f"{b} B"
+
+def fmt_delta(delta, base):
+    if delta == 0:
+        return "+0 B"
+    if base and base > 0:
+        pct = delta / base * 100
+        sign = "+" if delta > 0 else ""
+        indicator = r"${\color{red}▲}$ " if delta > 0 else r"${\color{green}▼}$ "
+        return f"{indicator}{sign}{fmt_size(abs(delta))} ({sign}{pct:.1f}%)"
+    sign = "+" if delta > 0 else ""
+    indicator = r"${\color{red}▲}$ " if delta > 0 else r"${\color{green}▼}$ "
+    return f"{indicator}{sign}{fmt_size(abs(delta))}"
+
+def sort_key(key):
+    parts = key.split("/")
+    if len(parts) == 2:
+        platform, binary = parts
+    else:
+        platform, binary = "", key
+    base_binary = binary.removesuffix(".exe")
+    return (base_binary, platform)
+
+# Group binaries by platform
+from collections import defaultdict
+platforms = defaultdict(list)
+for key in sorted(pr_sizes.keys(), key=sort_key):
+    parts = key.split("/")
+    if len(parts) == 2:
+        platform = parts[0]
+        binary = parts[1]
+    else:
+        platform = "other"
+        binary = key
+    platforms[platform].append((key, binary))
+
+# Preferred display order, primary platform first
+platform_order = ["linux_amd64", "linux_arm64", "windows_amd64"]
+ordered_platforms = [p for p in platform_order if p in platforms]
+ordered_platforms.extend(p for p in platforms if p not in platform_order)
+
+def build_table(platform, entries, main_sizes, release_sizes):
+    rows = []
+    total_pr = 0
+    total_main_base = 0
+    total_release_base = 0
+    total_main_delta = 0
+    total_release_delta = 0
+    has_main = False
+    has_release = False
+
+    for key, binary in entries:
+        pr_size = pr_sizes[key]
+        total_pr += pr_size
+        pr_col = fmt_size(pr_size)
+        main_col = "-"
+        release_col = "-"
+
+        if key in main_sizes:
+            has_main = True
+            delta = pr_size - main_sizes[key]
+            total_main_delta += delta
+            total_main_base += main_sizes[key]
+            main_col = fmt_delta(delta, main_sizes[key])
+
+        if key in release_sizes:
+            has_release = True
+            delta = pr_size - release_sizes[key]
+            total_release_delta += delta
+            total_release_base += release_sizes[key]
+            release_col = fmt_delta(delta, release_sizes[key])
+
+        rows.append(f"| {binary} | {pr_col} | {main_col} | {release_col} |")
+
+    total_main_col = "-"
+    total_release_col = "-"
+    if has_main:
+        total_main_col = f"**{fmt_delta(total_main_delta, total_main_base)}**"
+    if has_release:
+        total_release_col = f"**{fmt_delta(total_release_delta, total_release_base)}**"
+    rows.append(f"| **Total** | **{fmt_size(total_pr)}** | {total_main_col} | {total_release_col} |")
+
+    return rows
+
+# Build markdown
+repo = "aws/amazon-cloudwatch-agent"
+marker = "<!-- binary-size-report -->"
+
+main_header = "vs Main"
+if main_commit:
+    sha = main_commit[:7]
+    main_header = f"vs `main` ([`{sha}`](https://github.com/{repo}/commit/{sha}))"
+
+release_header = "vs Release"
+if release_tag:
+    release_header = f"vs [`{release_tag}`](https://github.com/{repo}/releases/tag/{release_tag})"
+
+table_header = f"| Binary | PR | {main_header} | {release_header} |"
+table_sep = "|--------|---:|--------:|-----------:|"
+
+lines = [
+    marker,
+    "## Binary Size Report",
+    "",
+]
+
+primary = ordered_platforms[0] if ordered_platforms else None
+if primary:
+    lines.append(f"### {primary.replace('_', '/')}")
+    lines.append("")
+    lines.append(table_header)
+    lines.append(table_sep)
+    lines.extend(build_table(primary, platforms[primary], main_sizes, release_sizes))
+    lines.append("")
+
+# Trend graph for linux/amd64 agent binary
+trend_key = "linux_amd64/amazon-cloudwatch-agent"
+if main_items and trend_key in pr_sizes:
+    trend_points = []
+    for item in reversed(main_items):
+        binaries, commit, tag = parse_item(item)
+        size = binaries.get(trend_key, 0)
+        if size > 0:
+            label = tag if tag else commit[:7]
+            trend_points.append((label, size, bool(tag), commit))
+
+    # Add PR as the rightmost point
+    trend_points.append(("PR", pr_sizes[trend_key], False, ""))
+
+    if len(trend_points) >= 3:
+        sizes = [p[1] for p in trend_points]
+        min_s = min(sizes)
+        max_s = max(sizes)
+        range_s = max_s - min_s
+        pad = range_s * 0.05 if range_s > 0 else 1_000_000
+        min_s -= pad
+        max_s += pad
+        height = 8
+        bar_width = 3
+        gap = 1
+        cell = bar_width + gap
+
+        graph_lines = []
+        graph_lines.append(f"linux/amd64 amazon-cloudwatch-agent (last {len(trend_points) - 1} main commits + this PR)")
+        graph_lines.append("")
+        for row in range(height, -1, -1):
+            if row == height:
+                label = f"{max_s/1_000_000:.0f}"
+            elif row == 0:
+                label = f"{min_s/1_000_000:.0f}"
+            else:
+                label = ""
+            line = f"{label:>4} ┤"
+            for i, (_, size, _, _) in enumerate(trend_points):
+                normalized = (size - min_s) / (max_s - min_s) * height
+                if normalized >= row + 0.5:
+                    line += "█" * bar_width + " " * gap
+                elif normalized >= row:
+                    line += "▄" * bar_width + " " * gap
+                else:
+                    line += " " * cell
+            graph_lines.append(line)
+
+        graph_lines.append(f" MB  └" + "─" * (cell * len(trend_points)))
+
+        # X-axis labels: show tags and "PR" marker
+        axis_labels = []
+        for i, (label, _, is_tag, _) in enumerate(trend_points):
+            if is_tag or label == "PR":
+                axis_labels.append((i, label))
+        # Always show first and last
+        if not any(i == 0 for i, _ in axis_labels):
+            axis_labels.insert(0, (0, trend_points[0][0]))
+        if not any(i == len(trend_points) - 1 for i, _ in axis_labels):
+            axis_labels.append((len(trend_points) - 1, trend_points[-1][0]))
+
+        axis = list(" " * (6 + cell * len(trend_points)))
+        for idx, lbl in sorted(axis_labels):
+            pos = 6 + idx * cell
+            for j, c in enumerate(lbl):
+                if pos + j < len(axis):
+                    axis[pos + j] = c
+        graph_lines.append("".join(axis).rstrip())
+
+        # Notable changes (outside code block for links)
+        jumps = []
+        for i in range(1, len(trend_points)):
+            delta = trend_points[i][1] - trend_points[i-1][1]
+            if abs(delta) > 1_000_000:
+                sign = "+" if delta > 0 else ""
+                lbl, _, is_tag, full_commit = trend_points[i]
+                if is_tag:
+                    link = f"[`{lbl}`](https://github.com/{repo}/releases/tag/{lbl})"
+                elif full_commit:
+                    link = f"[`{lbl}`](https://github.com/{repo}/commit/{full_commit})"
+                else:
+                    link = f"`{lbl}`"
+                jumps.append(f"- {sign}{delta/1_000_000:.1f} MB at {link}")
+
+        lines.append("")
+        lines.append("```")
+        lines.extend(graph_lines)
+        lines.append("```")
+        if jumps:
+            lines.append("")
+            lines.append("Notable changes:")
+            lines.extend(jumps)
+        lines.append("")
+
+for platform in ordered_platforms[1:]:
+    display_name = platform.replace("_", "/")
+    lines.append(f"<details>")
+    lines.append(f"<summary>{display_name}</summary>")
+    lines.append("")
+    lines.append(table_header)
+    lines.append(table_sep)
+    lines.extend(build_table(platform, platforms[platform], main_sizes, release_sizes))
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+lines.append("<details>")
+lines.append("<summary>Investigating size changes</summary>")
+lines.append("")
+lines.append("Use [go-size-analyzer](https://github.com/Zxilly/go-size-analyzer) to compare binaries:")
+lines.append("")
+lines.append("```bash")
+lines.append("GOEXPERIMENT=jsonv2 go install github.com/Zxilly/go-size-analyzer/cmd/gsa@latest")
+lines.append("gsa diff --old <baseline-binary> --new <new-binary>")
+lines.append("```")
+lines.append("")
+lines.append("</details>")
+lines.append("")
+
+print("\n".join(lines))
+EOF
+)
+
+if [[ -z "$COMMENT_BODY" ]]; then
+     echo "No report to post."
+     exit 0
+fi
+
+# Find existing comment with our marker, authored by github-actions[bot]
+EXISTING_COMMENT_ID=$(gh api "repos/{owner}/{repo}/issues/${PR_NUMBER}/comments" \
+     --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"${MARKER}\"))) | .id" 2>/dev/null || true)
+EXISTING_COMMENT_ID=$(echo "$EXISTING_COMMENT_ID" | head -1)
+
+if [[ -n "$EXISTING_COMMENT_ID" ]]; then
+     echo "Updating existing comment ${EXISTING_COMMENT_ID}..."
+     gh api "repos/{owner}/{repo}/issues/comments/${EXISTING_COMMENT_ID}" \
+          -X PATCH -f body="$COMMENT_BODY"
+else
+     echo "Posting new comment..."
+     gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+fi
+
+echo "Done."

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -144,6 +144,56 @@ jobs:
         if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true'
         run: make amazon-cloudwatch-agent-${{ matrix.family }}
 
+      - name: Collect binary sizes
+        if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true' && matrix.family != 'darwin' && matrix.os != 'windows-latest' && github.event_name == 'pull_request'
+        shell: bash
+        env:
+          RUNNER_OS: ${{ matrix.os }}
+        run: .github/scripts/collect-binary-sizes.sh
+
+      - name: Upload size report
+        if: steps.cached_binaries.outputs.cache-hit != 'true' && needs.changes.outputs.build == 'true' && matrix.family != 'darwin' && matrix.os != 'windows-latest' && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: size-report-${{ matrix.os }}
+          path: size-report-*.json
+          if-no-files-found: ignore
+          retention-days: 1
+
+  binary-size-report:
+    name: Binary Size Report
+    needs: [build, changes]
+    if: needs.changes.outputs.build == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        id: download
+        continue-on-error: true
+        with:
+          pattern: size-report-*
+          merge-multiple: true
+          path: ./size-reports
+
+      - name: Configure AWS Credentials
+        if: steps.download.outcome == 'success'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Generate and post report
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: .github/scripts/report-binary-sizes.sh ./size-reports
+
   test-data-race:
     needs: [lint, changes]
     name: Test data race
@@ -168,7 +218,7 @@ jobs:
     name: Verify All PR Build Jobs
     needs: [ changes, lint, build, test-data-race ]
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Check Job Status
         run: |

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -163,7 +163,7 @@ jobs:
   binary-size-report:
     name: Binary Size Report
     needs: [build, changes]
-    if: needs.changes.outputs.build == 'true' && github.event_name == 'pull_request'
+    if: needs.changes.outputs.build == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/PR-test.yml
+++ b/.github/workflows/PR-test.yml
@@ -42,7 +42,13 @@ jobs:
     steps:
       - id: check
         run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ready for testing') }}" == "true" ]]; then
+          # Fork PRs never receive secrets or id-token permissions, so the
+          # integration tests cannot run even if the label is added. Maintainers
+          # must push the branch to this repo to run them.
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "Fork PR - integration tests cannot run (no access to secrets)."
+            echo "has_label=false" >> $GITHUB_OUTPUT
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'ready for testing') }}" == "true" ]]; then
             echo "has_label=true" >> $GITHUB_OUTPUT
           else
             echo "has_label=false" >> $GITHUB_OUTPUT
@@ -350,6 +356,11 @@ jobs:
     steps:
       - name: Check for ready for testing label
         run: |
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "Fork PR - integration tests skipped (no access to secrets). Push branch to this repo to run them."
+            exit 0
+          fi
+
           if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
             echo "Draft PR - skipping label check."
             exit 0

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -47,6 +47,14 @@ jobs:
       TerraformAWSAssumeRole: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
       Bucket: ${{ vars.S3_INTEGRATION_BUCKET }}
 
+  RecordBinarySizes:
+    needs: [BuildAndUpload]
+    uses: ./.github/workflows/record-binary-sizes.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+
   BuildAndUploadPackages:
     uses: ./.github/workflows/test-build-packages.yml
     needs: [BuildAndUpload]

--- a/.github/workflows/record-binary-sizes.yml
+++ b/.github/workflows/record-binary-sizes.yml
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+name: Record Binary Sizes
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_call:
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Record binary sizes
+        env:
+          S3_BUCKET: ${{ vars.S3_INTEGRATION_BUCKET }}
+          COMMIT_HASH: ${{ github.sha }}
+        run: |
+          export COMMIT_DATE=$(git log -1 --format=%ct)
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            export TAG="${{ github.ref_name }}"
+          else
+            export TAG=""
+          fi
+          .github/scripts/record-binary-sizes.sh


### PR DESCRIPTION
# Description of changes
Add binary size reporting to PRs. When a PR triggers a build, the workflow compares binary sizes against the latest main commit and latest tagged release, then posts a summary comment on the PR.

- `record-binary-sizes.yml`: Reusable workflow that relies on the binary sizes from S3 (uploaded by BuildAndUpload in `build-test-artifacts.yml`) and writes them to a DynamoDB table to keep track of trends. It is triggered on merges to main and tag creation.
  - Several commits on `main` and tags were backfilled using the script.
- `report-binary-sizes.sh`: Posts a PR comment.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
_Describe what tests you have done._

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



