### PR TITLE
Fix Container Insights logs

### DIFF
--- a/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_cluster_config.json
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_cluster_config.json
@@ -1,0 +1,14 @@
+{
+  "agent": {
+    "region": "us-east-1"
+  },
+  "opentelemetry": {
+    "cluster_name": "TestCluster",
+    "collect": {
+      "container_insights": {
+        "collection_interval": 30,
+        "role": "cluster"
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_cluster_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_cluster_config.yaml
@@ -1,0 +1,915 @@
+connectors:
+    forward/opentelemetry: {}
+exporters:
+    otlphttp/metrics:
+        auth:
+            authenticator: agenthealth/opentelemetry_metrics
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: ""
+        max_idle_conns: 100
+        metrics_endpoint: https://monitoring.us-east-1.amazonaws.com/v1/metrics
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
+extensions:
+    agenthealth/opentelemetry_metrics:
+        additional_auth: sigv4auth/monitoring
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EKS
+                region_type: ACJ
+    nodemetadatacache/cw_k8s_ci_v0:
+        namespace: amazon-cloudwatch
+    server:
+        listen_addr: :4311
+        tls_ca_path: /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt
+        tls_cert_path: /etc/amazon-cloudwatch-observability-agent-server-cert/server.crt
+        tls_key_path: /etc/amazon-cloudwatch-observability-agent-server-cert/server.key
+    sigv4auth/monitoring:
+        assume_role: {}
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-east-1
+        request_timeout_seconds: 30
+        service: monitoring
+processors:
+    awsattributelimit/cw_k8s_ci_v0:
+        max_total_attributes: 150
+        unconditional_removal_keys:
+            - k8s.node.label.topology.kubernetes.io/region
+            - k8s.node.label.topology.kubernetes.io/zone
+            - k8s.node.label.topology.ebs.csi.aws.com/zone
+            - k8s.node.label.node.kubernetes.io/instance-type
+            - k8s.node.label.kubernetes.io/hostname
+            - k8s.node.label.helm.sh/chart
+            - k8s.node.label.release
+            - k8s.node.label.eks.amazonaws.com/nodegroup-image
+            - k8s.node.label.k8s.io/cloud-provider-aws
+            - k8s.node.label.eks.amazonaws.com/sourceLaunchTemplateId
+            - k8s.node.label.eks.amazonaws.com/sourceLaunchTemplateVersion
+            - k8s.pod.label.pod-template-hash
+            - k8s.pod.label.controller-revision-hash
+        unconditional_removal_prefixes:
+            - k8s.node.label.feature.node.kubernetes.io/
+            - k8s.node.label.beta.kubernetes.io/
+            - k8s.node.label.failure-domain.beta.kubernetes.io/
+            - k8s.node.label.alpha.eksctl.io/
+    batch/opentelemetry_metrics:
+        metadata_cardinality_limit: 1000
+        send_batch_max_size: 1000
+        send_batch_size: 1000
+        timeout: 30s
+    filter/cw_k8s_ci_v0_apiserver_build_info:
+        error_mode: ignore
+        metrics:
+            metric:
+                - name == "kubernetes_build_info"
+    filter/cw_k8s_ci_v0_scrape_metadata:
+        error_mode: ignore
+        metrics:
+            metric:
+                - IsMatch(name, "^(up|scrape_duration_seconds|scrape_samples_scraped|scrape_samples_post_metric_relabeling|scrape_series_added)$")
+    groupbyattrs/cw_k8s_ci_v0_ksm:
+        keys:
+            - pod
+            - namespace
+            - uid
+            - node
+            - container
+            - owner_name
+            - owner_kind
+            - deployment
+            - daemonset
+            - statefulset
+            - replicaset
+            - job_name
+            - cronjob
+    k8sattributes/cw_k8s_ci_v0_node:
+        auth_type: serviceAccount
+        exclude:
+            pods: null
+        extract:
+            labels:
+                - from: node
+                  key_regex: (.*)
+                  tag_name: k8s.node.label.$$$$1
+            metadata:
+                - k8s.node.name
+        passthrough: false
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.node.name
+    k8sattributes/cw_k8s_ci_v0_pod:
+        auth_type: serviceAccount
+        exclude:
+            pods: null
+        extract:
+            labels:
+                - from: pod
+                  key_regex: (.*)
+                  tag_name: k8s.pod.label.$$$$1
+            metadata:
+                - k8s.pod.uid
+                - k8s.node.name
+                - k8s.deployment.name
+                - k8s.statefulset.name
+                - k8s.daemonset.name
+                - k8s.replicaset.name
+                - k8s.job.name
+                - k8s.cronjob.name
+        passthrough: false
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
+    k8sattributes/opentelemetry:
+        auth_type: serviceAccount
+        context: ""
+        exclude:
+            pods: []
+        extract:
+            annotations:
+                - from: pod
+                  key: resource.opentelemetry.io/service.name
+                  key_regex: ""
+                  tag_name: resource.opentelemetry.io/service.name
+                - from: pod
+                  key: resource.opentelemetry.io/service.namespace
+                  key_regex: ""
+                  tag_name: resource.opentelemetry.io/service.namespace
+                - from: pod
+                  key: resource.opentelemetry.io/service.instance.id
+                  key_regex: ""
+                  tag_name: resource.opentelemetry.io/service.instance.id
+                - from: pod
+                  key: resource.opentelemetry.io/service.version
+                  key_regex: ""
+                  tag_name: resource.opentelemetry.io/service.version
+            labels:
+                - from: pod
+                  key: app.kubernetes.io/instance
+                  key_regex: ""
+                  tag_name: app.kubernetes.io/instance
+                - from: pod
+                  key: app.kubernetes.io/name
+                  key_regex: ""
+                  tag_name: app.kubernetes.io/name
+                - from: pod
+                  key: app.kubernetes.io/version
+                  key_regex: ""
+                  tag_name: app.kubernetes.io/version
+            metadata:
+                - k8s.namespace.name
+                - k8s.deployment.name
+                - k8s.replicaset.name
+                - k8s.statefulset.name
+                - k8s.daemonset.name
+                - k8s.job.name
+                - k8s.cronjob.name
+                - k8s.node.name
+                - k8s.pod.name
+                - k8s.pod.uid
+                - k8s.pod.start_time
+                - k8s.container.name
+            otel_annotations: false
+        filter:
+            namespace: ""
+            node: ""
+            node_from_env_var: K8S_NODE_NAME
+        kube_config_path: ""
+        passthrough: false
+        wait_for_metadata: false
+        wait_for_metadata_timeout: 10s
+    metricstarttime/cw_k8s_ci_v0: null
+    nodemetadataenricher/cw_k8s_ci_v0: null
+    resourcedetection/cw_k8s_ci_v0:
+        detectors:
+            - eks
+            - env
+            - ec2
+        override: false
+        timeout: 2s
+    resourcedetection/opentelemetry:
+        aks:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        azure:
+            resource_attributes:
+                azure.resourcegroup.name:
+                    enabled: true
+                azure.vm.name:
+                    enabled: true
+                azure.vm.scaleset.name:
+                    enabled: true
+                azure.vm.size:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            tags: []
+        consul:
+            address: ""
+            datacenter: ""
+            namespace: ""
+            resource_attributes:
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+            token_file: ""
+        detectors:
+            - eks
+            - env
+            - ec2
+        docker:
+            resource_attributes:
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+        ec2:
+            fail_on_missing_metadata: false
+            max_attempts: 3
+            max_backoff: 20s
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+            tags:
+                - ^kubernetes.io/cluster/.*$
+                - ^aws:autoscaling:groupName
+        ecs:
+            resource_attributes:
+                aws.ecs.cluster.arn:
+                    enabled: true
+                aws.ecs.launchtype:
+                    enabled: true
+                aws.ecs.task.arn:
+                    enabled: true
+                aws.ecs.task.family:
+                    enabled: true
+                aws.ecs.task.id:
+                    enabled: true
+                aws.ecs.task.revision:
+                    enabled: true
+                aws.log.group.arns:
+                    enabled: true
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.arns:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+        eks:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: false
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: false
+        elasticbeanstalk:
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                deployment.environment:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.version:
+                    enabled: true
+        gcp:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.id:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+                gcp.cloud_run.job.execution:
+                    enabled: true
+                gcp.cloud_run.job.task_index:
+                    enabled: true
+                gcp.gce.instance.hostname:
+                    enabled: false
+                gcp.gce.instance.name:
+                    enabled: false
+                gcp.gce.instance_group_manager.name:
+                    enabled: true
+                gcp.gce.instance_group_manager.region:
+                    enabled: true
+                gcp.gce.instance_group_manager.zone:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+        heroku:
+            resource_attributes:
+                cloud.provider:
+                    enabled: true
+                heroku.app.id:
+                    enabled: true
+                heroku.dyno.id:
+                    enabled: true
+                heroku.release.commit:
+                    enabled: true
+                heroku.release.creation_timestamp:
+                    enabled: true
+                service.instance.id:
+                    enabled: true
+                service.name:
+                    enabled: true
+                service.version:
+                    enabled: true
+        idle_conn_timeout: 1m30s
+        k8snode:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            node_from_env_var: ""
+            resource_attributes:
+                k8s.node.name:
+                    enabled: true
+                k8s.node.uid:
+                    enabled: true
+        kubeadm:
+            auth_type: serviceAccount
+            context: ""
+            kube_config_path: ""
+            resource_attributes:
+                k8s.cluster.name:
+                    enabled: true
+                k8s.cluster.uid:
+                    enabled: true
+        lambda:
+            resource_attributes:
+                aws.log.group.names:
+                    enabled: true
+                aws.log.stream.names:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                faas.instance:
+                    enabled: true
+                faas.max_memory:
+                    enabled: true
+                faas.name:
+                    enabled: true
+                faas.version:
+                    enabled: true
+        max_idle_conns: 100
+        openshift:
+            address: ""
+            resource_attributes:
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                k8s.cluster.name:
+                    enabled: true
+            tls: {}
+            token: ""
+        override: true
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.cpu.cache.l2.size:
+                    enabled: false
+                host.cpu.family:
+                    enabled: false
+                host.cpu.model.id:
+                    enabled: false
+                host.cpu.model.name:
+                    enabled: false
+                host.cpu.stepping:
+                    enabled: false
+                host.cpu.vendor.id:
+                    enabled: false
+                host.id:
+                    enabled: false
+                host.ip:
+                    enabled: false
+                host.mac:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: false
+                os.type:
+                    enabled: true
+                os.version:
+                    enabled: false
+        timeout: 2s
+    transform/cw_k8s_ci_v0_apiserver_cleanup_version:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - delete_key(attributes, "k8s.apiserver.version") where attributes["k8s.apiserver.version"] != nil
+    transform/cw_k8s_ci_v0_apiserver_extract_version:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.apiserver.version"], attributes["git_version"]) where attributes["git_version"] != nil and attributes["git_version"] != ""
+    transform/cw_k8s_ci_v0_clear_schema_url:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - set(resource.schema_url, "")
+    transform/cw_k8s_ci_v0_ksm_clean_resource:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - delete_key(attributes, "k8s.pod.name")
+                - delete_key(attributes, "k8s.pod.uid")
+                - delete_key(attributes, "k8s.namespace.name")
+                - delete_key(attributes, "k8s.node.name")
+                - delete_key(attributes, "k8s.container.name")
+                - delete_key(attributes, "k8s.deployment.name")
+                - delete_key(attributes, "k8s.replicaset.name")
+                - delete_key(attributes, "k8s.workload.name")
+                - delete_key(attributes, "k8s.workload.type")
+    transform/cw_k8s_ci_v0_ksm_promote:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"] != nil
+                - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"] != nil
+                - set(attributes["k8s.node.name"], attributes["node"]) where attributes["node"] != nil
+                - set(attributes["k8s.pod.uid"], attributes["uid"]) where attributes["uid"] != nil
+                - set(attributes["k8s.container.name"], attributes["container"]) where attributes["container"] != nil
+                - set(attributes["k8s.workload.name"], attributes["owner_name"]) where attributes["owner_name"] != nil
+                - set(attributes["k8s.workload.type"], attributes["owner_kind"]) where attributes["owner_kind"] != nil
+                - set(attributes["k8s.deployment.name"], attributes["deployment"]) where attributes["deployment"] != nil
+                - set(attributes["k8s.daemonset.name"], attributes["daemonset"]) where attributes["daemonset"] != nil
+                - set(attributes["k8s.statefulset.name"], attributes["statefulset"]) where attributes["statefulset"] != nil
+                - set(attributes["k8s.job.name"], attributes["job_name"]) where attributes["job_name"] != nil
+                - set(attributes["k8s.cronjob.name"], attributes["cronjob"]) where attributes["cronjob"] != nil
+                - set(attributes["k8s.replicaset.name"], attributes["replicaset"]) where attributes["replicaset"] != nil
+            - context: datapoint
+              statements:
+                - set(attributes["pod"], resource.attributes["pod"]) where resource.attributes["pod"] != nil
+                - set(attributes["namespace"], resource.attributes["namespace"]) where resource.attributes["namespace"] != nil
+                - set(attributes["node"], resource.attributes["node"]) where resource.attributes["node"] != nil
+                - set(attributes["uid"], resource.attributes["uid"]) where resource.attributes["uid"] != nil
+                - set(attributes["container"], resource.attributes["container"]) where resource.attributes["container"] != nil
+                - set(attributes["deployment"], resource.attributes["deployment"]) where resource.attributes["deployment"] != nil
+                - set(attributes["daemonset"], resource.attributes["daemonset"]) where resource.attributes["daemonset"] != nil
+                - set(attributes["statefulset"], resource.attributes["statefulset"]) where resource.attributes["statefulset"] != nil
+                - set(attributes["replicaset"], resource.attributes["replicaset"]) where resource.attributes["replicaset"] != nil
+                - set(attributes["job_name"], resource.attributes["job_name"]) where resource.attributes["job_name"] != nil
+                - set(attributes["cronjob"], resource.attributes["cronjob"]) where resource.attributes["cronjob"] != nil
+                - set(attributes["owner_name"], resource.attributes["owner_name"]) where resource.attributes["owner_name"] != nil
+                - set(attributes["owner_kind"], resource.attributes["owner_kind"]) where resource.attributes["owner_kind"] != nil
+    transform/cw_k8s_ci_v0_promote_component:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.component.name"], attributes["component"])
+    transform/cw_k8s_ci_v0_set_cloud_resource_id:
+        error_mode: ignore
+        metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["cloud.resource_id"], Concat(["arn:aws:eks:", attributes["cloud.region"], ":", attributes["cloud.account.id"], ":cluster/", attributes["k8s.cluster.name"]], "")) where attributes["cloud.region"] != nil and attributes["cloud.account.id"] != nil and attributes["k8s.cluster.name"] != nil
+    transform/cw_k8s_ci_v0_set_cluster_name:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.cluster.name"], "TestCluster")
+    transform/cw_k8s_ci_v0_set_component:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["component"], "apiserver")
+    transform/cw_k8s_ci_v0_set_scope_apiserver:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.version, resource.attributes["k8s.apiserver.version"]) where resource.attributes["k8s.apiserver.version"] != nil
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "apiserver")
+    transform/cw_k8s_ci_v0_set_scope_kube_state_metrics:
+        error_mode: ignore
+        metric_statements:
+            - context: scope
+              statements:
+                - set(scope.name, "github.com/kubernetes/kube-state-metrics")
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "kube-state-metrics")
+    transform/cw_k8s_ci_v0_set_unit:
+        error_mode: ignore
+        metric_statements:
+            - context: metric
+              statements:
+                - set(unit, "s") where IsMatch(name, ".*_seconds(_total)?$")
+                - set(unit, "ms") where IsMatch(name, ".*_milliseconds(_total)?$")
+                - set(unit, "us") where IsMatch(name, ".*_microseconds(_total)?$")
+                - set(unit, "ns") where IsMatch(name, ".*_nanoseconds(_total)?$")
+                - set(unit, "By") where IsMatch(name, ".*_bytes(_total)?$")
+                - set(unit, "KBy") where IsMatch(name, ".*_kilobytes(_total)?$")
+                - set(unit, "MBy") where IsMatch(name, ".*_megabytes(_total)?$")
+                - set(unit, "GBy") where IsMatch(name, ".*_gigabytes(_total)?$")
+                - set(unit, "KiBy") where IsMatch(name, ".*_kibibytes(_total)?$")
+                - set(unit, "MiBy") where IsMatch(name, ".*_mebibytes(_total)?$")
+                - set(unit, "GiBy") where IsMatch(name, ".*_gibibytes(_total)?$")
+                - set(unit, "Cel") where IsMatch(name, ".*_celsius$")
+                - set(unit, "Hz") where IsMatch(name, ".*_hertz$")
+                - set(unit, "1") where IsMatch(name, ".*_ratio$")
+                - set(unit, "%") where IsMatch(name, ".*_percent$")
+                - set(unit, "V") where IsMatch(name, ".*_volts$")
+                - set(unit, "W") where IsMatch(name, ".*_watts$")
+                - set(unit, "J") where IsMatch(name, ".*_joules$")
+                - set(unit, "A") where IsMatch(name, ".*_amperes$")
+                - set(unit, "m") where IsMatch(name, ".*_meters(_total)?$")
+                - set(unit, "1") where unit == "" and IsMatch(name, ".*_total$")
+    transform/cw_k8s_ci_v0_set_workload:
+        error_mode: ignore
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Deployment") where resource.attributes["k8s.workload.type"] == nil and resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "StatefulSet") where resource.attributes["k8s.workload.type"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.daemonset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "DaemonSet") where resource.attributes["k8s.workload.type"] == nil and resource.attributes["k8s.daemonset.name"] != nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Job") where resource.attributes["k8s.workload.type"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.cronjob.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "CronJob") where resource.attributes["k8s.workload.type"] == nil and resource.attributes["k8s.cronjob.name"] != nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "ReplicaSet") where resource.attributes["k8s.workload.type"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+    transform/identity:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.namespace"], resource.attributes["resource.opentelemetry.io/service.namespace"]) where resource.attributes["service.namespace"] == nil and resource.attributes["resource.opentelemetry.io/service.namespace"] != nil
+                - set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where resource.attributes["service.namespace"] == nil and resource.attributes["k8s.namespace.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["resource.opentelemetry.io/service.name"]) where resource.attributes["service.name"] == nil and resource.attributes["resource.opentelemetry.io/service.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["app.kubernetes.io/instance"]) where resource.attributes["service.name"] == nil and resource.attributes["app.kubernetes.io/instance"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["app.kubernetes.io/name"]) where resource.attributes["service.name"] == nil and resource.attributes["app.kubernetes.io/name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.pod.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.container.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.container.name"] != nil
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Format("arn:aws:eks:%s:%s:cluster/%s", [resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], resource.attributes["k8s.cluster.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["cloud.platform"] == "aws_eks"
+                - set(resource.attributes["cloud.resource_id"], Format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s", [resource.attributes["cloud.account.id"], resource.attributes["azure.resourcegroup.name"], resource.attributes["k8s.cluster.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["azure.resourcegroup.name"] != nil and resource.attributes["cloud.platform"] == "azure_aks"
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Deployment") where resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "StatefulSet") where resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.daemonset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "DaemonSet") where resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Job") where resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.cronjob.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "ReplicaSet") where resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["service.instance.id"], resource.attributes["resource.opentelemetry.io/service.instance.id"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["resource.opentelemetry.io/service.instance.id"] != nil
+                - set(resource.attributes["service.instance.id"], Concat([resource.attributes["k8s.namespace.name"], resource.attributes["k8s.pod.name"], resource.attributes["k8s.container.name"]], "/")) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.name"] != nil
+                - set(resource.attributes["service.version"], resource.attributes["resource.opentelemetry.io/service.version"]) where resource.attributes["service.version"] == nil and resource.attributes["resource.opentelemetry.io/service.version"] != nil
+                - set(resource.attributes["service.version"], resource.attributes["app.kubernetes.io/version"]) where resource.attributes["service.version"] == nil and resource.attributes["app.kubernetes.io/version"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], Concat([resource.attributes["k8s.cluster.name"], resource.attributes["k8s.namespace.name"]], "/")], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["k8s.namespace.name"] != nil
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.namespace")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.name")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.instance.id")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.version")
+                - delete_key(resource.attributes, "app.kubernetes.io/instance")
+                - delete_key(resource.attributes, "app.kubernetes.io/name")
+                - delete_key(resource.attributes, "app.kubernetes.io/version")
+        metric_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.namespace"], resource.attributes["resource.opentelemetry.io/service.namespace"]) where resource.attributes["service.namespace"] == nil and resource.attributes["resource.opentelemetry.io/service.namespace"] != nil
+                - set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where resource.attributes["service.namespace"] == nil and resource.attributes["k8s.namespace.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["resource.opentelemetry.io/service.name"]) where resource.attributes["service.name"] == nil and resource.attributes["resource.opentelemetry.io/service.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["app.kubernetes.io/instance"]) where resource.attributes["service.name"] == nil and resource.attributes["app.kubernetes.io/instance"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["app.kubernetes.io/name"]) where resource.attributes["service.name"] == nil and resource.attributes["app.kubernetes.io/name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.pod.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.container.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.container.name"] != nil
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Format("arn:aws:eks:%s:%s:cluster/%s", [resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], resource.attributes["k8s.cluster.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["cloud.platform"] == "aws_eks"
+                - set(resource.attributes["cloud.resource_id"], Format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s", [resource.attributes["cloud.account.id"], resource.attributes["azure.resourcegroup.name"], resource.attributes["k8s.cluster.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["azure.resourcegroup.name"] != nil and resource.attributes["cloud.platform"] == "azure_aks"
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Deployment") where resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "StatefulSet") where resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.daemonset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "DaemonSet") where resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Job") where resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.cronjob.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "ReplicaSet") where resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["service.instance.id"], resource.attributes["resource.opentelemetry.io/service.instance.id"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["resource.opentelemetry.io/service.instance.id"] != nil
+                - set(resource.attributes["service.instance.id"], Concat([resource.attributes["k8s.namespace.name"], resource.attributes["k8s.pod.name"], resource.attributes["k8s.container.name"]], "/")) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.name"] != nil
+                - set(resource.attributes["service.version"], resource.attributes["resource.opentelemetry.io/service.version"]) where resource.attributes["service.version"] == nil and resource.attributes["resource.opentelemetry.io/service.version"] != nil
+                - set(resource.attributes["service.version"], resource.attributes["app.kubernetes.io/version"]) where resource.attributes["service.version"] == nil and resource.attributes["app.kubernetes.io/version"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], Concat([resource.attributes["k8s.cluster.name"], resource.attributes["k8s.namespace.name"]], "/")], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["k8s.namespace.name"] != nil
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.namespace")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.name")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.instance.id")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.version")
+                - delete_key(resource.attributes, "app.kubernetes.io/instance")
+                - delete_key(resource.attributes, "app.kubernetes.io/name")
+                - delete_key(resource.attributes, "app.kubernetes.io/version")
+        trace_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["service.namespace"], resource.attributes["resource.opentelemetry.io/service.namespace"]) where resource.attributes["service.namespace"] == nil and resource.attributes["resource.opentelemetry.io/service.namespace"] != nil
+                - set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where resource.attributes["service.namespace"] == nil and resource.attributes["k8s.namespace.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["resource.opentelemetry.io/service.name"]) where resource.attributes["service.name"] == nil and resource.attributes["resource.opentelemetry.io/service.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["app.kubernetes.io/instance"]) where resource.attributes["service.name"] == nil and resource.attributes["app.kubernetes.io/instance"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["app.kubernetes.io/name"]) where resource.attributes["service.name"] == nil and resource.attributes["app.kubernetes.io/name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.pod.name"] != nil
+                - set(resource.attributes["service.name"], resource.attributes["k8s.container.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.container.name"] != nil
+                - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
+                - set(resource.attributes["cloud.resource_id"], Format("arn:aws:eks:%s:%s:cluster/%s", [resource.attributes["cloud.region"], resource.attributes["cloud.account.id"], resource.attributes["k8s.cluster.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["cloud.platform"] == "aws_eks"
+                - set(resource.attributes["cloud.resource_id"], Format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s", [resource.attributes["cloud.account.id"], resource.attributes["azure.resourcegroup.name"], resource.attributes["k8s.cluster.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["azure.resourcegroup.name"] != nil and resource.attributes["cloud.platform"] == "azure_aks"
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Deployment") where resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "StatefulSet") where resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.daemonset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "DaemonSet") where resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.job.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "Job") where resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.cronjob.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
+                - set(resource.attributes["k8s.workload.type"], "ReplicaSet") where resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+                - set(resource.attributes["service.instance.id"], resource.attributes["resource.opentelemetry.io/service.instance.id"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["resource.opentelemetry.io/service.instance.id"] != nil
+                - set(resource.attributes["service.instance.id"], Concat([resource.attributes["k8s.namespace.name"], resource.attributes["k8s.pod.name"], resource.attributes["k8s.container.name"]], "/")) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.name"] != nil
+                - set(resource.attributes["service.version"], resource.attributes["resource.opentelemetry.io/service.version"]) where resource.attributes["service.version"] == nil and resource.attributes["resource.opentelemetry.io/service.version"] != nil
+                - set(resource.attributes["service.version"], resource.attributes["app.kubernetes.io/version"]) where resource.attributes["service.version"] == nil and resource.attributes["app.kubernetes.io/version"] != nil
+                - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], Concat([resource.attributes["k8s.cluster.name"], resource.attributes["k8s.namespace.name"]], "/")], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["k8s.namespace.name"] != nil
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.namespace")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.name")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.instance.id")
+                - delete_key(resource.attributes, "resource.opentelemetry.io/service.version")
+                - delete_key(resource.attributes, "app.kubernetes.io/instance")
+                - delete_key(resource.attributes, "app.kubernetes.io/name")
+                - delete_key(resource.attributes, "app.kubernetes.io/version")
+    transform/set_cluster_name:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["k8s.cluster.name"], "TestCluster")
+        metric_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["k8s.cluster.name"], "TestCluster")
+        trace_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["k8s.cluster.name"], "TestCluster")
+receivers:
+    prometheus/cw_k8s_ci_v0_apiserver:
+        config:
+            global:
+                scrape_interval: 30s
+                scrape_timeout: 10s
+            scrape_configs:
+                - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                  job_name: kubernetes-apiserver
+                  kubernetes_sd_configs:
+                    - namespaces:
+                        names:
+                            - default
+                      role: endpoints
+                  relabel_configs:
+                    - action: keep
+                      regex: kubernetes
+                      source_labels:
+                        - __meta_kubernetes_service_name
+                    - action: keep
+                      regex: https
+                      source_labels:
+                        - __meta_kubernetes_endpoint_port_name
+                    - replacement: /metrics
+                      target_label: __metrics_path__
+                  scheme: https
+                  scrape_interval: 30s
+                  scrape_timeout: 10s
+                  tls_config:
+                    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                    insecure_skip_verify: false
+    prometheus/cw_k8s_ci_v0_kube_state_metrics:
+        config:
+            global:
+                scrape_interval: 30s
+                scrape_timeout: 10s
+            scrape_configs:
+                - job_name: kube-state-metrics
+                  scheme: https
+                  scrape_interval: 30s
+                  scrape_timeout: 10s
+                  static_configs:
+                    - targets:
+                        - kube-state-metrics.amazon-cloudwatch.svc:8443
+                  tls_config:
+                    ca_file: /etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt
+service:
+    extensions:
+        - sigv4auth/monitoring
+        - agenthealth/opentelemetry_metrics
+        - nodemetadatacache/cw_k8s_ci_v0
+        - server
+    pipelines:
+        metrics/cw_k8s_ci_v0_apiserver:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/cw_k8s_ci_v0_scrape_metadata
+                - transform/cw_k8s_ci_v0_set_unit
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_apiserver_extract_version
+                - filter/cw_k8s_ci_v0_apiserver_build_info
+                - transform/cw_k8s_ci_v0_set_scope_apiserver
+                - transform/cw_k8s_ci_v0_apiserver_cleanup_version
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - transform/cw_k8s_ci_v0_set_component
+                - transform/cw_k8s_ci_v0_promote_component
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - prometheus/cw_k8s_ci_v0_apiserver
+        metrics/cw_k8s_ci_v0_kube_state_metrics:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - filter/cw_k8s_ci_v0_scrape_metadata
+                - transform/cw_k8s_ci_v0_set_unit
+                - metricstarttime/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_scope_kube_state_metrics
+                - transform/cw_k8s_ci_v0_set_cluster_name
+                - transform/cw_k8s_ci_v0_ksm_clean_resource
+                - groupbyattrs/cw_k8s_ci_v0_ksm
+                - transform/cw_k8s_ci_v0_ksm_promote
+                - k8sattributes/cw_k8s_ci_v0_pod
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_set_workload
+                - nodemetadataenricher/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_clear_schema_url
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_set_cloud_resource_id
+                - awsattributelimit/cw_k8s_ci_v0
+            receivers:
+                - prometheus/cw_k8s_ci_v0_kube_state_metrics
+        metrics/opentelemetry:
+            exporters:
+                - otlphttp/metrics
+            processors:
+                - resourcedetection/opentelemetry
+                - k8sattributes/opentelemetry
+                - transform/set_cluster_name
+                - transform/identity
+                - batch/opentelemetry_metrics
+            receivers:
+                - forward/opentelemetry
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: None
+        traces:
+            level: None

--- a/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_node_config.json
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_node_config.json
@@ -6,7 +6,11 @@
     "cluster_name": "TestCluster",
     "collect": {
       "container_insights": {
-        "collection_interval": 30
+        "collection_interval": 30,
+        "role": "node",
+        "logs": {
+          "enabled": true
+        }
       }
     }
   }

--- a/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_node_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_node_config.yaml
@@ -1,6 +1,33 @@
 connectors:
     forward/opentelemetry: {}
 exporters:
+    otlphttp/logs:
+        auth:
+            authenticator: agenthealth/opentelemetry_logs
+        compression: gzip
+        encoding: proto
+        idle_conn_timeout: 1m30s
+        logs_endpoint: https://logs.us-east-1.amazonaws.com/v1/logs
+        max_idle_conns: 100
+        metrics_endpoint: ""
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_elapsed_time: 5m0s
+            max_interval: 30s
+            multiplier: 1.5
+            randomization_factor: 0.5
+        sending_queue:
+            block_on_overflow: false
+            blocking: false
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+            sizer: {}
+            wait_for_result: false
+        timeout: 30s
+        traces_endpoint: ""
+        write_buffer_size: 524288
     otlphttp/metrics:
         auth:
             authenticator: agenthealth/opentelemetry_metrics
@@ -29,6 +56,15 @@ exporters:
         traces_endpoint: ""
         write_buffer_size: 524288
 extensions:
+    agenthealth/opentelemetry_logs:
+        additional_auth: headers_setter/logs
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - '*'
+            usage_flags:
+                mode: EKS
+                region_type: ACJ
     agenthealth/opentelemetry_metrics:
         additional_auth: sigv4auth/monitoring
         is_usage_data_enabled: true
@@ -38,11 +74,36 @@ extensions:
             usage_flags:
                 mode: EKS
                 region_type: ACJ
+    awscloudwatchlogsprovisioner:
+        additional_auth: sigv4auth/logs
+        imds_retries: 1
+        logs_provision_failure_backoff: 5s
+        max_retries: 2
+        num_workers: 8
+        region: us-east-1
+        request_timeout_seconds: 10
+    headers_setter/logs:
+        additional_auth: awscloudwatchlogsprovisioner
+        headers:
+            - action: upsert
+              from_context: aws.log.group.name
+              key: x-aws-log-group
+            - action: upsert
+              from_context: aws.log.stream.name
+              key: x-aws-log-stream
     server:
         listen_addr: :4311
         tls_ca_path: /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt
         tls_cert_path: /etc/amazon-cloudwatch-observability-agent-server-cert/server.crt
         tls_key_path: /etc/amazon-cloudwatch-observability-agent-server-cert/server.key
+    sigv4auth/logs:
+        assume_role: {}
+        imds_retries: 1
+        max_retries: 2
+        num_workers: 8
+        region: us-east-1
+        request_timeout_seconds: 30
+        service: logs
     sigv4auth/monitoring:
         assume_role: {}
         imds_retries: 1
@@ -52,6 +113,12 @@ extensions:
         request_timeout_seconds: 30
         service: monitoring
 processors:
+    attributestocontext/opentelemetry:
+        actions:
+            - from_resource_attribute: aws.log.group.name
+              key: aws.log.group.name
+            - from_resource_attribute: aws.log.stream.name
+              key: aws.log.stream.name
     awsattributelimit/cw_k8s_ci_v0:
         max_total_attributes: 150
         unconditional_removal_keys:
@@ -89,6 +156,14 @@ processors:
               resource_names:
                 - vpc.amazonaws.com/efa
     awsneuron/cw_k8s_ci_v0: null
+    batch/opentelemetry_logs:
+        metadata_cardinality_limit: 1000
+        metadata_keys:
+            - aws.log.group.name
+            - aws.log.stream.name
+        send_batch_max_size: 10000
+        send_batch_size: 10000
+        timeout: 30s
     batch/opentelemetry_metrics:
         metadata_cardinality_limit: 1000
         send_batch_max_size: 1000
@@ -155,6 +230,19 @@ processors:
         exclude:
             pods: null
         extract:
+            annotations:
+                - from: pod
+                  key: resource.opentelemetry.io/service.name
+                  tag_name: resource.opentelemetry.io/service.name
+                - from: pod
+                  key: resource.opentelemetry.io/service.namespace
+                  tag_name: resource.opentelemetry.io/service.namespace
+                - from: pod
+                  key: resource.opentelemetry.io/service.instance.id
+                  tag_name: resource.opentelemetry.io/service.instance.id
+                - from: pod
+                  key: resource.opentelemetry.io/service.version
+                  tag_name: resource.opentelemetry.io/service.version
             labels:
                 - from: pod
                   key_regex: (.*)
@@ -168,6 +256,8 @@ processors:
                 - k8s.replicaset.name
                 - k8s.job.name
                 - k8s.cronjob.name
+                - k8s.pod.start_time
+                - k8s.container.name
         filter:
             node_from_env_var: K8S_NODE_NAME
         passthrough: false
@@ -239,10 +329,27 @@ processors:
     resourcedetection/cw_k8s_ci_v0:
         detectors:
             - eks
-            - env
             - ec2
-        override: false
-        timeout: 2s
+        ec2:
+            resource_attributes:
+                cloud.account.id:
+                    enabled: true
+                cloud.availability_zone:
+                    enabled: true
+                cloud.platform:
+                    enabled: true
+                cloud.provider:
+                    enabled: true
+                cloud.region:
+                    enabled: true
+                host.id:
+                    enabled: true
+                host.image.id:
+                    enabled: true
+                host.name:
+                    enabled: true
+                host.type:
+                    enabled: true
     resourcedetection/opentelemetry:
         aks:
             resource_attributes:
@@ -523,6 +630,13 @@ processors:
                 os.version:
                     enabled: false
         timeout: 2s
+    transform/cw_k8s_ci_v0_app_logs_set_log_destination:
+        error_mode: ignore
+        log_statements:
+            - context: resource
+              statements:
+                - set(attributes["aws.log.group.name"], "/aws/otel/containerinsights/TestCluster/application")
+                - set(attributes["aws.log.stream.name"], "${K8S_NODE_NAME}-application")
     transform/cw_k8s_ci_v0_cadvisor_promote:
         error_mode: ignore
         metric_statements:
@@ -586,6 +700,61 @@ processors:
                 - set(resource.attributes["volume_id"], attributes["volume_id"]) where attributes["volume_id"] != nil
                 - delete_key(attributes, "instance_id") where attributes["instance_id"] != nil
                 - delete_key(attributes, "volume_id") where attributes["volume_id"] != nil
+    transform/cw_k8s_ci_v0_logs_clear_schema_url:
+        error_mode: ignore
+        log_statements:
+            - context: resource
+              statements:
+                - set(resource.schema_url, "")
+    transform/cw_k8s_ci_v0_logs_set_cloud_resource_id:
+        error_mode: ignore
+        log_statements:
+            - context: resource
+              statements:
+                - set(attributes["cloud.resource_id"], Concat(["arn:aws:eks:", attributes["cloud.region"], ":", attributes["cloud.account.id"], ":cluster/", attributes["k8s.cluster.name"]], "")) where attributes["cloud.region"] != nil and attributes["cloud.account.id"] != nil and attributes["k8s.cluster.name"] != nil
+    transform/cw_k8s_ci_v0_logs_set_cluster_and_node:
+        error_mode: ignore
+        log_statements:
+            - context: resource
+              statements:
+                - set(attributes["k8s.cluster.name"], "TestCluster")
+                - set(attributes["k8s.node.name"], "${K8S_NODE_NAME}")
+    transform/cw_k8s_ci_v0_logs_set_scope_app:
+        error_mode: ignore
+        log_statements:
+            - context: scope
+              statements:
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "application-logs")
+    transform/cw_k8s_ci_v0_logs_set_scope_host:
+        error_mode: ignore
+        log_statements:
+            - context: scope
+              statements:
+                - set(scope.schema_url, "")
+                - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+                - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+                - set(attributes["cloudwatch.pipeline"], "host-logs")
+    transform/cw_k8s_ci_v0_logs_set_workload:
+        error_mode: ignore
+        log_statements:
+            - context: resource
+              statements:
+                - set(attributes["k8s.workload.name"], attributes["k8s.deployment.name"]) where attributes["k8s.deployment.name"] != nil
+                - set(attributes["k8s.workload.type"], "Deployment") where attributes["k8s.deployment.name"] != nil
+                - set(attributes["k8s.workload.name"], attributes["k8s.statefulset.name"]) where attributes["k8s.workload.name"] == nil and attributes["k8s.statefulset.name"] != nil
+                - set(attributes["k8s.workload.type"], "StatefulSet") where attributes["k8s.statefulset.name"] != nil and attributes["k8s.workload.type"] == nil
+                - set(attributes["k8s.workload.name"], attributes["k8s.daemonset.name"]) where attributes["k8s.workload.name"] == nil and attributes["k8s.daemonset.name"] != nil
+                - set(attributes["k8s.workload.type"], "DaemonSet") where attributes["k8s.daemonset.name"] != nil and attributes["k8s.workload.type"] == nil
+                - set(attributes["k8s.workload.name"], attributes["k8s.job.name"]) where attributes["k8s.workload.name"] == nil and attributes["k8s.job.name"] != nil
+                - set(attributes["k8s.workload.type"], "Job") where attributes["k8s.job.name"] != nil and attributes["k8s.workload.type"] == nil
+                - set(attributes["k8s.workload.name"], attributes["k8s.cronjob.name"]) where attributes["k8s.workload.name"] == nil and attributes["k8s.cronjob.name"] != nil
+                - set(attributes["k8s.workload.type"], "CronJob") where attributes["k8s.cronjob.name"] != nil and attributes["k8s.workload.type"] == nil
+                - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where attributes["k8s.workload.name"] == nil and attributes["k8s.replicaset.name"] != nil
+                - set(attributes["k8s.workload.type"], "ReplicaSet") where attributes["k8s.replicaset.name"] != nil and attributes["k8s.workload.type"] == nil
+                - set(attributes["service.name"], attributes["k8s.workload.name"]) where attributes["service.name"] == nil and attributes["k8s.workload.name"] != nil
     transform/cw_k8s_ci_v0_neuron_hw_attrs:
         error_mode: ignore
         metric_statements:
@@ -609,6 +778,13 @@ processors:
                 - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
                 - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
                 - delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil
+    transform/cw_k8s_ci_v0_node_logs_set_log_destination:
+        error_mode: ignore
+        log_statements:
+            - context: resource
+              statements:
+                - set(attributes["aws.log.group.name"], "/aws/otel/containerinsights/TestCluster/host")
+                - set(attributes["aws.log.stream.name"], "${K8S_NODE_NAME}-host")
     transform/cw_k8s_ci_v0_promote_node_name:
         error_mode: ignore
         metric_statements:
@@ -891,6 +1067,34 @@ processors:
                 - delete_key(resource.attributes, "app.kubernetes.io/instance")
                 - delete_key(resource.attributes, "app.kubernetes.io/name")
                 - delete_key(resource.attributes, "app.kubernetes.io/version")
+    transform/logs_cleanup:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - delete_key(resource.attributes, "aws.log.group.name")
+                - delete_key(resource.attributes, "aws.log.stream.name")
+                - delete_key(resource.attributes, "aws.log.source")
+        metric_statements: []
+        trace_statements: []
+    transform/logs_routing:
+        error_mode: ignore
+        flatten_data: false
+        log_statements:
+            - context: resource
+              error_mode: ignore
+              statements:
+                - set(resource.attributes["aws.log.group.name"], Concat(["/aws/cwagent", resource.attributes["k8s.cluster.name"], resource.attributes["aws.log.source"]], "/")) where resource.attributes["aws.log.group.name"] == nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["aws.log.source"] != nil
+                - set(resource.attributes["aws.log.group.name"], Concat(["/aws/cwagent", resource.attributes["k8s.cluster.name"], "default"], "/")) where resource.attributes["aws.log.group.name"] == nil and resource.attributes["k8s.cluster.name"] != nil
+                - set(resource.attributes["aws.log.group.name"], "/aws/cwagent/default") where resource.attributes["aws.log.group.name"] == nil
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["k8s.namespace.name"], resource.attributes["service.namespace"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["service.namespace"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], Concat([resource.attributes["k8s.namespace.name"], resource.attributes["service.name"]], "/")) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["service.name"] != nil and resource.attributes["service.name"] != "unknown_service"
+                - set(resource.attributes["aws.log.stream.name"], resource.attributes["k8s.namespace.name"]) where resource.attributes["aws.log.stream.name"] == nil and resource.attributes["k8s.namespace.name"] != nil
+                - set(resource.attributes["aws.log.stream.name"], "default") where resource.attributes["aws.log.stream.name"] == nil
+        metric_statements: []
+        trace_statements: []
     transform/set_cluster_name:
         error_mode: ignore
         flatten_data: false
