### PR TITLE
Add workload detection for PostgreSQL

### DIFF
--- a/cmd/workload-discovery/discovery.go
+++ b/cmd/workload-discovery/discovery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/internal/detector/filter"
 	"github.com/aws/amazon-cloudwatch-agent/internal/detector/java"
 	"github.com/aws/amazon-cloudwatch-agent/internal/detector/nvidia"
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector/postgresql"
 	"github.com/aws/amazon-cloudwatch-agent/internal/detector/util"
 	"github.com/aws/amazon-cloudwatch-agent/tool/paths"
 )
@@ -47,6 +48,7 @@ func NewDiscoverer(cfg Config, logger *slog.Logger) *Discoverer {
 		logger: logger,
 		processDetectors: []detector.ProcessDetector{
 			java.NewDetector(logger, filters.Process.Name),
+			postgresql.NewDetector(logger),
 		},
 		deviceDetectors: []detector.DeviceDetector{
 			nvidia.NewDetector(logger),

--- a/internal/detector/metadata.go
+++ b/internal/detector/metadata.go
@@ -30,6 +30,7 @@ const (
 	CategoryKafkaBroker Category = "KAFKA/BROKER"
 	CategoryKafkaClient Category = "KAFKA/CLIENT"
 	CategoryNvidiaGPU   Category = "NVIDIA_GPU"
+	CategoryPostgreSQL  Category = "POSTGRESQL"
 )
 
 // Status represents whether the resource requires more actions before telemetry is available.

--- a/internal/detector/postgresql/README.md
+++ b/internal/detector/postgresql/README.md
@@ -1,0 +1,24 @@
+# PostgreSQL Process Detector
+
+Detects PostgreSQL database server processes running on the system.
+
+## Overview
+
+The PostgreSQL detector identifies PostgreSQL server instances by checking for the `postgres` executable name. It is used by the `workload-discovery` command to automatically discover PostgreSQL workloads.
+
+## Detection Method
+
+The detector examines the executable path of each process and checks if the base name is `postgres`.
+
+## Status Results
+- `READY`: PostgreSQL process detected with a port (explicit via `-p` flag or `PGPORT`, otherwise defaults to 5432).
+
+## Sample Metadata Result
+```json
+{
+  "categories": ["POSTGRESQL"],
+  "name": "postgresql",
+  "status": "READY",
+  "telemetryPort": 5432
+}
+```

--- a/internal/detector/postgresql/extract/port.go
+++ b/internal/detector/postgresql/extract/port.go
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package extract
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector"
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector/util"
+)
+
+const (
+	portFlag            = "-p"
+	portEnvVar          = "PGPORT"
+	defaultPostgresPort = 5432
+)
+
+type portExtractor struct {
+	subExtractors []detector.PortExtractor
+}
+
+// NewPortExtractor creates a port extractor that attempts to find the PostgreSQL port
+// from command line arguments (-p flag) or environment variables (PGPORT).
+// Falls back to the default PostgreSQL port 5432.
+func NewPortExtractor() detector.PortExtractor {
+	return &portExtractor{
+		subExtractors: []detector.PortExtractor{
+			&cmdlinePortExtractor{},
+			&envPortExtractor{},
+		},
+	}
+}
+
+func (e *portExtractor) Extract(ctx context.Context, process detector.Process) (int, error) {
+	for _, sub := range e.subExtractors {
+		port, err := sub.Extract(ctx, process)
+		if err == nil {
+			return port, nil
+		}
+	}
+	return defaultPostgresPort, nil
+}
+
+// cmdlinePortExtractor extracts port from -p flag
+type cmdlinePortExtractor struct{}
+
+func (e *cmdlinePortExtractor) Extract(ctx context.Context, process detector.Process) (int, error) {
+	args, err := process.CmdlineSliceWithContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	for i, arg := range args {
+		if arg == portFlag && i+1 < len(args) {
+			port, err := strconv.Atoi(args[i+1])
+			if err == nil && util.IsValidPort(port) {
+				return port, nil
+			}
+		}
+		if strings.HasPrefix(arg, portFlag) && len(arg) > len(portFlag) {
+			port, err := strconv.Atoi(arg[len(portFlag):])
+			if err == nil && util.IsValidPort(port) {
+				return port, nil
+			}
+		}
+	}
+
+	return 0, detector.ErrExtractPort
+}
+
+// envPortExtractor extracts port from PGPORT environment variable
+type envPortExtractor struct{}
+
+func (e *envPortExtractor) Extract(ctx context.Context, process detector.Process) (int, error) {
+	env, err := process.EnvironWithContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 && parts[0] == portEnvVar {
+			port, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+			if err == nil && util.IsValidPort(port) {
+				return port, nil
+			}
+		}
+	}
+
+	return 0, detector.ErrExtractPort
+}

