### PR TITLE
Add platform-specific default configs

### DIFF
--- a/tool/downloader/downloader.go
+++ b/tool/downloader/downloader.go
@@ -105,7 +105,7 @@ func RunDownloader(mode, downloadLocation, outputDir, inputConfig, multiConfig s
 	case locationDefault:
 		if len(locationArray) == 2 {
 			name := locationArray[1]
-			cfg, ok := translatorconfig.DefaultJSONConfigFor(name)
+			cfg, ok := translatorconfig.DefaultJSONConfigFor(name, util.DetectKubernetesMode(mode) != "", util.DetectECS())
 			if !ok {
 				return fmt.Errorf("unknown default config %q", name)
 			}

--- a/tool/downloader/downloader_test.go
+++ b/tool/downloader/downloader_test.go
@@ -23,7 +23,7 @@ func TestRunDownloader_DefaultOtel(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(outputDir, "default_otel.tmp"))
 	require.NoError(t, err)
 
-	expected, ok := config.DefaultJSONConfigFor("otel")
+	expected, ok := config.DefaultJSONConfigFor("otel", false, false)
 	require.True(t, ok)
 	assert.JSONEq(t, expected, string(content))
 }

--- a/translator/cmdutil/translatorutil_test.go
+++ b/translator/cmdutil/translatorutil_test.go
@@ -439,7 +439,7 @@ func TestOpenTelemetryResourceAttributesSchemaValidation(t *testing.T) {
 }
 
 func TestDefaultOtelConfigSchemaValidation(t *testing.T) {
-	cfg, ok := config.DefaultJSONConfigFor("otel")
+	cfg, ok := config.DefaultJSONConfigFor("otel", false, false)
 	require.True(t, ok)
 	jsonMap, err := util.GetJsonMapFromJsonBytes([]byte(cfg))
 	require.NoError(t, err)

--- a/translator/config/defaultConfig.go
+++ b/translator/config/defaultConfig.go
@@ -3,12 +3,59 @@
 
 package config
 
+import _ "embed"
+
+// Platform-specific default configs. Unlike otel.json/otel_windows.json (which
+// are OS-build-tagged), these have no OS constraint - K8s/ECS are Linux - so
+// they live here rather than in a build-tagged file.
+//
+//go:embed defaults/otel_ecs.json
+var defaultOtelECSConfig string
+
+//go:embed defaults/otel_k8s.json
+var defaultOtelK8sConfig string
+
+// otelConfigName is the shared map key for the otel default config and its
+// platform variants (e.g. -c default:otel).
+const otelConfigName = "otel"
+
+// defaultConfigs holds the base configs addressable by name.
 var defaultConfigs = map[string]string{
-	"otel": defaultOtelConfig,
+	otelConfigName: defaultOtelConfig,
 }
 
-// DefaultJSONConfigFor returns the named default config if it exists.
-func DefaultJSONConfigFor(name string) (string, bool) {
+// platform enumerates the environments that get a platform-specific default
+// config variant. VMs (EC2, Azure VM) use the base config; K8s and ECS get
+// their own variants since host-level scraping inside a container reports the
+// container, not the host.
+type platform int
+
+const (
+	platformK8s platform = iota
+	platformECS
+)
+
+// platformConfigs holds the platform variants. Kept out of defaultConfigs so
+// they are NOT addressable by name (e.g. -c default:otel_ecs on a VM).
+var platformConfigs = map[platform]map[string]string{
+	platformK8s: {otelConfigName: defaultOtelK8sConfig},
+	platformECS: {otelConfigName: defaultOtelECSConfig},
+}
+
+// DefaultJSONConfigFor returns the platform-specific variant when the caller's
+// detected platform has one, falling back to the named base config otherwise.
+// Kubernetes takes precedence over ECS.
+func DefaultJSONConfigFor(name string, isKubernetes, isECS bool) (string, bool) {
+	switch {
+	case isKubernetes:
+		if cfg, ok := platformConfigs[platformK8s][name]; ok {
+			return cfg, true
+		}
+	case isECS:
+		if cfg, ok := platformConfigs[platformECS][name]; ok {
+			return cfg, true
+		}
+	}
 	cfg, ok := defaultConfigs[name]
 	return cfg, ok
 }

--- a/translator/config/defaultConfig_test.go
+++ b/translator/config/defaultConfig_test.go
@@ -11,17 +11,60 @@ import (
 )
 
 func TestDefaultJSONConfigFor_Otel(t *testing.T) {
-	cfg, ok := DefaultJSONConfigFor("otel")
+	cfg, ok := DefaultJSONConfigFor("otel", false, false)
 	require.True(t, ok)
 	assert.JSONEq(t, defaultOtelConfig, cfg)
 }
 
 func TestDefaultJSONConfigFor_Unknown(t *testing.T) {
-	_, ok := DefaultJSONConfigFor("unknown")
+	_, ok := DefaultJSONConfigFor("unknown", false, false)
 	assert.False(t, ok)
 }
 
 func TestDefaultJSONConfigFor_Empty(t *testing.T) {
-	_, ok := DefaultJSONConfigFor("")
+	_, ok := DefaultJSONConfigFor("", false, false)
+	assert.False(t, ok)
+}
+
+func TestDefaultJSONConfigFor_PlatformVariantsNotAddressableByName(t *testing.T) {
+	// The variant suffixes must not be resolvable as base config names, even
+	// when a platform is detected (e.g. -c default:otel_ecs on any host). The
+	// variants are only reachable via the platform flags on the base name.
+	_, ok := DefaultJSONConfigFor("otel_ecs", false, true)
+	assert.False(t, ok)
+	_, ok = DefaultJSONConfigFor("otel_k8s", true, false)
+	assert.False(t, ok)
+}
+
+func TestDefaultJSONConfigFor_OtelK8s(t *testing.T) {
+	cfg, ok := DefaultJSONConfigFor("otel", true, false)
+	require.True(t, ok)
+	assert.JSONEq(t, defaultOtelK8sConfig, cfg)
+	assert.Contains(t, cfg, "container_insights")
+	assert.NotContains(t, cfg, "host_metrics")
+}
+
+func TestDefaultJSONConfigFor_OtelECS(t *testing.T) {
+	cfg, ok := DefaultJSONConfigFor("otel", false, true)
+	require.True(t, ok)
+	assert.JSONEq(t, defaultOtelECSConfig, cfg)
+	assert.NotContains(t, cfg, "host_metrics")
+	assert.NotContains(t, cfg, "container_insights")
+}
+
+func TestDefaultJSONConfigFor_KubernetesTakesPrecedenceOverECS(t *testing.T) {
+	cfg, ok := DefaultJSONConfigFor("otel", true, true)
+	require.True(t, ok)
+	assert.JSONEq(t, defaultOtelK8sConfig, cfg)
+}
+
+func TestDefaultJSONConfigFor_VMFallsBackToBase(t *testing.T) {
+	cfg, ok := DefaultJSONConfigFor("otel", false, false)
+	require.True(t, ok)
+	assert.JSONEq(t, defaultOtelConfig, cfg)
+}
+
+func TestDefaultJSONConfigFor_UnknownWithPlatform(t *testing.T) {
+	_, ok := DefaultJSONConfigFor("unknown", true, false)
 	assert.False(t, ok)
 }

--- a/translator/config/defaults/otel_ecs.json
+++ b/translator/config/defaults/otel_ecs.json
@@ -6,7 +6,6 @@
   },
   "opentelemetry": {
     "collect": {
-      "host_metrics": {},
       "otlp": {
         "span_metrics_enabled": true
       }

--- a/translator/config/defaults/otel_k8s.json
+++ b/translator/config/defaults/otel_k8s.json
@@ -6,7 +6,7 @@
   },
   "opentelemetry": {
     "collect": {
-      "host_metrics": {},
+      "container_insights": {},
       "otlp": {
         "span_metrics_enabled": true
       }

--- a/translator/config/defaults/otel_windows.json
+++ b/translator/config/defaults/otel_windows.json
@@ -6,6 +6,7 @@
   },
   "opentelemetry": {
     "collect": {
+      "host_metrics": {},
       "otlp": {},
       "windows_events": {
         "collect_list": [

--- a/translator/jsonconfig/mergeJsonConfig.go
+++ b/translator/jsonconfig/mergeJsonConfig.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/internal/constants"
 	"github.com/aws/amazon-cloudwatch-agent/translator"
 	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/jsonconfig/mergeJsonUtil"
 	_ "github.com/aws/amazon-cloudwatch-agent/translator/registerrules"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util"
@@ -26,7 +27,7 @@ func MergeJsonConfigMaps(jsonConfigMapMap map[string]map[string]interface{}, def
 				log.Println("No json config files found, use the default ecs config")
 				return util.GetJsonMapFromJsonBytes([]byte(config.DefaultECSJsonConfig()))
 			}
-		} else if cfg, ok := config.DefaultJSONConfigFor(useDefault); ok {
+		} else if cfg, ok := config.DefaultJSONConfigFor(useDefault, context.CurrentContext().KubernetesMode() != "", util.DetectECS()); ok {
 			log.Printf("No json config files found, use the default %s config", useDefault)
 			return util.GetJsonMapFromJsonBytes([]byte(cfg))
 		}

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config.yaml
@@ -483,6 +483,17 @@ processors:
                 os.version:
                     enabled: false
         timeout: 2s
+    transform/host_metrics_scope:
+        error_mode: ignore
+        flatten_data: false
+        log_statements: []
+        metric_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(scope.attributes["cloudwatch.solution"], "otel-host-metrics")
+        trace_statements: []
     transform/identity:
         error_mode: ignore
         flatten_data: false
@@ -574,6 +585,41 @@ processors:
                 - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
                 - set(scope.attributes["cloudwatch.solution"], "otel-otlp")
 receivers:
+    hostmetrics/opentelemetry:
+        collection_interval: 30s
+        initial_delay: 1s
+        scrapers:
+            cpu:
+                metrics:
+                    system.cpu.frequency:
+                        enabled: true
+                    system.cpu.logical.count:
+                        enabled: true
+                    system.cpu.physical.count:
+                        enabled: true
+                    system.cpu.utilization:
+                        enabled: true
+            disk: null
+            filesystem:
+                metrics:
+                    system.filesystem.utilization:
+                        enabled: true
+            load: null
+            memory:
+                metrics:
+                    system.linux.memory.available:
+                        enabled: true
+                    system.linux.memory.dirty:
+                        enabled: true
+                    system.memory.limit:
+                        enabled: true
+                    system.memory.page_size:
+                        enabled: true
+                    system.memory.utilization:
+                        enabled: true
+            network: null
+            processes: null
+        timeout: 0s
     otlp/grpc_127_0_0_1_4317:
         protocols:
             grpc:
@@ -626,6 +672,13 @@ service:
             receivers:
                 - otlp/grpc_127_0_0_1_4317
                 - otlp/http_127_0_0_1_4318
+        metrics/host_metrics:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/host_metrics_scope
+            receivers:
+                - hostmetrics/opentelemetry
         metrics/opentelemetry:
             exporters:
                 - otlphttp/metrics

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_aks.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_aks.yaml
@@ -190,6 +190,43 @@ processors:
               key: aws.log.group.name
             - from_resource_attribute: aws.log.stream.name
               key: aws.log.stream.name
+    awsattributelimit/cw_k8s_ci_v0:
+        max_total_attributes: 150
+        unconditional_removal_keys:
+            - k8s.node.label.topology.kubernetes.io/region
+            - k8s.node.label.topology.kubernetes.io/zone
+            - k8s.node.label.topology.ebs.csi.aws.com/zone
+            - k8s.node.label.node.kubernetes.io/instance-type
+            - k8s.node.label.kubernetes.io/hostname
+            - k8s.node.label.helm.sh/chart
+            - k8s.node.label.release
+            - k8s.node.label.eks.amazonaws.com/nodegroup-image
+            - k8s.node.label.k8s.io/cloud-provider-aws
+            - k8s.node.label.eks.amazonaws.com/sourceLaunchTemplateId
+            - k8s.node.label.eks.amazonaws.com/sourceLaunchTemplateVersion
+            - k8s.pod.label.pod-template-hash
+            - k8s.pod.label.controller-revision-hash
+        unconditional_removal_prefixes:
+            - k8s.node.label.feature.node.kubernetes.io/
+            - k8s.node.label.beta.kubernetes.io/
+            - k8s.node.label.failure-domain.beta.kubernetes.io/
+            - k8s.node.label.alpha.eksctl.io/
+    awsdevicepodcorrelation/cw_k8s_ci_v0:
+        device_types:
+            - device_id_attribute: neuroncore
+              name: neuron-by-core
+              resource_names:
+                - aws.amazon.com/neuroncore
+            - device_id_attribute: neurondevice
+              name: neuron-by-device
+              resource_names:
+                - aws.amazon.com/neurondevice
+                - aws.amazon.com/neuron
+            - device_id_attribute: aws.efa.device
+              name: efa
+              resource_names:
+                - vpc.amazonaws.com/efa
+    awsneuron/cw_k8s_ci_v0: null
     batch/opentelemetry_logs:
         metadata_cardinality_limit: 1000
         metadata_keys:
@@ -208,6 +245,89 @@ processors:
         send_batch_max_size: 10000
         send_batch_size: 10000
         timeout: 30s
+    filter/cw_k8s_ci_v0_cadvisor_empty:
+        error_mode: ignore
+        metrics:
+            datapoint:
+                - attributes["container"] == "" and attributes["pod"] == ""
+                - attributes["container"] == "" and attributes["pod"] == nil
+                - attributes["container"] == nil and attributes["pod"] == ""
+                - attributes["container"] == nil and attributes["pod"] == nil
+    filter/cw_k8s_ci_v0_cadvisor_pod:
+        error_mode: ignore
+        metrics:
+            datapoint:
+                - attributes["container"] == "POD"
+    filter/cw_k8s_ci_v0_neuron:
+        error_mode: ignore
+        metrics:
+            metric:
+                - IsMatch(name, "^(neuron|execution_|hardware_ecc_)") != true
+    filter/cw_k8s_ci_v0_scrape_metadata:
+        error_mode: ignore
+        metrics:
+            metric:
+                - IsMatch(name, "^(up|scrape_duration_seconds|scrape_samples_scraped|scrape_samples_post_metric_relabeling|scrape_series_added)$")
+    groupbyattrs/cw_k8s_ci_v0_cadvisor:
+        keys:
+            - container
+            - pod
+            - namespace
+    groupbyattrs/cw_k8s_ci_v0_dcgm:
+        keys:
+            - pod
+            - namespace
+            - container
+    groupbyattrs/cw_k8s_ci_v0_neuron:
+        keys:
+            - k8s.pod.name
+            - k8s.namespace.name
+            - k8s.container.name
+    k8sattributes/cw_k8s_ci_v0_node:
+        auth_type: serviceAccount
+        exclude:
+            pods: null
+        extract:
+            labels:
+                - from: node
+                  key_regex: (.*)
+                  tag_name: k8s.node.label.$$$$1
+            metadata:
+                - k8s.node.name
+        filter:
+            node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.node.name
+    k8sattributes/cw_k8s_ci_v0_pod:
+        auth_type: serviceAccount
+        exclude:
+            pods: null
+        extract:
+            labels:
+                - from: pod
+                  key_regex: (.*)
+                  tag_name: k8s.pod.label.$$$$1
+            metadata:
+                - k8s.pod.uid
+                - k8s.node.name
+                - k8s.deployment.name
+                - k8s.statefulset.name
+                - k8s.daemonset.name
+                - k8s.replicaset.name
+                - k8s.job.name
+                - k8s.cronjob.name
+        filter:
+            node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
     k8sattributes/opentelemetry:
         auth_type: serviceAccount
         context: ""
@@ -266,6 +386,14 @@ processors:
         passthrough: false
         wait_for_metadata: false
         wait_for_metadata_timeout: 10s
+    metricstarttime/cw_k8s_ci_v0: null
+    resourcedetection/cw_k8s_ci_v0:
+        detectors:
+            - eks
+            - env
+            - ec2
+        override: false
+        timeout: 2s
     resourcedetection/opentelemetry:
         aks:
             resource_attributes:
@@ -544,6 +672,245 @@ processors:
                 os.version:
                     enabled: false
         timeout: 2s
+    transform/cw_k8s_ci_v0_cadvisor_promote:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"] != nil and attributes["container"] != ""
+                - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"] != nil
+                - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"] != nil
+            - context: datapoint
+              statements:
+                - set(attributes["container"], resource.attributes["container"]) where resource.attributes["container"] != nil
+                - set(attributes["pod"], resource.attributes["pod"]) where resource.attributes["pod"] != nil
+                - set(attributes["namespace"], resource.attributes["namespace"]) where resource.attributes["namespace"] != nil
+    transform/cw_k8s_ci_v0_clear_schema_url:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - set(resource.schema_url, "")
+    transform/cw_k8s_ci_v0_dcgm_promote:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"] != nil
+                - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"] != nil
+                - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"] != nil
+            - context: datapoint
+              statements:
+                - set(attributes["pod"], resource.attributes["pod"]) where resource.attributes["pod"] != nil
+                - set(attributes["namespace"], resource.attributes["namespace"]) where resource.attributes["namespace"] != nil
+                - set(attributes["container"], resource.attributes["container"]) where resource.attributes["container"] != nil
+                - delete_key(attributes, "Hostname") where attributes["Hostname"] != nil
+                - delete_key(attributes, "pci_bus_id") where attributes["pci_bus_id"] != nil
+    transform/cw_k8s_ci_v0_ebs_csi_promote:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["instance_id"], attributes["instance_id"]) where attributes["instance_id"] != nil
+                - set(resource.attributes["volume_id"], attributes["volume_id"]) where attributes["volume_id"] != nil
+                - delete_key(attributes, "instance_id") where attributes["instance_id"] != nil
+                - delete_key(attributes, "volume_id") where attributes["volume_id"] != nil
+    transform/cw_k8s_ci_v0_efa_promote:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil
+                - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+                - set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil
+                - delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil
+                - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
+                - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
+    transform/cw_k8s_ci_v0_lis_csi_promote:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["instance_id"], attributes["instance_id"]) where attributes["instance_id"] != nil
+                - set(resource.attributes["volume_id"], attributes["volume_id"]) where attributes["volume_id"] != nil
+                - delete_key(attributes, "instance_id") where attributes["instance_id"] != nil
+                - delete_key(attributes, "volume_id") where attributes["volume_id"] != nil
+    transform/cw_k8s_ci_v0_neuron_hw_attrs:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["aws.neuron.device"], attributes["neurondevice"]) where attributes["neurondevice"] != nil
+                - set(attributes["aws.neuron.core"], attributes["neuroncore"]) where attributes["neuroncore"] != nil
+                - delete_key(attributes, "neuroncore") where attributes["neuroncore"] != nil
+                - delete_key(attributes, "neurondevice") where attributes["neurondevice"] != nil
+                - delete_key(attributes, "instance_type") where attributes["instance_type"] != nil
+    transform/cw_k8s_ci_v0_neuron_promote:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil
+                - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+                - set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil
+                - set(resource.attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
+                - delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil
+                - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
+                - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
+                - delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil
+    transform/cw_k8s_ci_v0_promote_node_name:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.node.name"], attributes["node_name"]) where attributes["node_name"] != nil
+    transform/cw_k8s_ci_v0_set_cloud_resource_id:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["cloud.resource_id"], Concat(["arn:aws:eks:", attributes["cloud.region"], ":", attributes["cloud.account.id"], ":cluster/", attributes["k8s.cluster.name"]], "")) where attributes["cloud.region"] != nil and attributes["cloud.account.id"] != nil and attributes["k8s.cluster.name"] != nil
+    transform/cw_k8s_ci_v0_set_cluster_name:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.cluster.name"], "test-cluster")
+    transform/cw_k8s_ci_v0_set_node_name:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["node_name"], "${K8S_NODE_NAME}")
+    transform/cw_k8s_ci_v0_set_scope_cadvisor:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.name, "github.com/google/cadvisor")
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "cadvisor")
+    transform/cw_k8s_ci_v0_set_scope_dcgm:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.name, "github.com/NVIDIA/dcgm-exporter")
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "dcgm")
+    transform/cw_k8s_ci_v0_set_scope_ebs_csi:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "ebs-csi")
+    transform/cw_k8s_ci_v0_set_scope_efa:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "efa")
+    transform/cw_k8s_ci_v0_set_scope_kubeletstats:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "kubeletstats")
+    transform/cw_k8s_ci_v0_set_scope_lis_csi:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "lis-csi")
+    transform/cw_k8s_ci_v0_set_scope_neuron_monitor:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.name, "awsneuron")
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "neuron-monitor")
+    transform/cw_k8s_ci_v0_set_scope_node_exporter:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.name, "github.com/prometheus/node_exporter")
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "node-exporter")
+    transform/cw_k8s_ci_v0_set_unit:
+        error_mode: ignore
+        metric_statements:
+            - context: metric
+              statements:
+                - set(unit, "s") where IsMatch(name, ".*_seconds(_total)?$")
+                - set(unit, "ms") where IsMatch(name, ".*_milliseconds(_total)?$")
+                - set(unit, "us") where IsMatch(name, ".*_microseconds(_total)?$")
+                - set(unit, "ns") where IsMatch(name, ".*_nanoseconds(_total)?$")
+                - set(unit, "By") where IsMatch(name, ".*_bytes(_total)?$")
+                - set(unit, "KBy") where IsMatch(name, ".*_kilobytes(_total)?$")
+                - set(unit, "MBy") where IsMatch(name, ".*_megabytes(_total)?$")
+                - set(unit, "GBy") where IsMatch(name, ".*_gigabytes(_total)?$")
+                - set(unit, "KiBy") where IsMatch(name, ".*_kibibytes(_total)?$")
+                - set(unit, "MiBy") where IsMatch(name, ".*_mebibytes(_total)?$")
+                - set(unit, "GiBy") where IsMatch(name, ".*_gibibytes(_total)?$")
+                - set(unit, "Cel") where IsMatch(name, ".*_celsius$")
+                - set(unit, "Hz") where IsMatch(name, ".*_hertz$")
+                - set(unit, "1") where IsMatch(name, ".*_ratio$")
+                - set(unit, "%") where IsMatch(name, ".*_percent$")
+                - set(unit, "V") where IsMatch(name, ".*_volts$")
+                - set(unit, "W") where IsMatch(name, ".*_watts$")
+                - set(unit, "J") where IsMatch(name, ".*_joules$")
+                - set(unit, "A") where IsMatch(name, ".*_amperes$")
+                - set(unit, "m") where IsMatch(name, ".*_meters(_total)?$")
+                - set(unit, "1") where unit == "" and IsMatch(name, ".*_total$")
+                - set(unit, "%") where name == "DCGM_FI_DEV_GPU_UTIL"
+                - set(unit, "%") where name == "DCGM_FI_DEV_MEM_COPY_UTIL"
+                - set(unit, "%") where name == "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE"
+                - set(unit, "MiBy") where name == "DCGM_FI_DEV_FB_USED"
+                - set(unit, "MiBy") where name == "DCGM_FI_DEV_FB_FREE"
+                - set(unit, "MiBy") where name == "DCGM_FI_DEV_FB_TOTAL"
+                - set(unit, "Cel") where name == "DCGM_FI_DEV_GPU_TEMP"
+                - set(unit, "W") where name == "DCGM_FI_DEV_POWER_USAGE"
+                - set(unit, "MHz") where name == "DCGM_FI_DEV_SM_CLOCK"
+                - set(unit, "By") where IsMatch(name, "^neuroncore_memory_usage_.*")
+    transform/cw_k8s_ci_v0_set_workload:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Deployment") where resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "StatefulSet") where resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.daemonset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "DaemonSet") where resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Job") where resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.cronjob.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "ReplicaSet") where resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
     transform/identity:
         error_mode: ignore
         flatten_data: false
