### PR TITLE
windows: route OS-shutdown SIGTERM through SCM to unblock svc.Run

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -126,6 +126,10 @@ func reloadLoop(
 					log.Println("I! Reloading Telegraf config")
 					<-reload
 					reload <- true
+				} else {
+					// Route non-SIGHUP terminating signal through the SCM;
+					// see shutdown_signal_windows.go.
+					handleTerminatingSignalDispatch(stop, stopWaitTimeout)
 				}
 				cancel()
 			case <-stop:
@@ -439,6 +443,8 @@ func (p *program) run() {
 		p.aggregatorFilters,
 		p.processorFilters,
 	)
+	// Windows-only fallback: exit if SCM STOP was not taken.
+	handleTerminatingSignal()
 }
 func (p *program) Stop(_ service.Service) error {
 	close(stop)

--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -435,6 +435,7 @@ func (p *program) Start(_ service.Service) error {
 	return nil
 }
 func (p *program) run() {
+	defer signalRunComplete() // unblock main()'s waitRunComplete on any return
 	stop = make(chan struct{})
 	reloadLoop(
 		stop,
@@ -649,6 +650,9 @@ func main() {
 			if err != nil {
 				log.Println("E! " + err.Error())
 			}
+			// Wait for (*program).run to finish so otelcol.Shutdown can
+			// complete before the Go runtime calls ExitProcess.
+			waitRunComplete()
 		}
 	} else {
 		stop = make(chan struct{})

--- a/cmd/amazon-cloudwatch-agent/shutdown_signal.go
+++ b/cmd/amazon-cloudwatch-agent/shutdown_signal.go
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+// See shutdown_signal_windows.go for the workaround's purpose.
+
+// stopWaitTimeout bounds how long the signal goroutine waits for prg.Stop
+// after requestSCMStop is accepted. Declared as var for testability.
+var stopWaitTimeout = 30 * time.Second
+
+// terminatingSignalReceived flags that the SCM STOP path was NOT taken;
+// handleTerminatingSignal then os.Exit(0)s so svc.Run cannot block OS
+// shutdown. Accessed atomically.
+var terminatingSignalReceived atomic.Bool
+
+// requestSCMStopFn is a test seam over requestSCMStop.
+var requestSCMStopFn = requestSCMStop
+
+// handleTerminatingSignalDispatch is called by the signal goroutine on a
+// non-SIGHUP terminating signal. Tries SCM STOP; falls back to setting the
+// flag on failure or timeout.
+func handleTerminatingSignalDispatch(stopCh <-chan struct{}, timeout time.Duration) {
+	if requestSCMStopFn() {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case <-stopCh:
+		case <-timer.C:
+			log.Println("W! Windows service: SCM stop did not deliver in time; forcing fallback")
+			terminatingSignalReceived.Store(true)
+		}
+	} else {
+		terminatingSignalReceived.Store(true)
+	}
+}

--- a/cmd/amazon-cloudwatch-agent/shutdown_signal.go
+++ b/cmd/amazon-cloudwatch-agent/shutdown_signal.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"log"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -38,5 +39,34 @@ func handleTerminatingSignalDispatch(stopCh <-chan struct{}, timeout time.Durati
 		}
 	} else {
 		terminatingSignalReceived.Store(true)
+	}
+}
+
+// runCompleteChan is closed by signalRunComplete when (*program).run
+// finishes. main() waits on this via waitRunComplete so otelcol.Shutdown
+// and any pending flushes can complete before the process exits.
+// Declared as var so tests can substitute a fresh channel.
+var runCompleteChan = make(chan struct{})
+
+// runCompleteOnce guards close(runCompleteChan).
+var runCompleteOnce sync.Once
+
+// runCompleteTimeout bounds waitRunComplete so a stuck teardown cannot
+// indefinitely hold up the OS.
+var runCompleteTimeout = 30 * time.Second
+
+// signalRunComplete unblocks waitRunComplete. Safe to call multiple times.
+func signalRunComplete() {
+	runCompleteOnce.Do(func() { close(runCompleteChan) })
+}
+
+// waitRunComplete blocks until signalRunComplete or runCompleteTimeout,
+// whichever comes first. Logs a warning on timeout so the OS is not
+// held indefinitely.
+func waitRunComplete() {
+	select {
+	case <-runCompleteChan:
+	case <-time.After(runCompleteTimeout):
+		log.Printf("W! Windows service: waited %v for shutdown teardown to complete; exiting anyway", runCompleteTimeout)
 	}
 }

--- a/cmd/amazon-cloudwatch-agent/shutdown_signal_notwindows.go
+++ b/cmd/amazon-cloudwatch-agent/shutdown_signal_notwindows.go
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package main
+
+// requestSCMStop and handleTerminatingSignal are no-ops on non-Windows.
+func requestSCMStop() bool     { return false }
+func handleTerminatingSignal() {}