--- a/internal/detector/postgresql/extract/port_test.go
+++ b/internal/detector/postgresql/extract/port_test.go
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package extract
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector/detectortest"
+)
+
+func TestPortExtractor(t *testing.T) {
+	ctx := context.Background()
+	extractor := NewPortExtractor()
+
+	tests := map[string]struct {
+		setup    func(*detectortest.MockProcess)
+		wantPort int
+	}{
+		"Success/PortFromFlag": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres", "-p", "5433"}, nil)
+			},
+			wantPort: 5433,
+		},
+		"Success/PortFromFlagNoSpace": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres", "-p5434"}, nil)
+			},
+			wantPort: 5434,
+		},
+		"Success/PortFromEnv": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres"}, nil)
+				mp.On("EnvironWithContext", ctx).Return([]string{"PATH=/usr/bin", "PGPORT=5435"}, nil)
+			},
+			wantPort: 5435,
+		},
+		// cmdline is tried first; when it finds a port, env is never called
+		"Success/CmdlineTakesPrecedence": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres", "-p", "5433"}, nil)
+			},
+			wantPort: 5433,
+		},
+		"Success/DefaultPort": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres"}, nil)
+				mp.On("EnvironWithContext", ctx).Return([]string{"PATH=/usr/bin"}, nil)
+			},
+			wantPort: 5432,
+		},
+		"Success/DefaultPortWithOtherFlags": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres", "-D", "/var/lib/postgresql/data"}, nil)
+				mp.On("EnvironWithContext", ctx).Return([]string{}, nil)
+			},
+			wantPort: 5432,
+		},
+		"Success/DefaultOnAllSourcesFail": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("CmdlineSliceWithContext", ctx).Return(nil, assert.AnError)
+				mp.On("EnvironWithContext", ctx).Return(nil, assert.AnError)
+			},
+			wantPort: 5432,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			mp := new(detectortest.MockProcess)
+			tt.setup(mp)
+
+			port, err := extractor.Extract(ctx, mp)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPort, port)
+			mp.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/detector/postgresql/postgresql.go
+++ b/internal/detector/postgresql/postgresql.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package postgresql
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector"
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector/postgresql/extract"
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector/util"
+)
+
+const (
+	exeName = "postgres"
+)
+
+type postgresqlDetector struct {
+	logger        *slog.Logger
+	portExtractor detector.PortExtractor
+}
+
+var _ detector.ProcessDetector = (*postgresqlDetector)(nil)
+
+// NewDetector creates a new process detector that identifies PostgreSQL processes.
+func NewDetector(logger *slog.Logger) detector.ProcessDetector {
+	return &postgresqlDetector{
+		logger:        logger,
+		portExtractor: extract.NewPortExtractor(),
+	}
+}
+
+// Detect identifies PostgreSQL processes and returns metadata.
+// Only detects the main postgres process, not worker processes.
+func (d *postgresqlDetector) Detect(ctx context.Context, process detector.Process) (*detector.Metadata, error) {
+	exe, err := process.ExeWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	base := util.BaseExe(exe)
+	if base != exeName {
+		return nil, detector.ErrIncompatibleDetector
+	}
+
+	// Check if this is the main postgres process or a worker
+	args, err := process.CmdlineSliceWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(args) > 0 && strings.HasPrefix(strings.TrimSpace(args[0]), exeName+":") {
+		return nil, detector.ErrIncompatibleDetector
+	}
+
+	d.logger.Debug("PostgreSQL process detected", "pid", process.PID())
+
+	md := &detector.Metadata{
+		Name:       "postgresql",
+		Categories: []detector.Category{detector.CategoryPostgreSQL},
+	}
+
+	port, _ := d.portExtractor.Extract(ctx, process)
+
+	md.Status = detector.StatusReady
+	md.TelemetryPort = port
+
+	return md, nil
+}