@@ -732,7 +1099,65 @@ processors:
               statements:
                 - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
                 - set(scope.attributes["cloudwatch.solution"], "otel-otlp")
+    transform/set_cluster_name:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["k8s.cluster.name"], "test-cluster")
+        metric_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["k8s.cluster.name"], "test-cluster")
+        trace_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["k8s.cluster.name"], "test-cluster")
 receivers:
+    awsefareceiver/cw_k8s_ci_v0:
+        collection_interval: 30s
+    kubeletstats/cw_k8s_ci_v0:
+        auth_type: serviceAccount
+        collection_interval: 30s
+        endpoint: https://${HOST_IP}:10250
+        insecure_skip_verify: true
+        metric_groups:
+            - pod
+            - container
+            - node
+        metrics:
+            container.cpu.usage:
+                enabled: true
+            container.uptime:
+                enabled: true
+            k8s.container.cpu_limit_utilization:
+                enabled: true
+            k8s.container.cpu_request_utilization:
+                enabled: true
+            k8s.container.memory_limit_utilization:
+                enabled: true
+            k8s.container.memory_request_utilization:
+                enabled: true
+            k8s.node.cpu.usage:
+                enabled: true
+            k8s.node.uptime:
+                enabled: true
+            k8s.pod.cpu.usage:
+                enabled: true
+            k8s.pod.cpu_limit_utilization:
+                enabled: true
+            k8s.pod.cpu_request_utilization:
+                enabled: true
+            k8s.pod.memory_limit_utilization:
+                enabled: true
+            k8s.pod.memory_request_utilization:
+                enabled: true
+            k8s.pod.uptime:
+                enabled: true
     otlp/grpc_127_0_0_1_4317:
         protocols:
             grpc:
