### PR TITLE
Implement TestParse_Fields in statsd plugin

### DIFF
--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -651,8 +651,41 @@ func TestParse_TemplateFields(t *testing.T) {
 
 // Test that fields are parsed correctly
 func TestParse_Fields(t *testing.T) {
-	if false {
-		t.Errorf("TODO")
+	tests := []struct {
+		name      string
+		templates []string
+		bucket    string
+		field     string
+	}{
+		{
+			name:      "no template defaults to value",
+			templates: nil,
+			bucket:    "cpu.idle",
+			field:     "value",
+		},
+		{
+			name:      "template with field segment",
+			templates: []string{"measurement.field"},
+			bucket:    "cpu.idle",
+			field:     "idle",
+		},
+		{
+			name:      "template with multiple measurement and field",
+			templates: []string{"measurement.measurement.field"},
+			bucket:    "my.counter.f1",
+			field:     "f1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := NewTestStatsd()
+			s.Templates = test.templates
+			_, field, _ := s.parseName(test.bucket)
+			if field != test.field {
+				t.Errorf("Expected field %q, got %q", test.field, field)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
TestParse_Fields was a stub (if false { t.Errorf(TODO) }) that never ran. This implements it with 3 table-driven subtests covering the field return value of parseName():

1. No template: field defaults to value
2. Simple measurement.field template: field extracted from bucket
3. Multi-segment measurement.measurement.field template: field parsed correctly

All 3 subtests pass locally.