--- a/cmd/amazon-cloudwatch-agent/shutdown_signal_test.go
+++ b/cmd/amazon-cloudwatch-agent/shutdown_signal_test.go
@@ -1,0 +1,97 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---- terminatingSignalReceived atomic flag ---------------------------
+
+func TestTerminatingSignalReceived_DefaultUnset(t *testing.T) {
+	t.Cleanup(func() { terminatingSignalReceived.Store(false) })
+	if terminatingSignalReceived.Load() {
+		t.Fatal("terminatingSignalReceived was true before any Store()")
+	}
+}
+
+func TestTerminatingSignalReceived_SetLoad(t *testing.T) {
+	t.Cleanup(func() { terminatingSignalReceived.Store(false) })
+	terminatingSignalReceived.Store(true)
+	if !terminatingSignalReceived.Load() {
+		t.Fatal("terminatingSignalReceived was false after Store(true)")
+	}
+}
+
+func TestTerminatingSignalReceived_Race(t *testing.T) {
+	t.Cleanup(func() { terminatingSignalReceived.Store(false) })
+	const N = 64
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				terminatingSignalReceived.Store(true)
+			} else {
+				_ = terminatingSignalReceived.Load()
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// ---- handleTerminatingSignalDispatch ---------------------------------
+
+// withRequestSCMStopFn temporarily overrides requestSCMStopFn and resets
+// the terminatingSignalReceived flag for a test.
+func withRequestSCMStopFn(t *testing.T, fn func() bool) {
+	t.Helper()
+	old := requestSCMStopFn
+	requestSCMStopFn = fn
+	terminatingSignalReceived.Store(false)
+	t.Cleanup(func() {
+		requestSCMStopFn = old
+		terminatingSignalReceived.Store(false)
+	})
+}
+
+// When requestSCMStop returns false (no SCM path), dispatch must set the
+// fallback flag so handleTerminatingSignal can os.Exit later.
+func TestDispatch_SCMUnavailable_SetsFallbackFlag(t *testing.T) {
+	withRequestSCMStopFn(t, func() bool { return false })
+	stopCh := make(chan struct{})
+	handleTerminatingSignalDispatch(stopCh, 5*time.Millisecond)
+	if !terminatingSignalReceived.Load() {
+		t.Fatal("expected fallback flag set when SCM path is unavailable")
+	}
+}
+
+// When requestSCMStop returns true and close(stop) fires before the
+// timeout, dispatch must NOT set the fallback flag (SCM path OK).
+func TestDispatch_SCMSuccess_NoFallbackFlag(t *testing.T) {
+	withRequestSCMStopFn(t, func() bool { return true })
+	stopCh := make(chan struct{})
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(stopCh)
+	}()
+	handleTerminatingSignalDispatch(stopCh, 500*time.Millisecond)
+	if terminatingSignalReceived.Load() {
+		t.Fatal("expected NO fallback flag when SCM path completes cleanly")
+	}
+}
+
+// When requestSCMStop returns true but close(stop) never fires within the
+// timeout, dispatch must set the fallback flag.
+func TestDispatch_SCMAcceptedButTimeout_SetsFallbackFlag(t *testing.T) {
+	withRequestSCMStopFn(t, func() bool { return true })
+	stopCh := make(chan struct{}) // never closed
+	handleTerminatingSignalDispatch(stopCh, 20*time.Millisecond)
+	if !terminatingSignalReceived.Load() {
+		t.Fatal("expected fallback flag set after SCM path timeout")
+	}
+}

--- a/cmd/amazon-cloudwatch-agent/shutdown_signal_test.go
+++ b/cmd/amazon-cloudwatch-agent/shutdown_signal_test.go
@@ -95,3 +95,69 @@ func TestDispatch_SCMAcceptedButTimeout_SetsFallbackFlag(t *testing.T) {
 		t.Fatal("expected fallback flag set after SCM path timeout")
 	}
 }
+
+// ---- runComplete channel + wait -------------------------------------
+
+// resetRunComplete restores a fresh channel + Once so tests can exercise
+// signalRunComplete and waitRunComplete in isolation.
+func resetRunComplete() {
+	runCompleteChan = make(chan struct{})
+	runCompleteOnce = sync.Once{}
+}
+
+// signalRunComplete must be idempotent (close of a closed channel would
+// panic without sync.Once).
+func TestSignalRunComplete_Idempotent(t *testing.T) {
+	t.Cleanup(resetRunComplete)
+	resetRunComplete()
+
+	signalRunComplete()
+	signalRunComplete() // must not panic
+
+	select {
+	case <-runCompleteChan:
+	default:
+		t.Fatal("runCompleteChan not closed after signalRunComplete()")
+	}
+}
+
+// waitRunComplete must return promptly once signalRunComplete is called.
+func TestWaitRunComplete_ReturnsWhenSignaled(t *testing.T) {
+	t.Cleanup(resetRunComplete)
+	resetRunComplete()
+	oldTimeout := runCompleteTimeout
+	runCompleteTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { runCompleteTimeout = oldTimeout })
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		signalRunComplete()
+	}()
+
+	start := time.Now()
+	waitRunComplete()
+	elapsed := time.Since(start)
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("waitRunComplete took %v; expected quick return after signal", elapsed)
+	}
+}
+
+// waitRunComplete must fall through after runCompleteTimeout when no
+// signal arrives, so the OS is not held indefinitely.
+func TestWaitRunComplete_TimesOut(t *testing.T) {
+	t.Cleanup(resetRunComplete)
+	resetRunComplete()
+	oldTimeout := runCompleteTimeout
+	runCompleteTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { runCompleteTimeout = oldTimeout })
+
+	start := time.Now()
+	waitRunComplete()
+	elapsed := time.Since(start)
+	if elapsed < 15*time.Millisecond {
+		t.Fatalf("waitRunComplete returned in %v; expected ~20ms timeout", elapsed)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("waitRunComplete took %v; expected ~20ms timeout", elapsed)
+	}
+}

