### PR TITLE
Add set-env ctl action to persist agent environment variables

### DIFF
--- a/packaging/darwin/amazon-cloudwatch-agent-ctl
+++ b/packaging/darwin/amazon-cloudwatch-agent-ctl
@@ -32,13 +32,14 @@ readonly JSON="${CONFDIR}/amazon-cloudwatch-agent.json"
 readonly JSON_DIR="${CONFDIR}/amazon-cloudwatch-agent.d"
 readonly CV_LOG_FILE="${AGENTDIR}/logs/configuration-validation.log"
 readonly COMMON_CONIG="${CONFDIR}/common-config.toml"
+readonly ENV_CONFIG="${CONFDIR}/env-config.json"
 
 readonly ALL_CONFIG='all'
 
 UsageString="
 
 
-        usage: amazon-cloudwatch-agent-ctl -a stop|start|status|status-with-workloads|fetch-config|append-config|remove-config [-m ec2|onPremise|onPrem|auto] [-c default|ssm:<parameter-store-name>|file:<file-path>] [-s] [-d]
+        usage: amazon-cloudwatch-agent-ctl -a stop|start|status|status-with-workloads|fetch-config|append-config|remove-config|set-log-level|set-env [-m ec2|onPremise|onPrem|auto] [-c default|ssm:<parameter-store-name>|file:<file-path>] [-s] [-d] [-l INFO|DEBUG|WARN|ERROR|OFF] [-e KEY=VALUE]
 
         e.g.
         1. apply a SSM parameter store config on EC2 instance and restart the agent afterwards:
@@ -58,6 +59,8 @@ UsageString="
             fetch-config:                           use this json config as the agent's only configuration.
             append-config:                          append json config with the existing json configs if any.
             remove-config:                          remove json config based on the location (ssm parameter store name, file name)
+            set-log-level:                          sets the log level, followed by -l to provide the level in all caps.
+            set-env:                                sets an environment variable for the agent process, followed by -e to provide KEY=VALUE.
 
         -m: mode
             ec2:                                    indicate this is on ec2 host.
@@ -75,6 +78,15 @@ UsageString="
 
         -d: enable dual-stack endpoints for AWS API calls during config download
             this parameter is used for 'fetch-config', 'append-config' actions only.
+
+        -l: log level to set the agent to INFO, DEBUG, WARN, ERROR, or OFF
+            this parameter is used for 'set-log-level' only.
+
+        -e: environment variable to set for the agent process, in KEY=VALUE format
+            this parameter is used for 'set-env' only.
+            note: values that are also produced by agent config translation (such as
+            proxy, CA bundle, and log level settings) are overwritten from the agent
+            configuration on each fetch-config/append-config or agent restart.
 
 "
 
@@ -265,15 +277,59 @@ cwa_config() {
      fi
 }
 
+cwa_set_log_level() {
+     log_level="${1:-}"
+     case "${log_level}" in
+     INFO) ;;
+     DEBUG) ;;
+     ERROR) ;;
+     WARN) ;;
+     OFF) ;;
+     *)
+          echo "Invalid log level: ${log_level} ${UsageString}" >&2
+          exit 1
+          ;;
+     esac
+
+     if ! runEnvConfigCommand=$("${CMDDIR}/amazon-cloudwatch-agent" -setenv "CWAGENT_LOG_LEVEL=${log_level}" -envconfig "${ENV_CONFIG}" 2>&1); then
+          echo "${runEnvConfigCommand}" >&2
+          echo "Failed to set CWAGENT_LOG_LEVEL to ${log_level}" >&2
+          exit 1
+     fi
+     echo "${runEnvConfigCommand}"
+     echo "Set CWAGENT_LOG_LEVEL to ${log_level}"
+}
+
+cwa_set_env() {
+     env_kv="${1:-}"
+     case "${env_kv}" in
+     ?*=*) ;;
+     *)
+          echo "Invalid environment variable: '${env_kv}' (expected KEY=VALUE) ${UsageString}" >&2
+          exit 1
+          ;;
+     esac
+
+     if ! runEnvConfigCommand=$("${CMDDIR}/amazon-cloudwatch-agent" -setenv "${env_kv}" -envconfig "${ENV_CONFIG}" 2>&1); then
+          echo "${runEnvConfigCommand}" >&2
+          echo "Failed to set environment variable ${env_kv%%=*}" >&2
+          exit 1
+     fi
+     echo "${runEnvConfigCommand}"
+     echo "Set ${env_kv%%=*}"
+}
+
 main() {
      action=''
      config_location='default'
      restart='false'
      mode='auto'
      use_dualstack='false'
+     log_level=''
+     env_kv=''
 
      OPTIND=1
-     while getopts ":hsa:r:c:m:d" opt; do
+     while getopts ":hsa:r:c:m:dl:e:" opt; do
           case "${opt}" in
           h)
                echo "${UsageString}"