@@ -753,6 +1178,122 @@ receivers:
                 read_header_timeout: 0s
                 traces_url_path: /v1/traces
                 write_timeout: 0s
+    prometheus/cw_k8s_ci_v0_cadvisor:
+        config:
+            global:
+                scrape_interval: 30s
+                scrape_timeout: 10s
+            scrape_configs:
+                - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                  job_name: cadvisor
+                  metrics_path: /metrics/cadvisor
+                  scheme: https
+                  scrape_interval: 30s
+                  scrape_timeout: 10s
+                  static_configs:
+                    - targets:
+                        - ${HOST_IP}:10250
+                  tls_config:
+                    insecure_skip_verify: true
+    prometheus/cw_k8s_ci_v0_dcgm:
+        config:
+            global:
+                scrape_interval: 30s
+                scrape_timeout: 10s
+            scrape_configs:
+                - job_name: dcgm-exporter
+                  scheme: https
+                  scrape_interval: 30s
+                  scrape_timeout: 10s
+                  static_configs:
+                    - targets:
+                        - dcgm-exporter-service:9400
+                  tls_config:
+                    ca_file: /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt
+    prometheus/cw_k8s_ci_v0_ebs_csi_node:
+        config:
+            global:
+                scrape_interval: 30s
+                scrape_timeout: 10s
+            scrape_configs:
+                - job_name: ebs-csi-node
+                  kubernetes_sd_configs:
+                    - namespaces:
+                        names:
+                            - kube-system
+                      role: pod
+                  relabel_configs:
+                    - action: keep
+                      regex: ebs-csi-node
+                      source_labels:
+                        - __meta_kubernetes_pod_label_app
+                    - action: keep
+                      regex: ${K8S_NODE_NAME}
+                      source_labels:
+                        - __meta_kubernetes_pod_node_name
+                    - action: keep
+                      regex: metrics
+                      source_labels:
+                        - __meta_kubernetes_pod_container_port_name
+                  scrape_interval: 30s
+                  scrape_timeout: 10s
+    prometheus/cw_k8s_ci_v0_lis_csi_node:
+        config:
+            global:
+                scrape_interval: 30s
+                scrape_timeout: 10s
+            scrape_configs:
+                - job_name: lis-csi-node
+                  kubernetes_sd_configs:
+                    - namespaces:
+                        names:
+                            - kube-system
+                      role: pod
+                  relabel_configs:
+                    - action: keep
+                      regex: ec2-instance-store-plugin
+                      source_labels:
+                        - __meta_kubernetes_pod_label_app
+                    - action: keep
+                      regex: ${K8S_NODE_NAME}
+                      source_labels:
+                        - __meta_kubernetes_pod_node_name
+                    - action: keep
+                      regex: metrics
+                      source_labels:
+                        - __meta_kubernetes_pod_container_port_name
+                  scrape_interval: 30s
+                  scrape_timeout: 10s
+    prometheus/cw_k8s_ci_v0_neuron:
+        config:
+            global:
+                scrape_interval: 30s
+                scrape_timeout: 10s
+            scrape_configs:
+                - job_name: neuron-monitor
+                  scheme: https
+                  scrape_interval: 30s
+                  scrape_timeout: 10s
+                  static_configs:
+                    - targets:
+                        - neuron-monitor-service:8000
+                  tls_config:
+                    ca_file: /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt
+    prometheus/cw_k8s_ci_v0_node_exporter:
+        config:
+            global:
+                scrape_interval: 30s
+                scrape_timeout: 10s
+            scrape_configs:
+                - job_name: node-exporter
+                  scheme: https
+                  scrape_interval: 30s
+                  scrape_timeout: 10s
+                  static_configs:
+                    - targets:
+                        - node-exporter-service:9487
+                  tls_config:
+                    ca_file: /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt
 service:
     extensions:
         - sigv4auth/monitoring
