### PR TITLE
Allow deferred region resolution for Azure

### DIFF
--- a/tool/downloader/downloader.go
+++ b/tool/downloader/downloader.go
@@ -88,7 +88,7 @@ func RunDownloader(mode, downloadLocation, outputDir, inputConfig, multiConfig s
 		return fmt.Errorf("downloadLocation %s is malformed", downloadLocation)
 	}
 
-	if region == "" && locationArray[0] != locationDefault {
+	if region == "" && locationArray[0] != locationDefault && mode != translatorconfig.ModeAzureVM {
 		if mode == translatorconfig.ModeEC2 {
 			return fmt.Errorf("please check if you can access the metadata service. For example, on linux, run 'wget -q -O - http://169.254.169.254/latest/meta-data/instance-id && echo'")
 		}

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_aks.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_aks.yaml
@@ -30,7 +30,7 @@ exporters:
         compression: gzip
         encoding: proto
         idle_conn_timeout: 1m30s
-        logs_endpoint: https://logs.us-west-2.amazonaws.com/v1/logs
+        logs_endpoint: https://logs.${AWS_REGION}.amazonaws.com/v1/logs
         max_idle_conns: 100
         metrics_endpoint: ""
         retry_on_failure:
@@ -59,7 +59,7 @@ exporters:
         idle_conn_timeout: 1m30s
         logs_endpoint: ""
         max_idle_conns: 100
-        metrics_endpoint: https://monitoring.us-west-2.amazonaws.com/v1/metrics
+        metrics_endpoint: https://monitoring.${AWS_REGION}.amazonaws.com/v1/metrics
         retry_on_failure:
             enabled: true
             initial_interval: 5s
@@ -103,7 +103,7 @@ exporters:
             sizer: {}
             wait_for_result: false
         timeout: 30s
-        traces_endpoint: https://xray.us-west-2.amazonaws.com/v1/traces
+        traces_endpoint: https://xray.${AWS_REGION}.amazonaws.com/v1/traces
         write_buffer_size: 524288
 extensions:
     agenthealth/opentelemetry_logs:
@@ -114,7 +114,7 @@ extensions:
                 - '*'
             usage_flags:
                 mode: AKS
-                region_type: ACJ
+                region_type: RNF
     agenthealth/opentelemetry_metrics:
         additional_auth: sigv4auth/monitoring
         is_usage_data_enabled: true
@@ -123,7 +123,7 @@ extensions:
                 - '*'
             usage_flags:
                 mode: AKS
-                region_type: ACJ
+                region_type: RNF
     agenthealth/opentelemetry_traces:
         additional_auth: sigv4auth/xray
         is_usage_data_enabled: true
@@ -132,14 +132,14 @@ extensions:
                 - '*'
             usage_flags:
                 mode: AKS
-                region_type: ACJ
+                region_type: RNF
     awscloudwatchlogsprovisioner:
         additional_auth: sigv4auth/logs
         imds_retries: 1
         logs_provision_failure_backoff: 30s
         max_retries: 2
         num_workers: 8
-        region: us-west-2
+        region: ${AWS_REGION}
         request_timeout_seconds: 10
         role_arn: ${CWAGENT_ROLE_ARN}
     headers_setter/logs:
@@ -161,7 +161,7 @@ extensions:
         imds_retries: 1
         max_retries: 2
         num_workers: 8
-        region: us-west-2
+        region: ${AWS_REGION}
         request_timeout_seconds: 30
         role_arn: ${CWAGENT_ROLE_ARN}
         service: logs
@@ -170,7 +170,7 @@ extensions:
         imds_retries: 1
         max_retries: 2
         num_workers: 8
-        region: us-west-2
+        region: ${AWS_REGION}
         request_timeout_seconds: 30
         role_arn: ${CWAGENT_ROLE_ARN}
         service: monitoring
@@ -179,7 +179,7 @@ extensions:
         imds_retries: 1
         max_retries: 2
         num_workers: 8
-        region: us-west-2
+        region: ${AWS_REGION}
         request_timeout_seconds: 30
         role_arn: ${CWAGENT_ROLE_ARN}
         service: xray

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_azurevm.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_azurevm.yaml
@@ -30,7 +30,7 @@ exporters:
         compression: gzip
         encoding: proto
         idle_conn_timeout: 1m30s
-        logs_endpoint: https://logs.us-west-2.amazonaws.com/v1/logs
+        logs_endpoint: https://logs.${AWS_REGION}.amazonaws.com/v1/logs
         max_idle_conns: 100
         metrics_endpoint: ""
         retry_on_failure:
@@ -59,7 +59,7 @@ exporters:
         idle_conn_timeout: 1m30s
         logs_endpoint: ""
         max_idle_conns: 100
-        metrics_endpoint: https://monitoring.us-west-2.amazonaws.com/v1/metrics
+        metrics_endpoint: https://monitoring.${AWS_REGION}.amazonaws.com/v1/metrics
         retry_on_failure:
             enabled: true
             initial_interval: 5s
@@ -103,7 +103,7 @@ exporters:
             sizer: {}
             wait_for_result: false
         timeout: 30s
-        traces_endpoint: https://xray.us-west-2.amazonaws.com/v1/traces
+        traces_endpoint: https://xray.${AWS_REGION}.amazonaws.com/v1/traces
         write_buffer_size: 524288
 extensions:
     agenthealth/opentelemetry_logs:
@@ -114,7 +114,7 @@ extensions:
                 - '*'
             usage_flags:
                 mode: AZVM
-                region_type: ACJ
+                region_type: RNF
     agenthealth/opentelemetry_metrics:
         additional_auth: sigv4auth/monitoring
         is_usage_data_enabled: true
@@ -123,7 +123,7 @@ extensions:
                 - '*'
             usage_flags:
                 mode: AZVM
-                region_type: ACJ
+                region_type: RNF
     agenthealth/opentelemetry_traces:
         additional_auth: sigv4auth/xray
         is_usage_data_enabled: true
@@ -132,14 +132,14 @@ extensions:
                 - '*'
             usage_flags:
                 mode: AZVM
-                region_type: ACJ
+                region_type: RNF
     awscloudwatchlogsprovisioner:
         additional_auth: sigv4auth/logs
         imds_retries: 1
         logs_provision_failure_backoff: 30s
         max_retries: 2
         num_workers: 8
-        region: us-west-2
+        region: ${AWS_REGION}
         request_timeout_seconds: 10
         role_arn: ${CWAGENT_ROLE_ARN}
         web_identity_token_file: /opt/aws/amazon-cloudwatch-agent/etc/.oidc-token
@@ -160,7 +160,7 @@ extensions:
         imds_retries: 1
         max_retries: 2
         num_workers: 8
-        region: us-west-2
+        region: ${AWS_REGION}
         request_timeout_seconds: 30
         role_arn: ${CWAGENT_ROLE_ARN}
         service: logs
@@ -170,7 +170,7 @@ extensions:
         imds_retries: 1
         max_retries: 2
         num_workers: 8
-        region: us-west-2
+        region: ${AWS_REGION}
         request_timeout_seconds: 30
         role_arn: ${CWAGENT_ROLE_ARN}
         service: monitoring
@@ -180,7 +180,7 @@ extensions:
         imds_retries: 1
         max_retries: 2
         num_workers: 8
-        region: us-west-2
+        region: ${AWS_REGION}
         request_timeout_seconds: 30
         role_arn: ${CWAGENT_ROLE_ARN}
         service: xray

--- a/translator/tocwconfig/tocwconfig_unix_test.go
+++ b/translator/tocwconfig/tocwconfig_unix_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	globallogs "github.com/aws/amazon-cloudwatch-agent/translator/translate/logs"
 	otel "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel"
+	"github.com/aws/amazon-cloudwatch-agent/translator/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
 
@@ -191,7 +192,11 @@ func TestCombinedV1V2EKSConfig(t *testing.T) {
 func TestDefaultOtelConfigAzureVMTranslation(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetMode(config.ModeAzureVM)
-	agent.Global_Config.Region = "us-west-2"
+	// No AWS region source exists on Azure at translation time, so region
+	// detection returns empty and the translator falls back to ${AWS_REGION}.
+	util.DetectRegion = func(string, map[string]string) (string, string) {
+		return "", ""
+	}
 
 	cfg, ok := config.DefaultJSONConfigFor("otel")
 	require.True(t, ok)
@@ -229,7 +234,11 @@ func TestDefaultOtelConfigAKSTranslation(t *testing.T) {
 	context.CurrentContext().SetMode(config.ModeAzureVM)
 	context.CurrentContext().SetKubernetesMode(config.ModeAKS)
 	context.CurrentContext().SetRunInContainer(true)
-	agent.Global_Config.Region = "us-west-2"
+	// No AWS region source exists on Azure at translation time, so region
+	// detection returns empty and the translator falls back to ${AWS_REGION}.
+	util.DetectRegion = func(string, map[string]string) (string, string) {
+		return "", ""
+	}
 
 	cfg, ok := config.DefaultJSONConfigFor("otel")
 	require.True(t, ok)

--- a/translator/translate/agent/ruleRegion.go
+++ b/translator/translate/agent/ruleRegion.go
@@ -32,9 +32,16 @@ func (r *Region) ApplyRule(input interface{}) (returnKey string, returnVal inter
 	}
 	region, regionType := util.DetectRegion(ctx.Mode(), ctx.Credentials())
 
-	if region == "" {
+	if region == "" && ctx.Mode() != config.ModeAzureVM {
 		translator.AddErrorMessages(GetCurPath()+"ruleRegion/", fmt.Sprintf("Region info is missing for mode: %s",
 			ctx.Mode()))
+	}
+
+	// Azure has no AWS region source at translation time, so defer to the
+	// AWS_REGION environment variable, which is resolved at runtime.
+	if region == "" && ctx.Mode() == config.ModeAzureVM {
+		region = "${AWS_REGION}"
+		regionType = config.RegionTypeNotFound
 	}
 
 	Global_Config.Region = region

--- a/translator/translate/agent/ruleRegion.go
+++ b/translator/translate/agent/ruleRegion.go
@@ -32,16 +32,16 @@ func (r *Region) ApplyRule(input interface{}) (returnKey string, returnVal inter
 	}
 	region, regionType := util.DetectRegion(ctx.Mode(), ctx.Credentials())
 
-	if region == "" && ctx.Mode() != config.ModeAzureVM {
-		translator.AddErrorMessages(GetCurPath()+"ruleRegion/", fmt.Sprintf("Region info is missing for mode: %s",
-			ctx.Mode()))
-	}
-
-	// Azure has no AWS region source at translation time, so defer to the
-	// AWS_REGION environment variable, which is resolved at runtime.
-	if region == "" && ctx.Mode() == config.ModeAzureVM {
-		region = "${AWS_REGION}"
-		regionType = config.RegionTypeNotFound
+	if region == "" {
+		if ctx.Mode() == config.ModeAzureVM {
+			// Azure has no AWS region source at translation time, so defer to the
+			// AWS_REGION environment variable, which is resolved at runtime.
+			region = "${AWS_REGION}"
+			regionType = config.RegionTypeNotFound
+		} else {
+			translator.AddErrorMessages(GetCurPath()+"ruleRegion/", fmt.Sprintf("Region info is missing for mode: %s",
+				ctx.Mode()))
+		}
 	}
 
 	Global_Config.Region = region

--- a/translator/translate/agent/ruleRegion_test.go
+++ b/translator/translate/agent/ruleRegion_test.go
@@ -1,0 +1,97 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
+	"github.com/aws/amazon-cloudwatch-agent/translator/util"
+)
+
+func TestRegionRule(t *testing.T) {
+	origDetectRegion := util.DetectRegion
+	t.Cleanup(func() {
+		util.DetectRegion = origDetectRegion
+		context.ResetContext()
+		translator.ResetMessages()
+	})
+
+	testCases := map[string]struct {
+		input              string
+		mode               string
+		detectedRegion     string
+		detectedRegionType string
+		wantRegion         string
+		wantRegionType     string
+		wantError          bool
+	}{
+		"WithRegionInConfig": {
+			input:          `{"region": "us-east-1"}`,
+			mode:           config.ModeEC2,
+			wantRegion:     "us-east-1",
+			wantRegionType: config.RegionTypeAgentConfigJson,
+		},
+		"WithDetectedRegion": {
+			input:              `{}`,
+			mode:               config.ModeEC2,
+			detectedRegion:     "us-west-2",
+			detectedRegionType: config.RegionTypeEC2Metadata,
+			wantRegion:         "us-west-2",
+			wantRegionType:     config.RegionTypeEC2Metadata,
+		},
+		"WithMissingRegion/EC2": {
+			input:              `{}`,
+			mode:               config.ModeEC2,
+			detectedRegionType: config.RegionTypeNotFound,
+			wantRegionType:     config.RegionTypeNotFound,
+			wantError:          true,
+		},
+		"WithMissingRegion/AzureVM": {
+			input:              `{}`,
+			mode:               config.ModeAzureVM,
+			detectedRegionType: config.RegionTypeNotFound,
+			wantRegion:         "${AWS_REGION}",
+			wantRegionType:     config.RegionTypeNotFound,
+		},
+		"WithDetectedRegion/AzureVM": {
+			input:              `{}`,
+			mode:               config.ModeAzureVM,
+			detectedRegion:     "us-west-2",
+			detectedRegionType: config.RegionTypeCredsMap,
+			wantRegion:         "us-west-2",
+			wantRegionType:     config.RegionTypeCredsMap,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			translator.ResetMessages()
+			context.ResetContext()
+			context.CurrentContext().SetMode(testCase.mode)
+			util.DetectRegion = func(string, map[string]string) (string, string) {
+				return testCase.detectedRegion, testCase.detectedRegionType
+			}
+
+			var input any
+			require.NoError(t, json.Unmarshal([]byte(testCase.input), &input))
+
+			r := new(Region)
+			r.ApplyRule(input)
+
+			assert.Equal(t, testCase.wantRegion, Global_Config.Region)
+			assert.Equal(t, testCase.wantRegionType, Global_Config.RegionType)
+			if testCase.wantError {
+				assert.NotEmpty(t, translator.ErrorMessages)
+			} else {
+				assert.Empty(t, translator.ErrorMessages)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description of the issue
On Azure, the agent would not start because it was unable to detect the region as part of the downloader and the translator.

# Description of changes
- When mode is `AzureVM` and no AWS region is detected at translation time, the region translator now defers to `${AWS_REGION}` instead of erroring. This placeholder is resolved at runtime by OTel's `expandconverter` from `env-config.json`.
  - Same pattern is used by `${CWAGENT_ROLE_ARN}` for credentials
  - The config-downloader also skips the empty region error for AzureVM mode
  - The region is used for both AWS credentials and the OTLP endpoints.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Deployed to Azure VM and verified it can send successfully. Set the `env-config.json` to
```json
{
  "AWS_REGION": "us-east-1",
  "CWAGENT_ROLE_ARN": "arn:aws:iam::<account>:role/CloudWatchAgentServerRole"
}
```
where `arn:aws:iam::<account>:role/CloudWatchAgentServerRole` includes a trust policy with an identity provider

```json
{
    "Effect": "Allow",
    "Principal": {
        "Federated": "arn:aws:iam::<account>:oidc-provider/sts.windows.net/e305ee61-f29e-454d-bb70-825f6e067d1a/"
    },
    "Action": "sts:AssumeRoleWithWebIdentity",
    "Condition": {
        "StringEquals": {
            "sts.windows.net/e305ee61-f29e-454d-bb70-825f6e067d1a/:aud": "https://management.azure.com/"
        }
    }
}
```

Started with
```
sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -c default:otel -m auto -s
```

Host metrics successfully sent to `https://monitoring.us-east-1.amazonaws.com/v1/metrics`
```
{
  "@aws.account": "<account>",
  "@aws.region": "us-east-1",
  "@instrumentation.cloudwatch.solution": "otel-host-metrics",
  "@instrumentation.cloudwatch.source": "cloudwatch-agent",
  "@resource.azure.resourcegroup.name": "azure-test-rg",
  "@resource.azure.vm.name": "azure-test-vm",
  "@resource.azure.vm.size": "Standard_D2s_v3",
  "@resource.cloud.account.id": "<subscription>",
  "@resource.cloud.platform": "azure_vm",
  "@resource.cloud.provider": "azure",
  "@resource.cloud.region": "eastus",
  "@resource.cloud.resource_id": "/subscriptions/<subscription>/resourceGroups/azure-test-rg/providers/Microsoft.Compute/virtualMachines/azure-test-vm",
  "@resource.deployment.environment.name": "azure_vm:azure-test-rg",
  "@resource.host.id": "<host-id>",
  "@resource.host.name": "azure-test-vm",
  "__name__": "system.cpu.utilization",
  "__type__": "Gauge",
  "cpu": "cpu1",
  "state": "system"
}
```

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