@@ -284,6 +340,8 @@ main() {
           c) config_location="${OPTARG}" ;;
           m) mode="${OPTARG}" ;;
           d) use_dualstack='true' ;;
+          l) log_level="${OPTARG}" ;;
+          e) env_kv="${OPTARG}" ;;
           \?)
                echo "Invalid option: -${OPTARG} ${UsageString}" >&2
                ;;
@@ -320,6 +378,8 @@ main() {
      remove-config) cwa_config "${config_location}" "${restart}" "${mode}" 'remove' ;;
      status) cwa_status "false" ;;
      status-with-workloads) cwa_status "true" ;;
+     set-log-level) cwa_set_log_level "${log_level}" ;;
+     set-env) cwa_set_env "${env_kv}" ;;
           # helpers for ssm package scripts to workaround fact that it can't determine if invocation is due to
           # upgrade or install
      prep-restart) cwa_prep_restart ;;

--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -82,6 +82,9 @@ UsageString="
 
         -e: environment variable to set for the agent process, in KEY=VALUE format
             this parameter is used for 'set-env' only.
+            note: values that are also produced by agent config translation (such as
+            proxy, CA bundle, and log level settings) are overwritten from the agent
+            configuration on each fetch-config/append-config or agent restart.
 
 "
 
@@ -393,8 +396,12 @@ set_env() {
           ;;
      esac
 
-     runEnvConfigCommand=$("${CMDDIR}/amazon-cloudwatch-agent" -setenv "${env_kv}" -envconfig "${ENV_CONFIG}")
-     echo "${runEnvConfigCommand}" || return
+     if ! runEnvConfigCommand=$("${CMDDIR}/amazon-cloudwatch-agent" -setenv "${env_kv}" -envconfig "${ENV_CONFIG}" 2>&1); then
+          echo "${runEnvConfigCommand}" >&2
+          echo "Failed to set environment variable ${env_kv%%=*}" >&2
+          exit 1
+     fi
+     echo "${runEnvConfigCommand}"
      echo "Set ${env_kv%%=*}"
 }
 

--- a/packaging/dependencies/amazon-cloudwatch-agent-ctl
+++ b/packaging/dependencies/amazon-cloudwatch-agent-ctl
@@ -31,12 +31,13 @@ UsageString="
 
 
         usage:  amazon-cloudwatch-agent-ctl -a
-                stop|start|status|status-with-workloads|fetch-config|append-config|remove-config|set-log-level
+                stop|start|status|status-with-workloads|fetch-config|append-config|remove-config|set-log-level|set-env
                 [-m ec2|onPremise|onPrem|auto]
                 [-c default|all|ssm:<parameter-store-name>|file:<file-path>]
                 [-s]
                 [-d]
                 [-l INFO|DEBUG|WARN|ERROR|OFF]
+                [-e KEY=VALUE]
 
         e.g.
         1. apply a SSM parameter store config on EC2 instance and restart the agent afterwards:
@@ -57,6 +58,7 @@ UsageString="
             append-config:                          append json config with the existing json configs if any, followed by -c. Target config can be based on the location (ssm parameter store name, file name), or 'default'.
             remove-config:                          remove config for agent, followed by -c. Target config can be based on the location (ssm parameter store name, file name), or 'all'.
             set-log-level:                          sets the log level, followed by -l to provide the level in all caps.
+            set-env:                                sets an environment variable for the agent process, followed by -e to provide KEY=VALUE.
 
         -m: mode
             ec2:                                    indicate this is on ec2 host.