--- a/cmd/amazon-cloudwatch-agent/shutdown_signal_windows.go
+++ b/cmd/amazon-cloudwatch-agent/shutdown_signal_windows.go
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package main
+
+import (
+	"log"
+	"os"
+
+	winsvc "golang.org/x/sys/windows/svc"
+	winmgr "golang.org/x/sys/windows/svc/mgr"
+)
+
+// Workaround for Windows OS-shutdown deadlock (Event 6008 / Kernel-Power 41):
+// at OS shutdown, csrss delivers CTRL_SHUTDOWN (=> SIGTERM) to the collector
+// but SERVICE_CONTROL_SHUTDOWN goes to the launcher, not us. kardianos'
+// windowsService.Run only watches the SCM channel, so svc.Run stays blocked.
+// requestSCMStop finds this process's SCM entry by matching ProcessId (since
+// kardianos' config Name -- "telegraf" by default -- is not in SCM) and
+// issues STOP so kardianos' normal path can drive svc.Run to return.
+
+// scmManager / scmService: minimal interfaces so tests can substitute fakes.
+type scmManager interface {
+	Disconnect() error
+	ListServices() ([]string, error)
+	OpenService(name string) (scmService, error)
+}
+type scmService interface {
+	Close() error
+	Query() (winsvc.Status, error)
+	Control(cmd winsvc.Cmd) (winsvc.Status, error)
+}
+
+type realSCMManager struct{ m *winmgr.Mgr }
+
+func (r *realSCMManager) Disconnect() error               { return r.m.Disconnect() }
+func (r *realSCMManager) ListServices() ([]string, error) { return r.m.ListServices() }
+func (r *realSCMManager) OpenService(name string) (scmService, error) {
+	s, err := r.m.OpenService(name)
+	if err != nil {
+		return nil, err
+	}
+	return &realSCMService{s: s}, nil
+}
+
+type realSCMService struct{ s *winmgr.Service }
+
+func (r *realSCMService) Close() error                                  { return r.s.Close() }
+func (r *realSCMService) Query() (winsvc.Status, error)                 { return r.s.Query() }
+func (r *realSCMService) Control(cmd winsvc.Cmd) (winsvc.Status, error) { return r.s.Control(cmd) }
+
+// Test seams (single-writer via t.Cleanup, single-reader in shutdown path).
+var (
+	exitFunc       = os.Exit
+	isWinService   = func() bool { return windowsRunAsService() }
+	ownProcessID   = func() uint32 { return uint32(os.Getpid()) }
+	scmConnectFunc = func() (scmManager, error) {
+		m, err := winmgr.Connect()
+		if err != nil {
+			return nil, err
+		}
+		return &realSCMManager{m: m}, nil
+	}
+)
+
+// findOwnSCMServiceName returns the SCM service whose ProcessId matches
+// this process. Empty string if not found. Entries that cannot be opened
+// or queried are skipped.
+func findOwnSCMServiceName(m scmManager) (string, error) {
+	names, err := m.ListServices()
+	if err != nil {
+		return "", err
+	}
+	myPID := ownProcessID()
+	for _, name := range names {
+		s, err := m.OpenService(name)
+		if err != nil {
+			continue
+		}
+		status, err := s.Query()
+		s.Close()
+		if err == nil && status.ProcessId == myPID {
+			return name, nil
+		}
+	}
+	return "", nil
+}
+
+// requestSCMStop issues SERVICE_CONTROL_STOP against this process's own
+// SCM entry. Returns true on success.
+func requestSCMStop() bool {
+	if !isWinService() {
+		return false
+	}
+	m, err := scmConnectFunc()
+	if err != nil {
+		log.Printf("W! Windows service: SCM Connect failed: %v", err)
+		return false
+	}
+	defer m.Disconnect()
+
+	scmName, err := findOwnSCMServiceName(m)
+	if err != nil {
+		log.Printf("W! Windows service: SCM ListServices failed: %v", err)
+		return false
+	}
+	if scmName == "" {
+		log.Printf("W! Windows service: no SCM service found for own PID=%d", ownProcessID())
+		return false
+	}
+
+	s, err := m.OpenService(scmName)
+	if err != nil {
+		log.Printf("W! Windows service: SCM OpenService(%q) failed: %v", scmName, err)
+		return false
+	}
+	defer s.Close()
+	if _, err := s.Control(winsvc.Stop); err != nil {
+		log.Printf("W! Windows service: SCM Control(Stop) on %q failed: %v", scmName, err)
+		return false
+	}
+	log.Printf("I! Windows service: SCM Control(Stop) accepted on %q; waiting for prg.Stop", scmName)
+	return true
+}
+
+// handleTerminatingSignal is the fallback: exit the process iff the flag is
+// set (SCM path unavailable) and we're running as a Windows service.
+func handleTerminatingSignal() {
+	if !terminatingSignalReceived.Load() {
+		return
+	}
+	if !isWinService() {
+		return
+	}
+	log.Println("I! Windows service: SCM stop path unavailable; exiting to release svc.Run")
+	exitFunc(0)
+}