@@ -771,6 +1312,7 @@ service:
             processors:
                 - resourcedetection/opentelemetry
                 - k8sattributes/opentelemetry
+                - transform/set_cluster_name
                 - transform/identity
                 - transform/logs_routing
                 - attributestocontext/opentelemetry
@@ -787,12 +1329,181 @@ service:
             receivers:
                 - otlp/grpc_127_0_0_1_4317
                 - otlp/http_127_0_0_1_4318
+        metrics/cw_k8s_ci_v0_cadvisor:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/cw_k8s_ci_v0_scrape_metadata
+                - transform/cw_k8s_ci_v0_set_unit
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - filter/cw_k8s_ci_v0_cadvisor_empty
+                - filter/cw_k8s_ci_v0_cadvisor_pod
+                - groupbyattrs/cw_k8s_ci_v0_cadvisor
+                - transform/cw_k8s_ci_v0_cadvisor_promote
+                - transform/cw_k8s_ci_v0_set_node_name
+                - transform/cw_k8s_ci_v0_promote_node_name
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - k8sattributes/cw_k8s_ci_v0_node
+                - k8sattributes/cw_k8s_ci_v0_pod
+                - transform/cw_k8s_ci_v0_set_scope_cadvisor
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - transform/cw_k8s_ci_v0_set_workload
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - prometheus/cw_k8s_ci_v0_cadvisor
+        metrics/cw_k8s_ci_v0_dcgm:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/cw_k8s_ci_v0_scrape_metadata
+                - transform/cw_k8s_ci_v0_set_unit
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - groupbyattrs/cw_k8s_ci_v0_dcgm
+                - transform/cw_k8s_ci_v0_dcgm_promote
+                - k8sattributes/cw_k8s_ci_v0_pod
+                - transform/cw_k8s_ci_v0_set_node_name
+                - transform/cw_k8s_ci_v0_promote_node_name
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_set_scope_dcgm
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - transform/cw_k8s_ci_v0_set_workload
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - prometheus/cw_k8s_ci_v0_dcgm
+        metrics/cw_k8s_ci_v0_ebs_csi_node:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/cw_k8s_ci_v0_scrape_metadata
+                - transform/cw_k8s_ci_v0_set_unit
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - transform/cw_k8s_ci_v0_ebs_csi_promote
+                - transform/cw_k8s_ci_v0_set_node_name
+                - transform/cw_k8s_ci_v0_promote_node_name
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_set_scope_ebs_csi
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - transform/cw_k8s_ci_v0_set_workload
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - prometheus/cw_k8s_ci_v0_ebs_csi_node
+        metrics/cw_k8s_ci_v0_efa:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/cw_k8s_ci_v0_set_unit
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_scope_efa
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - awsdevicepodcorrelation/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_efa_promote
+                - transform/cw_k8s_ci_v0_set_node_name
+                - transform/cw_k8s_ci_v0_promote_node_name
+                - k8sattributes/cw_k8s_ci_v0_pod
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - transform/cw_k8s_ci_v0_set_workload
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - awsefareceiver/cw_k8s_ci_v0
+        metrics/cw_k8s_ci_v0_kubeletstats:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_scope_kubeletstats
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - k8sattributes/cw_k8s_ci_v0_pod
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - transform/cw_k8s_ci_v0_set_workload
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - kubeletstats/cw_k8s_ci_v0
+        metrics/cw_k8s_ci_v0_lis_csi_node:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/cw_k8s_ci_v0_scrape_metadata
+                - transform/cw_k8s_ci_v0_set_unit
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - transform/cw_k8s_ci_v0_lis_csi_promote
+                - transform/cw_k8s_ci_v0_set_node_name
+                - transform/cw_k8s_ci_v0_promote_node_name
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_set_scope_lis_csi
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - transform/cw_k8s_ci_v0_set_workload
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - prometheus/cw_k8s_ci_v0_lis_csi_node
+        metrics/cw_k8s_ci_v0_neuron:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/cw_k8s_ci_v0_scrape_metadata
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - filter/cw_k8s_ci_v0_neuron
+                - awsneuron/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_unit
+                - awsdevicepodcorrelation/cw_k8s_ci_v0
+                - groupbyattrs/cw_k8s_ci_v0_neuron
+                - transform/cw_k8s_ci_v0_neuron_promote
+                - transform/cw_k8s_ci_v0_neuron_hw_attrs
+                - k8sattributes/cw_k8s_ci_v0_pod
+                - transform/cw_k8s_ci_v0_set_node_name
+                - transform/cw_k8s_ci_v0_promote_node_name
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_set_scope_neuron_monitor
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - transform/cw_k8s_ci_v0_set_workload
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - prometheus/cw_k8s_ci_v0_neuron
+        metrics/cw_k8s_ci_v0_node_exporter:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/cw_k8s_ci_v0_scrape_metadata
+                - transform/cw_k8s_ci_v0_set_unit
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - transform/cw_k8s_ci_v0_set_node_name
+                - transform/cw_k8s_ci_v0_promote_node_name
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_set_scope_node_exporter
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - transform/cw_k8s_ci_v0_set_workload
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - prometheus/cw_k8s_ci_v0_node_exporter
         metrics/opentelemetry:
             exporters:
                 - otlphttp/metrics
             processors:
                 - resourcedetection/opentelemetry
                 - k8sattributes/opentelemetry