@@ -77,6 +79,9 @@ UsageString="
 
         -l: log level to set the agent to INFO, DEBUG, WARN, ERROR, or OFF
             this parameter is used for 'set-log-level' only.
+
+        -e: environment variable to set for the agent process, in KEY=VALUE format
+            this parameter is used for 'set-env' only.
 
 "
 
@@ -378,12 +383,28 @@ set_log_level_all() {
      echo "Set CWAGENT_LOG_LEVEL to ${log_level}"
 }
 
+set_env() {
+     env_kv="${1:-}"
+     case "${env_kv}" in
+     ?*=*) ;;
+     *)
+          echo "Invalid environment variable: '${env_kv}' (expected KEY=VALUE) ${UsageString}" >&2
+          exit 1
+          ;;
+     esac
+
+     runEnvConfigCommand=$("${CMDDIR}/amazon-cloudwatch-agent" -setenv "${env_kv}" -envconfig "${ENV_CONFIG}")
+     echo "${runEnvConfigCommand}" || return
+     echo "Set ${env_kv%%=*}"
+}
+
 main() {
      action=''
      cwa_config_location=''
      restart='false'
      mode='ec2'
      use_dualstack='false'
+     env_kv=''
 
      # detect which init system is in use
      if [ "$(/sbin/init --version 2>/dev/null | grep -c upstart)" = 1 ]; then
@@ -399,7 +420,7 @@ main() {
      fi
 
      OPTIND=1
-     while getopts ":hsa:c:m:l:d" opt; do
+     while getopts ":hsa:c:m:l:de:" opt; do
           case "${opt}" in
           h)
                echo "${UsageString}"
@@ -411,6 +432,7 @@ main() {
           m) mode="${OPTARG}" ;;
           l) log_level="${OPTARG}" ;;
           d) use_dualstack='true' ;;
+          e) env_kv="${OPTARG}" ;;
           \?)
                echo "Invalid option: -${OPTARG} ${UsageString}" >&2
                ;;
@@ -448,6 +470,7 @@ main() {
           # helper for rpm+deb uninstallation hooks, not expected to be called manually
      preun) preun_all ;;
      set-log-level) set_log_level_all "${log_level}" ;;
+     set-env) set_env "${env_kv}" ;;
      *)
           echo "Invalid action: ${action} ${UsageString}" >&2
           exit 1

--- a/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
+++ b/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
@@ -80,6 +80,9 @@ $UsageString = @"
 
         -e: environment variable to set for the agent process, in KEY=VALUE format
             this parameter is used for 'set-env' only.
+            note: values that are also produced by agent config translation (such as
+            proxy, CA bundle, and log level settings) are overwritten from the agent
+            configuration on each fetch-config/append-config or agent restart.
 
 "@
 
@@ -455,7 +458,9 @@ Function SetEnv() {
         Exit 1
     }
 
