### PR TITLE
fix(ecsutil): guard parseRegion against invalid TaskARN

### DIFF
--- a/translator/util/ecsutil/ecsutil.go
+++ b/translator/util/ecsutil/ecsutil.go
@@ -104,6 +104,7 @@ func (e *ecsUtil) parseRegion(em *ecsMetadataResponse) {
 	// When splitting the ARN with ":", the 4th segment is the region
 	if len(splitedContent) < 4 {
 		log.Printf("E! Invalid ecs task arn: %s", em.TaskARN)
+		return
 	}
 	e.Region = splitedContent[3]
 }

--- a/translator/util/ecsutil/ecsutil.go
+++ b/translator/util/ecsutil/ecsutil.go
@@ -112,10 +112,10 @@ func (e *ecsUtil) parseRegion(em *ecsMetadataResponse) {
 // There is only one format for ClusterArn (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Cluster.html)
 // arn:aws:ecs:region:aws_account_id:cluster/cluster-name
 func (e *ecsUtil) parseClusterName(em *ecsMetadataResponse) {
-	splitedContent := strings.Split(em.Cluster, "/")
-	// When splitting the ClusterName with /, the last is always the cluster name
-	if len(splitedContent) == 0 {
-		log.Printf("E! Invalid cluster arn: %s", em.Cluster)
+	if em.Cluster == "" {
+		log.Printf("E! Invalid ecs cluster name: %s", em.Cluster)
+		return
 	}
+	splitedContent := strings.Split(em.Cluster, "/")
 	e.Cluster = splitedContent[len(splitedContent)-1]
 }

--- a/translator/util/ecsutil/ecsutil_test.go
+++ b/translator/util/ecsutil/ecsutil_test.go
@@ -10,31 +10,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseRegion_ValidARN_ShortFormat(t *testing.T) {
-	e := &ecsUtil{}
-	em := &ecsMetadataResponse{TaskARN: "arn:aws:ecs:us-east-1:123456789012:task/abc123"}
-	e.parseRegion(em)
-	assert.Equal(t, "us-east-1", e.Region)
-}
+func TestParseRegion(t *testing.T) {
+	cases := []struct {
+		name       string
+		taskARN    string
+		wantRegion string
+	}{
+		{
+			name:       "valid short-format ARN",
+			taskARN:    "arn:aws:ecs:us-east-1:123456789012:task/abc123",
+			wantRegion: "us-east-1",
+		},
+		{
+			name:       "valid long-format ARN with cluster name",
+			taskARN:    "arn:aws:ecs:eu-west-2:123456789012:task/my-cluster/abc123",
+			wantRegion: "eu-west-2",
+		},
+		{
+			name:       "exactly 4 segments - boundary passing case",
+			taskARN:    "arn:aws:ecs:us-east-1",
+			wantRegion: "us-east-1",
+		},
+		{
+			name:       "exactly 3 segments - boundary failing case",
+			taskARN:    "arn:aws:ecs",
+			wantRegion: "",
+		},
+		{
+			name:       "single token - too few segments",
+			taskARN:    "not-an-arn",
+			wantRegion: "",
+		},
+		{
+			name:       "empty string",
+			taskARN:    "",
+			wantRegion: "",
+		},
+		{
+			name:       "4 segments with empty region field - structurally valid but missing region",
+			taskARN:    "arn:aws:ecs::123456789012:task/abc",
+			wantRegion: "",
+		},
+	}
 
-func TestParseRegion_ValidARN_LongFormat(t *testing.T) {
-	// Long-form ARN includes the cluster name segment before the task id.
-	e := &ecsUtil{}
-	em := &ecsMetadataResponse{TaskARN: "arn:aws:ecs:eu-west-2:123456789012:task/my-cluster/abc123"}
-	e.parseRegion(em)
-	assert.Equal(t, "eu-west-2", e.Region)
-}
-
-func TestParseRegion_InvalidARN_TooFewSegments(t *testing.T) {
-	e := &ecsUtil{}
-	em := &ecsMetadataResponse{TaskARN: "not-an-arn"}
-	require.NotPanics(t, func() { e.parseRegion(em) })
-	assert.Equal(t, "", e.Region)
-}
-
-func TestParseRegion_InvalidARN_Empty(t *testing.T) {
-	e := &ecsUtil{}
-	em := &ecsMetadataResponse{TaskARN: ""}
-	require.NotPanics(t, func() { e.parseRegion(em) })
-	assert.Equal(t, "", e.Region)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &ecsUtil{}
+			em := &ecsMetadataResponse{TaskARN: tc.taskARN}
+			require.NotPanics(t, func() { e.parseRegion(em) })
+			assert.Equal(t, tc.wantRegion, e.Region)
+		})
+	}
 }

--- a/translator/util/ecsutil/ecsutil_test.go
+++ b/translator/util/ecsutil/ecsutil_test.go
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package ecsutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRegion_ValidARN_ShortFormat(t *testing.T) {
+	e := &ecsUtil{}
+	em := &ecsMetadataResponse{TaskARN: "arn:aws:ecs:us-east-1:123456789012:task/abc123"}
+	e.parseRegion(em)
+	assert.Equal(t, "us-east-1", e.Region)
+}
+
+func TestParseRegion_ValidARN_LongFormat(t *testing.T) {
+	// Long-form ARN includes the cluster name segment before the task id.
+	e := &ecsUtil{}
+	em := &ecsMetadataResponse{TaskARN: "arn:aws:ecs:eu-west-2:123456789012:task/my-cluster/abc123"}
+	e.parseRegion(em)
+	assert.Equal(t, "eu-west-2", e.Region)
+}
+
+func TestParseRegion_InvalidARN_TooFewSegments(t *testing.T) {
+	e := &ecsUtil{}
+	em := &ecsMetadataResponse{TaskARN: "not-an-arn"}
+	require.NotPanics(t, func() { e.parseRegion(em) })
+	assert.Equal(t, "", e.Region)
+}
+
+func TestParseRegion_InvalidARN_Empty(t *testing.T) {
+	e := &ecsUtil{}
+	em := &ecsMetadataResponse{TaskARN: ""}
+	require.NotPanics(t, func() { e.parseRegion(em) })
+	assert.Equal(t, "", e.Region)
+}


### PR DESCRIPTION
# Description of the issue
parseRegion in translator/util/ecsutil panics with an index out of range when the ECS metadata endpoint returns a TaskARN with fewer than 4 colon-separated segments.

# Description of changes
* parseRegion: return after logging when the split TaskARN has fewer than 4 colon-separated segments
* Add ecsutil_test.go covering valid and invalid TaskARN inputs for parseRegion

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
* Added unit tests in ecsutil_test.go
* `go test ./translator/util/ecsutil/` passes locally

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.
