### PR TITLE
Preserve jvm.gc.name attribute in AppSignals GC runtime metrics

### DIFF
--- a/translator/tocwconfig/sampleConfig/appsignals_and_ecs_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_ecs_config.yaml
@@ -575,7 +575,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""
@@ -597,7 +598,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -728,7 +728,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""
@@ -750,7 +751,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -729,7 +729,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""
@@ -751,7 +752,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""

--- a/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.yaml
@@ -728,7 +728,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""
@@ -750,7 +751,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""

--- a/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.yaml
@@ -728,7 +728,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""
@@ -750,7 +751,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""

--- a/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_config.yaml
@@ -605,7 +605,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""
@@ -627,7 +628,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""

--- a/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_appsignals_fallback_config.yaml
@@ -595,7 +595,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""
@@ -617,7 +618,8 @@ processors:
                   aggregation_type: sum
                   experimental_scale: 0
                   label: ""
-                  label_set: []
+                  label_set:
+                    - name
                   label_value: ""
                   new_label: ""
                   new_value: ""

--- a/translator/translate/otel/processor/metricstransformprocessor/appsignals_runtime_config.yaml
+++ b/translator/translate/otel/processor/metricstransformprocessor/appsignals_runtime_config.yaml
@@ -110,7 +110,7 @@ transforms:
     new_name: JVMGCDuration
     operations:
     - action: aggregate_labels
-      label_set: []
+      label_set: ["name"]
       aggregation_type: sum
     - action: add_label
       new_label: Telemetry.Source
@@ -120,7 +120,7 @@ transforms:
     new_name: JVMGCCount
     operations:
       - action: aggregate_labels
-        label_set: []
+        label_set: ["name"]
         aggregation_type: sum
       - action: add_label
         new_label: Telemetry.Source

--- a/translator/translate/otel/processor/metricstransformprocessor/translator_test.go
+++ b/translator/translate/otel/processor/metricstransformprocessor/translator_test.go
@@ -139,3 +139,35 @@ func TestAppSignalsRuntime(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, len(expectedCfg.Transforms), len(actualCfg.Transforms))
 }
+
+func TestAppSignalsGCMetricsPreserveNameLabel(t *testing.T) {
+	transl := NewTranslatorWithName(common.AppSignals).(*translator)
+	conf := confmap.NewFromStringMap(testutil.GetJson(t, filepath.Join("testdata", "appsignals_config.json")))
+	translatedCfg, err := transl.Translate(conf)
+	require.NoError(t, err)
+	actualCfg, ok := translatedCfg.(*metricstransformprocessor.Config)
+	require.True(t, ok)
+
+	// Verify that JVMGCCount and JVMGCDuration transforms preserve the "name" label
+	// (jvm.gc.name attribute) so Topology can distinguish GC collector types.
+	gcMetrics := map[string]bool{
+		"JVMGCCount":    false,
+		"JVMGCDuration": false,
+	}
+
+	for _, transform := range actualCfg.Transforms {
+		if _, isGCMetric := gcMetrics[transform.NewName]; isGCMetric {
+			for _, op := range transform.Operations {
+				if op.Action == "aggregate_labels" {
+					assert.Contains(t, op.LabelSet, "name",
+						"Transform %s must preserve 'name' label (jvm.gc.name) for GC collector differentiation", transform.NewName)
+					gcMetrics[transform.NewName] = true
+				}
+			}
+		}
+	}
+
+	for metricName, found := range gcMetrics {
+		assert.True(t, found, "Expected to find transform with aggregate_labels operation for %s", metricName)
+	}
+}


### PR DESCRIPTION
## Summary

Preserves the `name` label (which carries the `jvm.gc.name` OTel attribute) on the aggregate `JVMGCCount` and `JVMGCDuration` AppSignals runtime metrics, enabling downstream consumers to differentiate GC collector types.

## Problem

The `JVMGCCount` and `JVMGCDuration` transform rules in `appsignals_runtime_config.yaml` used `label_set: []` in their `aggregate_labels` operation, which stripped **all** labels including the `name` attribute that identifies the GC collector type (e.g. `PS Scavenge`, `G1 Young Generation`).

## Changes

- Changed `label_set: []` to `label_set: ["name"]` for both `JVMGCCount` and `JVMGCDuration` transform rules
- Added unit test (`TestAppSignalsGCMetricsPreserveNameLabel`) that validates the `name` label is preserved

## Testing

- Unit tests pass
- E2E: built A/B agent binaries (main vs. this branch) on EC2, ran both against a Java app using Parallel GC with ADOT instrumentation. Baseline EMF has no `name` field; this branch emits the `name` attribute on every GC record in CloudWatch Logs.

Example EMF record from the `/aws/application-signals/data` log group:

```json
{
  "Environment": "eks:demo/default",
  "Service": "pet-clinic-frontend-java",
  "Telemetry.Source": "RuntimeMetric",
  "name": "PS Scavenge",
  "JVMGCCount": 7,
  "JVMGCDuration": 74,
  "_aws": {
    "CloudWatchMetrics": [{
      "Namespace": "ApplicationSignals",
      "Dimensions": [["Environment", "Service"]],
      "Metrics": [
        {"Name": "JVMGCCount", "Unit": "", "StorageResolution": 60},
        {"Name": "JVMGCDuration", "Unit": "", "StorageResolution": 60}
      ]
    }]
  }
}
```