-    & cmd /c "`"${CWAProgramFiles}\amazon-cloudwatch-agent.exe`" --setenv ${EnvVar} --envconfig ${ENV_CONFIG} 2>&1"
+    # Invoke directly (not via cmd /c) so the value is passed as a single
+    # argument and shell metacharacters or spaces in it are not interpreted.
+    & "${CWAProgramFiles}\amazon-cloudwatch-agent.exe" --setenv $EnvVar --envconfig $ENV_CONFIG
     CheckCMDResult "" "Set $(${EnvVar}.Split('=')[0])"
 }
 

--- a/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
+++ b/packaging/windows/amazon-cloudwatch-agent-ctl.ps1
@@ -15,6 +15,8 @@ Param (
     [Parameter(Mandatory = $false)]
     [string]$LogLevel = '',
     [Parameter(Mandatory = $false)]
+    [string]$EnvVar = '',
+    [Parameter(Mandatory = $false)]
     [switch]$d = $false,
     [parameter(ValueFromRemainingArguments=$true)]
     $unsupportedVars
@@ -27,12 +29,13 @@ $UsageString = @"
 
 
         usage:  amazon-cloudwatch-agent-ctl.ps1 -a
-                stop|start|status|status-with-workloads|fetch-config|append-config|remove-config|set-log-level
+                stop|start|status|status-with-workloads|fetch-config|append-config|remove-config|set-log-level|set-env
                 [-m ec2|onPremise|onPrem|auto]
                 [-c default|all|ssm:<parameter-store-name>|file:<file-path>]
                 [-s]
                 [-d]
                 [-l INFO|DEBUG|WARN|ERROR|OFF]
+                [-e KEY=VALUE]
 
         e.g.
         1. apply a SSM parameter store config on EC2 instance and restart the agent afterwards:
@@ -53,6 +56,7 @@ $UsageString = @"
             append-config:                          append json config with the existing json configs if any, followed by -c. Target config can be based on the location (ssm parameter store name, file name), or 'default'.
             remove-config:                          remove config for agent, followed by -c. Target config can be based on the location (ssm parameter store name, file name), or 'all'.
             set-log-level:                          sets the log level, followed by -l to provide the level in all caps.
+            set-env:                                sets an environment variable for the agent process, followed by -e to provide KEY=VALUE.
 
         -m: mode
             ec2:                                    indicate this is on ec2 host.
@@ -73,6 +77,9 @@ $UsageString = @"
 
         -l: log level to set the agent to INFO, DEBUG, WARN, ERROR, or OFF
             this parameter is used for 'set-log-level' only.
+
+        -e: environment variable to set for the agent process, in KEY=VALUE format
+            this parameter is used for 'set-env' only.
 
 "@
 
@@ -442,6 +449,16 @@ Function SetLogLevelAll() {
     CheckCMDResult "" "Set CWAGENT_LOG_LEVEL to ${LogLevel}"
 }
 
+Function SetEnv() {
+    if ($EnvVar -notmatch '^[^=]+=') {
+        Write-Output "Invalid environment variable: '${EnvVar}' (expected KEY=VALUE)`n${UsageString}"
+        Exit 1
+    }
+
+    & cmd /c "`"${CWAProgramFiles}\amazon-cloudwatch-agent.exe`" --setenv ${EnvVar} --envconfig ${ENV_CONFIG} 2>&1"
+    CheckCMDResult "" "Set $(${EnvVar}.Split('=')[0])"
+}
+
 Function main() {
     if (Get-Command 'Get-CimInstance' -CommandType Cmdlet -ErrorAction SilentlyContinue) {
         $CIM = $true
@@ -479,6 +496,7 @@ Function main() {
         cond-restart { CondRestartAll }
         preun { PreunAll }
         set-log-level { SetLogLevelAll }
+        set-env { SetEnv }
         default {
            Write-Output "Invalid action: ${Action}`n${UsageString}"
            Exit 1


### PR DESCRIPTION
# Description of the issue
Setup/enablement scripts need to persist environment variables such as `CWAGENT_ROLE_ARN` and `AWS_REGION` into `env-config.json`. Today the only way to do that is invoking the agent binary's internal `-setenv`/`-envconfig` flags directly and hardcoding the `env-config.json` path, bypassing the public ctl interface. The ctl script already wraps this exact mechanism for one specific key via `set-log-level`.

# Description of changes
Adds a generic `set-env` action to the Linux and Windows ctl scripts, following the existing `set-log-level` pattern:

- `amazon-cloudwatch-agent-ctl -a set-env -e KEY=VALUE` (Linux)
- `amazon-cloudwatch-agent-ctl.ps1 -a set-env -e KEY=VALUE` (Windows)

The action validates the KEY=VALUE format (rejects missing `=` or empty key) and delegates to the agent binary's `-setenv`, which merges the key into `env-config.json`. Keys set this way are retained across config translations per #2131, unless they are translator-managed keys.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested on EC2 with agent 1.300069.0b1529 plus this change, on both Amazon Linux 2023 (x86_64) and Windows Server 2022. On both platforms:

- `set-env` creates `env-config.json` when missing, merges additional keys, overwrites repeated keys
- Rejects `NOEQUALS`, `=value`, and missing `-e` with exit 1 and usage
- Custom keys survive `fetch-config` and full agent restart; translator-managed `CWAGENT_LOG_LEVEL` is wiped/regenerated from the JSON config as expected
- Agent process loads the vars at startup (verified via `I! MY_CUSTOM_VAR is set to ...` log lines) and the 30s env watcher hot-reloads changes
- `set-log-level` regression: still works end to end, including hot reload
