### PR TITLE
feat(dbi): split postgresql per-resource metrics to a dedicated 60s receiver

### DIFF
--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1836,6 +1836,11 @@
                       "username": { "type": "string" },
                       "password_file": { "type": "string" },
                       "ca_file": { "type": "string" },
+                      "per_resource_collection_interval": {
+                        "description": "How often per-resource (table/index) metrics are collected, in seconds. Defaults to 60 if omitted.",
+                        "type": "integer",
+                        "minimum": 0
+                      },
                       "logs": {
                         "type": "object",
                         "properties": {

--- a/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_ec2_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_ec2_config.yaml
@@ -542,9 +542,9 @@ processors:
         ec2_instance_tag_keys:
             - AutoScalingGroupName
         ec2_metadata_tags:
+            - ImageId
             - InstanceId
             - InstanceType
-            - ImageId
         imds_retries: 1
         middleware: agenthealth/statuscode
         refresh_tags_interval: 0s
@@ -1197,59 +1197,59 @@ receivers:
         initial_delay: 1s
         metrics:
             postgresql.backends:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.buffers.allocated:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.buffers.writes:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.checkpoint.count:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.duration:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.maxwritten:
-                enabled: true
+                enabled: false
             postgresql.blks_hit:
                 enabled: false
             postgresql.blks_read:
                 enabled: false
             postgresql.blocks_read:
-                enabled: true
+                enabled: false
             postgresql.commits:
-                enabled: true
+                enabled: false
             postgresql.connection.max:
-                enabled: true
+                enabled: false
             postgresql.database.count:
-                enabled: true
+                enabled: false
             postgresql.database.locks:
                 enabled: false
             postgresql.db_size:
-                enabled: true
+                enabled: false
             postgresql.deadlocks:
                 enabled: false
             postgresql.function.calls:
                 enabled: false
             postgresql.index.scans:
-                enabled: true
+                enabled: false
             postgresql.index.size:
-                enabled: true
+                enabled: false
             postgresql.operations:
-                enabled: true
+                enabled: false
             postgresql.replication.data_delay:
-                enabled: true
+                enabled: false
             postgresql.rollbacks:
-                enabled: true
+                enabled: false
             postgresql.rows:
-                enabled: true
+                enabled: false
             postgresql.sequential_scans:
                 enabled: false
             postgresql.sessions:
                 enabled: false
             postgresql.table.count:
-                enabled: true
+                enabled: false
             postgresql.table.size:
-                enabled: true
+                enabled: false
             postgresql.table.vacuum.count:
-                enabled: true
+                enabled: false
             postgresql.temp.io:
                 enabled: false
             postgresql.temp_files:
@@ -1265,11 +1265,11 @@ receivers:
             postgresql.tup_updated:
                 enabled: false
             postgresql.wal.age:
-                enabled: true
+                enabled: false
             postgresql.wal.delay:
                 enabled: false
             postgresql.wal.lag:
-                enabled: true
+                enabled: false
         passfile: sampleConfig/opentelemetry/testdata/.pgpass
         query_sample_collection:
             collection_interval: 1m0s
@@ -1326,7 +1326,7 @@ receivers:
             postgresql.blks_read:
                 enabled: false
             postgresql.blocks_read:
-                enabled: true
+                enabled: false
             postgresql.commits:
                 enabled: true
             postgresql.connection.max:
@@ -1342,17 +1342,17 @@ receivers:
             postgresql.function.calls:
                 enabled: false
             postgresql.index.scans:
-                enabled: true
+                enabled: false
             postgresql.index.size:
-                enabled: true
+                enabled: false
             postgresql.operations:
-                enabled: true
+                enabled: false
             postgresql.replication.data_delay:
                 enabled: true
             postgresql.rollbacks:
                 enabled: true
             postgresql.rows:
-                enabled: true
+                enabled: false
             postgresql.sequential_scans:
                 enabled: false
             postgresql.sessions:
@@ -1360,9 +1360,9 @@ receivers:
             postgresql.table.count:
                 enabled: true
             postgresql.table.size:
-                enabled: true
+                enabled: false
             postgresql.table.vacuum.count:
-                enabled: true
+                enabled: false
             postgresql.temp.io:
                 enabled: false
             postgresql.temp_files:
@@ -1383,6 +1383,119 @@ receivers:
                 enabled: false
             postgresql.wal.lag:
                 enabled: true
+        passfile: sampleConfig/opentelemetry/testdata/.pgpass
+        query_sample_collection:
+            collection_interval: 1s
+            enabled: true
+            max_rows_per_query: 500
+        resource_attributes:
+            postgresql.database.name:
+                enabled: true
+            postgresql.index.name:
+                enabled: true
+            postgresql.schema.name:
+                enabled: true
+            postgresql.table.name:
+                enabled: true
+            service.instance.id:
+                enabled: true
+        timeout: 0s
+        tls:
+            insecure: true
+            insecure_skip_verify: true
+        top_query_collection:
+            collection_interval: 1m0s
+            max_explain_each_interval: 1000
+            max_rows_per_query: 5000
+            query_plan_cache_size: 1000
+            query_plan_cache_ttl: 1h0m0s
+            top_n_query: 200
+        transport: tcp
+        username: cw_monitor
+    postgresql/metrics_perresource_0:
+        collection_interval: 1m0s
+        endpoint: localhost:5432
+        events:
+            db.server.query_sample:
+                enabled: false
+            db.server.top_query:
+                enabled: false
+        initial_delay: 1s
+        metrics:
+            postgresql.backends:
+                enabled: false
+            postgresql.bgwriter.buffers.allocated:
+                enabled: false
+            postgresql.bgwriter.buffers.writes:
+                enabled: false
+            postgresql.bgwriter.checkpoint.count:
+                enabled: false
+            postgresql.bgwriter.duration:
+                enabled: false
+            postgresql.bgwriter.maxwritten:
+                enabled: false
+            postgresql.blks_hit:
+                enabled: false
+            postgresql.blks_read:
+                enabled: false
+            postgresql.blocks_read:
+                enabled: true
+            postgresql.commits:
+                enabled: false
+            postgresql.connection.max:
+                enabled: false
+            postgresql.database.count:
+                enabled: false
+            postgresql.database.locks:
+                enabled: false
+            postgresql.db_size:
+                enabled: false
+            postgresql.deadlocks:
+                enabled: false
+            postgresql.function.calls:
+                enabled: false
+            postgresql.index.scans:
+                enabled: true
+            postgresql.index.size:
+                enabled: true
+            postgresql.operations:
+                enabled: true
+            postgresql.replication.data_delay:
+                enabled: false
+            postgresql.rollbacks:
+                enabled: false
+            postgresql.rows:
+                enabled: true
+            postgresql.sequential_scans:
+                enabled: false
+            postgresql.sessions:
+                enabled: false
+            postgresql.table.count:
+                enabled: false
+            postgresql.table.size:
+                enabled: true
+            postgresql.table.vacuum.count:
+                enabled: true
+            postgresql.temp.io:
+                enabled: false
+            postgresql.temp_files:
+                enabled: false
+            postgresql.tup_deleted:
+                enabled: false
+            postgresql.tup_fetched:
+                enabled: false
+            postgresql.tup_inserted:
+                enabled: false
+            postgresql.tup_returned:
+                enabled: false
+            postgresql.tup_updated:
+                enabled: false
+            postgresql.wal.age:
+                enabled: false
+            postgresql.wal.delay:
+                enabled: false
+            postgresql.wal.lag:
+                enabled: false
         passfile: sampleConfig/opentelemetry/testdata/.pgpass
         query_sample_collection:
             collection_interval: 1s
@@ -1606,6 +1719,7 @@ service:
                 - transform/dbi_fix_start_time
             receivers:
                 - postgresql/metrics_0
+                - postgresql/metrics_perresource_0
                 - count/dbi_dbload
                 - signaltometrics/dbi_topsql
         metrics/host:
@@ -1615,13 +1729,13 @@ service:
                 - ec2tagger
                 - awsentity/resource
             receivers:
-                - telegraf_procstat/1917393364
-                - telegraf_disk
                 - telegraf_processes
                 - telegraf_mem
-                - telegraf_swap
-                - telegraf_netstat
                 - telegraf_cpu
+                - telegraf_netstat
+                - telegraf_swap
+                - telegraf_disk
+                - telegraf_procstat/1917393364
         metrics/host_metrics:
             exporters:
                 - forward/opentelemetry
@@ -1636,8 +1750,8 @@ service:
                 - ec2tagger
                 - awsentity/service/telegraf
             receivers:
-                - telegraf_socket_listener
                 - telegraf_statsd
+                - telegraf_socket_listener
         metrics/hostDeltaMetrics:
             exporters:
                 - awscloudwatch
@@ -1646,8 +1760,8 @@ service:
                 - ec2tagger
                 - awsentity/resource
             receivers:
-                - telegraf_net
                 - telegraf_diskio
+                - telegraf_net
         metrics/opentelemetry:
             exporters:
                 - otlphttp/metrics

--- a/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_eks_config.yaml
@@ -1777,59 +1777,59 @@ receivers:
         initial_delay: 1s
         metrics:
             postgresql.backends:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.buffers.allocated:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.buffers.writes:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.checkpoint.count:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.duration:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.maxwritten:
-                enabled: true
+                enabled: false
             postgresql.blks_hit:
                 enabled: false
             postgresql.blks_read:
                 enabled: false
             postgresql.blocks_read:
-                enabled: true
+                enabled: false
             postgresql.commits:
-                enabled: true
+                enabled: false
             postgresql.connection.max:
-                enabled: true
+                enabled: false
             postgresql.database.count:
-                enabled: true
+                enabled: false
             postgresql.database.locks:
                 enabled: false
             postgresql.db_size:
-                enabled: true
+                enabled: false
             postgresql.deadlocks:
                 enabled: false
             postgresql.function.calls:
                 enabled: false
             postgresql.index.scans:
-                enabled: true
+                enabled: false
             postgresql.index.size:
-                enabled: true
+                enabled: false
             postgresql.operations:
-                enabled: true
+                enabled: false
             postgresql.replication.data_delay:
-                enabled: true
+                enabled: false
             postgresql.rollbacks:
-                enabled: true
+                enabled: false
             postgresql.rows:
-                enabled: true
+                enabled: false
             postgresql.sequential_scans:
                 enabled: false
             postgresql.sessions:
                 enabled: false
             postgresql.table.count:
-                enabled: true
+                enabled: false
             postgresql.table.size:
-                enabled: true
+                enabled: false
             postgresql.table.vacuum.count:
-                enabled: true
+                enabled: false
             postgresql.temp.io:
                 enabled: false
             postgresql.temp_files:
@@ -1845,11 +1845,11 @@ receivers:
             postgresql.tup_updated:
                 enabled: false
             postgresql.wal.age:
-                enabled: true
+                enabled: false
             postgresql.wal.delay:
                 enabled: false
             postgresql.wal.lag:
-                enabled: true
+                enabled: false
         passfile: sampleConfig/opentelemetry/testdata/.pgpass
         query_sample_collection:
             collection_interval: 1m0s
@@ -1906,7 +1906,7 @@ receivers:
             postgresql.blks_read:
                 enabled: false
             postgresql.blocks_read:
-                enabled: true
+                enabled: false
             postgresql.commits:
                 enabled: true
             postgresql.connection.max:
@@ -1922,17 +1922,17 @@ receivers:
             postgresql.function.calls:
                 enabled: false
             postgresql.index.scans:
-                enabled: true
+                enabled: false
             postgresql.index.size:
-                enabled: true
+                enabled: false
             postgresql.operations:
-                enabled: true
+                enabled: false
             postgresql.replication.data_delay:
                 enabled: true
             postgresql.rollbacks:
                 enabled: true
             postgresql.rows:
-                enabled: true
+                enabled: false
             postgresql.sequential_scans:
                 enabled: false
             postgresql.sessions:
@@ -1940,9 +1940,9 @@ receivers:
             postgresql.table.count:
                 enabled: true
             postgresql.table.size:
-                enabled: true
+                enabled: false
             postgresql.table.vacuum.count:
-                enabled: true
+                enabled: false
             postgresql.temp.io:
                 enabled: false
             postgresql.temp_files:
@@ -1963,6 +1963,119 @@ receivers:
                 enabled: false
             postgresql.wal.lag:
                 enabled: true
+        passfile: sampleConfig/opentelemetry/testdata/.pgpass
+        query_sample_collection:
+            collection_interval: 1s
+            enabled: true
+            max_rows_per_query: 500
+        resource_attributes:
+            postgresql.database.name:
+                enabled: true
+            postgresql.index.name:
+                enabled: true
+            postgresql.schema.name:
+                enabled: true
+            postgresql.table.name:
+                enabled: true
+            service.instance.id:
+                enabled: true
+        timeout: 0s
+        tls:
+            insecure: true
+            insecure_skip_verify: true
+        top_query_collection:
+            collection_interval: 1m0s
+            max_explain_each_interval: 1000
+            max_rows_per_query: 5000
+            query_plan_cache_size: 1000
+            query_plan_cache_ttl: 1h0m0s
+            top_n_query: 200
+        transport: tcp
+        username: cw_monitor
+    postgresql/metrics_perresource_0:
+        collection_interval: 1m0s
+        endpoint: localhost:5432
+        events:
+            db.server.query_sample:
+                enabled: false
+            db.server.top_query:
+                enabled: false
+        initial_delay: 1s
+        metrics:
+            postgresql.backends:
+                enabled: false
+            postgresql.bgwriter.buffers.allocated:
+                enabled: false
+            postgresql.bgwriter.buffers.writes:
+                enabled: false
+            postgresql.bgwriter.checkpoint.count:
+                enabled: false
+            postgresql.bgwriter.duration:
+                enabled: false
+            postgresql.bgwriter.maxwritten:
+                enabled: false
+            postgresql.blks_hit:
+                enabled: false
+            postgresql.blks_read:
+                enabled: false
+            postgresql.blocks_read:
+                enabled: true
+            postgresql.commits:
+                enabled: false
+            postgresql.connection.max:
+                enabled: false
+            postgresql.database.count:
+                enabled: false
+            postgresql.database.locks:
+                enabled: false
+            postgresql.db_size:
+                enabled: false
+            postgresql.deadlocks:
+                enabled: false
+            postgresql.function.calls:
+                enabled: false
+            postgresql.index.scans:
+                enabled: true
+            postgresql.index.size:
+                enabled: true
+            postgresql.operations:
+                enabled: true
+            postgresql.replication.data_delay:
+                enabled: false
+            postgresql.rollbacks:
+                enabled: false
+            postgresql.rows:
+                enabled: true
+            postgresql.sequential_scans:
+                enabled: false
+            postgresql.sessions:
+                enabled: false
+            postgresql.table.count:
+                enabled: false
+            postgresql.table.size:
+                enabled: true
+            postgresql.table.vacuum.count:
+                enabled: true
+            postgresql.temp.io:
+                enabled: false
+            postgresql.temp_files:
+                enabled: false
+            postgresql.tup_deleted:
+                enabled: false
+            postgresql.tup_fetched:
+                enabled: false
+            postgresql.tup_inserted:
+                enabled: false
+            postgresql.tup_returned:
+                enabled: false
+            postgresql.tup_updated:
+                enabled: false
+            postgresql.wal.age:
+                enabled: false
+            postgresql.wal.delay:
+                enabled: false
+            postgresql.wal.lag:
+                enabled: false
         passfile: sampleConfig/opentelemetry/testdata/.pgpass
         query_sample_collection:
             collection_interval: 1s
@@ -2471,6 +2584,7 @@ service:
                 - transform/dbi_fix_start_time
             receivers:
                 - postgresql/metrics_0
+                - postgresql/metrics_perresource_0
                 - count/dbi_dbload
                 - signaltometrics/dbi_topsql
         metrics/host:
@@ -2481,12 +2595,12 @@ service:
                 - awsentity/resource
             receivers:
                 - telegraf_netstat
+                - telegraf_cpu
+                - telegraf_processes
                 - telegraf_swap
+                - telegraf_mem
                 - telegraf_procstat/1917393364
                 - telegraf_disk
-                - telegraf_mem
-                - telegraf_processes
-                - telegraf_cpu
         metrics/host_metrics:
             exporters:
                 - forward/opentelemetry

--- a/translator/tocwconfig/sampleConfig/opentelemetry/dbi_config_linux.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/dbi_config_linux.yaml
@@ -884,59 +884,59 @@ receivers:
         initial_delay: 1s
         metrics:
             postgresql.backends:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.buffers.allocated:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.buffers.writes:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.checkpoint.count:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.duration:
-                enabled: true
+                enabled: false
             postgresql.bgwriter.maxwritten:
-                enabled: true
+                enabled: false
             postgresql.blks_hit:
                 enabled: false
             postgresql.blks_read:
                 enabled: false
             postgresql.blocks_read:
-                enabled: true
+                enabled: false
             postgresql.commits:
-                enabled: true
+                enabled: false
             postgresql.connection.max:
-                enabled: true
+                enabled: false
             postgresql.database.count:
-                enabled: true
+                enabled: false
             postgresql.database.locks:
                 enabled: false
             postgresql.db_size:
-                enabled: true
+                enabled: false
             postgresql.deadlocks:
                 enabled: false
             postgresql.function.calls:
                 enabled: false
             postgresql.index.scans:
-                enabled: true
+                enabled: false
             postgresql.index.size:
-                enabled: true
+                enabled: false
             postgresql.operations:
-                enabled: true
+                enabled: false
             postgresql.replication.data_delay:
-                enabled: true
+                enabled: false
             postgresql.rollbacks:
-                enabled: true
+                enabled: false
             postgresql.rows:
-                enabled: true
+                enabled: false
             postgresql.sequential_scans:
                 enabled: false
             postgresql.sessions:
                 enabled: false
             postgresql.table.count:
-                enabled: true
+                enabled: false
             postgresql.table.size:
-                enabled: true
+                enabled: false
             postgresql.table.vacuum.count:
-                enabled: true
+                enabled: false
             postgresql.temp.io:
                 enabled: false
             postgresql.temp_files:
@@ -952,11 +952,11 @@ receivers:
             postgresql.tup_updated:
                 enabled: false
             postgresql.wal.age:
-                enabled: true
+                enabled: false
             postgresql.wal.delay:
                 enabled: false
             postgresql.wal.lag:
-                enabled: true
+                enabled: false
         passfile: sampleConfig/opentelemetry/testdata/.pgpass
         query_sample_collection:
             collection_interval: 1m0s
@@ -1013,7 +1013,7 @@ receivers:
             postgresql.blks_read:
                 enabled: false
             postgresql.blocks_read:
-                enabled: true
+                enabled: false
             postgresql.commits:
                 enabled: true
             postgresql.connection.max:
@@ -1029,17 +1029,17 @@ receivers:
             postgresql.function.calls:
                 enabled: false
             postgresql.index.scans:
-                enabled: true
+                enabled: false
             postgresql.index.size:
-                enabled: true
+                enabled: false
             postgresql.operations:
-                enabled: true
+                enabled: false
             postgresql.replication.data_delay:
                 enabled: true
             postgresql.rollbacks:
                 enabled: true
             postgresql.rows:
-                enabled: true
+                enabled: false
             postgresql.sequential_scans:
                 enabled: false
             postgresql.sessions:
@@ -1047,9 +1047,9 @@ receivers:
             postgresql.table.count:
                 enabled: true
             postgresql.table.size:
-                enabled: true
+                enabled: false
             postgresql.table.vacuum.count:
-                enabled: true
+                enabled: false
             postgresql.temp.io:
                 enabled: false
             postgresql.temp_files:
@@ -1070,6 +1070,119 @@ receivers:
                 enabled: false
             postgresql.wal.lag:
                 enabled: true
+        passfile: sampleConfig/opentelemetry/testdata/.pgpass
+        query_sample_collection:
+            collection_interval: 1s
+            enabled: true
+            max_rows_per_query: 500
+        resource_attributes:
+            postgresql.database.name:
+                enabled: true
+            postgresql.index.name:
+                enabled: true
+            postgresql.schema.name:
+                enabled: true
+            postgresql.table.name:
+                enabled: true
+            service.instance.id:
+                enabled: true
+        timeout: 0s
+        tls:
+            insecure: true
+            insecure_skip_verify: true
+        top_query_collection:
+            collection_interval: 1m0s
+            max_explain_each_interval: 1000
+            max_rows_per_query: 5000
+            query_plan_cache_size: 1000
+            query_plan_cache_ttl: 1h0m0s
+            top_n_query: 200
+        transport: tcp
+        username: cw_monitor
+    postgresql/metrics_perresource_0:
+        collection_interval: 1m0s
+        endpoint: localhost:5432
+        events:
+            db.server.query_sample:
+                enabled: false
+            db.server.top_query:
+                enabled: false
+        initial_delay: 1s
+        metrics:
+            postgresql.backends:
+                enabled: false
+            postgresql.bgwriter.buffers.allocated:
+                enabled: false
+            postgresql.bgwriter.buffers.writes:
+                enabled: false
+            postgresql.bgwriter.checkpoint.count:
+                enabled: false
+            postgresql.bgwriter.duration:
+                enabled: false
+            postgresql.bgwriter.maxwritten:
+                enabled: false
+            postgresql.blks_hit:
+                enabled: false
+            postgresql.blks_read:
+                enabled: false
+            postgresql.blocks_read:
+                enabled: true
+            postgresql.commits:
+                enabled: false
+            postgresql.connection.max:
+                enabled: false
+            postgresql.database.count:
+                enabled: false
+            postgresql.database.locks:
+                enabled: false
+            postgresql.db_size:
+                enabled: false
+            postgresql.deadlocks:
+                enabled: false
+            postgresql.function.calls:
+                enabled: false
+            postgresql.index.scans:
+                enabled: true
+            postgresql.index.size:
+                enabled: true
+            postgresql.operations:
+                enabled: true
+            postgresql.replication.data_delay:
+                enabled: false
+            postgresql.rollbacks:
+                enabled: false
+            postgresql.rows:
+                enabled: true
+            postgresql.sequential_scans:
+                enabled: false
+            postgresql.sessions:
+                enabled: false
+            postgresql.table.count:
+                enabled: false
+            postgresql.table.size:
+                enabled: true
+            postgresql.table.vacuum.count:
+                enabled: true
+            postgresql.temp.io:
+                enabled: false
+            postgresql.temp_files:
+                enabled: false
+            postgresql.tup_deleted:
+                enabled: false
+            postgresql.tup_fetched:
+                enabled: false
+            postgresql.tup_inserted:
+                enabled: false
+            postgresql.tup_returned:
+                enabled: false
+            postgresql.tup_updated:
+                enabled: false
+            postgresql.wal.age:
+                enabled: false
+            postgresql.wal.delay:
+                enabled: false
+            postgresql.wal.lag:
+                enabled: false
         passfile: sampleConfig/opentelemetry/testdata/.pgpass
         query_sample_collection:
             collection_interval: 1s
@@ -1159,6 +1272,7 @@ service:
                 - transform/dbi_fix_start_time
             receivers:
                 - postgresql/metrics_0
+                - postgresql/metrics_perresource_0
                 - count/dbi_dbload
                 - signaltometrics/dbi_topsql
         metrics/host_metrics:

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator.go
@@ -108,8 +108,22 @@ func (t *dbiTranslator) translateMetrics() (*common.ComponentTranslators, error)
 	countConn := count.NewTranslator(common.DbiConnectorDbload)
 	s2mConn := signaltometrics.NewTranslator(common.DbiConnectorTopsql)
 
+	// Split postgresql metric collection into two receiver instances so per-resource
+	// (table/index) metrics are scraped at a configurable interval (default 60s) while
+	// server metrics stay at the default 10s. This caps per-resource ingestion volume
+	// for DBI GA pricing. The per-resource interval can be overridden via
+	// per_resource_collection_interval in the agent JSON config. The server instance
+	// keeps the events (query-sample / top-query) that feed DBLoad and TopSQL; the
+	// per-resource instance disables events so those are not double-counted.
+	serverRx := t.pgReceiver("metrics", postgresql.WithServerMetricsOnly())
+	perResourceRx := t.pgReceiver("metrics_perresource",
+		postgresql.WithPerResourceMetricsOnly(),
+		postgresql.WithCollectionInterval(t.cfg.perResourceCollectionInterval),
+		postgresql.WithEventsDisabled(),
+	)
+
 	return &common.ComponentTranslators{
-		Receivers: common.NewTranslatorMap[component.Config, component.ID](t.pgReceiver("metrics"), countConn, s2mConn),
+		Receivers: common.NewTranslatorMap[component.Config, component.ID](serverRx, perResourceRx, countConn, s2mConn),
 		Processors: common.NewTranslatorMap[component.Config, component.ID](
 			t.scopeTransform(),
 			transformprocessor.NewTranslatorWithName(common.DbiTransformResource+"_"+idx, transformprocessor.WithMetricResourceStatements(t.resourceStatements())),
@@ -125,7 +139,7 @@ func (t *dbiTranslator) translateLogToMetrics() (*common.ComponentTranslators, e
 	s2mConn := signaltometrics.NewTranslator(common.DbiConnectorTopsql)
 
 	return &common.ComponentTranslators{
-		Receivers:  common.NewTranslatorMap[component.Config, component.ID](t.pgReceiver("metrics")),
+		Receivers:  common.NewTranslatorMap[component.Config, component.ID](t.pgReceiver("metrics", postgresql.WithServerMetricsOnly())),
 		Processors: common.NewTranslatorMap[component.Config, component.ID](t.excludeMonitorFilter()),
 		Exporters:  common.NewTranslatorMap[component.Config, component.ID](countConn, s2mConn),
 		Extensions: common.NewTranslatorMap[component.Config, component.ID](),
@@ -138,7 +152,13 @@ func (t *dbiTranslator) translateRawEvents() (*common.ComponentTranslators, erro
 	fwd := forward.NewTranslator(common.OpenTelemetryKey)
 
 	return &common.ComponentTranslators{
-		Receivers: common.NewTranslatorMap[component.Config, component.ID](t.pgReceiver("events", postgresql.WithQuerySampleInterval(60*time.Second))),
+		// The events receiver feeds a logs pipeline only, so no metrics pipeline consumes
+		// it. Disable its metrics so the generated config reflects that instead of
+		// listing metrics that are never collected.
+		Receivers: common.NewTranslatorMap[component.Config, component.ID](t.pgReceiver("events",
+			postgresql.WithQuerySampleInterval(60*time.Second),
+			postgresql.WithMetricsDisabled(),
+		)),
 		Processors: common.NewTranslatorMap[component.Config, component.ID](
 			t.excludeMonitorFilter(),
 			t.scopeTransform(),

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translator_test.go
@@ -55,7 +55,7 @@ func TestDbiTranslate(t *testing.T) {
 		nExp       int
 		nConn      int
 	}{
-		{"metrics", dbiMetrics, "metrics/dbi_postgresql_0", 3, 3, 1, 3},
+		{"metrics", dbiMetrics, "metrics/dbi_postgresql_0", 4, 3, 1, 3},
 		{"log_to_metrics", dbiLogToMetrics, "logs/dbi_postgresql_0", 1, 1, 2, 2},
 		{"raw_events", dbiRawEvents, "logs/dbi_postgresql_rawevents_0", 1, 5, 1, 1},
 		{"server_logs", dbiServerLogs, "logs/dbi_postgresql_serverlogs_0", 1, 5, 1, 1},
@@ -99,7 +99,7 @@ func TestDbiTranslateMetrics_ComponentIDs(t *testing.T) {
 		connectors = append(connectors, c.ID().String())
 	})
 
-	assert.ElementsMatch(t, []string{"postgresql/metrics_0", "count/dbi_dbload", "signaltometrics/dbi_topsql"}, receivers)
+	assert.ElementsMatch(t, []string{"postgresql/metrics_0", "postgresql/metrics_perresource_0", "count/dbi_dbload", "signaltometrics/dbi_topsql"}, receivers)
 	assert.Equal(t, []string{"transform/dbi_scope", "transform/dbi_resource_0", "transform/dbi_fix_start_time"}, processors)
 	assert.ElementsMatch(t, []string{"forward/opentelemetry"}, exporters)
 	assert.ElementsMatch(t, []string{"forward/opentelemetry", "count/dbi_dbload", "signaltometrics/dbi_topsql"}, connectors)

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"go.opentelemetry.io/collector/confmap"
@@ -20,13 +21,14 @@ import (
 var ottlSafeRegex = regexp.MustCompile(`^[a-zA-Z0-9._@/:\-]+$`)
 
 type dbiInstanceConfig struct {
-	endpoint     string
-	username     string
-	passfile     string
-	caFile       string
-	instanceName string
-	logFilePath  string
-	isLocalhost  bool
+	endpoint                      string
+	username                      string
+	passfile                      string
+	caFile                        string
+	instanceName                  string
+	logFilePath                   string
+	isLocalhost                   bool
+	perResourceCollectionInterval time.Duration
 }
 
 func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
@@ -48,12 +50,13 @@ func NewTranslators(conf *confmap.Conf) common.PipelineTranslatorMap {
 }
 
 type pgRawInstance struct {
-	Endpoint     string `mapstructure:"endpoint"`
-	Username     string `mapstructure:"username"`
-	PasswordFile string `mapstructure:"password_file"`
-	CAFile       string `mapstructure:"ca_file"`
-	InstanceName string `mapstructure:"instance_name"`
-	Logs         struct {
+	Endpoint                      string `mapstructure:"endpoint"`
+	Username                      string `mapstructure:"username"`
+	PasswordFile                  string `mapstructure:"password_file"`
+	CAFile                        string `mapstructure:"ca_file"`
+	InstanceName                  string `mapstructure:"instance_name"`
+	PerResourceCollectionInterval int    `mapstructure:"per_resource_collection_interval"`
+	Logs                          struct {
 		FilePath string `mapstructure:"file_path"`
 	} `mapstructure:"logs"`
 }
@@ -66,14 +69,19 @@ func parseDbiPostgresqlInstances(conf *confmap.Conf) []dbiInstanceConfig {
 	}
 	instances := make([]dbiInstanceConfig, 0, len(raw))
 	for _, r := range raw {
+		perResourceInterval := 60 * time.Second
+		if r.PerResourceCollectionInterval > 0 {
+			perResourceInterval = time.Duration(r.PerResourceCollectionInterval) * time.Second
+		}
 		instances = append(instances, dbiInstanceConfig{
-			endpoint:     r.Endpoint,
-			username:     r.Username,
-			passfile:     r.PasswordFile,
-			caFile:       r.CAFile,
-			instanceName: r.InstanceName,
-			logFilePath:  r.Logs.FilePath,
-			isLocalhost:  isLocalhostEndpoint(r.Endpoint),
+			endpoint:                      r.Endpoint,
+			username:                      r.Username,
+			passfile:                      r.PasswordFile,
+			caFile:                        r.CAFile,
+			instanceName:                  r.InstanceName,
+			logFilePath:                   r.Logs.FilePath,
+			isLocalhost:                   isLocalhostEndpoint(r.Endpoint),
+			perResourceCollectionInterval: perResourceInterval,
 		})
 	}
 	return instances

--- a/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/databaseinsights/translators_test.go
@@ -5,8 +5,10 @@ package databaseinsights
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -111,4 +113,53 @@ func TestIsLocalhostEndpoint(t *testing.T) {
 	assert.True(t, isLocalhostEndpoint("[::1]:5432"))
 	assert.False(t, isLocalhostEndpoint("db.example.com:5432"))
 	assert.False(t, isLocalhostEndpoint(""))
+}
+
+func TestParseDbiPostgresqlInstances_PerResourceCollectionInterval(t *testing.T) {
+	tests := []struct {
+		name             string
+		intervalValue    interface{} // nil means field absent
+		expectedInterval time.Duration
+	}{
+		{
+			name:             "default when omitted",
+			intervalValue:    nil,
+			expectedInterval: 60 * time.Second,
+		},
+		{
+			name:             "custom value",
+			intervalValue:    120,
+			expectedInterval: 120 * time.Second,
+		},
+		{
+			name:             "zero falls back to default",
+			intervalValue:    0,
+			expectedInterval: 60 * time.Second,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := map[string]interface{}{ //nolint:gosec // test fixture path, not a real credential
+				"endpoint":      "localhost:5432",
+				"username":      "cw_monitor",
+				"password_file": "/etc/.pgpass",
+				"instance_name": "test-db",
+			}
+			if tc.intervalValue != nil {
+				instance["per_resource_collection_interval"] = tc.intervalValue
+			}
+			cfg := confmap.NewFromStringMap(map[string]interface{}{
+				"opentelemetry": map[string]interface{}{
+					"collect": map[string]interface{}{
+						"database_insights": map[string]interface{}{
+							"postgresql": []interface{}{instance},
+						},
+					},
+				},
+			})
+			instances := parseDbiPostgresqlInstances(cfg)
+			require.Len(t, instances, 1)
+			assert.Equal(t, tc.expectedInterval, instances[0].perResourceCollectionInterval)
+		})
+	}
 }

--- a/translator/translate/otel/receiver/postgresql/translator.go
+++ b/translator/translate/otel/receiver/postgresql/translator.go
@@ -4,6 +4,7 @@
 package postgresql
 
 import (
+	"reflect"
 	"strconv"
 	"time"
 
@@ -13,6 +14,28 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+// metricScope selects which subset of postgresql metrics a receiver instance emits.
+// It exists so DBI can run two postgresql receiver instances against the same database:
+// a server-metrics instance at the default (10s) interval and a per-resource
+// (table/index) instance at a slower (60s) interval, to cap per-resource ingestion
+// volume without slowing the server metrics.
+type metricScope int
+
+const (
+	// metricScopeAll keeps the receiver's default metric set (current behavior).
+	metricScopeAll metricScope = iota
+	// metricScopeServerOnly disables the per-resource (table/index) metrics, leaving
+	// the server/per-database metrics enabled.
+	metricScopeServerOnly
+	// metricScopePerResourceOnly enables ONLY the per-resource (table/index) metrics
+	// and disables everything else.
+	metricScopePerResourceOnly
+	// metricScopeNone disables every metric. Used by receiver instances that are wired
+	// into a logs pipeline only, so their metrics are never collected and leaving them
+	// enabled would misrepresent what the instance emits.
+	metricScopeNone
 )
 
 type Option func(*translator)
@@ -27,6 +50,9 @@ type translator struct {
 	isLocalhost         bool
 	index               int
 	querySampleInterval time.Duration
+	collectionInterval  time.Duration
+	metricScope         metricScope
+	eventsDisabled      bool
 }
 
 func WithName(name string) Option   { return func(t *translator) { t.name = name } }
@@ -38,6 +64,39 @@ func WithIsLocalhost(b bool) Option { return func(t *translator) { t.isLocalhost
 func WithIndex(i int) Option        { return func(t *translator) { t.index = i } }
 func WithQuerySampleInterval(d time.Duration) Option {
 	return func(t *translator) { t.querySampleInterval = d }
+}
+
+// WithCollectionInterval overrides the receiver's top-level scrape interval. When unset
+// (zero), the receiver inherits the upstream factory default (10s).
+func WithCollectionInterval(d time.Duration) Option {
+	return func(t *translator) { t.collectionInterval = d }
+}
+
+// WithServerMetricsOnly disables the per-resource (table/index) metrics so this
+// instance emits only server/per-database metrics.
+func WithServerMetricsOnly() Option {
+	return func(t *translator) { t.metricScope = metricScopeServerOnly }
+}
+
+// WithPerResourceMetricsOnly enables only the per-resource (table/index) metrics and
+// disables everything else, for the dedicated slower-interval instance.
+func WithPerResourceMetricsOnly() Option {
+	return func(t *translator) { t.metricScope = metricScopePerResourceOnly }
+}
+
+// WithMetricsDisabled disables every metric on this instance. Used for the events
+// receiver, which is wired into a logs pipeline only: no metrics pipeline consumes it,
+// so an enabled metric there is never collected and only misleads anyone reading the
+// generated config.
+func WithMetricsDisabled() Option {
+	return func(t *translator) { t.metricScope = metricScopeNone }
+}
+
+// WithEventsDisabled turns off the query-sample and top-query event streams. Used for
+// the metrics-only per-resource instance so it never duplicates the events (DBLoad /
+// TopSQL) produced by the primary server instance.
+func WithEventsDisabled() Option {
+	return func(t *translator) { t.eventsDisabled = true }
 }
 
 func NewTranslator(opts ...Option) common.ComponentTranslator {
@@ -80,8 +139,47 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	cfg.Metrics.PostgresqlTupUpdated.Enabled = false
 	cfg.Metrics.PostgresqlWalDelay.Enabled = false
 
-	cfg.Events.DbServerQuerySample.Enabled = true
-	cfg.Events.DbServerTopQuery.Enabled = true
+	// Split the metric set when requested so DBI can collect per-resource (table/index)
+	// metrics on a separate, slower receiver instance than the server metrics. Both
+	// modes only ever DISABLE metrics, so the split preserves the exact set of metrics
+	// emitted today (partitioned by cadence) rather than adding or dropping any.
+	switch t.metricScope {
+	case metricScopeAll:
+		// Keep the receiver's default metric set: no split requested.
+	case metricScopeServerOnly:
+		// Move the per-resource (table/index) metrics off to the dedicated instance.
+		forEachMetric(cfg, func(name string, enabled *bool) {
+			if perResourceMetricNames[name] {
+				*enabled = false
+			}
+		})
+	case metricScopePerResourceOnly:
+		// Keep only the per-resource metrics; disable everything else. Per-resource
+		// metrics are left at their existing enabled state, so a metric that was off
+		// (e.g. sequential_scans) is not newly introduced by the split.
+		forEachMetric(cfg, func(name string, enabled *bool) {
+			if !perResourceMetricNames[name] {
+				*enabled = false
+			}
+		})
+	case metricScopeNone:
+		// Logs-only instance: collect no metrics at all.
+		forEachMetric(cfg, func(_ string, enabled *bool) {
+			*enabled = false
+		})
+	}
+
+	if t.eventsDisabled {
+		cfg.Events.DbServerQuerySample.Enabled = false
+		cfg.Events.DbServerTopQuery.Enabled = false
+	} else {
+		cfg.Events.DbServerQuerySample.Enabled = true
+		cfg.Events.DbServerTopQuery.Enabled = true
+	}
+
+	if t.collectionInterval > 0 {
+		cfg.ControllerConfig.CollectionInterval = t.collectionInterval
+	}
 
 	cfg.Enabled = true
 	cfg.QuerySampleCollection.CollectionInterval = t.querySampleInterval
@@ -93,4 +191,35 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	cfg.MaxExplainEachInterval = 1000
 
 	return cfg, nil
+}
+
+// perResourceMetricNames is the set of per-resource (table/index) metrics, keyed by
+// mapstructure name. These are emitted by the receiver's collectTables / collectIndexes
+// with a postgresql.table.name / postgresql.index.name resource attribute.
+// postgresql.table.count is intentionally excluded: it is a per-database server metric
+// recorded alongside the other server metrics.
+var perResourceMetricNames = map[string]bool{
+	"postgresql.rows":               true,
+	"postgresql.operations":         true,
+	"postgresql.table.size":         true,
+	"postgresql.table.vacuum.count": true,
+	"postgresql.sequential_scans":   true,
+	"postgresql.blocks_read":        true,
+	"postgresql.index.scans":        true,
+	"postgresql.index.size":         true,
+}
+
+// forEachMetric invokes fn for every metric in the receiver's MetricsConfig, passing the
+// metric's mapstructure name and a pointer to its Enabled flag. It uses reflection so
+// metrics added upstream in the future are handled without changes here.
+func forEachMetric(cfg *postgresqlreceiver.Config, fn func(name string, enabled *bool)) {
+	v := reflect.ValueOf(&cfg.Metrics).Elem()
+	typ := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		ef := v.Field(i).FieldByName("Enabled")
+		if !ef.IsValid() || ef.Kind() != reflect.Bool || !ef.CanAddr() {
+			continue
+		}
+		fn(typ.Field(i).Tag.Get("mapstructure"), ef.Addr().Interface().(*bool))
+	}
 }

--- a/translator/translate/otel/receiver/postgresql/translator_test.go
+++ b/translator/translate/otel/receiver/postgresql/translator_test.go
@@ -4,6 +4,7 @@
 package postgresql
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -11,6 +12,42 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// perResourceMetricNames (the canonical set) is defined in translator.go and shared by
+// these tests.
+
+func baseOpts(extra ...Option) []Option {
+	return append([]Option{
+		WithEndpoint("localhost:5432"),
+		WithUsername("cw_monitor"),
+		WithPassfile("/etc/.pgpass"),
+		WithIsLocalhost(true),
+		WithIndex(0),
+	}, extra...)
+}
+
+func translateForTest(t *testing.T, opts ...Option) *postgresqlreceiver.Config {
+	t.Helper()
+	cfg, err := NewTranslator(opts...).Translate(nil)
+	require.NoError(t, err)
+	return cfg.(*postgresqlreceiver.Config)
+}
+
+// enabledMetricNames returns the set of metric names (mapstructure tags) whose Enabled
+// flag is true, via reflection over the receiver's MetricsConfig.
+func enabledMetricNames(t *testing.T, cfg *postgresqlreceiver.Config) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	v := reflect.ValueOf(cfg.Metrics)
+	typ := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		ef := v.Field(i).FieldByName("Enabled")
+		if ef.IsValid() && ef.Kind() == reflect.Bool && ef.Bool() {
+			out[typ.Field(i).Tag.Get("mapstructure")] = true
+		}
+	}
+	return out
+}
 
 func TestTranslator_ID(t *testing.T) {
 	tr := NewTranslator(WithName("metrics"), WithIndex(0))
@@ -97,4 +134,99 @@ func TestTranslator_Translate_CustomInterval(t *testing.T) {
 
 	assert.Equal(t, 5*time.Second, pgCfg.QuerySampleCollection.CollectionInterval)
 	assert.Equal(t, int64(500), pgCfg.QuerySampleCollection.MaxRowsPerQuery)
+}
+
+func TestTranslator_Translate_Defaults_MetricScope(t *testing.T) {
+	pgCfg := translateForTest(t, baseOpts()...)
+
+	// Default scope leaves per-resource metrics enabled, events on, and the top-level
+	// scrape interval at the upstream factory default (10s).
+	assert.Equal(t, 10*time.Second, pgCfg.ControllerConfig.CollectionInterval)
+	assert.True(t, pgCfg.Metrics.PostgresqlRows.Enabled)
+	assert.True(t, pgCfg.Metrics.PostgresqlIndexSize.Enabled)
+	assert.True(t, pgCfg.Events.DbServerQuerySample.Enabled)
+	assert.True(t, pgCfg.Events.DbServerTopQuery.Enabled)
+}
+
+func TestTranslator_ServerMetricsOnly(t *testing.T) {
+	pgCfg := translateForTest(t, baseOpts(WithServerMetricsOnly())...)
+
+	// Per-resource metrics are off; server/per-DB metrics (incl. table.count) stay on;
+	// events stay on; interval stays at the 10s default.
+	enabled := enabledMetricNames(t, pgCfg)
+	for n := range perResourceMetricNames {
+		assert.False(t, enabled[n], "per-resource metric %s must be disabled on server receiver", n)
+	}
+	assert.True(t, pgCfg.Metrics.PostgresqlTableCount.Enabled)
+	assert.True(t, pgCfg.Metrics.PostgresqlBackends.Enabled)
+	assert.True(t, pgCfg.Events.DbServerQuerySample.Enabled)
+	assert.Equal(t, 10*time.Second, pgCfg.ControllerConfig.CollectionInterval)
+}
+
+func TestTranslator_PerResourceMetricsOnly(t *testing.T) {
+	pgCfg := translateForTest(t, baseOpts(
+		WithPerResourceMetricsOnly(),
+		WithCollectionInterval(60*time.Second),
+		WithEventsDisabled(),
+	)...)
+
+	enabled := enabledMetricNames(t, pgCfg)
+	// Every enabled metric must be a per-resource metric.
+	for n := range enabled {
+		assert.Contains(t, perResourceMetricNames, n, "unexpected non-per-resource metric %s enabled", n)
+	}
+	// Metrics enabled by default (rows, index.size, ...) are present; a per-resource
+	// metric that was OFF by default (sequential_scans) stays off -- the split does not
+	// introduce new metrics.
+	assert.True(t, pgCfg.Metrics.PostgresqlRows.Enabled)
+	assert.True(t, pgCfg.Metrics.PostgresqlIndexSize.Enabled)
+	assert.False(t, pgCfg.Metrics.PostgresqlSequentialScans.Enabled)
+	// table.count is a server metric and must be off here.
+	assert.False(t, pgCfg.Metrics.PostgresqlTableCount.Enabled)
+	// 60s interval and events disabled so it never duplicates DBLoad / TopSQL.
+	assert.Equal(t, 60*time.Second, pgCfg.ControllerConfig.CollectionInterval)
+	assert.False(t, pgCfg.Events.DbServerQuerySample.Enabled)
+	assert.False(t, pgCfg.Events.DbServerTopQuery.Enabled)
+}
+
+// TestTranslator_MetricsDisabled covers the events receiver's scope: it is wired into a
+// logs pipeline only, so it must emit no metrics while keeping the query-sample and
+// top-query events that are its whole purpose.
+func TestTranslator_MetricsDisabled(t *testing.T) {
+	pgCfg := translateForTest(t, baseOpts(WithMetricsDisabled())...)
+
+	assert.Empty(t, enabledMetricNames(t, pgCfg), "no metric may be enabled on a logs-only receiver")
+	assert.True(t, pgCfg.Events.DbServerQuerySample.Enabled)
+	assert.True(t, pgCfg.Events.DbServerTopQuery.Enabled)
+}
+
+// TestTranslator_MetricSets_Disjoint guards against double emission AND against the
+// split adding/dropping metrics: the server (10s) and per-resource (60s) enabled sets
+// must be disjoint, and their union must equal the default single-receiver enabled set.
+func TestTranslator_MetricSets_Disjoint(t *testing.T) {
+	defaultEnabled := enabledMetricNames(t, translateForTest(t, baseOpts()...))
+	server := enabledMetricNames(t, translateForTest(t, baseOpts(WithServerMetricsOnly())...))
+	perResource := enabledMetricNames(t, translateForTest(t, baseOpts(WithPerResourceMetricsOnly())...))
+
+	// Disjoint: nothing enabled on both instances.
+	for n := range perResource {
+		assert.False(t, server[n], "metric %s is enabled on BOTH the server and per-resource receivers (double emission)", n)
+	}
+	// Server receiver enables no per-resource metric; per-resource receiver enables only
+	// per-resource metrics.
+	for n := range server {
+		assert.NotContains(t, perResourceMetricNames, n, "server receiver must not enable per-resource metric %s", n)
+	}
+	for n := range perResource {
+		assert.Contains(t, perResourceMetricNames, n, "per-resource receiver must not enable non-per-resource metric %s", n)
+	}
+	// Union preservation: the split neither adds nor drops any emitted metric.
+	union := map[string]bool{}
+	for n := range server {
+		union[n] = true
+	}
+	for n := range perResource {
+		union[n] = true
+	}
+	assert.Equal(t, defaultEnabled, union, "server+per-resource union must equal the default enabled metric set")
 }


### PR DESCRIPTION

# Description of the issue

Database Insights collects per-resource (table/index) metrics and server metrics from a single PostgreSQL receiver at the default 10s interval. Per-resource metrics scale with the number of relations in the monitored database — a database with thousands of tables produces thousands of readings each scrape. Collecting them every 10s is unnecessary for the DBI experience and inflates ingestion volume.

# Description of changes

**Per-resource metrics split to a dedicated receiver at 60s (configurable):**
- The DBI metrics pipeline now runs two `postgresql` receiver instances per monitored database: one for server/per-database metrics at the default 10s, and one for per-resource (table/index) metrics at 60s.
- A new per-instance config field `per_resource_collection_interval` (in seconds) lets customers override the 60s default. If omitted or zero, defaults to 60s.
- Both scopes only ever disable metrics — the set of metrics emitted is identical to before, partitioned by cadence.
- The per-resource instance disables events (query-sample / top-query) so DBLoad and TopSQL are not double-counted.
- A reflection-based helper (`forEachMetric`) walks the receiver's generated metrics config so per-resource metrics are matched by mapstructure name rather than hand-maintained field references.
- `TestTranslator_MetricSets_Disjoint` asserts the two scopes are disjoint and their union equals the default enabled set, guarding against double emission or metric loss.

**Events receiver metrics disabled (`WithMetricsDisabled` / `metricScopeNone`):**
- The events receiver now explicitly disables all metrics, since it feeds a logs pipeline only and the metrics were never collected. The generated config now reflects what the instance actually emits.

**Config shape (unchanged if field omitted):**
```json
{
  "opentelemetry": {
    "collect": {
      "database_insights": {
        "postgresql": [{
          "endpoint": "localhost:5432",
          "username": "cw_monitor",
          "password_file": "/opt/.pgpass",
          "per_resource_collection_interval": 120
        }]
      }
    }
  }
}
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- `TestTranslator_MetricSets_Disjoint` — proves server + per-resource union equals the default set (no drop, no double emission)
- `TestTranslator_ServerMetricsOnly` / `TestTranslator_PerResourceMetricsOnly` — per-field assertions on each scope
- `TestTranslator_MetricsDisabled` — events receiver emits zero metrics, events survive
- `TestParseDbiPostgresqlInstances_PerResourceCollectionInterval` — default (60s), custom (120s), zero-falls-back-to-default
- `TestTranslator_Translate_Defaults_MetricScope` — default scope unchanged
- tocwconfig golden tests (`TestDBIConfigLinux`, `TestCombinedV1V2EC2Config`, `TestCombinedV1V2EKSConfig`) — regenerated and passing
- Local end-to-end: built agent from branch, ran against real PostgreSQL 14 (Docker), confirmed server metrics at 10s (6 samples/min) and per-resource at 60s (1 sample/min) via CloudWatch SampleCount in account 923855483676
- `al2023:otel_collect_database_insights_test` passed in CI (16m58s) on an earlier push of this branch

# Requirements

1. [x] Run `make fmt` and `make fmt-sh`
2. [x] Run `make lint`