--- a/cmd/amazon-cloudwatch-agent/shutdown_signal_windows_test.go
+++ b/cmd/amazon-cloudwatch-agent/shutdown_signal_windows_test.go
@@ -1,0 +1,311 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	winsvc "golang.org/x/sys/windows/svc"
+)
+
+// ---- fake scmManager / scmService for unit tests --------------------
+
+type fakeSCM struct {
+	listErr      error
+	names        []string
+	openFn       func(name string) (scmService, error)
+	disconnected bool
+}
+
+func (f *fakeSCM) Disconnect() error { f.disconnected = true; return nil }
+func (f *fakeSCM) ListServices() ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.names, nil
+}
+func (f *fakeSCM) OpenService(name string) (scmService, error) {
+	if f.openFn != nil {
+		return f.openFn(name)
+	}
+	return nil, errors.New("no openFn")
+}
+
+type fakeSvc struct {
+	pid        uint32
+	queryErr   error
+	controlErr error
+	closed     bool
+	controlCmd winsvc.Cmd
+}
+
+func (s *fakeSvc) Close() error { s.closed = true; return nil }
+func (s *fakeSvc) Query() (winsvc.Status, error) {
+	if s.queryErr != nil {
+		return winsvc.Status{}, s.queryErr
+	}
+	return winsvc.Status{ProcessId: s.pid}, nil
+}
+func (s *fakeSvc) Control(cmd winsvc.Cmd) (winsvc.Status, error) {
+	s.controlCmd = cmd
+	if s.controlErr != nil {
+		return winsvc.Status{}, s.controlErr
+	}
+	return winsvc.Status{State: winsvc.StopPending}, nil
+}
+
+// withSeams swaps in test doubles for the Windows-only seams and restores
+// them (and resets terminatingSignalReceived) on cleanup. Pass nil to
+// leave a seam at its default.
+func withSeams(t *testing.T,
+	exit func(int),
+	isSvc func() bool,
+	pid func() uint32,
+	connect func() (scmManager, error),
+) {
+	t.Helper()
+	oldExit, oldSvc, oldPid, oldConn := exitFunc, isWinService, ownProcessID, scmConnectFunc
+	if exit != nil {
+		exitFunc = exit
+	}
+	if isSvc != nil {
+		isWinService = isSvc
+	}
+	if pid != nil {
+		ownProcessID = pid
+	}
+	if connect != nil {
+		scmConnectFunc = connect
+	}
+	t.Cleanup(func() {
+		exitFunc, isWinService, ownProcessID, scmConnectFunc = oldExit, oldSvc, oldPid, oldConn
+		terminatingSignalReceived.Store(false)
+	})
+}
+
+// ---- findOwnSCMServiceName -------------------------------------------
+
+func TestFindOwnSCMServiceName_MatchByPID(t *testing.T) {
+	svcs := map[string]*fakeSvc{
+		"Foo":                   {pid: 100},
+		"Bar":                   {pid: 200},
+		"AmazonCloudWatchAgent": {pid: 3968},
+		"Baz":                   {pid: 400},
+	}
+	m := &fakeSCM{
+		names:  []string{"Foo", "Bar", "AmazonCloudWatchAgent", "Baz"},
+		openFn: func(name string) (scmService, error) { return svcs[name], nil },
+	}
+	withSeams(t, nil, nil, func() uint32 { return 3968 }, nil)
+
+	name, err := findOwnSCMServiceName(m)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if name != "AmazonCloudWatchAgent" {
+		t.Fatalf("expected AmazonCloudWatchAgent, got %q", name)
+	}
+	if !svcs["Foo"].closed || !svcs["Bar"].closed || !svcs["AmazonCloudWatchAgent"].closed {
+		t.Errorf("expected Close() on every visited service")
+	}
+	if svcs["Baz"].closed {
+		t.Errorf("walker should have stopped at match; Baz was not visited")
+	}
+}
+
+func TestFindOwnSCMServiceName_NoMatch(t *testing.T) {
+	m := &fakeSCM{
+		names:  []string{"Foo", "Bar"},
+		openFn: func(_ string) (scmService, error) { return &fakeSvc{pid: 999}, nil },
+	}
+	withSeams(t, nil, nil, func() uint32 { return 3968 }, nil)
+
+	name, err := findOwnSCMServiceName(m)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if name != "" {
+		t.Fatalf("expected empty, got %q", name)
+	}
+}
+
+func TestFindOwnSCMServiceName_ListServicesError(t *testing.T) {
+	sentinel := errors.New("list err")
+	m := &fakeSCM{listErr: sentinel}
+	withSeams(t, nil, nil, nil, nil)
+
+	name, err := findOwnSCMServiceName(m)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel err, got %v", err)
+	}
+	if name != "" {
+		t.Fatalf("expected empty on error, got %q", name)
+	}
+}
+
+func TestFindOwnSCMServiceName_SkipsOpenErrors(t *testing.T) {
+	svcs := map[string]*fakeSvc{"AmazonCloudWatchAgent": {pid: 3968}}
+	m := &fakeSCM{
+		names: []string{"Denied", "AmazonCloudWatchAgent"},
+		openFn: func(name string) (scmService, error) {
+			if name == "Denied" {
+				return nil, errors.New("access denied")
+			}
+			return svcs[name], nil
+		},
+	}
+	withSeams(t, nil, nil, func() uint32 { return 3968 }, nil)
+
+	name, err := findOwnSCMServiceName(m)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if name != "AmazonCloudWatchAgent" {
+		t.Fatalf("expected AmazonCloudWatchAgent, got %q", name)
+	}
+}
+
+func TestFindOwnSCMServiceName_SkipsQueryErrors(t *testing.T) {
+	failing := &fakeSvc{queryErr: errors.New("query err")}
+	target := &fakeSvc{pid: 3968}
+	m := &fakeSCM{
+		names: []string{"QueryFails", "AmazonCloudWatchAgent"},
+		openFn: func(name string) (scmService, error) {
+			if name == "QueryFails" {
+				return failing, nil
+			}
+			return target, nil
+		},
+	}
+	withSeams(t, nil, nil, func() uint32 { return 3968 }, nil)
+
+	name, err := findOwnSCMServiceName(m)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if name != "AmazonCloudWatchAgent" {
+		t.Fatalf("expected AmazonCloudWatchAgent, got %q", name)
+	}
+	if !failing.closed {
+		t.Errorf("failing service should still be Close()d after Query err")
+	}
+}
+
+// ---- requestSCMStop --------------------------------------------------
+
+func TestRequestSCMStop_NotAService(t *testing.T) {
+	withSeams(t, nil, func() bool { return false }, nil, nil)
+	if requestSCMStop() {
+		t.Fatal("expected false when not running as a Windows service")
+	}
+}
+
+func TestRequestSCMStop_ConnectFail(t *testing.T) {
+	sentinel := errors.New("connect err")
+	withSeams(t, nil,
+		func() bool { return true }, nil,
+		func() (scmManager, error) { return nil, sentinel },
+	)
+	if requestSCMStop() {
+		t.Fatal("expected false on SCM Connect failure")
+	}
+}
+
+func TestRequestSCMStop_NoMatchingService(t *testing.T) {
+	m := &fakeSCM{
+		names:  []string{"Foo"},
+		openFn: func(_ string) (scmService, error) { return &fakeSvc{pid: 999}, nil },
+	}
+	withSeams(t, nil,
+		func() bool { return true },
+		func() uint32 { return 3968 },
+		func() (scmManager, error) { return m, nil },
+	)
+	if requestSCMStop() {
+		t.Fatal("expected false when no SCM service matches our PID")
+	}
+	if !m.disconnected {
+		t.Error("Disconnect() should have been called")
+	}
+}
+
+func TestRequestSCMStop_ControlSTOPFail(t *testing.T) {
+	target := &fakeSvc{pid: 3968, controlErr: errors.New("control err")}
+	m := &fakeSCM{
+		names:  []string{"AmazonCloudWatchAgent"},
+		openFn: func(_ string) (scmService, error) { return target, nil },
+	}
+	withSeams(t, nil,
+		func() bool { return true },
+		func() uint32 { return 3968 },
+		func() (scmManager, error) { return m, nil },
+	)
+	if requestSCMStop() {
+		t.Fatal("expected false when Control(Stop) fails")
+	}
+}
+
+func TestRequestSCMStop_Success(t *testing.T) {
+	target := &fakeSvc{pid: 3968}
+	m := &fakeSCM{
+		names:  []string{"AmazonCloudWatchAgent"},
+		openFn: func(_ string) (scmService, error) { return target, nil },
+	}
+	withSeams(t, nil,
+		func() bool { return true },
+		func() uint32 { return 3968 },
+		func() (scmManager, error) { return m, nil },
+	)
+	if !requestSCMStop() {
+		t.Fatal("expected requestSCMStop success")
+	}
+	if target.controlCmd != winsvc.Stop {
+		t.Errorf("expected winsvc.Stop, got %v", target.controlCmd)
+	}
+	if !target.closed {
+		t.Error("Close() should have been called on the target service")
+	}
+	if !m.disconnected {
+		t.Error("Disconnect() should have been called on the manager")
+	}
+}
+
+// ---- handleTerminatingSignal -----------------------------------------
+
+func TestHandleTerminatingSignal_FlagUnset_NoExit(t *testing.T) {
+	called := false
+	withSeams(t, func(int) { called = true }, func() bool { return true }, nil, nil)
+	terminatingSignalReceived.Store(false)
+	handleTerminatingSignal()
+	if called {
+		t.Fatal("exitFunc should not have been called with flag unset")
+	}
+}
+
+func TestHandleTerminatingSignal_NotAService_NoExit(t *testing.T) {
+	called := false
+	withSeams(t, func(int) { called = true }, func() bool { return false }, nil, nil)
+	terminatingSignalReceived.Store(true)
+	handleTerminatingSignal()
+	if called {
+		t.Fatal("exitFunc should not have been called when not a service")
+	}
+}
+
+func TestHandleTerminatingSignal_FlagSetAndService_Exits(t *testing.T) {
+	var exitCode int
+	called := false
+	withSeams(t, func(code int) { exitCode = code; called = true }, func() bool { return true }, nil, nil)
+	terminatingSignalReceived.Store(true)
+	handleTerminatingSignal()
+	if !called {
+		t.Fatal("exitFunc should have been called")
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+}


### PR DESCRIPTION
# Description of the issue

Related issue: Fixes #2214

At OS shutdown, when the collector runs as a Windows service child (spawned by `start-amazon-cloudwatch-agent.exe`), csrss delivers `CTRL_SHUTDOWN` to the child (mapped to `SIGTERM` by the Go runtime) but the SCM does not route `SERVICE_CONTROL_SHUTDOWN` to it (that goes to the SCM-registered launcher). `kardianos/service` v1.2.1's non-interactive `Run()` [waits only on the SCM channel and does not watch `SIGTERM`](https://github.com/kardianos/service/blob/v1.2.1/service_windows.go#L191), so `svc.Run` never returns, `main` never returns, and the runtime's `ctrlHandler` is parked in [`block()`](https://go.googlesource.com/go/%2B/master/src/runtime/os_windows.go#1047). csrss meanwhile waits for the process to exit; the whole system shutdown deadlocks (~4–5 min → `Event ID 6008` + `Kernel-Power 41`). `sc stop` / `Stop-Service` (SCM STOP via `ControlService`) is unaffected.

The issue is scoped to non-container Windows service installs: Windows containers take the `-console true` path at `cmd/start-amazon-cloudwatch-agent/path_windows.go:43` and exit cleanly, and non-Windows builds call `reloadLoop` directly from `main`, both of which are unaffected. `kardianos` already accepts `SERVICE_CONTROL_SHUTDOWN` via [`cmdsAccepted` at `service_windows.go:182`](https://github.com/kardianos/service/blob/v1.2.1/service_windows.go#L182), so the handler is present — the deadlock in stage 1 (SIGTERM in `block()`) simply prevents stage 2 (the SCM shutdown control) from ever being reached.

# Description of changes

Minimal, scoped, and no-op outside the affected case. When a non-SIGHUP terminating OS signal reaches `reloadLoop`'s signal goroutine and we're running as a Windows service, this PR issues `SERVICE_CONTROL_STOP` against our **own** SCM entry via `x/sys/windows/svc/mgr`, then lets kardianos's normal STOP path (`prg.Stop` → `close(stop)`) drive `svc.Run` to return cleanly. Falls back to `os.Exit(0)` only if the SCM path is unavailable.

Why not `kardianos/service.Service.Stop()` directly: kardianos looks up the service by its own `Config.Name` (`*fServiceName`, default `"telegraf"` here), which is not registered in the SCM. The collector's real SCM registration is `AmazonCloudWatchAgent` (or whatever the operator installed under `--service-name`), and its `ProcessId` in the SCM points to the collector (SCM tracks the collector's PID, not the launcher's, after the launcher's SetServiceStatus handoff). We discover this entry by enumerating SCM services and matching `ProcessId` against `os.Getpid()` — no hardcoded name, so custom `--service-name` installations continue to work.

`cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go` (2 hunks / +6 lines):
- In `reloadLoop`'s signal goroutine, on a non-SIGHUP terminating signal, call `handleTerminatingSignalDispatch(stop, stopWaitTimeout)`. It tries SCM STOP first and blocks on `<-stop` (bounded by `stopWaitTimeout` = 30s). On failure or timeout, sets `terminatingSignalReceived`. Then the existing `cancel()` runs.
- In `(*program).run()`, after `reloadLoop` returns, call `handleTerminatingSignal()` — the fallback which `os.Exit(0)`s iff the flag was set.

New files under `cmd/amazon-cloudwatch-agent/`:

- `shutdown_signal.go` — package-level state (`stopWaitTimeout`, `terminatingSignalReceived atomic.Bool`, `requestSCMStopFn` test seam) and the cross-platform `handleTerminatingSignalDispatch(stopCh, timeout)`.
- `shutdown_signal_windows.go` — the Windows implementation: minimal `scmManager` / `scmService` interfaces (so tests can substitute fakes) with concrete adapters over `winmgr.Mgr` / `winmgr.Service`, four test seams (`exitFunc`, `isWinService`, `ownProcessID`, `scmConnectFunc`), `findOwnSCMServiceName(m)` (enumerate + match ProcessId, skips ACCESS_DENIED and Query errors), `requestSCMStop()` (Connect → find → Control(Stop)), and `handleTerminatingSignal()` (fallback `exitFunc(0)`).
- `shutdown_signal_notwindows.go` — `requestSCMStop() { return false }` and `handleTerminatingSignal() {}` under `//go:build !windows`.
- `shutdown_signal_test.go` — cross-platform tests: 3 atomic-flag tests + 3 dispatch tests using the `requestSCMStopFn` seam (success path, SCM-unavailable path, SCM-accepted-but-timeout path).
- `shutdown_signal_windows_test.go` — Windows-only tests using fake `scmManager` / `scmService`: 5 `findOwnSCMServiceName` scenarios (match-by-PID / no-match / ListServices error / skips-OpenService-errors / skips-Query-errors), 5 `requestSCMStop` scenarios (not-a-service / Connect fail / no-matching-service / Control fail / success), and 3 `handleTerminatingSignal` scenarios (flag-unset / not-a-service / flag+service → exit).

### Follow-up: main waits for teardown before ExitProcess

Once SCM STOP unblocks `svc.Run`, `main` returns and the Go runtime calls `ExitProcess`. But `otelcol.Shutdown` runs on a parallel goroutine (from otelcol's own SIGTERM handler); if it hasn't finished by the time `main` returns, its teardown is truncated — the final `"Shutdown complete."` log line and any pending flushes are dropped silently. In practice on this codebase `Shutdown` is intrinsically sub-second so the race is rarely observable, but a slow-shutdown plugin, a network flush, or any future teardown work would surface it.

The second commit (`15cb73d`) adds a done-channel signalled by `(*program).run` and waited on by `main` after `s.Run()` returns:

- `shutdown_signal.go` (+30 lines): `runCompleteChan` (chan struct{}) plus `sync.Once` guard, `runCompleteTimeout = 30s`, `signalRunComplete()`, `waitRunComplete()`.
- `amazon-cloudwatch-agent.go` (+4 lines): `(*program).run` defers `signalRunComplete` so it fires on every normal return path. `main`'s Windows service branch waits on `runCompleteChan` after `s.Run` returns.
- `shutdown_signal_test.go` (+66 lines): 3 new tests — idempotent signal, wait-then-signal, wait-then-timeout.

kardianos still reports `SERVICE_STOPPED` to SCM as soon as `prg.Stop` returns, so the OS shutdown of *other* services proceeds in parallel. Only this process is held back, and only until its own teardown finishes — capped at `runCompleteTimeout` so a stuck teardown cannot indefinitely hold up the OS. The Windows-fallback `os.Exit(0)` path is unaffected: `defer` doesn't run on `os.Exit`, but the process terminates immediately anyway, which is the intended behaviour of that fallback.

Behaviour matrix:

| Path | requestSCMStop returns | Signal-goroutine action | handleTerminatingSignal | Effect |
|---|---|---|---|---|
| SCM STOP (`sc stop` → prg.Stop → close(stop)) | not called (`<-stop` branch of outer select) | `cancel()` | no-op (flag unset) | unchanged |
| SIGHUP reload | not called (SIGHUP branch) | reload, `cancel()` | no-op (flag unset) | unchanged |
| Non-Windows | `false` (compile-time no-op) | `terminatingSignalReceived.Store(true); cancel()` | no-op (build tag) | unchanged (same as pristine) |
| Windows interactive / console (`windowsRunAsService()==false`) | `false` | same as above | early-return | unchanged |
| **Windows service + OS shutdown, SCM STOP delivered** | **`true`** | dispatch → `<-stop` fires → `cancel()` | no-op (flag NOT set) | **kardianos's normal STOP path drives svc.Run to return; main exits normally** |
| Windows service + SCM path unavailable (Connect / ListServices / no match / OpenService / Control failed) | `false` | flag set, `cancel()` | `os.Exit(0)` | fallback, OS shutdown proceeds |
| Windows service + SCM accepted but prg.Stop did not fire within 30s | `true` then timeout | flag set at timeout, `cancel()` | `os.Exit(0)` | fallback, OS shutdown proceeds |

No new module dependencies (`golang.org/x/sys` is already in `go.mod`; the workaround uses its `windows/svc` and `windows/svc/mgr` subpackages).

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- **Unit tests (new)** — 22 tests in total, all passing.

  Cross-platform (`shutdown_signal_test.go`, 9 tests):
  - `TestTerminatingSignalReceived_DefaultUnset` / `_SetLoad` / `_Race`: package-level `atomic.Bool` semantics (Race launches 64 goroutines, safe under `-race`).
  - `TestDispatch_SCMUnavailable_SetsFallbackFlag`: `requestSCMStopFn=false` → fallback flag set.
  - `TestDispatch_SCMSuccess_NoFallbackFlag`: `requestSCMStopFn=true` + `close(stop)` before timeout → fallback flag NOT set.
  - `TestDispatch_SCMAcceptedButTimeout_SetsFallbackFlag`: `requestSCMStopFn=true` + timeout expires → fallback flag set.
  - `TestSignalRunComplete_Idempotent`: `signalRunComplete` uses `sync.Once` so a double invocation does not panic on a closed channel.
  - `TestWaitRunComplete_ReturnsWhenSignaled`: `waitRunComplete` returns promptly once `signalRunComplete` fires.
  - `TestWaitRunComplete_TimesOut`: `waitRunComplete` falls through after `runCompleteTimeout` when no signal arrives.

  Windows-only (`shutdown_signal_windows_test.go`, 13 tests) using fake `scmManager` / `scmService` + seams:
  - `TestFindOwnSCMServiceName_MatchByPID` / `_NoMatch` / `_ListServicesError` / `_SkipsOpenErrors` / `_SkipsQueryErrors`: enumeration finds the entry by ProcessId; robust against per-service ACCESS_DENIED and Query errors; every opened service is `Close()`d.
  - `TestRequestSCMStop_NotAService` / `_ConnectFail` / `_NoMatchingService` / `_ControlSTOPFail` / `_Success`: each failure mode returns `false` and cleans up (`Disconnect`, `Close`); the success path issues `winsvc.Stop`.
  - `TestHandleTerminatingSignal_FlagUnset_NoExit` / `_NotAService_NoExit` / `_FlagSetAndService_Exits`: `exitFunc(0)` is called only when both preconditions hold.

  Result on the validation host (`go test -v -count=1 ./cmd/amazon-cloudwatch-agent -run '^(TestTerminatingSignalReceived|TestDispatch|TestSignalRunComplete|TestWaitRunComplete|TestFindOwnSCMServiceName|TestRequestSCMStop|TestHandleTerminatingSignal)'`):
  ```
  --- PASS: TestTerminatingSignalReceived_DefaultUnset (0.00s)
  --- PASS: TestTerminatingSignalReceived_SetLoad (0.00s)
  --- PASS: TestTerminatingSignalReceived_Race (0.00s)
  --- PASS: TestDispatch_SCMUnavailable_SetsFallbackFlag (0.00s)
  --- PASS: TestDispatch_SCMSuccess_NoFallbackFlag (0.01s)
  --- PASS: TestDispatch_SCMAcceptedButTimeout_SetsFallbackFlag (0.02s)
  --- PASS: TestSignalRunComplete_Idempotent (0.00s)
  --- PASS: TestWaitRunComplete_ReturnsWhenSignaled (0.01s)
  --- PASS: TestWaitRunComplete_TimesOut (0.02s)
  --- PASS: TestFindOwnSCMServiceName_MatchByPID (0.00s)
  --- PASS: TestFindOwnSCMServiceName_NoMatch (0.00s)
  --- PASS: TestFindOwnSCMServiceName_ListServicesError (0.00s)
  --- PASS: TestFindOwnSCMServiceName_SkipsOpenErrors (0.00s)
  --- PASS: TestFindOwnSCMServiceName_SkipsQueryErrors (0.00s)
  --- PASS: TestRequestSCMStop_NotAService (0.00s)
  --- PASS: TestRequestSCMStop_ConnectFail (0.00s)
  --- PASS: TestRequestSCMStop_NoMatchingService (0.00s)
  --- PASS: TestRequestSCMStop_ControlSTOPFail (0.00s)
  --- PASS: TestRequestSCMStop_Success (0.00s)
  --- PASS: TestHandleTerminatingSignal_FlagUnset_NoExit (0.00s)
  --- PASS: TestHandleTerminatingSignal_NotAService_NoExit (0.00s)
  --- PASS: TestHandleTerminatingSignal_FlagSetAndService_Exits (0.00s)
  PASS
  ok  github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent  2.477s
  ```

- **`go test -race`** — same 22 tests, executed with `CGO_ENABLED=1` and gcc from MinGW-w64 14.2.0 for the race detector. All 22 PASS, no data races reported.

- **Static checks** — executed against a fresh clone of `main` + this PR's commit on Windows Server 2022 with Go 1.25.8. Tools installed via the same `go install` / release-download commands the Makefile uses.
  - `go fmt ./...` — clean.
  - `goimports -l -local github.com/aws/amazon-cloudwatch-agent` on the six touched/new files — all clean.
  - `impi --local github.com/aws/amazon-cloudwatch-agent --scheme stdThirdPartyLocal` on the six files — all clean.
  - `addlicense -check -l MIT -c "Amazon.com, Inc. or its affiliates."` on the six files — all rc=0.
  - `go vet ./cmd/amazon-cloudwatch-agent` reports one finding at line 120 (`sigchanyzer: misuse of unbuffered os.Signal channel as argument to signal.Notify`, from `signals := make(chan os.Signal)`). This finding is present on `main` at HEAD~1 as well and is unrelated to this PR.
  - `golangci-lint run --timeout 5m ./cmd/amazon-cloudwatch-agent` (v2.12.2 — the Makefile version) reports 7 findings on this PR and 7 findings on `main` at HEAD~2. `Compare-Object` between the two runs: **NEW findings: 0**, **REMOVED findings: 0**. The three lines that appear in the raw diff (`G706` 269→273, `G114` 523→530, `revive superfluous-else` 635→642) are the same rules on the same statements, shifted downward by the lines these two commits add above each finding (+4, +7, +7 respectively; total +10 lines added to `amazon-cloudwatch-agent.go`). All findings are on code paths this PR does not touch.

- **End-to-end (Windows Server 2022, EC2 m5.xlarge)** — same host used for the reproduction, with `WaitToKillServiceTimeout=300000` to expose the deadlock. Wrapper left pristine; only the collector rebuilt.

  Five scenarios were run, isolating the effect of each commit:

  | # | Collector build | otelcol.Shutdown | `"Shutdown complete."` logged | OS shutdown |
  |---|---|---|---|---|
  | 1 | Pristine `main` | <1 s | YES | 290 s → `6008` + `Kernel-Power 41` |
  | 2 | `main` + a6a1a93 | <1 s | YES | 48 s, no 6008/41 |
  | 3 | `main` + a6a1a93 + 10 s sleep injected inside `Service.Shutdown` (validation only, not part of PR) | 10 s | **NO — truncated** | 78 s, no 6008/41 |
  | 4 | `main` + a6a1a93 + 15cb73d + the same 10 s sleep injected inside `Service.Shutdown` | 10 s | **YES — full sequence preserved** | 78 s, no 6008/41 |
  | 5 | `main` + a6a1a93 + 15cb73d (this PR head) | <1 s | YES | 33 s, no 6008/41 |

  Rows 3 → 4 form the direct A/B: same teardown-slowing patch, only difference is the wait mechanism from commit `15cb73d`. In row 3 the process was terminated during `otelcol.Shutdown` (Event 7036 recorded the CWA "Stopped" transition at the same millisecond the sleep started); in row 4 `main` blocked in `waitRunComplete` until the full teardown sequence completed and only then returned.

  Row 5 confirms the wait mechanism adds no observable overhead in the normal case: every teardown log entry lands in the same second, SCM records the "Stopped" transition ~ms later, and total OS shutdown is well within the same range as row 2 (both are within observed EC2 platform variance for this instance).

  Agent log around shutdown in scenario 4:
  ```
  ... "Received signal from OS","signal":"terminated"
  ... "Starting shutdown..."
  ... "[RACETEST] injected sleep 10s starts"
  ... Windows service: SCM Control(Stop) accepted on "AmazonCloudWatchAgent"; waiting for prg.Stop
  ... Profiler is stopped during shutdown
  ... [10 seconds elapse]
  ... "[RACETEST] injected sleep 10s done"
  ... "Stopping extensions..."
  ... "Pod to Service Environment Mapping TTL Cache stopped"
  ... "Shutdown complete."
  ```
  In scenario 3 (same test without the wait) everything after "SCM Control(Stop) accepted" was cut off.

  Agent log around shutdown in scenario 5 (production representative — both commits, no injected delay):
  ```
  ... "Received signal from OS","signal":"terminated"
  ... "Starting shutdown..."
  ... "Stopping extensions..."
  ... "Pod to Service Environment Mapping TTL Cache stopped"
  ... "Shutdown complete."
  ... Windows service: SCM Control(Stop) accepted on "AmazonCloudWatchAgent"; waiting for prg.Stop
  ... Profiler is stopped during shutdown
  ```

  System event log in scenarios 2/4/5: `1074` (shutdown initiated) → `6006` (EventLog stopped normally) → `7036` (`AmazonCloudWatchAgent` transitioned to Stopped). No `6008`, no `41`. `sc stop` unchanged (~0.3 s).

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.