+                - transform/set_cluster_name
                 - transform/identity
                 - batch/opentelemetry_metrics
             receivers:
@@ -813,6 +1524,7 @@ service:
             processors:
                 - resourcedetection/opentelemetry
                 - k8sattributes/opentelemetry
+                - transform/set_cluster_name
                 - transform/identity
                 - batch/opentelemetry_traces
             receivers:

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_azurevm.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_azurevm.yaml
@@ -487,6 +487,17 @@ processors:
                 os.version:
                     enabled: false
         timeout: 2s
+    transform/host_metrics_scope:
+        error_mode: ignore
+        flatten_data: false
+        log_statements: []
+        metric_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(scope.attributes["cloudwatch.solution"], "otel-host-metrics")
+        trace_statements: []
     transform/identity:
         error_mode: ignore
         flatten_data: false
@@ -578,6 +589,41 @@ processors:
                 - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
                 - set(scope.attributes["cloudwatch.solution"], "otel-otlp")
 receivers:
+    hostmetrics/opentelemetry:
+        collection_interval: 30s
+        initial_delay: 1s
+        scrapers:
+            cpu:
+                metrics:
+                    system.cpu.frequency:
+                        enabled: true
+                    system.cpu.logical.count:
+                        enabled: true
+                    system.cpu.physical.count:
+                        enabled: true
+                    system.cpu.utilization:
+                        enabled: true
+            disk: null
+            filesystem:
+                metrics:
+                    system.filesystem.utilization:
+                        enabled: true
+            load: null
+            memory:
+                metrics:
+                    system.linux.memory.available:
+                        enabled: true
+                    system.linux.memory.dirty:
+                        enabled: true
+                    system.memory.limit:
+                        enabled: true
+                    system.memory.page_size:
+                        enabled: true
+                    system.memory.utilization:
+                        enabled: true
+            network: null
+            processes: null
+        timeout: 0s
     otlp/grpc_127_0_0_1_4317:
         protocols:
             grpc:
@@ -631,6 +677,13 @@ service:
             receivers:
                 - otlp/grpc_127_0_0_1_4317
                 - otlp/http_127_0_0_1_4318
+        metrics/host_metrics:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/host_metrics_scope
+            receivers:
+                - hostmetrics/opentelemetry
         metrics/opentelemetry:
             exporters:
                 - otlphttp/metrics

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_windows.yaml
@@ -471,6 +471,17 @@ processors:
                 os.version:
                     enabled: false
         timeout: 2s
+    transform/host_metrics_scope:
+        error_mode: ignore
+        flatten_data: false
+        log_statements: []
+        metric_statements:
+            - context: scope
+              error_mode: ignore
+              statements:
+                - set(scope.attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(scope.attributes["cloudwatch.solution"], "otel-host-metrics")
+        trace_statements: []
     transform/identity:
         error_mode: ignore
         flatten_data: false
@@ -576,6 +587,34 @@ processors:
         metric_statements: []
         trace_statements: []
 receivers:
+    hostmetrics/opentelemetry:
+        collection_interval: 30s
+        initial_delay: 1s
+        scrapers:
+            cpu:
+                metrics:
+                    system.cpu.logical.count:
+                        enabled: true
+                    system.cpu.physical.count:
+                        enabled: true
+                    system.cpu.utilization:
+                        enabled: true
+            disk: null
+            filesystem:
+                metrics:
+                    system.filesystem.utilization:
+                        enabled: true
+            load: null
+            memory:
+                metrics:
+                    system.memory.limit:
+                        enabled: true
+                    system.memory.page_size:
+                        enabled: true
+                    system.memory.utilization:
+                        enabled: true
+            network: null
+        timeout: 0s
     otlp/grpc_127_0_0_1_4317:
         protocols:
             grpc:
@@ -679,6 +718,13 @@ service:
                 - transform/windows_events_scope
             receivers:
                 - windowseventlog/system_396641996
+        metrics/host_metrics:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/host_metrics_scope
+            receivers:
+                - hostmetrics/opentelemetry
         metrics/opentelemetry:
             exporters:
                 - otlphttp/metrics

--- a/translator/tocwconfig/tocwconfig_unix_test.go
+++ b/translator/tocwconfig/tocwconfig_unix_test.go
@@ -197,7 +197,7 @@ func TestDefaultOtelConfigAzureVMTranslation(t *testing.T) {
 		return "", ""
 	}
 
-	cfg, ok := config.DefaultJSONConfigFor("otel")
+	cfg, ok := config.DefaultJSONConfigFor("otel", false, false)
 	require.True(t, ok)
 
 	var input any
@@ -216,7 +216,7 @@ func TestDefaultOtelConfigECSTranslation(t *testing.T) {
 	ecsutil.GetECSUtilSingleton().Region = "us-west-2"
 	agent.Global_Config.Region = "us-west-2"
 
-	cfg, ok := config.DefaultJSONConfigFor("otel")
+	cfg, ok := config.DefaultJSONConfigFor("otel", false, true)
 	require.True(t, ok)
 
 	var input any
@@ -233,13 +233,16 @@ func TestDefaultOtelConfigAKSTranslation(t *testing.T) {
 	context.CurrentContext().SetMode(config.ModeAzureVM)
 	context.CurrentContext().SetKubernetesMode(config.ModeAKS)
 	context.CurrentContext().SetRunInContainer(true)
+	// container_insights has no cluster_name in the default config, so it falls
+	// back to the K8S_CLUSTER_NAME env var (there is no EC2 tagger on Azure).
+	t.Setenv("K8S_CLUSTER_NAME", "test-cluster")
 	// No AWS region source exists on Azure at translation time, so region
 	// detection returns empty and the translator falls back to ${AWS_REGION}.
 	util.DetectRegion = func(string, map[string]string) (string, string) {
 		return "", ""
 	}
 
-	cfg, ok := config.DefaultJSONConfigFor("otel")
+	cfg, ok := config.DefaultJSONConfigFor("otel", true, false)
 	require.True(t, ok)
 
 	var input any
@@ -255,7 +258,7 @@ func TestDefaultOtelConfigTranslation(t *testing.T) {
 	context.CurrentContext().SetMode(config.ModeEC2)
 	agent.Global_Config.Region = "us-west-2"
 
-	cfg, ok := config.DefaultJSONConfigFor("otel")
+	cfg, ok := config.DefaultJSONConfigFor("otel", false, false)
 	require.True(t, ok)
 
 	var input any

--- a/translator/tocwconfig/tocwconfig_windows_test.go
+++ b/translator/tocwconfig/tocwconfig_windows_test.go
@@ -44,7 +44,7 @@ func TestDefaultOtelConfigWindowsTranslation(t *testing.T) {
 	agent.Global_Config.Region = "us-west-2"
 	agent.Global_Config.RegionType = config.RegionTypeCredsMap
 
-	cfg, ok := config.DefaultJSONConfigFor("otel")
+	cfg, ok := config.DefaultJSONConfigFor("otel", false, false)
 	require.True(t, ok)
 
 	var input any

--- a/translator/util/sdkutil.go
+++ b/translator/util/sdkutil.go
@@ -78,6 +78,13 @@ func DetectAgentMode(configuredMode string) string {
 	return config.ModeOnPrem
 }
 
+// DetectECS reports whether the agent is running on ECS. It indirects the
+// ecsutil singleton so callers don't depend on it directly, mirroring
+// DetectKubernetesMode.
+func DetectECS() bool {
+	return ecsutil.GetECSUtilSingleton().IsECS()
+}
+
 func DetectKubernetesMode(configuredMode string) string {
 	// RUN_IN_AKS is an explicit env signal (no I/O), so short-circuit before the EKS in-cluster probe.
 	if IsAKS() {


### PR DESCRIPTION
# Description of changes
- Added `host_metrics` to the `default:otel` config for both Linux and Windows
- Added platform-specific `default:otel` variants so the config matches where the agent runs:
  - `otel_k8s.json` (EKS/AKS): `container_insights` + `otlp`
  - `otel_ecs.json`: `otlp` only

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated unit tests to verify translation.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