@@ -912,6 +1116,44 @@ processors:
 receivers:
     awsefareceiver/cw_k8s_ci_v0:
         collection_interval: 30s
+    filelog/cw_k8s_ci_v0_app:
+        exclude:
+            - /var/log/containers/cloudwatch-agent*
+            - /var/log/containers/fluent-bit*
+            - /var/log/containers/aws-node*
+            - /var/log/containers/kube-proxy*
+        include:
+            - /var/log/containers/*.log
+        include_file_name: false
+        include_file_path: true
+        max_concurrent_files: 100
+        operators:
+            - id: extract_metadata_from_filepath
+              parse_from: attributes["log.file.path"]
+              parse_to: resource
+              regex: ^.*\/(?P<pod>[^_]+)_(?P<namespace>[^_]+)_(?P<container>.+)-[a-f0-9]{64}\.log$
+              type: regex_parser
+            - from: resource.pod
+              to: resource["k8s.pod.name"]
+              type: move
+            - from: resource.namespace
+              to: resource["k8s.namespace.name"]
+              type: move
+            - from: resource.container
+              to: resource["k8s.container.name"]
+              type: move
+            - id: parse_container_log
+              type: container_log_parser
+        start_at: end
+    filelog/cw_k8s_ci_v0_node:
+        include:
+            - /var/log/messages
+            - /var/log/dmesg
+            - /var/log/secure
+        include_file_name: false
+        include_file_path: true
+        max_concurrent_files: 100
+        start_at: end
     kubeletstats/cw_k8s_ci_v0:
         auth_type: serviceAccount
         collection_interval: 30s
@@ -1070,8 +1312,54 @@ service:
     extensions:
         - sigv4auth/monitoring
         - agenthealth/opentelemetry_metrics
+        - sigv4auth/logs
+        - awscloudwatchlogsprovisioner
+        - headers_setter/logs
+        - agenthealth/opentelemetry_logs
         - server
     pipelines:
+        logs/cw_k8s_ci_v0_app:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/cw_k8s_ci_v0_logs_set_cluster_and_node
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_logs_set_cloud_resource_id
+                - k8sattributes/cw_k8s_ci_v0_node
+                - k8sattributes/cw_k8s_ci_v0_pod
+                - transform/cw_k8s_ci_v0_logs_set_scope_app
+                - transform/cw_k8s_ci_v0_logs_clear_schema_url
+                - transform/cw_k8s_ci_v0_logs_set_workload
+                - transform/cw_k8s_ci_v0_app_logs_set_log_destination
+            receivers:
+                - filelog/cw_k8s_ci_v0_app
+        logs/cw_k8s_ci_v0_node:
+            exporters:
+                - forward/opentelemetry
+            processors:
+                - transform/cw_k8s_ci_v0_logs_set_cluster_and_node
+                - resourcedetection/cw_k8s_ci_v0
+                - transform/cw_k8s_ci_v0_logs_set_cloud_resource_id
+                - k8sattributes/cw_k8s_ci_v0_node
+                - transform/cw_k8s_ci_v0_logs_set_scope_host
+                - transform/cw_k8s_ci_v0_logs_clear_schema_url
+                - transform/cw_k8s_ci_v0_node_logs_set_log_destination
+            receivers:
+                - filelog/cw_k8s_ci_v0_node
+        logs/opentelemetry:
+            exporters:
+                - otlphttp/logs
+            processors:
+                - resourcedetection/opentelemetry
+                - k8sattributes/opentelemetry
+                - transform/set_cluster_name
+                - transform/identity
+                - transform/logs_routing
+                - attributestocontext/opentelemetry
+                - transform/logs_cleanup
+                - batch/opentelemetry_logs
+            receivers:
+                - forward/opentelemetry
         metrics/cw_k8s_ci_v0_cadvisor:
             exporters:
                 - forward/opentelemetry

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -339,38 +339,43 @@ func TestHostMetricsConfig(t *testing.T) {
 }
 
 func TestContainerInsightsConfig(t *testing.T) {
-	resetContext(t)
-	context.CurrentContext().SetMode(config.ModeEC2)
-	context.CurrentContext().SetKubernetesMode(config.ModeEKS)
-
 	// Cannot use checkTranslation here because the container_insights prometheus
 	// receiver references /var/run/secrets/kubernetes.io/serviceaccount/token
 	// which only exists inside K8s pods. Translate without collector validation.
-	agent.Global_Config = *new(agent.Agent)
-	translator.SetTargetPlatform("linux")
-	var input interface{}
-	blob, err := os.ReadFile("./sampleConfig/opentelemetry/container_insights_config.json")
-	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal(blob, &input))
-	_, _ = cmdutil.TranslateJsonMapToTomlConfig(input)
+	// One golden per role: node (daemonset metrics + logs) and cluster (apiserver + KSM).
+	for _, name := range []string{"container_insights_node_config", "container_insights_cluster_config"} {
+		t.Run(name, func(t *testing.T) {
+			resetContext(t)
+			context.CurrentContext().SetMode(config.ModeEC2)
+			context.CurrentContext().SetKubernetesMode(config.ModeEKS)
 
-	var expected interface{}
-	bs, err := os.ReadFile("./sampleConfig/opentelemetry/container_insights_config.yaml")
-	require.NoError(t, err)
-	require.NoError(t, yaml.Unmarshal(bs, &expected))
+			agent.Global_Config = *new(agent.Agent)
+			translator.SetTargetPlatform("linux")
+			var input interface{}
+			blob, err := os.ReadFile("./sampleConfig/opentelemetry/" + name + ".json")
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(blob, &input))
+			_, _ = cmdutil.TranslateJsonMapToTomlConfig(input)
 
-	var actual interface{}
-	cfg, err := otel.TranslateWithoutValidation(input, context.CurrentContext().Os())
-	require.NoError(t, err)
-	yamlConfig, err := mapstructure.Marshal(cfg)
-	require.NoError(t, err)
-	yamlStr := toyamlconfig.ToYamlConfig(yamlConfig)
-	require.NoError(t, yaml.Unmarshal([]byte(yamlStr), &actual))
+			var expected interface{}
+			bs, err := os.ReadFile("./sampleConfig/opentelemetry/" + name + ".yaml")
+			require.NoError(t, err)
+			require.NoError(t, yaml.Unmarshal(bs, &expected))
 
-	opt := cmpopts.SortSlices(func(x, y interface{}) bool {
-		return pretty.Sprint(x) < pretty.Sprint(y)
-	})
-	require.True(t, cmp.Equal(expected, actual, opt), "D! YAML diff: %s", cmp.Diff(expected, actual))
+			var actual interface{}
+			cfg, err := otel.TranslateWithoutValidation(input, context.CurrentContext().Os())
+			require.NoError(t, err)
+			yamlConfig, err := mapstructure.Marshal(cfg)
+			require.NoError(t, err)
+			yamlStr := toyamlconfig.ToYamlConfig(yamlConfig)
+			require.NoError(t, yaml.Unmarshal([]byte(yamlStr), &actual))
+
+			opt := cmpopts.SortSlices(func(x, y interface{}) bool {
+				return pretty.Sprint(x) < pretty.Sprint(y)
+			})
+			require.True(t, cmp.Equal(expected, actual, opt), "D! YAML diff: %s", cmp.Diff(expected, actual))
+		})
+	}
 }
 
 func TestPrometheusOtelPipelineConfig(t *testing.T) {

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/common.go
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/common.go
@@ -91,13 +91,22 @@ func getCollectionInterval(conf *confmap.Conf) time.Duration {
 	}, defaultCollectionInterval)
 }
 
-// logsEnabled returns true if container_insights.logs.enabled is set to true.
-func logsEnabled(conf *confmap.Conf) bool {
+// LogsEnabled reports whether container_insights log collection is enabled.
+func LogsEnabled(conf *confmap.Conf) bool {
 	if conf == nil {
 		return false
 	}
 	key := common.ConfigKey(ciConfigKey, "logs", "enabled")
 	return common.GetOrDefaultBool(conf, key, false)
+}
+
+// HasLogPipelines reports whether container_insights produces log source pipelines
+// (role node with logs enabled) that forward into the shared logs/opentelemetry pipeline.
+func HasLogPipelines(conf *confmap.Conf) bool {
+	if conf == nil || !conf.IsSet(ciConfigKey) {
+		return false
+	}
+	return getRole(conf) == roleNode && LogsEnabled(conf)
 }
 
 // getRole resolves the container insights pipeline role using the following

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/common_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/common_test.go
@@ -104,7 +104,48 @@ func TestLogsEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, logsEnabled(tt.cfg))
+			assert.Equal(t, tt.want, LogsEnabled(tt.cfg))
+		})
+	}
+}
+
+func TestHasLogPipelines(t *testing.T) {
+	// ciConf builds a config with the given container_insights role and logs.enabled.
+	// An empty role omits the JSON field so getRole falls back to its default (node).
+	ciConf := func(role string, logsEnabled bool) *confmap.Conf {
+		ci := map[string]interface{}{
+			"logs": map[string]interface{}{"enabled": logsEnabled},
+		}
+		if role != "" {
+			ci["role"] = role
+		}
+		return confmap.NewFromStringMap(map[string]interface{}{
+			"opentelemetry": map[string]interface{}{
+				"collect": map[string]interface{}{
+					"container_insights": ci,
+				},
+			},
+		})
+	}
+
+	tests := []struct {
+		name string
+		cfg  *confmap.Conf
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"container_insights not set", confmap.NewFromStringMap(map[string]interface{}{
+			"opentelemetry": map[string]interface{}{"collect": map[string]interface{}{}},
+		}), false},
+		{"node role with logs enabled", ciConf(roleNode, true), true},
+		{"node role with logs disabled", ciConf(roleNode, false), false},
+		{"default role (node) with logs enabled", ciConf("", true), true},
+		{"cluster role with logs enabled", ciConf(roleCluster, true), false},
+		{"cluster role with logs disabled", ciConf(roleCluster, false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasLogPipelines(tt.cfg))
 		})
 	}
 }

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/filelog_app.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/filelog_app.yaml
@@ -166,55 +166,7 @@ processors:
       statements:
       - set(attributes["aws.log.group.name"], "{{.AppLogGroup}}")
       - set(attributes["aws.log.stream.name"], "{{.AppLogStream}}")
-  attributestocontext/cw_k8s_ci_v0:
-    actions:
-    - key: aws.log.group.name
-      from_resource_attribute: aws.log.group.name
-    - key: aws.log.stream.name
-      from_resource_attribute: aws.log.stream.name
-  transform/cw_k8s_ci_v0_app_logs_cleanup:
-    error_mode: ignore
-    log_statements:
-    - context: resource
-      statements:
-      - delete_key(attributes, "aws.log.group.name")
-      - delete_key(attributes, "aws.log.stream.name")
-  batch/cw_k8s_ci_v0_logs_dest:
-    send_batch_max_size: 500
-    send_batch_size: 500
-    timeout: 5s
-exporters:
-  otlphttp/cw_k8s_ci_v0_app_logs_dest:
-    auth:
-      authenticator: headers_setter/cw_k8s_ci_v0_app_logs
-    compression: none
-    endpoint: https://logs.{{.Region}}.amazonaws.com:443
-    sending_queue:
-      num_consumers: 10
-      queue_size: 500
-    tls:
-      insecure: false
-extensions:
-  sigv4auth/cw_k8s_ci_v0_logs_dest:
-    region: {{.Region}}
-    service: logs
-  awscloudwatchlogsprovisioner/cw_k8s_ci_v0_logs:
-    additional_auth: sigv4auth/cw_k8s_ci_v0_logs_dest
-    region: {{.Region}}
-  headers_setter/cw_k8s_ci_v0_app_logs:
-    additional_auth: awscloudwatchlogsprovisioner/cw_k8s_ci_v0_logs
-    headers:
-    - key: x-aws-log-group
-      from_context: aws.log.group.name
-      action: upsert
-    - key: x-aws-log-stream
-      from_context: aws.log.stream.name
-      action: upsert
 service:
-  extensions:
-  - sigv4auth/cw_k8s_ci_v0_logs_dest
-  - awscloudwatchlogsprovisioner/cw_k8s_ci_v0_logs
-  - headers_setter/cw_k8s_ci_v0_app_logs
   pipelines:
     logs/cw_k8s_ci_v0_app:
       receivers:
@@ -229,8 +181,5 @@ service:
       - transform/cw_k8s_ci_v0_logs_clear_schema_url
       - transform/cw_k8s_ci_v0_logs_set_workload
       - transform/cw_k8s_ci_v0_app_logs_set_log_destination
-      - attributestocontext/cw_k8s_ci_v0
-      - transform/cw_k8s_ci_v0_app_logs_cleanup
-      - batch/cw_k8s_ci_v0_logs_dest
       exporters:
-      - otlphttp/cw_k8s_ci_v0_app_logs_dest
+      - forward/opentelemetry

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/filelog_node.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/filelog_node.yaml
@@ -86,55 +86,7 @@ processors:
       statements:
       - set(attributes["aws.log.group.name"], "{{.NodeLogGroup}}")
       - set(attributes["aws.log.stream.name"], "{{.NodeLogStream}}")
-  attributestocontext/cw_k8s_ci_v0:
-    actions:
-    - key: aws.log.group.name
-      from_resource_attribute: aws.log.group.name
-    - key: aws.log.stream.name
-      from_resource_attribute: aws.log.stream.name
-  transform/cw_k8s_ci_v0_node_logs_cleanup:
-    error_mode: ignore
-    log_statements:
-    - context: resource
-      statements:
-      - delete_key(attributes, "aws.log.group.name")
-      - delete_key(attributes, "aws.log.stream.name")
-  batch/cw_k8s_ci_v0_logs_dest:
-    send_batch_max_size: 500
-    send_batch_size: 500
-    timeout: 5s
-exporters:
-  otlphttp/cw_k8s_ci_v0_node_logs_dest:
-    auth:
-      authenticator: headers_setter/cw_k8s_ci_v0_node_logs
-    compression: none
-    endpoint: https://logs.{{.Region}}.amazonaws.com:443
-    sending_queue:
-      num_consumers: 10
-      queue_size: 500
-    tls:
-      insecure: false
-extensions:
-  sigv4auth/cw_k8s_ci_v0_logs_dest:
-    region: {{.Region}}
-    service: logs
-  awscloudwatchlogsprovisioner/cw_k8s_ci_v0_logs:
-    additional_auth: sigv4auth/cw_k8s_ci_v0_logs_dest
-    region: {{.Region}}
-  headers_setter/cw_k8s_ci_v0_node_logs:
-    additional_auth: awscloudwatchlogsprovisioner/cw_k8s_ci_v0_logs
-    headers:
-    - key: x-aws-log-group
-      from_context: aws.log.group.name
-      action: upsert
-    - key: x-aws-log-stream
-      from_context: aws.log.stream.name
-      action: upsert
 service:
-  extensions:
-  - sigv4auth/cw_k8s_ci_v0_logs_dest
-  - awscloudwatchlogsprovisioner/cw_k8s_ci_v0_logs
-  - headers_setter/cw_k8s_ci_v0_node_logs
   pipelines:
     logs/cw_k8s_ci_v0_node:
       receivers:
@@ -147,8 +99,5 @@ service:
       - transform/cw_k8s_ci_v0_logs_set_scope_host
       - transform/cw_k8s_ci_v0_logs_clear_schema_url
       - transform/cw_k8s_ci_v0_node_logs_set_log_destination
-      - attributestocontext/cw_k8s_ci_v0
-      - transform/cw_k8s_ci_v0_node_logs_cleanup
-      - batch/cw_k8s_ci_v0_logs_dest
       exporters:
-      - otlphttp/cw_k8s_ci_v0_node_logs_dest
+      - forward/opentelemetry

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/translator.go
@@ -56,10 +56,8 @@ var ebsCsiYAML string
 //go:embed lis_csi.yaml
 var lisCsiYAML string
 
-// CI logs pipelines are self-contained with dedicated exporters (compression: none)
-// to match the helm chart behavior for FluentBit migration parity. They cannot share
-// the base logs/opentelemetry exporter which uses gzip compression. See:
-// https://github.com/aws-observability/helm-charts/blob/main/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+// CI logs pipelines are source pipelines: they collect and enrich, then forward
+// into the shared logs/opentelemetry export pipeline (auth, headers, batch, exporter).
 
 //go:embed filelog_app.yaml
 var filelogAppYAML string
@@ -98,8 +96,9 @@ func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
 		translators.Set(newYAMLPipeline("ebs_csi_node", pipeline.SignalMetrics, ebsCsiYAML))
 		translators.Set(newYAMLPipeline("lis_csi_node", pipeline.SignalMetrics, lisCsiYAML))
 
-		// Daemonset logs pipelines (gated by logs.enabled)
-		if logsEnabled(conf) {
+		// Daemonset logs pipelines (gated by logs.enabled). These are source
+		// pipelines that forward into the shared logs/opentelemetry export pipeline.
+		if LogsEnabled(conf) {
 			translators.Set(newYAMLPipeline("app", pipeline.SignalLogs, filelogAppYAML))
 			translators.Set(newYAMLPipeline("node", pipeline.SignalLogs, filelogNodeYAML))
 		}

--- a/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
+++ b/translator/translate/otel/pipeline/opentelemetry/translator_logs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/awscloudwatchlogsprovisioner"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/headerssetter"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/opentelemetry/containerinsights"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/attributestocontext"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/batchprocessor"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/processor/k8sattributesprocessor"
@@ -53,7 +54,9 @@ func (t *baseLogsTranslator) Translate(conf *confmap.Conf) (*common.ComponentTra
 	if runtime.GOOS == "windows" {
 		keys = append(keys, common.WindowsEventsConfigKey)
 	}
-	if err := common.ValidateAnySet(conf, t.ID(), keys); err != nil {
+	// Activate the shared logs pipeline when Container Insights produces log
+	// source pipelines (role=node with logs.enabled).
+	if err := common.ValidateAnySet(conf, t.ID(), keys); err != nil && !containerinsights.HasLogPipelines(conf) {
 		return nil, err
 	}
 


### PR DESCRIPTION
### Description of changes

Container Insights logs enabled via the OTEL path (role: node + logs.enabled: true) never reach CloudWatch, the exporter 400s with "log group cannot be null or empty" and records are dropped. Root cause: `batch/cw_k8s_ci_v0_logs_dest` had no `metadata_keys`, so the batch processor discards the request context. That drops` aws.log.group.name/aws.log.stream.name`, so headers_setter emits an empty x-aws-log-group header

To fix this, we refactor the CI log pipelines into source pipelines that forward into the existing shared `logs/opentelemetry` export pipeline. That shared pipeline already has the correct batch with `metadata_keys` which fixes the bugs and CI logs reach CloudWatch now.

### Changes:

  - filelog_app.yaml / filelog_node.yaml: CI log pipelines now export to forward/opentelemetry; removed the CI-specific sigv4auth, headers_setter, `awscloudwatchlogsprovisioner`, otlphttp/*_logs_dest, batch, and `attributestocontext`.
  - Activate the shared logs/opentelemetry pipeline for CI via baseLogsTranslator which depends on `containerinsights.HasLogPipelines`
  - Golden yaml coverage: split sample into `container_insights_node_config` (role node, logs on) and `container_insights_cluster_config` (role cluster) and regenerate expected YAMLs.

### License

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Tests

  - CWAgent translator yaml now shows CI logs forwarding into the shared logs/opentelemetry pipeline.
  - EKS (cwagent-sandbox): CI metrics + app logs flow through the shared pipeline; `/aws/otel/containerinsights/mcommey-otelci-shared/application` created, 
  - CloudWatch console / query studio: metrics visible via @resource.k8s.cluster.name.
  
<img width="2022" height="825" alt="Screenshot 2026-07-31 at 13 07 55" src="https://github.com/user-attachments/assets/e12251d6-2219-479a-97e0-e7f4391119b0" />
<img width="1989" height="701" alt="Screenshot 2026-07-31 at 13 07 17" src="https://github.com/user-attachments/assets/203e592e-1b3a-4a70-b821-45971e038ffb" />