--- a/internal/detector/postgresql/postgresql_test.go
+++ b/internal/detector/postgresql/postgresql_test.go
@@ -1,0 +1,129 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package postgresql
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector"
+	"github.com/aws/amazon-cloudwatch-agent/internal/detector/detectortest"
+)
+
+func TestDetect(t *testing.T) {
+	ctx := context.Background()
+	testCases := map[string]struct {
+		setup   func(*detectortest.MockProcess)
+		want    *detector.Metadata
+		wantErr error
+	}{
+		"Success/PostgreSQL_DefaultPort": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("/usr/bin/postgres", nil)
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres"}, nil)
+				mp.On("EnvironWithContext", ctx).Return([]string{}, nil)
+			},
+			want: &detector.Metadata{
+				Name:          "postgresql",
+				Categories:    []detector.Category{detector.CategoryPostgreSQL},
+				Status:        detector.StatusReady,
+				TelemetryPort: 5432,
+			},
+		},
+		"Success/PostgreSQL_CustomPort": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("/usr/bin/postgres", nil)
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres", "-p", "5433"}, nil)
+			},
+			want: &detector.Metadata{
+				Name:          "postgresql",
+				Categories:    []detector.Category{detector.CategoryPostgreSQL},
+				Status:        detector.StatusReady,
+				TelemetryPort: 5433,
+			},
+		},
+		"Success/PostgreSQL_PortFromEnv": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("/usr/bin/postgres", nil)
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres", "-D", "/data"}, nil)
+				mp.On("EnvironWithContext", ctx).Return([]string{"PGPORT=5434"}, nil)
+			},
+			want: &detector.Metadata{
+				Name:          "postgresql",
+				Categories:    []detector.Category{detector.CategoryPostgreSQL},
+				Status:        detector.StatusReady,
+				TelemetryPort: 5434,
+			},
+		},
+		"Success/PostgreSQL_UsrLocal": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("/usr/local/pgsql/bin/postgres", nil)
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres", "-D", "/data"}, nil)
+				mp.On("EnvironWithContext", ctx).Return([]string{}, nil)
+			},
+			want: &detector.Metadata{
+				Name:          "postgresql",
+				Categories:    []detector.Category{detector.CategoryPostgreSQL},
+				Status:        detector.StatusReady,
+				TelemetryPort: 5432,
+			},
+		},
+		"Incompatible/WorkerProcess_IOWorker": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("/usr/bin/postgres", nil)
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres: io worker 0"}, nil)
+			},
+			wantErr: detector.ErrIncompatibleDetector,
+		},
+		"Incompatible/WorkerProcess_Checkpointer": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("/usr/bin/postgres", nil)
+				mp.On("CmdlineSliceWithContext", ctx).Return([]string{"postgres: checkpointer"}, nil)
+			},
+			wantErr: detector.ErrIncompatibleDetector,
+		},
+		"Incompatible/MySQL": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("/usr/bin/mysqld", nil)
+			},
+			wantErr: detector.ErrIncompatibleDetector,
+		},
+		"Error/ExeWithContext": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("", assert.AnError)
+			},
+			wantErr: assert.AnError,
+		},
+		"Error/CmdlineSliceWithContext": {
+			setup: func(mp *detectortest.MockProcess) {
+				mp.On("ExeWithContext", ctx).Return("/usr/bin/postgres", nil)
+				mp.On("CmdlineSliceWithContext", ctx).Return(nil, assert.AnError)
+			},
+			wantErr: assert.AnError,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mp := new(detectortest.MockProcess)
+			testCase.setup(mp)
+
+			d := NewDetector(slog.Default())
+			got, err := d.Detect(ctx, mp)
+
+			if testCase.wantErr != nil {
+				require.ErrorIs(t, err, testCase.wantErr)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.want, got)
+			}
+			mp.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
# Description of the issue
Adds workload detection support for PostgreSQL database servers as part of the workload-discovery feature

# Description of changes
Implements a PostgreSQL process detector that:

  - Identifies PostgreSQL server instances by checking for the postgres executable
  - Filters out PostgreSQL worker processes by detecting the `:` pattern in cmdline
  - Extracts the listening port from process arguments (-p flag) or the PGPORT environment variable, defaulting to `5432` if neither is set. This is consistent with the upstream `OTEL PostgreSQL receiver `default
  - Always returns READY status with the resolved port
  
#### New files:

  - `nternal/detector/postgresql/postgresql.go` - Main detector implementation
  - `internal/detector/postgresql/extract/port.go` - Port extraction logic
  - Unit tests for both components
  
# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
 - Added unit tests for PostgreSQL detector (postgresql_test.go)
  - Added unit tests for port extractor (port_test.go)
  - make fmt and make lint pass

Test on AL2023:
```
[ec2-user@ip-172-31-85-207 ~]$  sudo /tmp/workload-discovery -debug
time=2026-06-04T18:55:28.897Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/internal/detector/nvidia/nvidia.go:36 msg="Starting NVIDIA GPU detection"
time=2026-06-04T18:55:28.897Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/internal/detector/nvidia/nvidia.go:39 msg="No NVIDIA GPU devices found"
time=2026-06-04T18:55:28.917Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/cmd/workload-discovery/discovery.go:105 msg="Starting discovery" num_process=110 num_worker=2
time=2026-06-04T18:55:28.921Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/internal/detector/postgresql/postgresql.go:60 msg="PostgreSQL process detected" pid=108075
time=2026-06-04T18:55:28.921Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/cmd/workload-discovery/discovery.go:201 msg="Detected supported workload(s) for process" pid=108075 categories=[POSTGRESQL]
time=2026-06-04T18:55:28.922Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/cmd/workload-discovery/discovery.go:165 msg="Process skipped due to pre-filter" pid=187928
time=2026-06-04T18:55:28.922Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/cmd/workload-discovery/discovery.go:165 msg="Process skipped due to pre-filter" pid=187930
time=2026-06-04T18:55:28.922Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/cmd/workload-discovery/discovery.go:165 msg="Process skipped due to pre-filter" pid=187931
time=2026-06-04T18:55:28.922Z level=DEBUG source=github.com/aws/amazon-cloudwatch-agent/cmd/workload-discovery/discovery.go:93 msg="Discovered metadata" elapsed=24.892452ms
[
  {
    "categories": [
      "POSTGRESQL"
    ],
    "name": "postgresql",
    "telemetry_port": 5432,
    "status": "READY"
  }
]
[ec2-user@ip-172-31-85-207 ~]$ 
```

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



