### PR TITLE
Add onboarding scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,132 @@
+# Amazon CloudWatch Agent onboarding scripts
+
+Scripts to set up the CloudWatch Agent to send OpenTelemetry (OTLP) telemetry to CloudWatch, across AWS and Azure platforms.
+
+```
+scripts/
+  setup.sh          onboarding dispatcher (pick a platform, runs the scripts below)
+  aws/setup.sh      AWS-side: IAM trust + install (EC2, ECS, EKS); trust-only for Azure
+  azure/setup.sh    Azure-side: identity + install (VM, AKS)
+  install.sh        agent install payload run on a Linux target
+  install.ps1       agent install payload run on a Windows target
+```
+
+## Platforms
+
+| Platform    | What it does                                                                              |
+|-------------|-------------------------------------------------------------------------------------------|
+| `aws_ec2`   | Instance-profile role + install via SSM                                                   |
+| `aws_ecs`   | Task role + prints the sidecar container definition to add                                |
+| `aws_eks`   | Pod Identity (addon + role + association) + the CloudWatch Observability EKS add-on       |
+| `azure_vm`  | Managed identity + AWS IAM trust + install via `az vm run-command`                        |
+| `azure_aks` | OIDC issuer / workload identity + AWS IAM trust + the CloudWatch Observability Helm chart |
+
+## Quick start
+
+The dispatcher is a convenience wrapper. It fetches the setup scripts over the
+network, so it needs `curl` and outbound access.
+
+```sh
+# AWS EKS
+curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/setup.sh \
+  | CWAGENT_PLATFORM=aws_eks CWAGENT_K8S_CLUSTER_NAME=my-cluster CWAGENT_AWS_REGION=us-east-1 sh
+
+# Azure AKS (from a shell with both the Azure and AWS CLIs)
+curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/setup.sh \
+  | CWAGENT_PLATFORM=azure_aks CWAGENT_AZURE_RESOURCE_GROUP=my-rg CWAGENT_K8S_CLUSTER_NAME=my-cluster CWAGENT_AWS_REGION=us-east-1 sh
+```
+
+Run `./setup.sh` with no platform on a terminal for an interactive wizard.
+
+### AWS platforms
+
+`aws_ec2` / `aws_ecs` / `aws_eks` run entirely in one AWS shell (needs `aws` and
+`jq`, with IAM write access). The dispatcher runs `aws/setup.sh`, which does both
+trust and install.
+
+### Azure platforms
+
+`azure_vm` / `azure_aks` span two clouds: identity and install need the Azure
+CLI (Azure Cloud Shell), trust needs the AWS CLI (AWS CloudShell). In a shell
+with both CLIs the dispatcher runs the whole chain. Otherwise it runs whichever
+step this shell can and prints a command to paste into the next shell, carrying
+the values produced so far.
+
+The flow is `azure/setup.sh` (identity) -> `aws/setup.sh` (trust) -> `azure/setup.sh`
+(install). `azure/setup.sh` picks its mode from whether the IAM role ARN is set:
+
+- **ARN set**: identity and install in one run. The agent retries with backoff
+  until the AWS trust is in place.
+- **ARN unset**: identity only, then stops. Run `aws/setup.sh` to create the role
+  and trust, then rerun `azure/setup.sh` with `CWAGENT_AWS_ROLE_ARN` set to install.
+
+## Running the setup scripts directly
+
+The setup scripts document their own inputs and can be run without the
+dispatcher.
+
+```sh
+# AWS EKS: trust + install in one AWS shell
+CWAGENT_PLATFORM=aws_eks CWAGENT_K8S_CLUSTER_NAME=my-cluster CWAGENT_AWS_REGION=us-east-1 \
+  ./aws/setup.sh
+
+# Azure AKS with the ARN known up front: identity + install in one Azure shell
+CWAGENT_PLATFORM=azure_aks CWAGENT_AWS_ROLE_ARN=arn:aws:iam::123456789012:role/CloudWatchAgentServerRole \
+  CWAGENT_AWS_REGION=us-east-1 CWAGENT_AZURE_RESOURCE_GROUP=my-rg CWAGENT_K8S_CLUSTER_NAME=my-cluster \
+  ./azure/setup.sh
+```
+
+## Environment variables
+
+### Common
+
+| Variable                                | Meaning                                                                  |
+|-----------------------------------------|--------------------------------------------------------------------------|
+| `CWAGENT_PLATFORM`                      | `aws_ec2` \| `aws_ecs` \| `aws_eks` \| `azure_vm` \| `azure_aks`         |
+| `CWAGENT_AWS_ROLE_NAME`                 | IAM role name (default: `CloudWatchAgentServerRole`)                     |
+| `CWAGENT_AWS_REGION`                    | AWS region telemetry is sent to                                          |
+| `CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH` | When set (`1`/`true`/`yes`/`on`), enable Transaction Search if it is off |
+
+### Per platform
+
+| Variable                           | Applies to              | Meaning                                                                                 |
+|------------------------------------|-------------------------|-----------------------------------------------------------------------------------------|
+| `CWAGENT_AWS_INSTANCE_ID`          | `aws_ec2`               | EC2 instance ID                                                                         |
+| `CWAGENT_AWS_UPDATE_INSTANCE_ROLE` | `aws_ec2`               | When set (`1`/`true`/`yes`/`on`), attach the policy to the role already on the instance |
+| `CWAGENT_AWS_ECS_LAUNCH_TYPE`      | `aws_ecs`               | `fargate` \| `ec2` (default: `fargate`)                                                 |
+| `CWAGENT_K8S_CLUSTER_NAME`         | `aws_eks`, `azure_aks`  | Cluster name                                                                            |
+| `CWAGENT_AZURE_RESOURCE_GROUP`     | `azure_vm`, `azure_aks` | Resource group                                                                          |
+| `CWAGENT_AZURE_VM_NAME`            | `azure_vm`              | VM name                                                                                 |
+| `CWAGENT_AWS_ROLE_ARN`             | `azure_vm`, `azure_aks` | IAM role ARN; when set, `azure/setup.sh` also installs                                  |
+| `CWAGENT_AZURE_TENANT_ID`          | `azure_vm`              | Azure tenant ID (produced by `azure/setup.sh`, consumed by `aws/setup.sh`)              |
+| `CWAGENT_AZURE_OIDC_ISSUER`        | `azure_aks`             | AKS OIDC issuer URL (produced by `azure/setup.sh`, consumed by `aws/setup.sh`)          |
+
+The agent runs in the `amazon-cloudwatch` namespace on Kubernetes. Telemetry uses
+the default OpenTelemetry configuration (`default:otel`): OTel Container Insights
+and logs on the node agent, plus a cluster-scraper for cluster-level metrics.
+
+## Requirements
+
+The quickest way to meet these is a cloud shell, which comes preauthenticated
+with the CLIs installed: **AWS CloudShell** for the AWS steps, **Azure Cloud
+Shell** for the Azure steps.
+
+- **AWS platforms:** `aws` (v2.22+ recommended), `jq`, IAM write access. EKS
+  installs the CloudWatch Observability EKS add-on (no `helm`/`kubectl` needed).
+  Enabling Transaction Search also needs `logs:PutResourcePolicy` and the
+  `xray:*TraceSegmentDestination` permissions.
+- **Azure platforms:** `az` (v2.47+ recommended). AKS install additionally uses
+  `helm` and `kubectl` when present. If either is missing the script prints the
+  install command to run from a shell that has them.
+- **Targets:** EC2/VM installs fetch `install.sh` (Linux) or `install.ps1`
+  (Windows) onto the host. Windows needs `iconv` on the launching shell to build
+  the encoded command.
+
+## Notes
+
+- **OTLP traces need Transaction Search**, a per-region account setting. The AWS
+  trust step reports when it is off. Set `CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH=1`
+  to have it enabled.
+- **Safe to re-run.** IAM trust statements and policies are merged, not replaced;
+  a role keeps its other trust statements, and an instance keeps its profile.
+- **Boolean env vars** accept `1`, `true`, `yes`, or `on` (case-insensitive).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,11 +28,11 @@ network, so it needs `curl` and outbound access.
 
 ```sh
 # AWS EKS
-curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/setup.sh \
+curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/main/scripts/setup.sh \
   | CWAGENT_PLATFORM=aws_eks CWAGENT_K8S_CLUSTER_NAME=my-cluster CWAGENT_AWS_REGION=us-east-1 sh
 
 # Azure AKS (from a shell with both the Azure and AWS CLIs)
-curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/setup.sh \
+curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/main/scripts/setup.sh \
   | CWAGENT_PLATFORM=azure_aks CWAGENT_AZURE_RESOURCE_GROUP=my-rg CWAGENT_K8S_CLUSTER_NAME=my-cluster CWAGENT_AWS_REGION=us-east-1 sh
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,7 @@ CWAGENT_PLATFORM=azure_aks CWAGENT_AWS_ROLE_ARN=arn:aws:iam::123456789012:role/C
 |-----------------------------------------|--------------------------------------------------------------------------|
 | `CWAGENT_PLATFORM`                      | `aws_ec2` \| `aws_ecs` \| `aws_eks` \| `azure_vm` \| `azure_aks`         |
 | `CWAGENT_AWS_ROLE_NAME`                 | IAM role name (default: `CloudWatchAgentServerRole`)                     |
-| `CWAGENT_AWS_REGION`                    | AWS region telemetry is sent to                                          |
+| `CWAGENT_AWS_REGION`                    | AWS region telemetry is sent to (required)                               |
 | `CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH` | When set (`1`/`true`/`yes`/`on`), enable Transaction Search if it is off |
 
 ### Per platform

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -95,8 +95,10 @@ CWAGENT_PLATFORM=azure_aks CWAGENT_AWS_ROLE_ARN=arn:aws:iam::123456789012:role/C
 | `CWAGENT_AWS_UPDATE_INSTANCE_ROLE` | `aws_ec2`               | When set (`1`/`true`/`yes`/`on`), attach the policy to the role already on the instance |
 | `CWAGENT_AWS_ECS_LAUNCH_TYPE`      | `aws_ecs`               | `fargate` \| `ec2` (default: `fargate`)                                                 |
 | `CWAGENT_K8S_CLUSTER_NAME`         | `aws_eks`, `azure_aks`  | Cluster name                                                                            |
-| `CWAGENT_AZURE_RESOURCE_GROUP`     | `azure_vm`, `azure_aks` | Resource group                                                                          |
-| `CWAGENT_AZURE_VM_NAME`            | `azure_vm`              | VM name                                                                                 |
+| `CWAGENT_AZURE_RESOURCE_ID`        | `azure_vm`, `azure_aks` | Full ARM resource ID (subscription + group + name in one value); recommended            |
+| `CWAGENT_AZURE_SUBSCRIPTION`       | `azure_vm`, `azure_aks` | Subscription ID or name (Cloud Shell's default is used when unset)                      |
+| `CWAGENT_AZURE_RESOURCE_GROUP`     | `azure_vm`, `azure_aks` | Resource group (not needed when `CWAGENT_AZURE_RESOURCE_ID` is set)                     |
+| `CWAGENT_AZURE_VM_NAME`            | `azure_vm`              | VM name (not needed when `CWAGENT_AZURE_RESOURCE_ID` is set)                            |
 | `CWAGENT_AWS_ROLE_ARN`             | `azure_vm`, `azure_aks` | IAM role ARN; when set, `azure/setup.sh` also installs                                  |
 | `CWAGENT_AZURE_TENANT_ID`          | `azure_vm`              | Azure tenant ID (produced by `azure/setup.sh`, consumed by `aws/setup.sh`)              |
 | `CWAGENT_AZURE_OIDC_ISSUER`        | `azure_aks`             | AKS OIDC issuer URL (produced by `azure/setup.sh`, consumed by `aws/setup.sh`)          |

--- a/scripts/aws/setup.sh
+++ b/scripts/aws/setup.sh
@@ -1,0 +1,991 @@
+#!/bin/sh
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+# Amazon CloudWatch Agent - AWS setup (trust + install)
+#
+# Sets up the IAM role the agent assumes to send OpenTelemetry (OTLP) telemetry
+# to CloudWatch and attaches CloudWatchAgentServerPolicy. What happens after that
+# depends on the platform:
+#
+#   aws_ec2     trust (instance-profile role) + install via SSM
+#   aws_ecs     trust (task role) + print the sidecar container definition
+#   aws_eks     trust (Pod Identity) + install the Observability EKS add-on
+#   azure_vm    trust only (web-identity for the Azure tenant OIDC provider),
+#               install runs on the Azure side via azure/setup.sh
+#   azure_aks   trust only (web-identity for the AKS issuer OIDC provider),
+#               install runs on the Azure side via azure/setup.sh
+#
+# Safe to re-run: trust statements and policies are merged, not replaced, and an
+# instance keeps its profile.
+#
+# Requires IAM write access, "aws", and "jq". For azure_vm and azure_aks it also
+# takes an identity value from the Azure setup (the tenant ID or the OIDC issuer
+# URL). Outputs the role ARN.
+#
+# Usage:
+#     CWAGENT_PLATFORM=aws_eks \
+#     CWAGENT_K8S_CLUSTER_NAME=my-cluster \
+#     CWAGENT_AWS_REGION=us-east-1 \
+#       ./aws/setup.sh
+#
+# Environment variables:
+#   Common:
+#     CWAGENT_PLATFORM                        aws_ec2 | aws_ecs | aws_eks | azure_vm | azure_aks
+#     CWAGENT_AWS_ROLE_NAME                   IAM role name (default: CloudWatchAgentServerRole)
+#     CWAGENT_AWS_REGION                      AWS region telemetry is sent to (required,
+#                                             falls back to the AWS CLI config if unset)
+#     CWAGENT_EMIT_ENV                        When set (1/true/yes/on), print eval-able
+#                                             KEY='value' lines on stdout, logging to stderr
+#     CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH   When set (1/true/yes/on), enable Transaction
+#                                             Search (a per-region account setting OTLP
+#                                             traces need) if it is off
+#   aws_ec2:
+#     CWAGENT_AWS_INSTANCE_ID                 EC2 instance ID
+#     CWAGENT_AWS_UPDATE_INSTANCE_ROLE        When set (1/true/yes/on), attach the policy
+#                                             to the role already on the instance
+#   aws_ecs:
+#     CWAGENT_AWS_ECS_LAUNCH_TYPE             fargate | ec2 (default: fargate)
+#   aws_eks:
+#     CWAGENT_K8S_CLUSTER_NAME                Cluster name
+#   azure_vm:
+#     CWAGENT_AZURE_TENANT_ID                 Azure tenant ID
+#   azure_aks:
+#     CWAGENT_AZURE_OIDC_ISSUER               AKS OIDC issuer URL
+
+set -eu
+
+PLATFORM="${CWAGENT_PLATFORM:-}"
+TENANT_ID="${CWAGENT_AZURE_TENANT_ID:-}"
+OIDC_ISSUER="${CWAGENT_AZURE_OIDC_ISSUER:-}"
+INSTANCE_ID="${CWAGENT_AWS_INSTANCE_ID:-}"
+UPDATE_INSTANCE_ROLE="${CWAGENT_AWS_UPDATE_INSTANCE_ROLE:-}"
+ENABLE_TXN_SEARCH="${CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH:-}"
+CLUSTER_NAME="${CWAGENT_K8S_CLUSTER_NAME:-}"
+ROLE_NAME="${CWAGENT_AWS_ROLE_NAME:-CloudWatchAgentServerRole}"
+REGION="${CWAGENT_AWS_REGION:-}"
+EMIT_ENV="${CWAGENT_EMIT_ENV:-}"
+ECS_LAUNCH_TYPE="${CWAGENT_AWS_ECS_LAUNCH_TYPE:-}"
+
+# Where the target fetches the install payload (install.sh / install.ps1) from.
+SCRIPT_BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts"
+# The agent's namespace is fixed: the EKS add-on always installs into
+# amazon-cloudwatch, and the operator/chart centers on it, so it is not settable.
+K8S_NAMESPACE="amazon-cloudwatch"
+
+# True when a flag is an affirmative value (1, true, yes, on, case-insensitive).
+# One truthiness rule for every CWAGENT_* boolean.
+is_true() {
+     case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+     1 | true | yes | on) return 0 ;;
+     *) return 1 ;;
+     esac
+}
+
+# =============================================================================
+# Output helpers
+#
+# Under CWAGENT_EMIT_ENV stdout carries only the eval-able KEY='value' lines the
+# parent shell captures and evaluates, so readable output (including any install
+# transcript) goes to fd 3 (redirected to stderr here, stdout otherwise) and
+# every command must keep its own output off plain stdout. A stray line that
+# looks like an assignment is indistinguishable from a real one.
+# =============================================================================
+
+if is_true "${EMIT_ENV}"; then
+     exec 3>&2
+else
+     exec 3>&1
+fi
+
+section() { printf '\n%s\n' "$1" >&3; }
+if [ -t 3 ]; then
+     log() { printf '  \033[32m✓\033[0m %s\n' "$1" >&3; }
+     logaction() { printf '  \033[33m+\033[0m %s\n' "$1" >&3; }
+     logwarn() { printf '  \033[33m!\033[0m %s\n' "$1" >&3; }
+     die() {
+          printf '  \033[31m✗\033[0m %s\n' "$1" >&2
+          exit 1
+     }
+     ask() { printf '\033[1m▸ %s\033[0m ' "$1" >&3; }
+else
+     log() { printf '  ✓ %s\n' "$1" >&3; }
+     logaction() { printf '  + %s\n' "$1" >&3; }
+     logwarn() { printf '  ! %s\n' "$1" >&3; }
+     die() {
+          printf '  ✗ %s\n' "$1" >&2
+          exit 1
+     }
+     ask() { printf '▸ %s ' "$1" >&3; }
+fi
+
+usage() {
+     rc="${1:-1}"
+     out=2
+     [ "${rc}" = "0" ] && out=1
+     cat >&${out} <<EOF
+Usage:
+  CWAGENT_PLATFORM=aws_eks   CWAGENT_K8S_CLUSTER_NAME=<cluster>  $0
+  CWAGENT_PLATFORM=aws_ec2   CWAGENT_AWS_INSTANCE_ID=i-123       $0
+  CWAGENT_PLATFORM=aws_ecs                                       $0
+  CWAGENT_PLATFORM=azure_aks CWAGENT_AZURE_OIDC_ISSUER=https://... $0
+  CWAGENT_PLATFORM=azure_vm  CWAGENT_AZURE_TENANT_ID=<tenant>    $0
+
+Environment variables:
+  Common:
+    CWAGENT_PLATFORM                        aws_ec2 | aws_ecs | aws_eks | azure_vm | azure_aks
+    CWAGENT_AWS_ROLE_NAME                   IAM role name (default: CloudWatchAgentServerRole)
+    CWAGENT_AWS_REGION                      AWS region telemetry is sent to (required)
+    CWAGENT_EMIT_ENV                        Print eval-able KEY='value' lines on stdout
+    CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH   Enable Transaction Search in the region
+  aws_ec2:
+    CWAGENT_AWS_INSTANCE_ID                 EC2 instance ID
+    CWAGENT_AWS_UPDATE_INSTANCE_ROLE        Attach the policy to the existing role
+  aws_ecs:
+    CWAGENT_AWS_ECS_LAUNCH_TYPE             fargate | ec2 (default: fargate)
+  aws_eks:
+    CWAGENT_K8S_CLUSTER_NAME                Cluster name
+  azure_vm:
+    CWAGENT_AZURE_TENANT_ID                 Azure tenant ID
+  azure_aks:
+    CWAGENT_AZURE_OIDC_ISSUER               AKS OIDC issuer URL
+EOF
+     exit "${rc}"
+}
+
+# =============================================================================
+# Env-var emit (CWAGENT_EMIT_ENV)
+#
+# Under CWAGENT_EMIT_ENV, emit_env prints accumulated values as eval-able
+# KEY='value' lines on stdout. Single-quoted for the documented
+# eval "$(... | CWAGENT_EMIT_ENV=1 sh)" usage.
+# =============================================================================
+
+ENV_VARS=""
+add_env() {
+     [ -n "$2" ] || return 0
+     ENV_VARS="${ENV_VARS}$1=$2
+"
+}
+
+emit_env() {
+     is_true "${EMIT_ENV}" || return 0
+     printf '%s' "${ENV_VARS}" | while IFS= read -r line; do
+          [ -n "${line}" ] || continue
+          value="${line#*=}"
+          # Escape single quotes (' -> '\'') so the emitted line survives the
+          # documented eval intact even if a value ever contains one.
+          escaped=$(printf '%s' "${value}" | sed "s/'/'\\\\''/g")
+          printf "%s='%s'\n" "${line%%=*}" "${escaped}"
+     done
+}
+
+# POSIX version compare: true when $1 >= $2 as major.minor.patch. Pure parameter
+# expansion (no `sort -V`, a GNU/BSD extension) and length-agnostic, so "2.47"
+# compares equal to "2.47.0". Missing minor/patch fields count as 0.
+version_ge() {
+     _a_maj=${1%%.*}
+     _a_rest=${1#*.}
+     _a_min=${_a_rest%%.*}
+     _a_pat=${_a_rest#*.}
+     _b_maj=${2%%.*}
+     _b_rest=${2#*.}
+     _b_min=${_b_rest%%.*}
+     _b_pat=${_b_rest#*.}
+     case "$1" in *.*.*) : ;; *.*) _a_pat=0 ;; *)
+          _a_min=0
+          _a_pat=0
+          ;;
+     esac
+     case "$2" in *.*.*) : ;; *.*) _b_pat=0 ;; *)
+          _b_min=0
+          _b_pat=0
+          ;;
+     esac
+     [ "$_a_maj" -ne "$_b_maj" ] && {
+          [ "$_a_maj" -gt "$_b_maj" ]
+          return
+     }
+     [ "$_a_min" -ne "$_b_min" ] && {
+          [ "$_a_min" -gt "$_b_min" ]
+          return
+     }
+     [ "$_a_pat" -ge "$_b_pat" ]
+}
+
+# =============================================================================
+# Interactive mode
+#
+# The identity values (tenant ID, OIDC issuer) come from the Azure identity
+# setup. When run by hand they can be pasted in at the prompts rather than
+# passed through the environment.
+# =============================================================================
+
+prompt() {
+     var="$1"
+     label="$2"
+     default="${3:-}"
+     eval "current=\${${var}}"
+     [ -n "${current}" ] && return
+     while true; do
+          if [ -n "${default}" ]; then
+               ask "${label} [${default}]:"
+          else
+               ask "${label}:"
+          fi
+          # A read failure (EOF on closed stdin) would loop forever with no
+          # default, and abort under set -e otherwise, so treat it as give-up.
+          read -r input || die "no input for ${label}"
+          input="${input:-${default}}"
+          [ -n "${input}" ] && break
+     done
+     # Assign without re-quoting the value, so a pasted name containing " ` or
+     # $(...) is stored literally rather than being re-parsed by the shell.
+     eval "${var}=\$input"
+}
+
+interactive_setup() {
+     printf '\nSelect platform:\n' >&3
+     printf '  aws_ec2     EC2 instance\n' >&3
+     printf '  aws_ecs     ECS task (sidecar)\n' >&3
+     printf '  aws_eks     EKS cluster\n' >&3
+     printf '  azure_vm    Azure VM\n' >&3
+     printf '  azure_aks   AKS cluster\n' >&3
+     ask "Platform:"
+     read -r choice || die "no platform selected"
+     case "${choice}" in
+     aws_ec2) PLATFORM=aws_ec2 ;;
+     aws_ecs) PLATFORM=aws_ecs ;;
+     aws_eks) PLATFORM=aws_eks ;;
+     azure_vm) PLATFORM=azure_vm ;;
+     azure_aks) PLATFORM=azure_aks ;;
+     *) die "invalid platform: ${choice}" ;;
+     esac
+
+     printf '\n' >&3
+     case "${PLATFORM}" in
+     aws_ec2)
+          prompt INSTANCE_ID "Instance ID"
+          ;;
+     aws_ecs)
+          prompt ECS_LAUNCH_TYPE "Launch type (fargate|ec2)" "fargate"
+          ;;
+     aws_eks)
+          prompt CLUSTER_NAME "Cluster name"
+          ;;
+     azure_vm)
+          prompt TENANT_ID "Azure tenant ID"
+          ;;
+     azure_aks)
+          prompt OIDC_ISSUER "AKS OIDC issuer URL"
+          ;;
+     esac
+     # `prompt` returns early on a non-empty current value, and ROLE_NAME always
+     # has one (the built-in default), so ask directly with the default filled in.
+     ask "IAM role name [${ROLE_NAME}]:"
+     read -r role_input || die "no input for IAM role name"
+     [ -n "${role_input}" ] && ROLE_NAME="${role_input}"
+}
+
+check_prerequisites() {
+     command -v aws >/dev/null 2>&1 || die "AWS CLI is required but not installed"
+     command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+     AWS_CLI_VERSION=$(aws --version 2>&1 | sed -n 's|.*aws-cli/\([0-9.]*\).*|\1|p' | head -n 1)
+     [ -n "${AWS_CLI_VERSION}" ] || AWS_CLI_VERSION="0.0.0"
+     if ! version_ge "${AWS_CLI_VERSION}" "2.22.0"; then
+          logwarn "AWS CLI ${AWS_CLI_VERSION} detected (2.22+ recommended for full functionality)"
+     fi
+     AWS_IDENTITY=$(aws sts get-caller-identity --query '[Account, Arn]' --output text 2>&1) || die "AWS credentials not configured (run 'aws configure' or set AWS_PROFILE)"
+     AWS_ACCOUNT=$(printf '%s' "${AWS_IDENTITY}" | cut -f1)
+     AWS_ARN=$(printf '%s' "${AWS_IDENTITY}" | cut -f2)
+     AWS_ALIAS=$(aws iam list-account-aliases --query 'AccountAliases[0]' --output text 2>/dev/null || true)
+     if [ -n "${AWS_ALIAS}" ] && [ "${AWS_ALIAS}" != "None" ]; then
+          log "AWS account: ${AWS_ACCOUNT} (${AWS_ALIAS})"
+     else
+          log "AWS account: ${AWS_ACCOUNT}"
+     fi
+     log "AWS identity: ${AWS_ARN}"
+}
+
+# =============================================================================
+# Shared helpers
+# =============================================================================
+
+ensure_iam_role() {
+     new_statement="$1"
+     full_policy="{\"Version\":\"2012-10-17\",\"Statement\":[${new_statement}]}"
+
+     # One get-role serves both the existence probe and the current-policy fetch:
+     # a failure means the role is absent, so create it and return.
+     if ! existing=$(aws iam get-role --role-name "${ROLE_NAME}" \
+          --query 'Role.AssumeRolePolicyDocument' --output json 2>/dev/null); then
+          logaction "Creating IAM role ${ROLE_NAME}"
+          aws iam create-role \
+               --role-name "${ROLE_NAME}" \
+               --assume-role-policy-document "${full_policy}" \
+               >/dev/null
+          return
+     fi
+
+     new_principal=$(printf '%s' "${new_statement}" | jq -r \
+          '(.Principal | if type == "object" then to_entries[0].value else . end)')
+
+     # Statements for different principals coexist on one role (EC2, ECS, EKS,
+     # and the Azure federations all key off distinct principals). For this
+     # principal: identical means nothing to do, different means replace (not
+     # leave stale, e.g. a changed :sub namespace), absent means append.
+     state=$(printf '%s' "${existing}" | jq -r \
+          --arg principal "${new_principal}" \
+          --argjson stmt "${new_statement}" \
+          '[.Statement[] | select((.Principal | if type == "object" then to_entries[0].value else . end) == $principal)] as $m
+           | if ($m | length) == 0 then "absent"
+             elif ($m | any(. == $stmt)) then "current"
+             else "stale" end')
+
+     if [ "${state}" = "current" ]; then
+          log "IAM role ${ROLE_NAME} trust policy up to date"
+          return
+     fi
+
+     if [ "${state}" = "stale" ]; then
+          logaction "Updating trust statement on ${ROLE_NAME}"
+          merged=$(printf '%s' "${existing}" | jq \
+               --arg principal "${new_principal}" \
+               --argjson stmt "${new_statement}" \
+               '.Statement = ([.Statement[] | select((.Principal | if type == "object" then to_entries[0].value else . end) != $principal)] + [$stmt])')
+     else
+          logaction "Merging trust statement into ${ROLE_NAME}"
+          merged=$(printf '%s' "${existing}" | jq \
+               --argjson stmt "${new_statement}" \
+               '.Statement += [$stmt]')
+     fi
+
+     aws iam update-assume-role-policy \
+          --role-name "${ROLE_NAME}" \
+          --policy-document "${merged}" \
+          >/dev/null
+}
+
+attach_permissions_policy() {
+     # attach-role-policy is idempotent (re-attaching the same policy succeeds),
+     # so let a real failure (AccessDenied, NoSuchEntity) surface via set -e
+     # rather than swallowing it and falsely logging success.
+     aws iam attach-role-policy \
+          --role-name "${ROLE_NAME}" \
+          --policy-arn arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy >/dev/null
+     log "Managed policy CloudWatchAgentServerPolicy attached"
+}
+
+# Register the OIDC provider for a web-identity federation if AWS does not
+# already have it. $1 = substring identifying an existing provider ARN, $2 =
+# provider URL, $3 = client-id (audience), $4 = thumbprint (optional: Azure AD's
+# is fixed, AKS issuers are fetched from the HTTPS endpoint so none is passed).
+ensure_oidc_provider() {
+     match="$1"
+     url="$2"
+     client_id="$3"
+     thumbprint="${4:-}"
+
+     existing=$(aws iam list-open-id-connect-providers \
+          --query "OpenIDConnectProviderList[?contains(Arn, '${match}')].Arn | [0]" \
+          --output text 2>/dev/null || true)
+     if [ -n "${existing}" ] && [ "${existing}" != "None" ]; then
+          log "OIDC provider exists"
+          return
+     fi
+
+     logaction "Registering OIDC provider"
+     if [ -n "${thumbprint}" ]; then
+          aws iam create-open-id-connect-provider --url "${url}" \
+               --client-id-list "${client_id}" --thumbprint-list "${thumbprint}" >/dev/null
+     else
+          aws iam create-open-id-connect-provider --url "${url}" \
+               --client-id-list "${client_id}" >/dev/null
+     fi
+}
+
+TXN_SEARCH_DOC="https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Enable-TransactionSearch.html"
+
+ensure_transaction_search() {
+     TRACE_DEST_RC=""
+     TRACE_DEST=$(aws xray get-trace-segment-destination --region "${REGION}" --query 'Destination' --output text 2>/dev/null) || TRACE_DEST_RC=$?
+
+     if [ -n "${TRACE_DEST_RC}" ]; then
+          logwarn "Could not check Transaction Search. OTLP traces need it enabled in ${REGION}:"
+          logwarn "${TXN_SEARCH_DOC}"
+          return
+     fi
+     if [ "${TRACE_DEST}" = "CloudWatchLogs" ]; then
+          return
+     fi
+
+     if [ -t 0 ] && ! is_true "${EMIT_ENV}" && ! is_true "${ENABLE_TXN_SEARCH}"; then
+          ask "Enable Transaction Search for the whole account in ${REGION}? [y/N]"
+          read -r answer || answer=""
+          case "${answer}" in [yY]*) ENABLE_TXN_SEARCH="true" ;; esac
+     fi
+
+     if ! is_true "${ENABLE_TXN_SEARCH}"; then
+          logwarn "OTLP traces need Transaction Search, which is off in ${REGION}. Enabling it"
+          logwarn "changes how X-Ray traces are ingested for the whole account in this region."
+          logwarn "Rerun with CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH=true to enable it, or:"
+          logwarn "${TXN_SEARCH_DOC}"
+          return
+     fi
+
+     logaction "Enabling Transaction Search in ${REGION}"
+     # Two steps: a resource policy letting X-Ray write spans into CloudWatch
+     # Logs, then flipping the trace segment destination. Without the policy the
+     # destination flips but X-Ray can't write, so spans never land.
+     TXN_POLICY=$(
+          cat <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "TransactionSearchXRayAccess",
+        "Effect": "Allow",
+        "Principal": { "Service": "xray.amazonaws.com" },
+        "Action": "logs:PutLogEvents",
+        "Resource": [
+          "arn:aws:logs:${REGION}:${AWS_ACCOUNT}:log-group:aws/spans:*",
+          "arn:aws:logs:${REGION}:${AWS_ACCOUNT}:log-group:/aws/application-signals/data:*"
+        ],
+        "Condition": {
+          "ArnLike": { "aws:SourceArn": "arn:aws:xray:${REGION}:${AWS_ACCOUNT}:*" },
+          "StringEquals": { "aws:SourceAccount": "${AWS_ACCOUNT}" }
+        }
+      }
+    ]
+}
+EOF
+     )
+     TXN_ERR=$(
+          aws logs put-resource-policy --policy-name TransactionSearchXRayAccess \
+               --policy-document "${TXN_POLICY}" --region "${REGION}" 2>&1 >/dev/null &&
+               aws xray update-trace-segment-destination --destination CloudWatchLogs --region "${REGION}" 2>&1 >/dev/null
+     ) || TXN_RC=1
+     if [ -z "${TXN_RC:-}" ]; then
+          log "Transaction Search enabled"
+     else
+          logwarn "Could not enable Transaction Search:"
+          logwarn "${TXN_ERR}"
+          logwarn "${TXN_SEARCH_DOC}"
+     fi
+}
+
+# =============================================================================
+# AWS EC2 trust
+# =============================================================================
+
+trust_aws_ec2() {
+     if [ -z "${INSTANCE_ID}" ]; then usage; fi
+
+     EC2_ROLE_TRUST='{
+    "Effect": "Allow",
+    "Principal": { "Service": "ec2.amazonaws.com" },
+    "Action": "sts:AssumeRole"
+  }'
+
+     # An instance with a profile keeps it: swapping would revoke the role's
+     # other permissions, which this script can't know about. So attach the
+     # policy to the existing role instead. That modifies a pre-existing role
+     # this script didn't create, so it requires explicit opt-in. The role
+     # already trusts ec2.amazonaws.com, so no trust change is needed.
+     CURRENT_PROFILE_ARN=$(aws ec2 describe-iam-instance-profile-associations \
+          --filters "Name=instance-id,Values=${INSTANCE_ID}" "Name=state,Values=associated" \
+          --query 'IamInstanceProfileAssociations[0].IamInstanceProfile.Arn' \
+          --region "${REGION}" --output text 2>/dev/null || true)
+
+     if [ -n "${CURRENT_PROFILE_ARN}" ] && [ "${CURRENT_PROFILE_ARN}" != "None" ]; then
+          PROFILE_NAME="${CURRENT_PROFILE_ARN##*/}"
+          EXISTING_ROLE=$(aws iam get-instance-profile \
+               --instance-profile-name "${PROFILE_NAME}" \
+               --query 'InstanceProfile.Roles[0].RoleName' --output text 2>/dev/null || true)
+
+          if [ -z "${EXISTING_ROLE}" ] || [ "${EXISTING_ROLE}" = "None" ]; then
+               die "Instance profile ${PROFILE_NAME} has no role attached"
+          fi
+
+          section "Using existing instance profile..."
+          log "Instance profile ${PROFILE_NAME} attached to ${INSTANCE_ID}"
+          log "Role: ${EXISTING_ROLE}"
+          ROLE_NAME="${EXISTING_ROLE}"
+
+          # Nothing to do if the policy is already there, so a re-run stays quiet
+          # and needs no opt-in.
+          if aws iam list-attached-role-policies --role-name "${ROLE_NAME}" \
+               --query 'AttachedPolicies[?PolicyName==`CloudWatchAgentServerPolicy`] | [0].PolicyName' \
+               --output text 2>/dev/null | grep -q CloudWatchAgentServerPolicy; then
+               log "Managed policy CloudWatchAgentServerPolicy already attached"
+               return
+          fi
+
+          if [ -t 0 ] && ! is_true "${EMIT_ENV}" && ! is_true "${UPDATE_INSTANCE_ROLE}"; then
+               ask "Attach CloudWatchAgentServerPolicy to ${ROLE_NAME}? [y/N]"
+               read -r answer || answer=""
+               case "${answer}" in [yY]*) UPDATE_INSTANCE_ROLE="true" ;; esac
+          fi
+          if ! is_true "${UPDATE_INSTANCE_ROLE}"; then
+               die "${ROLE_NAME} is missing CloudWatchAgentServerPolicy. Attach it manually, or set CWAGENT_AWS_UPDATE_INSTANCE_ROLE=true to have this script attach it"
+          fi
+
+          attach_permissions_policy
+          return
+     fi
+
+     # No profile attached: create the role, its instance profile, and associate.
+     PROFILE_NAME="${ROLE_NAME}"
+
+     section "Configuring IAM role..."
+     ensure_iam_role "${EC2_ROLE_TRUST}"
+     attach_permissions_policy
+
+     section "Configuring instance profile..."
+     ensure_instance_profile "${PROFILE_NAME}"
+     logaction "Associating instance profile with ${INSTANCE_ID}"
+     aws ec2 associate-iam-instance-profile \
+          --instance-id "${INSTANCE_ID}" \
+          --iam-instance-profile Name="${PROFILE_NAME}" --region "${REGION}" >/dev/null
+}
+
+# Create and bind the instance profile if absent. The sleep covers IAM's
+# eventual consistency before association.
+ensure_instance_profile() {
+     profile="$1"
+     if aws iam get-instance-profile --instance-profile-name "${profile}" >/dev/null 2>&1; then
+          log "Instance profile ${profile} exists"
+          return
+     fi
+     logaction "Creating instance profile ${profile}"
+     aws iam create-instance-profile --instance-profile-name "${profile}" >/dev/null
+     aws iam add-role-to-instance-profile \
+          --instance-profile-name "${profile}" --role-name "${ROLE_NAME}" >/dev/null
+     logaction "Waiting for propagation..."
+     sleep 10
+}
+
+# =============================================================================
+# AWS ECS trust
+# =============================================================================
+
+trust_aws_ecs() {
+     section "Configuring IAM task role..."
+
+     ensure_iam_role '{
+    "Effect": "Allow",
+    "Principal": { "Service": "ecs-tasks.amazonaws.com" },
+    "Action": "sts:AssumeRole"
+  }'
+
+     attach_permissions_policy
+}
+
+# =============================================================================
+# AWS EKS trust
+# =============================================================================
+
+trust_aws_eks() {
+     if [ -z "${CLUSTER_NAME}" ]; then usage; fi
+
+     section "Configuring EKS Pod Identity..."
+
+     if aws eks describe-addon --cluster-name "${CLUSTER_NAME}" --addon-name eks-pod-identity-agent --region "${REGION}" >/dev/null 2>&1; then
+          log "Pod Identity Agent addon installed"
+     else
+          logaction "Installing Pod Identity Agent addon"
+          aws eks create-addon \
+               --cluster-name "${CLUSTER_NAME}" \
+               --addon-name eks-pod-identity-agent \
+               --region "${REGION}" >/dev/null
+     fi
+
+     section "Configuring IAM role..."
+
+     ensure_iam_role '{
+    "Effect": "Allow",
+    "Principal": { "Service": "pods.eks.amazonaws.com" },
+    "Action": ["sts:AssumeRole", "sts:TagSession"]
+  }'
+
+     attach_permissions_policy
+
+     ROLE_ARN=$(aws iam get-role \
+          --role-name "${ROLE_NAME}" \
+          --query Role.Arn --output text)
+
+     section "Configuring pod identity association..."
+
+     EXISTING_ASSOC=$(aws eks list-pod-identity-associations \
+          --cluster-name "${CLUSTER_NAME}" \
+          --namespace "${K8S_NAMESPACE}" \
+          --service-account cloudwatch-agent \
+          --region "${REGION}" \
+          --query 'associations[0].associationId' --output text 2>/dev/null || true)
+
+     if [ -n "${EXISTING_ASSOC}" ] && [ "${EXISTING_ASSOC}" != "None" ]; then
+          EXISTING_ROLE=$(aws eks describe-pod-identity-association \
+               --cluster-name "${CLUSTER_NAME}" \
+               --association-id "${EXISTING_ASSOC}" \
+               --region "${REGION}" \
+               --query 'association.roleArn' --output text 2>/dev/null || true)
+          if [ "${EXISTING_ROLE}" = "${ROLE_ARN}" ]; then
+               log "Pod identity association exists"
+          else
+               logaction "Updating association role to ${ROLE_ARN}"
+               aws eks update-pod-identity-association \
+                    --cluster-name "${CLUSTER_NAME}" \
+                    --association-id "${EXISTING_ASSOC}" \
+                    --role-arn "${ROLE_ARN}" \
+                    --region "${REGION}" >/dev/null
+          fi
+     else
+          logaction "Creating association for ${K8S_NAMESPACE}/cloudwatch-agent"
+          aws eks create-pod-identity-association \
+               --cluster-name "${CLUSTER_NAME}" \
+               --region "${REGION}" \
+               --namespace "${K8S_NAMESPACE}" \
+               --service-account cloudwatch-agent \
+               --role-arn "${ROLE_ARN}" >/dev/null
+     fi
+}
+
+# =============================================================================
+# Azure VM trust
+# =============================================================================
+
+trust_azure_vm() {
+     if [ -z "${TENANT_ID}" ]; then
+          die "CWAGENT_AZURE_TENANT_ID is required for azure_vm (produced by azure/setup.sh)"
+     fi
+
+     OIDC_AUDIENCE="https://management.azure.com/"
+
+     section "Configuring AWS trust..."
+
+     ensure_oidc_provider "sts.windows.net/${TENANT_ID}/" \
+          "https://sts.windows.net/${TENANT_ID}/" \
+          "${OIDC_AUDIENCE}" \
+          "626d44e704d1ceabe3bf0d53397464ac8080142c"
+
+     TRUST_STATEMENT=$(
+          cat <<EOF
+{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::${AWS_ACCOUNT}:oidc-provider/sts.windows.net/${TENANT_ID}/"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "sts.windows.net/${TENANT_ID}/:aud": "${OIDC_AUDIENCE}"
+      }
+    }
+  }
+EOF
+     )
+
+     ensure_iam_role "${TRUST_STATEMENT}"
+     attach_permissions_policy
+}
+
+# =============================================================================
+# Azure AKS trust
+# =============================================================================
+
+trust_azure_aks() {
+     if [ -z "${OIDC_ISSUER}" ]; then
+          die "CWAGENT_AZURE_OIDC_ISSUER is required for azure_aks (produced by azure/setup.sh)"
+     fi
+
+     OIDC_HOST="${OIDC_ISSUER#https://}"
+
+     section "Configuring AWS trust..."
+
+     ensure_oidc_provider "${OIDC_HOST}" "${OIDC_ISSUER}" sts.amazonaws.com
+
+     TRUST_STATEMENT=$(
+          cat <<EOF
+{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::${AWS_ACCOUNT}:oidc-provider/${OIDC_HOST}"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "${OIDC_HOST}:sub": "system:serviceaccount:${K8S_NAMESPACE}:cloudwatch-agent",
+        "${OIDC_HOST}:aud": "sts.amazonaws.com"
+      }
+    }
+  }
+EOF
+     )
+
+     ensure_iam_role "${TRUST_STATEMENT}"
+     attach_permissions_policy
+}
+
+# =============================================================================
+# Install payload builders (EC2 path)
+# =============================================================================
+
+# Emit the one-line command that fetches install.sh and runs it on a Linux target.
+linux_install_cmd() {
+     printf 'curl -fsSL %s/install.sh | sh' "${SCRIPT_BASE_URL}"
+}
+
+# Windows counterpart. The fetch is wrapped into one -EncodedCommand base64
+# payload (UTF-16LE) so the outer command needs no quoting through SSM.
+windows_install_cmd() {
+     ps_script="Invoke-WebRequest -Uri ${SCRIPT_BASE_URL}/install.ps1 -OutFile \$env:TEMP\\cwagent-install.ps1; & \$env:TEMP\\cwagent-install.ps1"
+     encoded=$(printf '%s' "${ps_script}" | iconv -f utf-8 -t utf-16le 2>/dev/null | base64 | tr -d '\n')
+     [ -n "${encoded}" ] || return 1
+     printf 'powershell -NoProfile -EncodedCommand %s' "${encoded}"
+}
+
+# Run a command on an EC2 instance via SSM. $1 = document name
+# (AWS-RunShellScript | AWS-RunPowerShellScript), $2 = command.
+run_via_ssm() {
+     ssm_doc="$1"
+     ssm_cmd="$2"
+
+     logaction "Running install via SSM"
+     COMMAND_ID=$(aws ssm send-command \
+          --instance-ids "${INSTANCE_ID}" \
+          --document-name "${ssm_doc}" \
+          --parameters "commands=[\"${ssm_cmd}\"]" \
+          --region "${REGION}" --query 'Command.CommandId' --output text)
+
+     aws ssm wait command-executed \
+          --command-id "${COMMAND_ID}" \
+          --instance-id "${INSTANCE_ID}" --region "${REGION}" 2>/dev/null || true
+
+     SSM_OUTPUT=$(aws ssm get-command-invocation \
+          --command-id "${COMMAND_ID}" \
+          --instance-id "${INSTANCE_ID}" \
+          --region "${REGION}" --query 'StandardOutputContent' --output text)
+     SSM_STATUS_DETAIL=$(aws ssm get-command-invocation \
+          --command-id "${COMMAND_ID}" \
+          --instance-id "${INSTANCE_ID}" \
+          --region "${REGION}" --query 'StatusDetails' --output text)
+
+     printf '%s\n' "${SSM_OUTPUT}" >&3
+     if [ "${SSM_STATUS_DETAIL}" != "Success" ]; then
+          aws ssm get-command-invocation \
+               --command-id "${COMMAND_ID}" \
+               --instance-id "${INSTANCE_ID}" \
+               --region "${REGION}" --query 'StandardErrorContent' --output text >&2
+          die "SSM command finished with status: ${SSM_STATUS_DETAIL}"
+     fi
+}
+
+# =============================================================================
+# AWS EC2 install
+# =============================================================================
+
+install_aws_ec2() {
+     if [ -z "${INSTANCE_ID}" ]; then usage; fi
+
+     INSTANCE_PLATFORM=$(aws ec2 describe-instances \
+          --instance-ids "${INSTANCE_ID}" \
+          --region "${REGION}" \
+          --query 'Reservations[0].Instances[0].Platform' --output text 2>/dev/null || true)
+
+     SSM_STATUS=$(aws ssm describe-instance-information \
+          --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+          --query 'InstanceInformationList[0].PingStatus' \
+          --region "${REGION}" --output text 2>/dev/null || true)
+
+     if [ "${SSM_STATUS}" = "Online" ]; then
+          section "Installing agent on ${INSTANCE_ID}..."
+          if [ "${INSTANCE_PLATFORM}" = "windows" ]; then
+               if INSTALL_CMD=$(windows_install_cmd); then
+                    run_via_ssm "AWS-RunPowerShellScript" "${INSTALL_CMD}"
+                    log "Agent installed on ${INSTANCE_ID}"
+                    return
+               fi
+          else
+               if INSTALL_CMD=$(linux_install_cmd); then
+                    run_via_ssm "AWS-RunShellScript" "${INSTALL_CMD}"
+                    log "Agent installed on ${INSTANCE_ID}"
+                    return
+               fi
+          fi
+          logwarn "could not build the install command (iconv is required for Windows targets)"
+     else
+          logwarn "SSM agent is not available on ${INSTANCE_ID}"
+     fi
+
+     printf '\n' >&3
+     printf 'Done. Run the following on %s to install and start the agent:\n' "${INSTANCE_ID}" >&3
+     printf '\n' >&3
+     if [ "${INSTANCE_PLATFORM}" = "windows" ]; then
+          printf '%s\n' "  # PowerShell, as Administrator:" >&3
+          printf '%s\n' "  Invoke-WebRequest -Uri ${SCRIPT_BASE_URL}/install.ps1 -OutFile \$env:TEMP\\install.ps1; & \$env:TEMP\\install.ps1" >&3
+     else
+          printf '%s\n' "  curl -fsSL ${SCRIPT_BASE_URL}/install.sh | sudo sh" >&3
+     fi
+}
+
+# =============================================================================
+# AWS EKS install
+# =============================================================================
+
+install_aws_eks() {
+     if [ -z "${CLUSTER_NAME}" ]; then usage; fi
+
+     # The add-on injects k8sMode and clusterName, so configuration-values carries
+     # only the pipeline config: OTel Container Insights + logs on, v1 CI/FluentBit
+     # off, and the node + cluster-scraper agents.
+     ADDON_CONFIG='{"containerInsights":{"enabled":false},"containerLogs":{"enabled":false},"otelContainerInsights":{"enabled":true,"logs":{"enabled":true}},"agents":[{"name":"cloudwatch-agent","config":"default:otel"},{"name":"cloudwatch-agent-cluster-scraper","mode":"deployment","config":"default"}]}'
+
+     section "Installing the CloudWatch Observability add-on on ${CLUSTER_NAME}..."
+     # create-addon for a new install, update-addon if it already exists.
+     # --resolve-conflicts is left at its NONE default, so a re-run never
+     # silently overwrites a value changed by hand on the add-on.
+     if aws eks describe-addon --cluster-name "${CLUSTER_NAME}" --addon-name amazon-cloudwatch-observability --region "${REGION}" >/dev/null 2>&1; then
+          logaction "Updating add-on configuration"
+          aws eks update-addon \
+               --cluster-name "${CLUSTER_NAME}" \
+               --addon-name amazon-cloudwatch-observability \
+               --configuration-values "${ADDON_CONFIG}" \
+               --region "${REGION}" >/dev/null
+     else
+          logaction "Creating add-on"
+          aws eks create-addon \
+               --cluster-name "${CLUSTER_NAME}" \
+               --addon-name amazon-cloudwatch-observability \
+               --configuration-values "${ADDON_CONFIG}" \
+               --region "${REGION}" >/dev/null
+     fi
+     # create/update is async. Wait for active, but a slow activation shouldn't
+     # fail the run, so on timeout just point at the status command.
+     if aws eks wait addon-active --cluster-name "${CLUSTER_NAME}" --addon-name amazon-cloudwatch-observability --region "${REGION}" 2>/dev/null; then
+          log "Add-on active on ${CLUSTER_NAME}"
+     else
+          logwarn "Add-on submitted, still activating. Check: aws eks describe-addon --cluster-name ${CLUSTER_NAME} --addon-name amazon-cloudwatch-observability --region ${REGION}"
+     fi
+}
+
+# =============================================================================
+# AWS ECS install
+#
+# The ECS "install" is a container added to an existing task definition, so this
+# prints that definition rather than deploying anything.
+# =============================================================================
+
+install_aws_ecs() {
+     ECS_LAUNCH_TYPE="${ECS_LAUNCH_TYPE:-fargate}"
+
+     section "Add this container to the task definition's containerDefinitions:"
+     printf '\n' >&3
+     cat >&3 <<EOF
+    {
+      "name": "cloudwatch-agent",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+      "essential": false,$(
+          if [ "${ECS_LAUNCH_TYPE}" = "ec2" ]; then
+               cat <<PORTS
+
+      "portMappings": [
+        { "containerPort": 4317, "hostPort": 4317, "protocol": "tcp" },
+        { "containerPort": 4318, "hostPort": 4318, "protocol": "tcp" }
+      ],
+PORTS
+          fi
+     )
+      "environment": [
+        { "name": "USE_DEFAULT_CONFIG", "value": "otel" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "True",
+          "awslogs-group": "/ecs/cloudwatch-agent",
+          "awslogs-region": "${REGION}",
+          "awslogs-stream-prefix": "agent"
+        }
+      }
+    }
+EOF
+
+     printf '\n' >&3
+     printf 'Also set on the task definition:\n' >&3
+     if [ "${ECS_LAUNCH_TYPE}" = "ec2" ]; then
+          printf '%s\n' "  \"taskRoleArn\": \"${ROLE_ARN}\"," >&3
+          printf '%s\n' "  \"networkMode\": \"bridge\"" >&3
+          printf '\n' >&3
+          printf '%s\n' "Add to the application container:" >&3
+          printf '%s\n' "  \"links\": [\"cloudwatch-agent\"]" >&3
+          printf '%s\n' "  \"environment\": [{\"name\": \"OTEL_EXPORTER_OTLP_ENDPOINT\", \"value\": \"http://cloudwatch-agent:4317\"}]" >&3
+     else
+          printf '%s\n' "  \"taskRoleArn\": \"${ROLE_ARN}\"" >&3
+     fi
+}
+
+main() {
+     case "${1:-}" in -h | --help) usage 0 ;; esac
+
+     # Interactive only on a real TTY and never under CWAGENT_EMIT_ENV (the
+     # dispatcher eval-chains this script and cannot answer prompts).
+     if [ -t 0 ] && ! is_true "${EMIT_ENV}" && [ -z "${PLATFORM}" ]; then
+          interactive_setup
+     fi
+
+     case "${PLATFORM}" in
+     aws_ec2 | aws_ecs | aws_eks | azure_vm | azure_aks) ;;
+     *) die "unsupported platform: ${PLATFORM:-<unset>} (valid: aws_ec2, aws_ecs, aws_eks, azure_vm, azure_aks)" ;;
+     esac
+
+     check_prerequisites
+
+     # Region is baked into the role/endpoint and is where telemetry lands, so
+     # never guess it: fail rather than default silently.
+     if [ -z "${REGION}" ]; then
+          REGION=$(aws configure get region 2>/dev/null || true)
+     fi
+     if [ -z "${REGION}" ] && [ -t 0 ] && ! is_true "${EMIT_ENV}"; then
+          prompt REGION "AWS region telemetry is sent to"
+     fi
+     [ -n "${REGION}" ] || die "CWAGENT_AWS_REGION is required (set it or run 'aws configure set region <region>')"
+
+     # Trust always runs. The Azure platforms stop after emitting the ARN
+     # (install happens on the Azure side).
+     case "${PLATFORM}" in
+     aws_ec2) trust_aws_ec2 ;;
+     aws_ecs) trust_aws_ecs ;;
+     aws_eks) trust_aws_eks ;;
+     azure_vm) trust_azure_vm ;;
+     azure_aks) trust_azure_aks ;;
+     esac
+
+     ROLE_ARN=$(aws iam get-role \
+          --role-name "${ROLE_NAME}" \
+          --query Role.Arn --output text)
+     log "Role ARN: ${ROLE_ARN}"
+
+     ensure_transaction_search
+
+     case "${PLATFORM}" in
+     aws_ec2) install_aws_ec2 ;;
+     aws_eks) install_aws_eks ;;
+     aws_ecs) install_aws_ecs ;;
+     azure_vm | azure_aks)
+          log "Trust configured. Install runs on the Azure side (azure/setup.sh) with the role ARN above."
+          ;;
+     esac
+
+     add_env CWAGENT_PLATFORM "${PLATFORM}"
+     add_env CWAGENT_AWS_ROLE_ARN "${ROLE_ARN}"
+     add_env CWAGENT_AWS_REGION "${REGION}"
+     # Carried through so a later step (or a paste command) is self-contained,
+     # with no values to re-enter by hand.
+     add_env CWAGENT_AWS_INSTANCE_ID "${INSTANCE_ID}"
+     add_env CWAGENT_K8S_CLUSTER_NAME "${CLUSTER_NAME}"
+
+     emit_env
+}
+
+main "$@"

--- a/scripts/aws/setup.sh
+++ b/scripts/aws/setup.sh
@@ -69,7 +69,7 @@ EMIT_ENV="${CWAGENT_EMIT_ENV:-}"
 ECS_LAUNCH_TYPE="${CWAGENT_AWS_ECS_LAUNCH_TYPE:-}"
 
 # Where the target fetches the install payload (install.sh / install.ps1) from.
-SCRIPT_BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts"
+SCRIPT_BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/main/scripts"
 # The agent's namespace is fixed: the EKS add-on always installs into
 # amazon-cloudwatch, and the operator/chart centers on it, so it is not settable.
 K8S_NAMESPACE="amazon-cloudwatch"

--- a/scripts/aws/setup.sh
+++ b/scripts/aws/setup.sh
@@ -126,11 +126,11 @@ usage() {
      [ "${rc}" = "0" ] && out=1
      cat >&${out} <<EOF
 Usage:
-  CWAGENT_PLATFORM=aws_eks   CWAGENT_K8S_CLUSTER_NAME=<cluster>  $0
-  CWAGENT_PLATFORM=aws_ec2   CWAGENT_AWS_INSTANCE_ID=i-123       $0
-  CWAGENT_PLATFORM=aws_ecs                                       $0
-  CWAGENT_PLATFORM=azure_aks CWAGENT_AZURE_OIDC_ISSUER=https://... $0
-  CWAGENT_PLATFORM=azure_vm  CWAGENT_AZURE_TENANT_ID=<tenant>    $0
+  CWAGENT_PLATFORM=aws_eks   CWAGENT_AWS_REGION=us-east-1 CWAGENT_K8S_CLUSTER_NAME=<cluster>    $0
+  CWAGENT_PLATFORM=aws_ec2   CWAGENT_AWS_REGION=us-east-1 CWAGENT_AWS_INSTANCE_ID=i-123         $0
+  CWAGENT_PLATFORM=aws_ecs   CWAGENT_AWS_REGION=us-east-1                                       $0
+  CWAGENT_PLATFORM=azure_aks CWAGENT_AWS_REGION=us-east-1 CWAGENT_AZURE_OIDC_ISSUER=https://... $0
+  CWAGENT_PLATFORM=azure_vm  CWAGENT_AWS_REGION=us-east-1 CWAGENT_AZURE_TENANT_ID=<tenant>      $0
 
 Environment variables:
   Common:
@@ -732,14 +732,20 @@ EOF
 # =============================================================================
 
 # Emit the one-line command that fetches install.sh and runs it on a Linux target.
+# SSM RunCommand sets AWS_SHARED_CREDENTIALS_FILE to the DHMC role's credentials,
+# which the SDK prefers over the instance profile we just attached; unset it so
+# config-downloader uses the instance profile (which has CloudWatchAgentServerPolicy).
+# No-op on non-DHMC instances, where the variable is not set.
 linux_install_cmd() {
-     printf 'curl -fsSL %s/install.sh | sh' "${SCRIPT_BASE_URL}"
+     printf 'unset AWS_SHARED_CREDENTIALS_FILE; curl -fsSL %s/install.sh | sh' "${SCRIPT_BASE_URL}"
 }
 
 # Windows counterpart. The fetch is wrapped into one -EncodedCommand base64
 # payload (UTF-16LE) so the outer command needs no quoting through SSM.
+# Remove-Item Env:AWS_SHARED_CREDENTIALS_FILE for the same reason as the Linux
+# path: SSM sets it to the DHMC role's creds, which shadow the instance profile.
 windows_install_cmd() {
-     ps_script="Invoke-WebRequest -Uri ${SCRIPT_BASE_URL}/install.ps1 -OutFile \$env:TEMP\\cwagent-install.ps1; & \$env:TEMP\\cwagent-install.ps1"
+     ps_script="Remove-Item Env:AWS_SHARED_CREDENTIALS_FILE -ErrorAction SilentlyContinue; Invoke-WebRequest -Uri ${SCRIPT_BASE_URL}/install.ps1 -OutFile \$env:TEMP\\cwagent-install.ps1; & \$env:TEMP\\cwagent-install.ps1"
      encoded=$(printf '%s' "${ps_script}" | iconv -f utf-8 -t utf-16le 2>/dev/null | base64 | tr -d '\n')
      [ -n "${encoded}" ] || return 1
      printf 'powershell -NoProfile -EncodedCommand %s' "${encoded}"

--- a/scripts/azure/setup.sh
+++ b/scripts/azure/setup.sh
@@ -42,6 +42,17 @@
 #     CWAGENT_AWS_ROLE_ARN          IAM role ARN, install runs too when set
 #     CWAGENT_AWS_REGION            AWS region telemetry is sent to (required
 #                                   for install)
+#     CWAGENT_AZURE_SUBSCRIPTION    Subscription ID or name the resource lives
+#                                   in (Cloud Shell's ambient default is used
+#                                   when unset). When combined with
+#                                   CWAGENT_AZURE_RESOURCE_ID, a GUID is
+#                                   checked against the ID up front; a name is
+#                                   verified after sign-in
+#     CWAGENT_AZURE_RESOURCE_ID     Full ARM resource ID of the VM / AKS
+#                                   cluster; supplies the subscription,
+#                                   resource group, and name in one value.
+#                                   Individual CWAGENT_AZURE_* values that
+#                                   contradict it are rejected
 #     CWAGENT_AZURE_RESOURCE_GROUP  Resource group
 #     CWAGENT_EMIT_ENV              When set (1/true/yes/on), print eval-able KEY='value'
 #                                   lines on stdout and route all logging to stderr
@@ -55,10 +66,15 @@ set -eu
 PLATFORM="${CWAGENT_PLATFORM:-}"
 ROLE_ARN="${CWAGENT_AWS_ROLE_ARN:-}"
 REGION="${CWAGENT_AWS_REGION:-}"
+SUBSCRIPTION="${CWAGENT_AZURE_SUBSCRIPTION:-}"
+RESOURCE_ID="${CWAGENT_AZURE_RESOURCE_ID:-}"
 RESOURCE_GROUP="${CWAGENT_AZURE_RESOURCE_GROUP:-}"
 VM_NAME="${CWAGENT_AZURE_VM_NAME:-}"
 CLUSTER_NAME="${CWAGENT_K8S_CLUSTER_NAME:-}"
 EMIT_ENV="${CWAGENT_EMIT_ENV:-}"
+# Set in main when CWAGENT_AZURE_SUBSCRIPTION is a display name and a resource
+# ID is also given; consumed by check_prerequisites for the deferred check.
+GIVEN_SUBSCRIPTION_NAME=""
 HELM_CHART_REPO="https://aws-observability.github.io/helm-charts"
 
 # Where the VM fetches the install payload (install.sh / install.ps1) from.
@@ -127,6 +143,9 @@ Environment variables:
     CWAGENT_PLATFORM              azure_vm | azure_aks
     CWAGENT_AWS_ROLE_ARN          IAM role ARN; when set, install runs too
     CWAGENT_AWS_REGION            AWS region (required for install)
+    CWAGENT_AZURE_SUBSCRIPTION    Subscription ID or name of the resource
+    CWAGENT_AZURE_RESOURCE_ID     Full ARM resource ID (subscription + group + name);
+                                  conflicting individual values are rejected
     CWAGENT_AZURE_RESOURCE_GROUP  Resource group
     CWAGENT_EMIT_ENV              Print eval-able KEY='value' lines on stdout
   azure_vm:
@@ -258,19 +277,90 @@ interactive_setup() {
      esac
 }
 
+# Split an ARM resource ID into subscription / resource group / name, and return
+# the provider type so the caller can reject an ID from the wrong platform.
+# ARM treats resource IDs case-insensitively, so the structure is validated
+# against a lowercased copy (accepting any casing of the fixed segments), while
+# the extracted values keep the caller's original casing.
+parse_resource_id() {
+     _lower=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+     case "${_lower}" in
+     /subscriptions/*/resourcegroups/*/providers/*/*/*) : ;;
+     *) die "not a valid Azure resource ID: $1" ;;
+     esac
+     # Field positions are fixed by the validation above. The last variable
+     # soaks up everything from the provider namespace on (type/name, plus any
+     # child-resource segments), of which the final two are the type and name.
+     IFS=/ read -r _ _ SUBSCRIPTION _ RESOURCE_GROUP _ _ _type_and_name <<EOF
+$1
+EOF
+     RESOURCE_NAME="${_type_and_name##*/}"
+     _type_and_name="${_type_and_name%/*}"
+     RESOURCE_TYPE="${_type_and_name##*/}"
+}
+
+# Die when an individually-supplied CWAGENT_AZURE_* value contradicts what
+# CWAGENT_AZURE_RESOURCE_ID resolves to. Matching or absent values are fine —
+# only a genuine conflict is an error, so existing single-variable and
+# ID-only invocations are unaffected. ARM treats these identifiers
+# case-insensitively, so the comparison does too.
+# $1 = variable name (for the message), $2 = given value, $3 = resolved value.
+check_resource_id_conflict() {
+     [ -n "$2" ] || return 0
+     _given=$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')
+     _resolved=$(printf '%s' "$3" | tr '[:upper:]' '[:lower:]')
+     [ "${_given}" = "${_resolved}" ] ||
+          die "$1='$2' conflicts with CWAGENT_AZURE_RESOURCE_ID (which resolves to '$3')
+Pass the resource ID or the individual values, not both with different targets."
+}
+
+# True when $1 is GUID-shaped (8-4-4-4-12 hex groups) — the only form the
+# subscription segment of an ARM resource ID can take. Used to tell a
+# subscription ID apart from a display name.
+is_guid() {
+     printf '%s' "$1" | grep -Eiq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+}
+
 check_prerequisites() {
      command -v az >/dev/null 2>&1 || die "Azure CLI is required but not installed"
      AZ_CLI_VERSION=$(az version --query '"azure-cli"' -o tsv 2>/dev/null || echo "0.0.0")
      if ! version_ge "${AZ_CLI_VERSION}" "2.47.0"; then
           logwarn "Azure CLI ${AZ_CLI_VERSION} detected (2.47+ recommended for full functionality)"
      fi
+     # Pin every subsequent az call to the resource's subscription; without this
+     # they all resolve against Cloud Shell's ambient default, and ARM answers
+     # for a resource in another subscription with an AuthorizationFailed that
+     # is indistinguishable from a genuine RBAC gap.
+     if [ -n "${SUBSCRIPTION}" ]; then
+          az_err=$(az account set --subscription "${SUBSCRIPTION}" 2>&1) ||
+               die "cannot select subscription ${SUBSCRIPTION}: ${az_err}
+Check 'az account list'; if it is in another tenant, run: az login --tenant <tenant-id>"
+          log "Subscription: ${SUBSCRIPTION}"
+     fi
      # One az account show for the liveness check, subscription id/name, and
      # tenant id (used later for the azure_vm identity emit).
-     AZ_ACCOUNT=$(az account show --query "[id, name, tenantId]" -o tsv 2>/dev/null) ||
+     # The nested [[...]] makes -o tsv emit one tab-separated row; a flat
+     # [...] array would print one value per line, breaking the cut parsing.
+     AZ_ACCOUNT=$(az account show --query "[[id, name, tenantId]]" -o tsv 2>/dev/null) ||
           die "Azure CLI not logged in (run 'az login')"
      AZ_SUB=$(printf '%s' "${AZ_ACCOUNT}" | cut -f1)
      AZ_NAME=$(printf '%s' "${AZ_ACCOUNT}" | cut -f2)
      AZ_TENANT=$(printf '%s' "${AZ_ACCOUNT}" | cut -f3)
+     # Deferred conflict check: the subscription was given as a display name
+     # (or a non-canonical form) alongside a resource ID, so it could not be
+     # compared to the ID's GUID up front (see main). The account is now
+     # pinned to the ID's subscription; accept a match on either its id or
+     # its display name — the same lookup semantics az account set uses — so
+     # a misclassification by is_guid can never produce a false conflict.
+     if [ -n "${GIVEN_SUBSCRIPTION_NAME}" ]; then
+          _given_lower=$(printf '%s' "${GIVEN_SUBSCRIPTION_NAME}" | tr '[:upper:]' '[:lower:]')
+          _sub_lower=$(printf '%s' "${AZ_SUB}" | tr '[:upper:]' '[:lower:]')
+          _name_lower=$(printf '%s' "${AZ_NAME}" | tr '[:upper:]' '[:lower:]')
+          if [ "${_given_lower}" != "${_sub_lower}" ] && [ "${_given_lower}" != "${_name_lower}" ]; then
+               die "CWAGENT_AZURE_SUBSCRIPTION='${GIVEN_SUBSCRIPTION_NAME}' conflicts with CWAGENT_AZURE_RESOURCE_ID (which resolves to '${AZ_SUB}', name '${AZ_NAME}')
+Pass the resource ID or the individual values, not both with different targets."
+          fi
+     fi
      if [ -n "${AZ_NAME}" ]; then
           log "Azure subscription: ${AZ_SUB} (${AZ_NAME})"
      else
@@ -364,10 +454,14 @@ setup_azure_vm() {
      # One az vm show for both fields: the identity (to decide whether to assign
      # one) and the OS type (to pick the install payload). A tsv list projection
      # returns them tab-separated on one line, in query order.
+     # The nested [[...]] makes -o tsv emit one tab-separated row (null
+     # renders as "None"); a flat [...] array would print one value per line,
+     # making cut return both lines and IDENTITY test truthy for a VM with no
+     # identity at all.
      VM_INFO=$(az vm show \
           --resource-group "${RESOURCE_GROUP}" \
           --name "${VM_NAME}" \
-          --query "[identity.principalId, storageProfile.osDisk.osType]" -o tsv 2>/dev/null || true)
+          --query "[[identity.principalId, storageProfile.osDisk.osType]]" -o tsv 2>/dev/null || true)
      IDENTITY=$(printf '%s' "${VM_INFO}" | cut -f1)
      VM_OS=$(printf '%s' "${VM_INFO}" | cut -f2)
 
@@ -433,18 +527,22 @@ setup_azure_aks() {
 
      section "Configuring AKS cluster..."
 
-     # One az aks show for both the enabled flag and the issuer URL (present when
-     # already enabled). Only re-fetch the URL after enabling it ourselves.
+     # One az aks show for the two enabled flags and the issuer URL (present
+     # when OIDC is already enabled). Both flags must be checked: newer AKS
+     # enables the OIDC issuer at creation by default, but never workload
+     # identity, so keying on the issuer alone would skip the update and leave
+     # workload identity off.
      AKS_INFO=$(az aks show \
           --resource-group "${RESOURCE_GROUP}" \
           --name "${CLUSTER_NAME}" \
-          --query "[oidcIssuerProfile.enabled, oidcIssuerProfile.issuerUrl]" -o tsv 2>/dev/null || true)
+          --query "[[oidcIssuerProfile.enabled, securityProfile.workloadIdentity.enabled, oidcIssuerProfile.issuerUrl]]" -o tsv 2>/dev/null || true)
      OIDC_ENABLED=$(printf '%s' "${AKS_INFO}" | cut -f1)
-     OIDC_ISSUER=$(printf '%s' "${AKS_INFO}" | cut -f2)
+     WI_ENABLED=$(printf '%s' "${AKS_INFO}" | cut -f2)
+     OIDC_ISSUER=$(printf '%s' "${AKS_INFO}" | cut -f3)
 
      # az -o tsv renders a JSON boolean via Python str(), i.e. "True"/"False",
      # so match case-insensitively rather than against a lowercase "true".
-     if [ "$(printf '%s' "${OIDC_ENABLED}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+     if [ "$(printf '%s%s' "${OIDC_ENABLED}" "${WI_ENABLED}" | tr '[:upper:]' '[:lower:]')" = "truetrue" ]; then
           log "OIDC issuer and workload identity enabled"
      else
           logaction "Enabling OIDC issuer and workload identity (this may take a few minutes)"
@@ -550,6 +648,40 @@ main() {
      # Region is only needed for the install, so require it only when the ARN is set.
      if [ -n "${ROLE_ARN}" ]; then
           [ -n "${REGION}" ] || die "CWAGENT_AWS_REGION is required to install"
+     fi
+
+     # A full ARM resource ID carries the subscription, resource group, and name
+     # in one value; resolve it into the existing variables so the rest of the
+     # script is untouched. Individually-supplied CWAGENT_AZURE_* values that
+     # contradict the ID fail loudly rather than being silently overridden.
+     if [ -n "${RESOURCE_ID}" ]; then
+          _given_subscription="${SUBSCRIPTION}"
+          _given_resource_group="${RESOURCE_GROUP}"
+          _given_vm_name="${VM_NAME}"
+          _given_cluster_name="${CLUSTER_NAME}"
+          parse_resource_id "${RESOURCE_ID}"
+          # ARM compares the type segment case-insensitively too; the original
+          # casing is kept for the mismatch message.
+          _resource_type_lower=$(printf '%s' "${RESOURCE_TYPE}" | tr '[:upper:]' '[:lower:]')
+          case "${PLATFORM}:${_resource_type_lower}" in
+          azure_vm:virtualmachines) VM_NAME="${RESOURCE_NAME}" ;;
+          azure_aks:managedclusters) CLUSTER_NAME="${RESOURCE_NAME}" ;;
+          *) die "resource ID is a ${RESOURCE_TYPE}, which does not match CWAGENT_PLATFORM=${PLATFORM}" ;;
+          esac
+          # The ID's subscription segment is always a GUID, but the user may
+          # have supplied CWAGENT_AZURE_SUBSCRIPTION as a display name (the
+          # documented "ID or name" contract). A name can only be compared
+          # after az resolves the account, so defer that case to
+          # check_prerequisites instead of failing on a guaranteed
+          # name-vs-GUID mismatch here.
+          if is_guid "${_given_subscription}" || [ -z "${_given_subscription}" ]; then
+               check_resource_id_conflict "CWAGENT_AZURE_SUBSCRIPTION" "${_given_subscription}" "${SUBSCRIPTION}"
+          else
+               GIVEN_SUBSCRIPTION_NAME="${_given_subscription}"
+          fi
+          check_resource_id_conflict "CWAGENT_AZURE_RESOURCE_GROUP" "${_given_resource_group}" "${RESOURCE_GROUP}"
+          check_resource_id_conflict "CWAGENT_AZURE_VM_NAME" "${_given_vm_name}" "${VM_NAME}"
+          check_resource_id_conflict "CWAGENT_K8S_CLUSTER_NAME" "${_given_cluster_name}" "${CLUSTER_NAME}"
      fi
 
      check_prerequisites

--- a/scripts/azure/setup.sh
+++ b/scripts/azure/setup.sh
@@ -1,0 +1,565 @@
+#!/bin/sh
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+# Amazon CloudWatch Agent - Azure setup (identity + install)
+#
+# Configures the Azure-side identity the agent uses and installs it:
+#
+#   azure_vm    assigns a system-assigned managed identity to the VM, then
+#               pushes install.sh to it via "az vm run-command"
+#               (requires: az)
+#   azure_aks   enables the OIDC issuer and workload identity on the cluster
+#               (an "az aks update" that can take several minutes), then
+#               installs the CloudWatch Observability Helm chart when helm and
+#               kubectl are present, otherwise prints the command (requires: az)
+#
+# Two modes, keyed on CWAGENT_AWS_ROLE_ARN:
+#
+#   Set: identity AND install in one run. Install can precede the AWS trust
+#     setup and the agent retries with backoff until the trust is in place.
+#
+#   Unset: identity only, then stop (for anyone without the ARN yet). Run
+#     aws/setup.sh to get the ARN, then rerun with it set. Identity is
+#     idempotent, so the rerun just installs.
+#
+# Usage:
+#   Interactive (TTY):
+#     ./azure/setup.sh
+#
+#   Environment variables (piped/automated):
+#     CWAGENT_PLATFORM=azure_aks \
+#     CWAGENT_AWS_ROLE_ARN=arn:aws:iam::... \
+#     CWAGENT_AWS_REGION=us-east-1 \
+#     CWAGENT_AZURE_RESOURCE_GROUP=rg \
+#     CWAGENT_K8S_CLUSTER_NAME=cluster \
+#       ./azure/setup.sh
+#
+# Environment variables:
+#   Common:
+#     CWAGENT_PLATFORM              azure_vm | azure_aks
+#     CWAGENT_AWS_ROLE_ARN          IAM role ARN, install runs too when set
+#     CWAGENT_AWS_REGION            AWS region telemetry is sent to (required
+#                                   for install)
+#     CWAGENT_AZURE_RESOURCE_GROUP  Resource group
+#     CWAGENT_EMIT_ENV              When set (1/true/yes/on), print eval-able KEY='value'
+#                                   lines on stdout and route all logging to stderr
+#   azure_vm:
+#     CWAGENT_AZURE_VM_NAME         VM name
+#   azure_aks:
+#     CWAGENT_K8S_CLUSTER_NAME      Cluster name
+
+set -eu
+
+PLATFORM="${CWAGENT_PLATFORM:-}"
+ROLE_ARN="${CWAGENT_AWS_ROLE_ARN:-}"
+REGION="${CWAGENT_AWS_REGION:-}"
+RESOURCE_GROUP="${CWAGENT_AZURE_RESOURCE_GROUP:-}"
+VM_NAME="${CWAGENT_AZURE_VM_NAME:-}"
+CLUSTER_NAME="${CWAGENT_K8S_CLUSTER_NAME:-}"
+EMIT_ENV="${CWAGENT_EMIT_ENV:-}"
+HELM_CHART_REPO="https://aws-observability.github.io/helm-charts"
+
+# Where the VM fetches the install payload (install.sh / install.ps1) from.
+SCRIPT_BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts"
+K8S_NAMESPACE="amazon-cloudwatch"
+
+# True when a flag is an affirmative value (1, true, yes, on, case-insensitive).
+# One truthiness rule for every CWAGENT_* boolean.
+is_true() {
+     case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+     1 | true | yes | on) return 0 ;;
+     *) return 1 ;;
+     esac
+}
+
+# =============================================================================
+# Output helpers
+#
+# Under CWAGENT_EMIT_ENV stdout carries only the eval-able KEY='value' lines the
+# parent shell captures and evaluates, so readable output (including the install
+# transcript) goes to fd 3 (redirected to stderr here, stdout otherwise) and
+# every command must keep its own output off plain stdout. A stray line that
+# looks like an assignment is indistinguishable from a real one.
+# =============================================================================
+
+if is_true "${EMIT_ENV}"; then
+     exec 3>&2
+else
+     exec 3>&1
+fi
+
+section() { printf '\n%s\n' "$1" >&3; }
+if [ -t 3 ]; then
+     log() { printf '  \033[32m✓\033[0m %s\n' "$1" >&3; }
+     logaction() { printf '  \033[33m+\033[0m %s\n' "$1" >&3; }
+     logwarn() { printf '  \033[33m!\033[0m %s\n' "$1" >&3; }
+     die() {
+          printf '  \033[31m✗\033[0m %s\n' "$1" >&2
+          exit 1
+     }
+     ask() { printf '\033[1m▸ %s\033[0m ' "$1" >&3; }
+else
+     log() { printf '  ✓ %s\n' "$1" >&3; }
+     logaction() { printf '  + %s\n' "$1" >&3; }
+     logwarn() { printf '  ! %s\n' "$1" >&3; }
+     die() {
+          printf '  ✗ %s\n' "$1" >&2
+          exit 1
+     }
+     ask() { printf '▸ %s ' "$1" >&3; }
+fi
+
+usage() {
+     rc="${1:-1}"
+     out=2
+     [ "${rc}" = "0" ] && out=1
+     cat >&${out} <<EOF
+Usage:
+  $0                    Interactive wizard (TTY)
+
+  Or via environment variables:
+  CWAGENT_PLATFORM=azure_aks CWAGENT_AWS_ROLE_ARN=arn:aws:iam::... CWAGENT_AWS_REGION=us-east-1 $0
+
+Environment variables:
+  Common:
+    CWAGENT_PLATFORM              azure_vm | azure_aks
+    CWAGENT_AWS_ROLE_ARN          IAM role ARN; when set, install runs too
+    CWAGENT_AWS_REGION            AWS region (required for install)
+    CWAGENT_AZURE_RESOURCE_GROUP  Resource group
+    CWAGENT_EMIT_ENV              Print eval-able KEY='value' lines on stdout
+  azure_vm:
+    CWAGENT_AZURE_VM_NAME         VM name
+  azure_aks:
+    CWAGENT_K8S_CLUSTER_NAME      Cluster name
+EOF
+     exit "${rc}"
+}
+
+# =============================================================================
+# Env-var emit (CWAGENT_EMIT_ENV)
+#
+# Values are single-quoted for the documented
+# eval "$(... | CWAGENT_EMIT_ENV=1 sh)" usage.
+# =============================================================================
+
+ENV_VARS=""
+add_env() {
+     [ -n "$2" ] || return 0
+     ENV_VARS="${ENV_VARS}$1=$2
+"
+}
+
+emit_env() {
+     is_true "${EMIT_ENV}" || return 0
+     printf '%s' "${ENV_VARS}" | while IFS= read -r line; do
+          [ -n "${line}" ] || continue
+          value="${line#*=}"
+          # Escape single quotes (' -> '\'') so the emitted line survives the
+          # documented eval intact even if a value ever contains one.
+          escaped=$(printf '%s' "${value}" | sed "s/'/'\\\\''/g")
+          printf "%s='%s'\n" "${line%%=*}" "${escaped}"
+     done
+}
+
+# POSIX version compare: true when $1 >= $2 as major.minor.patch. Pure parameter
+# expansion (no `sort -V`, a GNU/BSD extension) and length-agnostic, so "2.47"
+# compares equal to "2.47.0". Missing minor/patch fields count as 0.
+version_ge() {
+     _a_maj=${1%%.*}
+     _a_rest=${1#*.}
+     _a_min=${_a_rest%%.*}
+     _a_pat=${_a_rest#*.}
+     _b_maj=${2%%.*}
+     _b_rest=${2#*.}
+     _b_min=${_b_rest%%.*}
+     _b_pat=${_b_rest#*.}
+     case "$1" in *.*.*) : ;; *.*) _a_pat=0 ;; *)
+          _a_min=0
+          _a_pat=0
+          ;;
+     esac
+     case "$2" in *.*.*) : ;; *.*) _b_pat=0 ;; *)
+          _b_min=0
+          _b_pat=0
+          ;;
+     esac
+     [ "$_a_maj" -ne "$_b_maj" ] && {
+          [ "$_a_maj" -gt "$_b_maj" ]
+          return
+     }
+     [ "$_a_min" -ne "$_b_min" ] && {
+          [ "$_a_min" -gt "$_b_min" ]
+          return
+     }
+     [ "$_a_pat" -ge "$_b_pat" ]
+}
+
+# ARN-unknown mode: identity is done but install waits on the AWS trust setup.
+# Emitted to fd 3 so it never lands on stdout's CWAGENT_EMIT_ENV KEY='value' lines.
+print_await_arn() {
+     printf '\n' >&3
+     log "Azure identity configured (install pending the IAM role ARN)"
+     printf '\nNext: run aws/setup.sh with the identity value above to create the IAM\n' >&3
+     printf 'role and trust, then rerun this with CWAGENT_AWS_ROLE_ARN set to install the\n' >&3
+     printf 'agent.\n' >&3
+}
+
+# =============================================================================
+# Interactive mode
+# =============================================================================
+
+prompt() {
+     var="$1"
+     label="$2"
+     default="${3:-}"
+     eval "current=\${${var}}"
+     [ -n "${current}" ] && return
+     while true; do
+          if [ -n "${default}" ]; then
+               ask "${label} [${default}]:"
+          else
+               ask "${label}:"
+          fi
+          # A read failure (EOF on closed stdin) would loop forever with no
+          # default, and abort under set -e otherwise, so treat it as give-up.
+          read -r input || die "no input for ${label}"
+          input="${input:-${default}}"
+          [ -n "${input}" ] && break
+     done
+     # Assign without re-quoting the value, so a pasted name containing " ` or
+     # $(...) is stored literally rather than being re-parsed by the shell.
+     eval "${var}=\$input"
+}
+
+interactive_setup() {
+     printf '\nSelect platform:\n' >&3
+     printf '  azure_vm    Azure VM\n' >&3
+     printf '  azure_aks   AKS cluster\n' >&3
+     ask "Platform:"
+     read -r choice || die "no platform selected"
+     case "${choice}" in
+     azure_vm) PLATFORM=azure_vm ;;
+     azure_aks) PLATFORM=azure_aks ;;
+     *) die "invalid platform: ${choice}" ;;
+     esac
+
+     printf '\n' >&3
+     case "${PLATFORM}" in
+     azure_vm)
+          prompt RESOURCE_GROUP "Resource group"
+          prompt VM_NAME "VM name"
+          ;;
+     azure_aks)
+          prompt RESOURCE_GROUP "Resource group"
+          prompt CLUSTER_NAME "Cluster name"
+          ;;
+     esac
+}
+
+check_prerequisites() {
+     command -v az >/dev/null 2>&1 || die "Azure CLI is required but not installed"
+     AZ_CLI_VERSION=$(az version --query '"azure-cli"' -o tsv 2>/dev/null || echo "0.0.0")
+     if ! version_ge "${AZ_CLI_VERSION}" "2.47.0"; then
+          logwarn "Azure CLI ${AZ_CLI_VERSION} detected (2.47+ recommended for full functionality)"
+     fi
+     # One az account show for the liveness check, subscription id/name, and
+     # tenant id (used later for the azure_vm identity emit).
+     AZ_ACCOUNT=$(az account show --query "[id, name, tenantId]" -o tsv 2>/dev/null) ||
+          die "Azure CLI not logged in (run 'az login')"
+     AZ_SUB=$(printf '%s' "${AZ_ACCOUNT}" | cut -f1)
+     AZ_NAME=$(printf '%s' "${AZ_ACCOUNT}" | cut -f2)
+     AZ_TENANT=$(printf '%s' "${AZ_ACCOUNT}" | cut -f3)
+     if [ -n "${AZ_NAME}" ]; then
+          log "Azure subscription: ${AZ_SUB} (${AZ_NAME})"
+     else
+          log "Azure subscription: ${AZ_SUB}"
+     fi
+}
+
+# =============================================================================
+# Install payload builders (VM path)
+# =============================================================================
+
+# Emit the one-line command that fetches install.sh and runs it on a Linux
+# target, with the given env assignments as a prefix. $1 = env assignments.
+linux_install_cmd() {
+     envs="$1"
+     printf 'curl -fsSL %s/install.sh | %s sh' "${SCRIPT_BASE_URL}" "${envs}"
+}
+
+# Windows counterpart. The prelude + fetch are wrapped into one -EncodedCommand
+# base64 payload (UTF-16LE) so the outer command needs no quoting through
+# run-command. $1 = PowerShell env prelude (e.g. "$env:CWAGENT_CLOUD='azure'; ")
+windows_install_cmd() {
+     ps_prelude="$1"
+     ps_script="${ps_prelude}Invoke-WebRequest -Uri ${SCRIPT_BASE_URL}/install.ps1 -OutFile \$env:TEMP\\cwagent-install.ps1; & \$env:TEMP\\cwagent-install.ps1"
+     encoded=$(printf '%s' "${ps_script}" | iconv -f utf-8 -t utf-16le 2>/dev/null | base64 | tr -d '\n')
+     [ -n "${encoded}" ] || return 1
+     printf 'powershell -NoProfile -EncodedCommand %s' "${encoded}"
+}
+
+# Run a command on an Azure VM via run-command. $1 = command ID
+# (RunShellScript | RunPowerShellScript), $2 = command.
+run_via_az() {
+     az_command_id="$1"
+     az_cmd="$2"
+     RUN_MESSAGE=""
+
+     logaction "Running install via az vm run-command"
+     RUN_RESULT=$(az vm run-command invoke \
+          --resource-group "${RESOURCE_GROUP}" \
+          --name "${VM_NAME}" \
+          --command-id "${az_command_id}" \
+          --scripts "${az_cmd}" \
+          -o json)
+
+     # run-command returns one of two shapes: older builds emit separate
+     # ComponentStatus/StdOut|StdErr entries, current ones return a single entry
+     # whose message embeds both as "[stdout]\n...\n\n[stderr]\n...". Try the
+     # split entries first, then fall back to splitting the combined message.
+     if command -v jq >/dev/null 2>&1; then
+          STDOUT=$(printf '%s' "${RUN_RESULT}" | jq -r '.value[] | select(.code == "ComponentStatus/StdOut/succeeded") | .message')
+          STDERR=$(printf '%s' "${RUN_RESULT}" | jq -r '.value[] | select(.code == "ComponentStatus/StdErr/succeeded") | .message')
+          if [ -z "${STDOUT}" ] && [ -z "${STDERR}" ]; then
+               RUN_MESSAGE=$(printf '%s' "${RUN_RESULT}" | jq -r 'first(.value[] | select(.message != null) | .message) // ""')
+          fi
+     else
+          STDOUT=$(printf '%s' "${RUN_RESULT}" | grep -A1 '"ComponentStatus/StdOut/succeeded"' | tail -1 | sed 's/.*"message": "//;s/"$//')
+          STDERR=$(printf '%s' "${RUN_RESULT}" | grep -A1 '"ComponentStatus/StdErr/succeeded"' | tail -1 | sed 's/.*"message": "//;s/"$//')
+          if [ -z "${STDOUT}" ] && [ -z "${STDERR}" ]; then
+               RUN_MESSAGE=$(printf '%s' "${RUN_RESULT}" | grep '"message":' | head -1 | sed 's/.*"message": "//;s/"$//')
+               # Turn the JSON-escaped newlines back into real ones so the split works.
+               RUN_MESSAGE=$(printf '%b' "${RUN_MESSAGE}")
+          fi
+     fi
+
+     if [ -n "${RUN_MESSAGE:-}" ]; then
+          STDOUT=$(printf '%s' "${RUN_MESSAGE}" | sed -n '/^\[stdout\]$/,/^\[stderr\]$/p' | sed '1d;$d')
+          STDERR=$(printf '%s' "${RUN_MESSAGE}" | sed -n '/^\[stderr\]$/,$p' | sed '1d')
+     fi
+
+     # run-command masks the exit code and the agent logs benign errors to
+     # stderr, so key success off the install script's stdout sentinel (printed
+     # only after it asserts the agent is running). Show stdout either way, and
+     # add the stderr transcript only on failure, for diagnosis.
+     if [ -n "${STDOUT}" ]; then printf '%s\n' "${STDOUT}" >&3; fi
+
+     if ! printf '%s' "${STDOUT}" | grep -q 'Amazon CloudWatch Agent installed and running\.'; then
+          [ -n "${STDERR}" ] && printf '%s\n' "${STDERR}" >&2
+          die "Install script failed on ${VM_NAME}"
+     fi
+}
+
+# =============================================================================
+# Azure VM: identity + install
+# =============================================================================
+
+setup_azure_vm() {
+     if [ -z "${RESOURCE_GROUP}" ] || [ -z "${VM_NAME}" ]; then usage; fi
+
+     section "Configuring Azure VM identity..."
+
+     # One az vm show for both fields: the identity (to decide whether to assign
+     # one) and the OS type (to pick the install payload). A tsv list projection
+     # returns them tab-separated on one line, in query order.
+     VM_INFO=$(az vm show \
+          --resource-group "${RESOURCE_GROUP}" \
+          --name "${VM_NAME}" \
+          --query "[identity.principalId, storageProfile.osDisk.osType]" -o tsv 2>/dev/null || true)
+     IDENTITY=$(printf '%s' "${VM_INFO}" | cut -f1)
+     VM_OS=$(printf '%s' "${VM_INFO}" | cut -f2)
+
+     if [ -n "${IDENTITY}" ] && [ "${IDENTITY}" != "None" ]; then
+          log "Managed identity enabled on ${VM_NAME}"
+     else
+          logaction "Enabling managed identity (this may take a few minutes)"
+          az vm identity assign \
+               --resource-group "${RESOURCE_GROUP}" \
+               --name "${VM_NAME}" \
+               --output none
+          log "Managed identity enabled on ${VM_NAME}"
+     fi
+
+     TENANT_ID="${AZ_TENANT}"
+     log "Tenant: ${TENANT_ID}"
+
+     add_env CWAGENT_PLATFORM "${PLATFORM}"
+     add_env CWAGENT_AZURE_TENANT_ID "${TENANT_ID}"
+
+     # No ARN yet: identity is done, emit the tenant ID for the AWS trust step and stop.
+     if [ -z "${ROLE_ARN}" ]; then
+          print_await_arn
+          return
+     fi
+
+     section "Installing agent on ${VM_NAME}..."
+     if [ "${VM_OS}" = "Windows" ]; then
+          ps_prelude="\$env:CWAGENT_CLOUD='azure'; \$env:CWAGENT_AWS_ROLE_ARN='${ROLE_ARN}'; \$env:CWAGENT_AWS_REGION='${REGION}'; "
+          if INSTALL_CMD=$(windows_install_cmd "${ps_prelude}"); then
+               run_via_az "RunPowerShellScript" "${INSTALL_CMD}"
+               log "Agent installed on ${VM_NAME}"
+               return
+          fi
+     else
+          install_env="CWAGENT_CLOUD=azure CWAGENT_AWS_ROLE_ARN=${ROLE_ARN} CWAGENT_AWS_REGION=${REGION}"
+          if INSTALL_CMD=$(linux_install_cmd "${install_env}"); then
+               run_via_az "RunShellScript" "${INSTALL_CMD}"
+               log "Agent installed on ${VM_NAME}"
+               return
+          fi
+     fi
+     logwarn "could not build the install command (iconv is required for Windows targets)"
+
+     printf '\n' >&3
+     printf 'Done. Run the following on %s to install and start the agent:\n' "${VM_NAME}" >&3
+     printf '\n' >&3
+     if [ "${VM_OS}" = "Windows" ]; then
+          printf '%s\n' "  # PowerShell, as Administrator:" >&3
+          printf '%s\n' "  \$env:CWAGENT_CLOUD='azure'; \$env:CWAGENT_AWS_ROLE_ARN='${ROLE_ARN}'; \$env:CWAGENT_AWS_REGION='${REGION}'" >&3
+          printf '%s\n' "  Invoke-WebRequest -Uri ${SCRIPT_BASE_URL}/install.ps1 -OutFile \$env:TEMP\\install.ps1; & \$env:TEMP\\install.ps1" >&3
+     else
+          printf '%s\n' "  curl -fsSL ${SCRIPT_BASE_URL}/install.sh | sudo ${install_env} sh" >&3
+     fi
+}
+
+# =============================================================================
+# Azure AKS: identity + install
+# =============================================================================
+
+setup_azure_aks() {
+     if [ -z "${RESOURCE_GROUP}" ] || [ -z "${CLUSTER_NAME}" ]; then usage; fi
+
+     section "Configuring AKS cluster..."
+
+     # One az aks show for both the enabled flag and the issuer URL (present when
+     # already enabled). Only re-fetch the URL after enabling it ourselves.
+     AKS_INFO=$(az aks show \
+          --resource-group "${RESOURCE_GROUP}" \
+          --name "${CLUSTER_NAME}" \
+          --query "[oidcIssuerProfile.enabled, oidcIssuerProfile.issuerUrl]" -o tsv 2>/dev/null || true)
+     OIDC_ENABLED=$(printf '%s' "${AKS_INFO}" | cut -f1)
+     OIDC_ISSUER=$(printf '%s' "${AKS_INFO}" | cut -f2)
+
+     # az -o tsv renders a JSON boolean via Python str(), i.e. "True"/"False",
+     # so match case-insensitively rather than against a lowercase "true".
+     if [ "$(printf '%s' "${OIDC_ENABLED}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+          log "OIDC issuer and workload identity enabled"
+     else
+          logaction "Enabling OIDC issuer and workload identity (this may take a few minutes)"
+          az aks update \
+               --resource-group "${RESOURCE_GROUP}" \
+               --name "${CLUSTER_NAME}" \
+               --enable-oidc-issuer \
+               --enable-workload-identity \
+               --output none
+          # Re-fetch the now-populated issuer URL. No "|| true" here (unlike the
+          # probe above): we just changed cluster state, so a failure should
+          # surface loudly rather than leave OIDC_ISSUER empty.
+          OIDC_ISSUER=$(az aks show \
+               --resource-group "${RESOURCE_GROUP}" \
+               --name "${CLUSTER_NAME}" \
+               --query "oidcIssuerProfile.issuerUrl" -o tsv)
+     fi
+
+     log "OIDC issuer: ${OIDC_ISSUER}"
+
+     add_env CWAGENT_PLATFORM "${PLATFORM}"
+     add_env CWAGENT_AZURE_OIDC_ISSUER "${OIDC_ISSUER}"
+
+     # No ARN yet: identity is done, emit the OIDC issuer for the AWS trust step and stop.
+     if [ -z "${ROLE_ARN}" ]; then
+          print_await_arn
+          return
+     fi
+
+     # Install directly when helm and kubectl are available, otherwise print the
+     # commands to run from a shell that has them.
+     if command -v helm >/dev/null 2>&1 && command -v kubectl >/dev/null 2>&1; then
+          section "Installing CloudWatch Observability Helm chart on ${CLUSTER_NAME}..."
+          logaction "Configuring kubeconfig for ${CLUSTER_NAME}"
+          az aks get-credentials --resource-group "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --overwrite-existing >&3
+
+          logaction "Installing via Helm"
+          # --force-update surfaces (not swallows) a stale-URL conflict if the
+          # repo alias already points somewhere else.
+          helm repo add --force-update aws-observability "${HELM_CHART_REPO}" >&3
+          helm repo update >&3
+          # Every agents[] entry is listed, not just the one being changed: --set replaces a whole
+          # list element rather than merging into it, so setting agents[0] alone drops the chart's
+          # default agents[1] and the cluster scraper is never created.
+          helm upgrade --install amazon-cloudwatch-observability aws-observability/amazon-cloudwatch-observability \
+               --set k8sMode=AKS \
+               --set roleArn="${ROLE_ARN}" \
+               --set region="${REGION}" \
+               --set clusterName="${CLUSTER_NAME}" \
+               --set containerInsights.enabled=false \
+               --set containerLogs.enabled=false \
+               --set otelContainerInsights.enabled=true \
+               --set otelContainerInsights.logs.enabled=true \
+               --set-string 'agents[0].name=cloudwatch-agent' \
+               --set-string 'agents[0].config=default:otel' \
+               --set-string 'agents[1].name=cloudwatch-agent-cluster-scraper' \
+               --set-string 'agents[1].mode=deployment' \
+               --set-string 'agents[1].config=default' \
+               --namespace "${K8S_NAMESPACE}" \
+               --create-namespace >&3
+          log "Chart installed on ${CLUSTER_NAME}"
+     else
+          printf '\n' >&3
+          printf 'Done. Install the Amazon CloudWatch Observability Helm chart (requires kubeconfig for %s):\n' "${CLUSTER_NAME}" >&3
+          printf '\n' >&3
+          {
+               printf '%s\n' "  helm repo add aws-observability ${HELM_CHART_REPO}"
+               printf '%s\n' "  helm repo update"
+               printf '  helm upgrade --install amazon-cloudwatch-observability aws-observability/amazon-cloudwatch-observability \\\n'
+               printf '    --set k8sMode=AKS \\\n'
+               printf '    --set roleArn=%s \\\n' "${ROLE_ARN}"
+               printf '    --set region=%s \\\n' "${REGION}"
+               printf '    --set clusterName=%s \\\n' "${CLUSTER_NAME}"
+               printf '    --set containerInsights.enabled=false \\\n'
+               printf '    --set containerLogs.enabled=false \\\n'
+               printf '    --set otelContainerInsights.enabled=true \\\n'
+               printf '    --set otelContainerInsights.logs.enabled=true \\\n'
+               printf "    --set-string 'agents[0].name=cloudwatch-agent' \\\\\n"
+               printf "    --set-string 'agents[0].config=default:otel' \\\\\n"
+               printf "    --set-string 'agents[1].name=cloudwatch-agent-cluster-scraper' \\\\\n"
+               printf "    --set-string 'agents[1].mode=deployment' \\\\\n"
+               printf "    --set-string 'agents[1].config=default' \\\\\n"
+               printf '    --namespace %s \\\n' "${K8S_NAMESPACE}"
+               printf '    --create-namespace\n'
+          } >&3
+     fi
+}
+
+main() {
+     case "${1:-}" in -h | --help) usage 0 ;; esac
+
+     # Interactive only on a real TTY and never under CWAGENT_EMIT_ENV (the
+     # dispatcher eval-chains this script and cannot answer prompts).
+     if [ -t 0 ] && ! is_true "${EMIT_ENV}" && [ -z "${PLATFORM}" ]; then
+          interactive_setup
+     fi
+
+     case "${PLATFORM}" in
+     azure_vm | azure_aks) ;;
+     *) die "unsupported platform: ${PLATFORM:-<unset>} (valid: azure_vm, azure_aks)" ;;
+     esac
+
+     # Region is only needed for the install, so require it only when the ARN is set.
+     if [ -n "${ROLE_ARN}" ]; then
+          [ -n "${REGION}" ] || die "CWAGENT_AWS_REGION is required to install"
+     fi
+
+     check_prerequisites
+
+     case "${PLATFORM}" in
+     azure_vm) setup_azure_vm ;;
+     azure_aks) setup_azure_aks ;;
+     esac
+
+     emit_env
+}
+
+main "$@"

--- a/scripts/azure/setup.sh
+++ b/scripts/azure/setup.sh
@@ -44,10 +44,7 @@
 #                                   for install)
 #     CWAGENT_AZURE_SUBSCRIPTION    Subscription ID or name the resource lives
 #                                   in (Cloud Shell's ambient default is used
-#                                   when unset). When combined with
-#                                   CWAGENT_AZURE_RESOURCE_ID, a GUID is
-#                                   checked against the ID up front; a name is
-#                                   verified after sign-in
+#                                   when unset)
 #     CWAGENT_AZURE_RESOURCE_ID     Full ARM resource ID of the VM / AKS
 #                                   cluster; supplies the subscription,
 #                                   resource group, and name in one value.
@@ -96,8 +93,7 @@ is_true() {
 # Under CWAGENT_EMIT_ENV stdout carries only the eval-able KEY='value' lines the
 # parent shell captures and evaluates, so readable output (including the install
 # transcript) goes to fd 3 (redirected to stderr here, stdout otherwise) and
-# every command must keep its own output off plain stdout. A stray line that
-# looks like an assignment is indistinguishable from a real one.
+# every command must keep its own output off plain stdout.
 # =============================================================================
 
 if is_true "${EMIT_ENV}"; then
@@ -264,6 +260,12 @@ interactive_setup() {
      *) die "invalid platform: ${choice}" ;;
      esac
 
+     # A resource ID already carries the group and name (resolved in main), so
+     # only prompt for them when one was not supplied.
+     if [ -n "${RESOURCE_ID}" ]; then
+          return
+     fi
+
      printf '\n' >&3
      case "${PLATFORM}" in
      azure_vm)
@@ -300,10 +302,8 @@ EOF
 }
 
 # Die when an individually-supplied CWAGENT_AZURE_* value contradicts what
-# CWAGENT_AZURE_RESOURCE_ID resolves to. Matching or absent values are fine —
-# only a genuine conflict is an error, so existing single-variable and
-# ID-only invocations are unaffected. ARM treats these identifiers
-# case-insensitively, so the comparison does too.
+# CWAGENT_AZURE_RESOURCE_ID resolves to. Matching or absent values are fine.
+# ARM treats these identifiers case-insensitively, so the comparison does too.
 # $1 = variable name (for the message), $2 = given value, $3 = resolved value.
 check_resource_id_conflict() {
      [ -n "$2" ] || return 0
@@ -321,37 +321,34 @@ is_guid() {
      printf '%s' "$1" | grep -Eiq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 }
 
+# Pin az to the target subscription without az account set mutating the user's
+# persistent default.
+az_scoped() {
+     if [ -n "${SUBSCRIPTION}" ]; then
+          az "$@" --subscription "${SUBSCRIPTION}"
+     else
+          az "$@"
+     fi
+}
+
 check_prerequisites() {
      command -v az >/dev/null 2>&1 || die "Azure CLI is required but not installed"
      AZ_CLI_VERSION=$(az version --query '"azure-cli"' -o tsv 2>/dev/null || echo "0.0.0")
      if ! version_ge "${AZ_CLI_VERSION}" "2.47.0"; then
           logwarn "Azure CLI ${AZ_CLI_VERSION} detected (2.47+ recommended for full functionality)"
      fi
-     # Pin every subsequent az call to the resource's subscription; without this
-     # they all resolve against Cloud Shell's ambient default, and ARM answers
-     # for a resource in another subscription with an AuthorizationFailed that
-     # is indistinguishable from a genuine RBAC gap.
-     if [ -n "${SUBSCRIPTION}" ]; then
-          az_err=$(az account set --subscription "${SUBSCRIPTION}" 2>&1) ||
-               die "cannot select subscription ${SUBSCRIPTION}: ${az_err}
-Check 'az account list'; if it is in another tenant, run: az login --tenant <tenant-id>"
-          log "Subscription: ${SUBSCRIPTION}"
-     fi
-     # One az account show for the liveness check, subscription id/name, and
-     # tenant id (used later for the azure_vm identity emit).
-     # The nested [[...]] makes -o tsv emit one tab-separated row; a flat
-     # [...] array would print one value per line, breaking the cut parsing.
-     AZ_ACCOUNT=$(az account show --query "[[id, name, tenantId]]" -o tsv 2>/dev/null) ||
-          die "Azure CLI not logged in (run 'az login')"
+     # Scoped account show doubles as the liveness + access check and fills
+     # AZ_SUB/AZ_NAME/AZ_TENANT from the target subscription (used by the
+     # deferred conflict check and the azure_vm identity emit). The nested
+     # [[...]] makes -o tsv emit one tab-separated row instead of one per line.
+     AZ_ACCOUNT=$(az_scoped account show --query "[[id, name, tenantId]]" -o tsv 2>/dev/null) ||
+          die "cannot access ${SUBSCRIPTION:-the default subscription} (run 'az login'; check 'az account list'; if it is in another tenant, run: az login --tenant <tenant-id>)"
      AZ_SUB=$(printf '%s' "${AZ_ACCOUNT}" | cut -f1)
      AZ_NAME=$(printf '%s' "${AZ_ACCOUNT}" | cut -f2)
      AZ_TENANT=$(printf '%s' "${AZ_ACCOUNT}" | cut -f3)
-     # Deferred conflict check: the subscription was given as a display name
-     # (or a non-canonical form) alongside a resource ID, so it could not be
-     # compared to the ID's GUID up front (see main). The account is now
-     # pinned to the ID's subscription; accept a match on either its id or
-     # its display name — the same lookup semantics az account set uses — so
-     # a misclassification by is_guid can never produce a false conflict.
+     # Deferred conflict check: a subscription given as a display name alongside
+     # a resource ID couldn't be compared to the ID's GUID up front (see main).
+     # The scoped account show resolved it, so match on either its id or name.
      if [ -n "${GIVEN_SUBSCRIPTION_NAME}" ]; then
           _given_lower=$(printf '%s' "${GIVEN_SUBSCRIPTION_NAME}" | tr '[:upper:]' '[:lower:]')
           _sub_lower=$(printf '%s' "${AZ_SUB}" | tr '[:upper:]' '[:lower:]')
@@ -398,7 +395,7 @@ run_via_az() {
      RUN_MESSAGE=""
 
      logaction "Running install via az vm run-command"
-     RUN_RESULT=$(az vm run-command invoke \
+     RUN_RESULT=$(az_scoped vm run-command invoke \
           --resource-group "${RESOURCE_GROUP}" \
           --name "${VM_NAME}" \
           --command-id "${az_command_id}" \
@@ -451,14 +448,10 @@ setup_azure_vm() {
 
      section "Configuring Azure VM identity..."
 
-     # One az vm show for both fields: the identity (to decide whether to assign
-     # one) and the OS type (to pick the install payload). A tsv list projection
-     # returns them tab-separated on one line, in query order.
-     # The nested [[...]] makes -o tsv emit one tab-separated row (null
-     # renders as "None"); a flat [...] array would print one value per line,
-     # making cut return both lines and IDENTITY test truthy for a VM with no
-     # identity at all.
-     VM_INFO=$(az vm show \
+     # One az vm show for the identity (whether to assign one) and the OS type
+     # (which install payload). The nested [[...]] emits one tab-separated row
+     # (null renders "None"); a flat [...] would print one value per line.
+     VM_INFO=$(az_scoped vm show \
           --resource-group "${RESOURCE_GROUP}" \
           --name "${VM_NAME}" \
           --query "[[identity.principalId, storageProfile.osDisk.osType]]" -o tsv 2>/dev/null || true)
@@ -469,7 +462,7 @@ setup_azure_vm() {
           log "Managed identity enabled on ${VM_NAME}"
      else
           logaction "Enabling managed identity (this may take a few minutes)"
-          az vm identity assign \
+          az_scoped vm identity assign \
                --resource-group "${RESOURCE_GROUP}" \
                --name "${VM_NAME}" \
                --output none
@@ -532,7 +525,7 @@ setup_azure_aks() {
      # enables the OIDC issuer at creation by default, but never workload
      # identity, so keying on the issuer alone would skip the update and leave
      # workload identity off.
-     AKS_INFO=$(az aks show \
+     AKS_INFO=$(az_scoped aks show \
           --resource-group "${RESOURCE_GROUP}" \
           --name "${CLUSTER_NAME}" \
           --query "[[oidcIssuerProfile.enabled, securityProfile.workloadIdentity.enabled, oidcIssuerProfile.issuerUrl]]" -o tsv 2>/dev/null || true)
@@ -542,11 +535,13 @@ setup_azure_aks() {
 
      # az -o tsv renders a JSON boolean via Python str(), i.e. "True"/"False",
      # so match case-insensitively rather than against a lowercase "true".
-     if [ "$(printf '%s%s' "${OIDC_ENABLED}" "${WI_ENABLED}" | tr '[:upper:]' '[:lower:]')" = "truetrue" ]; then
+     _oidc_lower=$(printf '%s' "${OIDC_ENABLED}" | tr '[:upper:]' '[:lower:]')
+     _wi_lower=$(printf '%s' "${WI_ENABLED}" | tr '[:upper:]' '[:lower:]')
+     if [ "${_oidc_lower}" = "true" ] && [ "${_wi_lower}" = "true" ]; then
           log "OIDC issuer and workload identity enabled"
      else
           logaction "Enabling OIDC issuer and workload identity (this may take a few minutes)"
-          az aks update \
+          az_scoped aks update \
                --resource-group "${RESOURCE_GROUP}" \
                --name "${CLUSTER_NAME}" \
                --enable-oidc-issuer \
@@ -555,7 +550,7 @@ setup_azure_aks() {
           # Re-fetch the now-populated issuer URL. No "|| true" here (unlike the
           # probe above): we just changed cluster state, so a failure should
           # surface loudly rather than leave OIDC_ISSUER empty.
-          OIDC_ISSUER=$(az aks show \
+          OIDC_ISSUER=$(az_scoped aks show \
                --resource-group "${RESOURCE_GROUP}" \
                --name "${CLUSTER_NAME}" \
                --query "oidcIssuerProfile.issuerUrl" -o tsv)
@@ -577,7 +572,7 @@ setup_azure_aks() {
      if command -v helm >/dev/null 2>&1 && command -v kubectl >/dev/null 2>&1; then
           section "Installing CloudWatch Observability Helm chart on ${CLUSTER_NAME}..."
           logaction "Configuring kubeconfig for ${CLUSTER_NAME}"
-          az aks get-credentials --resource-group "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --overwrite-existing >&3
+          az_scoped aks get-credentials --resource-group "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --overwrite-existing >&3
 
           logaction "Installing via Helm"
           # --force-update surfaces (not swallows) a stale-URL conflict if the
@@ -668,12 +663,9 @@ main() {
           azure_aks:managedclusters) CLUSTER_NAME="${RESOURCE_NAME}" ;;
           *) die "resource ID is a ${RESOURCE_TYPE}, which does not match CWAGENT_PLATFORM=${PLATFORM}" ;;
           esac
-          # The ID's subscription segment is always a GUID, but the user may
-          # have supplied CWAGENT_AZURE_SUBSCRIPTION as a display name (the
-          # documented "ID or name" contract). A name can only be compared
-          # after az resolves the account, so defer that case to
-          # check_prerequisites instead of failing on a guaranteed
-          # name-vs-GUID mismatch here.
+          # The ID's subscription segment is a GUID, but CWAGENT_AZURE_SUBSCRIPTION
+          # may be a display name. A name can only be compared after az resolves
+          # the account, so defer that case to check_prerequisites.
           if is_guid "${_given_subscription}" || [ -z "${_given_subscription}" ]; then
                check_resource_id_conflict "CWAGENT_AZURE_SUBSCRIPTION" "${_given_subscription}" "${SUBSCRIPTION}"
           else

--- a/scripts/azure/setup.sh
+++ b/scripts/azure/setup.sh
@@ -75,7 +75,7 @@ GIVEN_SUBSCRIPTION_NAME=""
 HELM_CHART_REPO="https://aws-observability.github.io/helm-charts"
 
 # Where the VM fetches the install payload (install.sh / install.ps1) from.
-SCRIPT_BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts"
+SCRIPT_BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/main/scripts"
 K8S_NAMESPACE="amazon-cloudwatch"
 
 # True when a flag is an affirmative value (1, true, yes, on, case-insensitive).

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,93 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+# Amazon CloudWatch Agent - install (Windows)
+#
+# Downloads and installs the CloudWatch Agent MSI, then configures and
+# starts it with the default OpenTelemetry (OTLP) configuration. Run as
+# Administrator.
+#
+# Safe to re-run.
+#
+# Usage:
+#     .\install.ps1
+#     Invoke-WebRequest -Uri <hosted-url>/install.ps1 -OutFile $env:TEMP\install.ps1; & $env:TEMP\install.ps1
+#
+# Environment variables:
+#     CWAGENT_CLOUD         Target cloud: aws | azure (default: aws)
+#     CWAGENT_AWS_ROLE_ARN  AWS IAM role ARN (required for azure)
+#     CWAGENT_AWS_REGION    AWS region to send telemetry to (required for azure)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$DownloadBase = "https://amazoncloudwatch-agent.s3.amazonaws.com"
+$Cloud = if ($Env:CWAGENT_CLOUD) { $Env:CWAGENT_CLOUD } else { 'aws' }
+$RoleArn = if ($Env:CWAGENT_AWS_ROLE_ARN) { $Env:CWAGENT_AWS_ROLE_ARN } else { '' }
+$Region = if ($Env:CWAGENT_AWS_REGION) { $Env:CWAGENT_AWS_REGION } else { '' }
+
+$CWADirectory = 'Amazon\AmazonCloudWatchAgent'
+$CWAProgramFiles = "${Env:ProgramFiles}\${CWADirectory}"
+$Ctl = "${CWAProgramFiles}\amazon-cloudwatch-agent-ctl.ps1"
+
+# --- validate ---
+if ($Cloud -notin @('aws', 'azure')) {
+    Write-Error "unsupported cloud '${Cloud}' (expected: aws, azure)"
+}
+if ($Cloud -eq 'azure') {
+    if (-not $RoleArn) {
+        Write-Error "CWAGENT_AWS_ROLE_ARN is required for azure cloud"
+    }
+    if (-not $Region) {
+        Write-Error "CWAGENT_AWS_REGION is required for azure cloud"
+    }
+}
+
+$identity = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $identity.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "must be run as Administrator"
+}
+
+# --- download ---
+$MsiPath = "${Env:TEMP}\amazon-cloudwatch-agent.msi"
+$Url = "${DownloadBase}/windows/amd64/latest/amazon-cloudwatch-agent.msi"
+[Console]::Error.WriteLine("Downloading ${Url}")
+# Windows PowerShell 5.1 (the default under az vm run-command / EC2) negotiates
+# TLS 1.0 by default, which S3 rejects, so force TLS 1.2. -UseBasicParsing avoids the
+# IE engine, absent on Server Core.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri $Url -OutFile $MsiPath -UseBasicParsing
+
+# --- install ---
+[Console]::Error.WriteLine("Installing package...")
+$process = Start-Process msiexec.exe -ArgumentList "/i `"${MsiPath}`" /qn /norestart" -Wait -PassThru
+# 3010/1641 are success-with-reboot-required codes (/norestart returns them), not failures.
+if ($process.ExitCode -notin @(0, 3010, 1641)) {
+    Write-Error "msiexec failed with exit code $($process.ExitCode)"
+}
+Remove-Item $MsiPath -Force -ErrorAction SilentlyContinue
+
+# --- configure + start ---
+# Send the fetch-config transcript to stderr so stdout carries only the status
+# readout and success sentinel below.
+if ($Cloud -eq 'azure') {
+    # CWAGENT_ROLE_ARN here is the agent's own env var (its default:otel config
+    # expands ${CWAGENT_ROLE_ARN}), not the CWAGENT_AWS_ROLE_ARN input read
+    # above. Do not rename it to match.
+    & $Ctl -Action set-env -EnvVar "CWAGENT_ROLE_ARN=${RoleArn}" 2>&1 | ForEach-Object { [Console]::Error.WriteLine($_) }
+    & $Ctl -Action set-env -EnvVar "AWS_REGION=${Region}" 2>&1 | ForEach-Object { [Console]::Error.WriteLine($_) }
+    & $Ctl -Action fetch-config -Mode auto -ConfigLocation default:otel -Start 2>&1 | ForEach-Object { [Console]::Error.WriteLine($_) }
+} else {
+    & $Ctl -Action fetch-config -Mode ec2 -ConfigLocation default:otel -Start 2>&1 | ForEach-Object { [Console]::Error.WriteLine($_) }
+}
+
+# fetch-config can exit 0 while leaving the agent stopped, so assert it is
+# actually running rather than trust the exit status.
+$Status = (& $Ctl -Action status | Out-String)
+if (-not ($Status -match '"status":\s*"running"')) {
+    [Console]::Error.WriteLine($Status)
+    Write-Error "agent did not start. Check the amazon-cloudwatch-agent log"
+}
+
+Write-Output "Amazon CloudWatch Agent installed and running."
+Write-Output $Status.TrimEnd()

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -20,6 +20,7 @@
 
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 
 $DownloadBase = "https://amazoncloudwatch-agent.s3.amazonaws.com"
 $Cloud = if ($Env:CWAGENT_CLOUD) { $Env:CWAGENT_CLOUD } else { 'aws' }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+# Amazon CloudWatch Agent - install (Linux)
+#
+# Downloads and installs the CloudWatch Agent package, then configures and
+# starts it with the default OpenTelemetry (OTLP) configuration. Run as root on
+# the target host.
+#
+# Safe to re-run.
+#
+# Usage:
+#     sudo ./install.sh
+#     curl -fsSL <hosted-url>/install.sh | sudo sh
+#
+# Environment variables:
+#     CWAGENT_CLOUD         Target cloud: aws | azure (default: aws)
+#     CWAGENT_AWS_ROLE_ARN  AWS IAM role ARN (required for azure)
+#     CWAGENT_AWS_REGION    AWS region to send telemetry to (required for azure)
+
+main() {
+     set -eu
+
+     DOWNLOAD_BASE="https://amazoncloudwatch-agent.s3.amazonaws.com"
+     CLOUD="${CWAGENT_CLOUD:-aws}"
+     ROLE_ARN="${CWAGENT_AWS_ROLE_ARN:-}"
+     REGION="${CWAGENT_AWS_REGION:-}"
+     INSTALL_ROOT="/opt/aws/amazon-cloudwatch-agent"
+     CTL="${INSTALL_ROOT}/bin/amazon-cloudwatch-agent-ctl"
+
+     # --- validate ---
+     case "${CLOUD}" in
+     aws | azure) ;;
+     *) die "unsupported cloud '${CLOUD}' (expected: aws, azure)" ;;
+     esac
+
+     if [ "${CLOUD}" = "azure" ]; then
+          [ -n "${ROLE_ARN}" ] || die "CWAGENT_AWS_ROLE_ARN is required for azure cloud"
+          [ -n "${REGION}" ] || die "CWAGENT_AWS_REGION is required for azure cloud"
+     fi
+
+     [ "$(id -u)" -eq 0 ] || die "must be run as root"
+
+     # --- detect arch ---
+     case "$(uname -m)" in
+     x86_64) ARCH="amd64" ;;
+     aarch64) ARCH="arm64" ;;
+     *) die "unsupported architecture $(uname -m)" ;;
+     esac
+
+     # --- detect package type ---
+     PKGTYPE="$(detect_package_type)" || die "unable to detect a supported package manager"
+
+     # --- download + install ---
+     # To stderr: the download/install transcript (curl progress, rpm/dpkg
+     # output) must stay off stdout, which carries only the success sentinel.
+     install_"${PKGTYPE}" >&2
+
+     # --- configure + start ---
+     # Send the fetch-config transcript to stderr so stdout carries only the
+     # status readout and success sentinel below.
+     if [ "${CLOUD}" = "azure" ]; then
+          # CWAGENT_ROLE_ARN here is the agent's own env var (its default:otel
+          # config expands ${CWAGENT_ROLE_ARN}), not the CWAGENT_AWS_ROLE_ARN
+          # input read above. Do not rename it to match.
+          "${CTL}" -a set-env -e "CWAGENT_ROLE_ARN=${ROLE_ARN}" >&2
+          "${CTL}" -a set-env -e "AWS_REGION=${REGION}" >&2
+          "${CTL}" -a fetch-config -m auto -c default:otel -s >&2
+     else
+          "${CTL}" -a fetch-config -m ec2 -c default:otel -s >&2
+     fi
+
+     # fetch-config can exit 0 while leaving the agent stopped, so assert it is
+     # actually running rather than trust the exit status. Guard the capture with
+     # || true so a non-zero status still reaches the diagnostic below under set -e.
+     STATUS="$("${CTL}" -a status)" || true
+     if ! printf '%s' "${STATUS}" | grep -q '"status": *"running"'; then
+          printf '%s\n' "${STATUS}" >&2
+          die "agent did not start. Check ${INSTALL_ROOT}/logs/amazon-cloudwatch-agent.log"
+     fi
+
+     echo "Amazon CloudWatch Agent installed and running."
+     printf '%s\n' "${STATUS}"
+}
+
+die() {
+     echo "Error: $1" >&2
+     exit 1
+}
+
+detect_package_type() {
+     if [ -f /etc/os-release ]; then
+          . /etc/os-release
+          case "${ID:-}" in
+          amzn | centos | rhel | fedora | rocky | almalinux | ol | sles | opensuse*)
+               echo rpm
+               return
+               ;;
+          ubuntu | debian | raspbian | pop | linuxmint)
+               echo deb
+               return
+               ;;
+          esac
+     fi
+     command -v rpm >/dev/null 2>&1 && {
+          echo rpm
+          return
+     }
+     command -v dpkg >/dev/null 2>&1 && {
+          echo deb
+          return
+     }
+     return 1
+}
+
+download() {
+     url="$1"
+     dest="$2"
+     echo "Downloading ${url}"
+     curl -fsSL "${url}" -o "${dest}" || die "failed to download ${url}"
+}
+
+install_rpm() {
+     pkg="/tmp/amazon-cloudwatch-agent.rpm"
+     download "${DOWNLOAD_BASE}/amazon_linux/${ARCH}/latest/amazon-cloudwatch-agent.rpm" "${pkg}"
+     echo "Installing package..."
+     rpm -Uvh --replacepkgs "${pkg}"
+     rm -f "${pkg}"
+}
+
+install_deb() {
+     pkg="/tmp/amazon-cloudwatch-agent.deb"
+     download "${DOWNLOAD_BASE}/ubuntu/${ARCH}/latest/amazon-cloudwatch-agent.deb" "${pkg}"
+     echo "Installing package..."
+     dpkg -i "${pkg}"
+     rm -f "${pkg}"
+}
+
+main

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,390 @@
+#!/bin/sh
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+# Amazon CloudWatch Agent - onboarding setup (dispatcher)
+#
+# Optional convenience wrapper over the standalone setup scripts, which document
+# their own inputs and can be run directly instead. This one picks the platform
+# and runs them in order:
+#
+#   aws_ec2 / aws_ecs / aws_eks
+#       aws/setup.sh (trust + install, one AWS shell)
+#   azure_vm / azure_aks
+#       azure/setup.sh (identity) -> aws/setup.sh (trust) -> azure/setup.sh (install)
+#
+# azure/setup.sh sets up the Azure identity while the role ARN is unknown, and
+# installs once it is known. aws/setup.sh sets up the AWS trust (plus install on
+# the AWS-native platforms). The dispatcher supplies the ARN across the handoff,
+# giving the Azure chain identity -> trust -> install.
+#
+# AWS-native platforms run in one AWS shell. The Azure platforms span clouds:
+# identity and install need the Azure CLI, trust needs the AWS CLI. This runs
+# whichever steps the current shell can, then prints a command to paste into the
+# next shell, carrying the values produced so far.
+#
+# The setup scripts are always fetched over the network, never read from
+# alongside this file, so this needs "curl" and outbound access even when run
+# from a local copy.
+#
+# Usage:
+#   ./setup.sh                          Interactive wizard (TTY)
+#   CWAGENT_PLATFORM=aws_ec2 CWAGENT_AWS_INSTANCE_ID=i-123 ./setup.sh
+#
+# Environment variables:
+#   CWAGENT_PLATFORM                      aws_ec2 | aws_ecs | aws_eks | azure_vm | azure_aks
+#   CWAGENT_AWS_ROLE_NAME                 IAM role name (default: CloudWatchAgentServerRole)
+#   CWAGENT_AWS_REGION                    AWS region telemetry is sent to
+#   CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH When set (1/true/yes/on), enable Transaction
+#                                         Search if it is off
+#
+#   EC2:
+#   CWAGENT_AWS_INSTANCE_ID               EC2 instance ID
+#   CWAGENT_AWS_UPDATE_INSTANCE_ROLE      When set (1/true/yes/on), attach the policy
+#                                         to the role already on the instance
+#
+#   ECS:
+#   CWAGENT_AWS_ECS_LAUNCH_TYPE           fargate | ec2
+#
+#   Azure:
+#   CWAGENT_AZURE_RESOURCE_GROUP          Resource group
+#   CWAGENT_AZURE_VM_NAME                 VM name (azure_vm only)
+#
+#   Kubernetes (EKS, AKS):
+#   CWAGENT_K8S_CLUSTER_NAME              Cluster name
+
+set -eu
+
+PLATFORM="${CWAGENT_PLATFORM:-}"
+ROLE_NAME="${CWAGENT_AWS_ROLE_NAME:-CloudWatchAgentServerRole}"
+REGION="${CWAGENT_AWS_REGION:-}"
+INSTANCE_ID="${CWAGENT_AWS_INSTANCE_ID:-}"
+UPDATE_INSTANCE_ROLE="${CWAGENT_AWS_UPDATE_INSTANCE_ROLE:-}"
+ENABLE_TXN_SEARCH="${CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH:-}"
+CLUSTER_NAME="${CWAGENT_K8S_CLUSTER_NAME:-}"
+RESOURCE_GROUP="${CWAGENT_AZURE_RESOURCE_GROUP:-}"
+VM_NAME="${CWAGENT_AZURE_VM_NAME:-}"
+ECS_LAUNCH_TYPE="${CWAGENT_AWS_ECS_LAUNCH_TYPE:-}"
+# Identity/trust values that cross from one setup script to the next. On a
+# resumed shell they arrive via the paste command, otherwise the runs below
+# produce them.
+TENANT_ID="${CWAGENT_AZURE_TENANT_ID:-}"
+OIDC_ISSUER="${CWAGENT_AZURE_OIDC_ISSUER:-}"
+ROLE_ARN="${CWAGENT_AWS_ROLE_ARN:-}"
+
+# Where the setup scripts are fetched from and what the paste commands point at.
+BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts"
+
+# =============================================================================
+# Output helpers
+# =============================================================================
+
+if [ -t 1 ]; then
+     die() {
+          printf '  \033[31m✗\033[0m %s\n' "$1" >&2
+          exit 1
+     }
+     ask() { printf '\033[1m▸ %s\033[0m ' "$1"; }
+else
+     die() {
+          printf '  ✗ %s\n' "$1" >&2
+          exit 1
+     }
+     ask() { printf '▸ %s ' "$1"; }
+fi
+
+usage() {
+     rc="${1:-1}"
+     out=2
+     [ "${rc}" = "0" ] && out=1
+     cat >&${out} <<EOF
+Usage:
+  $0                    Interactive wizard (TTY)
+
+  Or via environment variables:
+  CWAGENT_PLATFORM=aws_ec2 CWAGENT_AWS_INSTANCE_ID=i-123 $0
+
+Environment variables:
+  CWAGENT_PLATFORM                        aws_ec2 | aws_ecs | aws_eks | azure_vm | azure_aks
+  CWAGENT_AWS_ROLE_NAME                   IAM role name (default: CloudWatchAgentServerRole)
+  CWAGENT_AWS_REGION                      AWS region telemetry is sent to
+  CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH   Enable Transaction Search in the region
+
+  EC2:
+  CWAGENT_AWS_INSTANCE_ID                 EC2 instance ID
+  CWAGENT_AWS_UPDATE_INSTANCE_ROLE        Attach the policy to the existing role
+
+  ECS:
+  CWAGENT_AWS_ECS_LAUNCH_TYPE             fargate | ec2
+
+  Azure:
+  CWAGENT_AZURE_RESOURCE_GROUP            Resource group
+  CWAGENT_AZURE_VM_NAME                   VM name (azure_vm only)
+
+  Kubernetes (EKS, AKS):
+  CWAGENT_K8S_CLUSTER_NAME                Cluster name
+EOF
+     exit "${rc}"
+}
+
+# =============================================================================
+# Interactive wizard
+#
+# Collects the platform and its inputs up front so the setup scripts can run
+# non-interactively (they are invoked with the values already in the
+# environment, and under CWAGENT_EMIT_ENV they cannot prompt at all).
+# =============================================================================
+
+prompt() {
+     var="$1"
+     label="$2"
+     default="${3:-}"
+     eval "current=\${${var}}"
+     [ -n "${current}" ] && return
+     while true; do
+          if [ -n "${default}" ]; then
+               ask "${label} [${default}]:"
+          else
+               ask "${label}:"
+          fi
+          # A read failure (EOF on closed stdin) would loop forever with no
+          # default, and abort under set -e otherwise, so treat it as give-up.
+          read -r input || die "no input for ${label}"
+          input="${input:-${default}}"
+          [ -n "${input}" ] && break
+     done
+     # Assign without re-quoting the value, so a pasted name containing " ` or
+     # $(...) is stored literally rather than being re-parsed by the shell.
+     eval "${var}=\$input"
+}
+
+interactive_setup() {
+     if [ -z "${PLATFORM}" ]; then
+          printf '\nSelect platform:\n'
+          printf '  aws_ec2     EC2 instance\n'
+          printf '  aws_ecs     ECS task (sidecar)\n'
+          printf '  aws_eks     EKS cluster (add-on)\n'
+          printf '  azure_vm    Azure VM\n'
+          printf '  azure_aks   AKS cluster (Helm)\n'
+          ask "Platform:"
+          read -r PLATFORM || die "no platform selected"
+     fi
+
+     printf '\n'
+     case "${PLATFORM}" in
+     aws_ec2) prompt INSTANCE_ID "Instance ID" ;;
+     aws_ecs) prompt ECS_LAUNCH_TYPE "Launch type (fargate|ec2)" "fargate" ;;
+     aws_eks)
+          prompt CLUSTER_NAME "Cluster name"
+          ;;
+     azure_vm)
+          prompt RESOURCE_GROUP "Resource group"
+          prompt VM_NAME "VM name"
+          ;;
+     azure_aks)
+          prompt RESOURCE_GROUP "Resource group"
+          prompt CLUSTER_NAME "Cluster name"
+          ;;
+     *) die "invalid platform: ${PLATFORM}" ;;
+     esac
+
+     # Offer the AWS CLI's configured region as the default when present.
+     if [ -z "${REGION}" ] && have_aws; then
+          REGION=$(aws configure get region 2>/dev/null || true)
+     fi
+     prompt REGION "AWS region telemetry is sent to" "${REGION}"
+     prompt ROLE_NAME "IAM role name" "${ROLE_NAME}"
+}
+
+# =============================================================================
+# Script runners
+# =============================================================================
+
+have_az() { command -v az >/dev/null 2>&1; }
+have_aws() { command -v aws >/dev/null 2>&1; }
+
+# Export everything the setup scripts read, so a plain "sh <script>" inherits it.
+# Empty values are harmless: the scripts fall back to their own defaults.
+export_env() {
+     export CWAGENT_PLATFORM="${PLATFORM}"
+     export CWAGENT_AWS_ROLE_NAME="${ROLE_NAME}"
+     export CWAGENT_AWS_REGION="${REGION}"
+     export CWAGENT_AWS_INSTANCE_ID="${INSTANCE_ID}"
+     export CWAGENT_AWS_UPDATE_INSTANCE_ROLE="${UPDATE_INSTANCE_ROLE}"
+     export CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH="${ENABLE_TXN_SEARCH}"
+     export CWAGENT_K8S_CLUSTER_NAME="${CLUSTER_NAME}"
+     export CWAGENT_AZURE_RESOURCE_GROUP="${RESOURCE_GROUP}"
+     export CWAGENT_AZURE_VM_NAME="${VM_NAME}"
+     export CWAGENT_AWS_ECS_LAUNCH_TYPE="${ECS_LAUNCH_TYPE}"
+     export CWAGENT_AZURE_TENANT_ID="${TENANT_ID}"
+     export CWAGENT_AZURE_OIDC_ISSUER="${OIDC_ISSUER}"
+     export CWAGENT_AWS_ROLE_ARN="${ROLE_ARN}"
+}
+
+# Fetch a hosted setup script to stdout, failing loudly if it cannot be had.
+# Piping curl straight into sh would hide the download error: the pipeline takes
+# sh's status, and sh reading empty stdin exits 0, so a 404 looks like a script
+# that ran and did nothing.
+fetch_script() {
+     rel="$1"
+     command -v curl >/dev/null 2>&1 || die "curl is required to fetch ${rel}"
+     curl -fsSL "${BASE_URL}/${rel}" || die "could not fetch ${BASE_URL}/${rel}"
+}
+
+# Run a setup script for its readable output. CWAGENT_EMIT_ENV is unset so its
+# progress prints normally. Fetch into a variable first (see fetch_script): a
+# piped fetch_script would mask a 404.
+run_script() {
+     rel="$1"
+     export_env
+     script=$(fetch_script "${rel}")
+     printf '%s' "${script}" | CWAGENT_EMIT_ENV='' sh
+}
+
+# The identity/trust values a script may hand back, each folded into a local below.
+EMITTED_KEYS="CWAGENT_AZURE_TENANT_ID
+CWAGENT_AZURE_OIDC_ISSUER
+CWAGENT_AWS_ROLE_ARN
+CWAGENT_AWS_REGION
+CWAGENT_K8S_CLUSTER_NAME"
+
+# Run a script under CWAGENT_EMIT_ENV and fold its emitted CWAGENT_* values back
+# into this shell, so the next run and any paste command pick them up. The
+# script routes its own logging to stderr, so progress is still visible.
+load_script() {
+     rel="$1"
+     export_env
+     # Fetch first (see run_script): a piped fetch_script would mask a 404.
+     script=$(fetch_script "${rel}")
+     emitted=$(printf '%s' "${script}" | CWAGENT_EMIT_ENV=1 sh)
+     # A script's stdout is untrusted, so eval only lines matching an allowlisted
+     # key in the exact KEY='value' form. An unfiltered eval would let a stray
+     # line redefine PATH or a download URL.
+     for key in ${EMITTED_KEYS}; do
+          safe_line=$(printf '%s\n' "${emitted}" | grep -E "^${key}='[^']*'\$" | tail -1 || true)
+          [ -n "${safe_line}" ] || continue
+          eval "export ${safe_line}"
+     done
+     TENANT_ID="${CWAGENT_AZURE_TENANT_ID:-${TENANT_ID}}"
+     OIDC_ISSUER="${CWAGENT_AZURE_OIDC_ISSUER:-${OIDC_ISSUER}}"
+     ROLE_ARN="${CWAGENT_AWS_ROLE_ARN:-${ROLE_ARN}}"
+     CLUSTER_NAME="${CWAGENT_K8S_CLUSTER_NAME:-${CLUSTER_NAME}}"
+     REGION="${CWAGENT_AWS_REGION:-${REGION}}"
+}
+
+# Assert a run produced the value the next one needs. A run that failed to
+# fetch or died early still lets the chain continue otherwise, and the symptom
+# surfaces later as a resume command silently missing a key.
+require_output() {
+     [ -n "$2" ] || die "$1 did not produce $3. Rerun it."
+}
+
+# The identity run yields the tenant ID for a VM and the OIDC issuer for AKS.
+require_identity_output() {
+     case "${PLATFORM}" in
+     azure_vm) require_output "azure/setup.sh" "${TENANT_ID}" "a tenant ID" ;;
+     azure_aks) require_output "azure/setup.sh" "${OIDC_ISSUER}" "an OIDC issuer URL" ;;
+     esac
+}
+
+# Print the command to re-run this script in the next shell. Over-includes the
+# known values: this script re-derives which step to run from which are set, so
+# a superset is harmless and keeps the paste one self-contained block.
+print_resume() {
+     hint="$1"
+     block=""
+     add_kv() {
+          [ -n "$2" ] || return 0
+          block="${block}      $1='$2' \\
+"
+     }
+     add_kv CWAGENT_PLATFORM "${PLATFORM}"
+     add_kv CWAGENT_AZURE_TENANT_ID "${TENANT_ID}"
+     add_kv CWAGENT_AZURE_OIDC_ISSUER "${OIDC_ISSUER}"
+     add_kv CWAGENT_AWS_ROLE_ARN "${ROLE_ARN}"
+     add_kv CWAGENT_AZURE_RESOURCE_GROUP "${RESOURCE_GROUP}"
+     add_kv CWAGENT_AZURE_VM_NAME "${VM_NAME}"
+     add_kv CWAGENT_K8S_CLUSTER_NAME "${CLUSTER_NAME}"
+     add_kv CWAGENT_AWS_REGION "${REGION}"
+     [ "${ROLE_NAME}" = "CloudWatchAgentServerRole" ] || add_kv CWAGENT_AWS_ROLE_NAME "${ROLE_NAME}"
+
+     printf '\nNext: run this in %s\n\n' "${hint}"
+     # Strip the first line's indent so the pipe aligns with it: the paste reads
+     # "curl ... \ | KEY='v' \ <indented KEYs> \ sh".
+     printf '  curl -fsSL %s/setup.sh \\\n    | %s      sh\n' "${BASE_URL}" "${block#      }"
+}
+
+# =============================================================================
+# Orchestration
+# =============================================================================
+
+# AWS-native platforms run entirely in one AWS shell.
+orchestrate_aws() {
+     have_aws || die "AWS CLI is required for ${PLATFORM} (run in a shell that has it, e.g. AWS CloudShell)"
+     run_script aws/setup.sh
+}
+
+# Azure platforms span clouds. identity_done / trust_done are read off the
+# values already in the environment, so each shell resumes at the right step.
+orchestrate_azure() {
+     case "${PLATFORM}" in
+     azure_vm) [ -n "${TENANT_ID}" ] && identity_done=1 || identity_done="" ;;
+     azure_aks) [ -n "${OIDC_ISSUER}" ] && identity_done=1 || identity_done="" ;;
+     esac
+     [ -n "${ROLE_ARN}" ] && trust_done=1 || trust_done=""
+
+     # Drive the ARN-unknown flow: identity first (ROLE_ARN empty), then install
+     # after trust supplies the ARN.
+     if have_az && have_aws; then
+          # One shell with both CLIs: run the whole chain.
+          if [ -z "${identity_done}" ]; then
+               load_script azure/setup.sh
+               require_identity_output
+          fi
+          if [ -z "${trust_done}" ]; then
+               load_script aws/setup.sh
+               require_output "aws/setup.sh" "${ROLE_ARN}" "an IAM role ARN"
+          fi
+          run_script azure/setup.sh
+     elif have_aws; then
+          # AWS shell: only the trust step belongs here.
+          [ -n "${identity_done}" ] || die "run azure/setup.sh in Azure Cloud Shell first (it produces the tenant ID / OIDC issuer the trust step needs)"
+          if [ -z "${trust_done}" ]; then
+               load_script aws/setup.sh
+               require_output "aws/setup.sh" "${ROLE_ARN}" "an IAM role ARN"
+          fi
+          print_resume "Azure Cloud Shell (has the Azure CLI)"
+     elif have_az; then
+          # Azure shell: run identity if pending, install once trust is done.
+          if [ -z "${identity_done}" ]; then
+               load_script azure/setup.sh
+               require_identity_output
+               print_resume "AWS CloudShell (has the AWS CLI)"
+          elif [ -n "${trust_done}" ]; then
+               run_script azure/setup.sh
+          else
+               print_resume "AWS CloudShell (has the AWS CLI)"
+          fi
+     else
+          die "need the Azure CLI (identity/install) and/or the AWS CLI (trust) for ${PLATFORM}"
+     fi
+}
+
+main() {
+     case "${1:-}" in -h | --help) usage 0 ;; esac
+
+     if [ -t 0 ] && [ -z "${PLATFORM}" ]; then
+          interactive_setup
+     elif [ -z "${PLATFORM}" ]; then
+          usage
+     fi
+
+     case "${PLATFORM}" in
+     aws_ec2 | aws_ecs | aws_eks) orchestrate_aws ;;
+     azure_vm | azure_aks) orchestrate_azure ;;
+     *) die "unsupported platform: ${PLATFORM} (valid: aws_ec2, aws_ecs, aws_eks, azure_vm, azure_aks)" ;;
+     esac
+}
+
+main "$@"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -82,7 +82,7 @@ OIDC_ISSUER="${CWAGENT_AZURE_OIDC_ISSUER:-}"
 ROLE_ARN="${CWAGENT_AWS_ROLE_ARN:-}"
 
 # Where the setup scripts are fetched from and what the paste commands point at.
-BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts"
+BASE_URL="https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/main/scripts"
 
 # =============================================================================
 # Output helpers

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -48,6 +48,12 @@
 #   CWAGENT_AWS_ECS_LAUNCH_TYPE           fargate | ec2
 #
 #   Azure:
+#   CWAGENT_AZURE_RESOURCE_ID             Full ARM resource ID of the VM / AKS
+#                                         cluster (subscription + group + name in
+#                                         one value); the recommended way to
+#                                         identify the resource
+#   CWAGENT_AZURE_SUBSCRIPTION            Subscription ID or name (Cloud Shell's
+#                                         default is used when unset)
 #   CWAGENT_AZURE_RESOURCE_GROUP          Resource group
 #   CWAGENT_AZURE_VM_NAME                 VM name (azure_vm only)
 #
@@ -63,6 +69,8 @@ INSTANCE_ID="${CWAGENT_AWS_INSTANCE_ID:-}"
 UPDATE_INSTANCE_ROLE="${CWAGENT_AWS_UPDATE_INSTANCE_ROLE:-}"
 ENABLE_TXN_SEARCH="${CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH:-}"
 CLUSTER_NAME="${CWAGENT_K8S_CLUSTER_NAME:-}"
+RESOURCE_ID="${CWAGENT_AZURE_RESOURCE_ID:-}"
+SUBSCRIPTION="${CWAGENT_AZURE_SUBSCRIPTION:-}"
 RESOURCE_GROUP="${CWAGENT_AZURE_RESOURCE_GROUP:-}"
 VM_NAME="${CWAGENT_AZURE_VM_NAME:-}"
 ECS_LAUNCH_TYPE="${CWAGENT_AWS_ECS_LAUNCH_TYPE:-}"
@@ -119,6 +127,8 @@ Environment variables:
   CWAGENT_AWS_ECS_LAUNCH_TYPE             fargate | ec2
 
   Azure:
+  CWAGENT_AZURE_RESOURCE_ID               Full ARM resource ID (subscription + group + name)
+  CWAGENT_AZURE_SUBSCRIPTION              Subscription ID or name
   CWAGENT_AZURE_RESOURCE_GROUP            Resource group
   CWAGENT_AZURE_VM_NAME                   VM name (azure_vm only)
 
@@ -179,12 +189,18 @@ interactive_setup() {
           prompt CLUSTER_NAME "Cluster name"
           ;;
      azure_vm)
-          prompt RESOURCE_GROUP "Resource group"
-          prompt VM_NAME "VM name"
+          # A resource ID already carries the group and name, so only prompt for
+          # them when one was not supplied.
+          if [ -z "${RESOURCE_ID}" ]; then
+               prompt RESOURCE_GROUP "Resource group"
+               prompt VM_NAME "VM name"
+          fi
           ;;
      azure_aks)
-          prompt RESOURCE_GROUP "Resource group"
-          prompt CLUSTER_NAME "Cluster name"
+          if [ -z "${RESOURCE_ID}" ]; then
+               prompt RESOURCE_GROUP "Resource group"
+               prompt CLUSTER_NAME "Cluster name"
+          fi
           ;;
      *) die "invalid platform: ${PLATFORM}" ;;
      esac
@@ -214,6 +230,8 @@ export_env() {
      export CWAGENT_AWS_UPDATE_INSTANCE_ROLE="${UPDATE_INSTANCE_ROLE}"
      export CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH="${ENABLE_TXN_SEARCH}"
      export CWAGENT_K8S_CLUSTER_NAME="${CLUSTER_NAME}"
+     export CWAGENT_AZURE_RESOURCE_ID="${RESOURCE_ID}"
+     export CWAGENT_AZURE_SUBSCRIPTION="${SUBSCRIPTION}"
      export CWAGENT_AZURE_RESOURCE_GROUP="${RESOURCE_GROUP}"
      export CWAGENT_AZURE_VM_NAME="${VM_NAME}"
      export CWAGENT_AWS_ECS_LAUNCH_TYPE="${ECS_LAUNCH_TYPE}"
@@ -303,6 +321,8 @@ print_resume() {
      add_kv CWAGENT_AZURE_TENANT_ID "${TENANT_ID}"
      add_kv CWAGENT_AZURE_OIDC_ISSUER "${OIDC_ISSUER}"
      add_kv CWAGENT_AWS_ROLE_ARN "${ROLE_ARN}"
+     add_kv CWAGENT_AZURE_RESOURCE_ID "${RESOURCE_ID}"
+     add_kv CWAGENT_AZURE_SUBSCRIPTION "${SUBSCRIPTION}"
      add_kv CWAGENT_AZURE_RESOURCE_GROUP "${RESOURCE_GROUP}"
      add_kv CWAGENT_AZURE_VM_NAME "${VM_NAME}"
      add_kv CWAGENT_K8S_CLUSTER_NAME "${CLUSTER_NAME}"


### PR DESCRIPTION
# Description of changes
Adds a set of onboarding scripts under `scripts/`:
- `setup.sh`: Acts as a dispatcher if you have all dependencies available locally
- `aws/setup.sh`: AWS-side IAM trust + install (EC2 via SSM, ECS sidecar definition, EKS via the CloudWatch Observability EKS add-on). Trust-only when driving an Azure install.
- `azure/setup.sh`: Azure-side identity + install (VM via `az vm run-command`, AKS via the CloudWatch Observability Helm chart).
- `install.sh` / `install.ps1`: the agent install payload run on a Linux/Windows target. Fetches the package from the global S3 bucket and configures `default:otel`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested on Azure VM, AKS, EC2, ECS, and EKS.

### Azure VM
Azure CloudShell
```
[ ~ ]$ curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/azure/setup.sh \
    | CWAGENT_PLATFORM=azure_vm \
      CWAGENT_AZURE_RESOURCE_ID='/subscriptions/<subscription-id>/resourceGroups/CWAGENT-VM-TEST-RG/providers/Microsoft.Compute/virtualMachines/cwagent-vm-test' \
      CWAGENT_AWS_ROLE_ARN='arn:aws:iam::<account-id>:role/CloudWatchAgentServerRole' \
      CWAGENT_AWS_REGION=us-east-1 \
      sh
  ✓ Azure subscription: <subscription-id> (<subscription-name>)

Configuring Azure VM identity...
  ✓ Managed identity enabled on cwagent-vm-test
  ✓ Tenant: <tenant-id>

Installing agent on cwagent-vm-test...
  + Running install via az vm run-command
Amazon CloudWatch Agent installed and running.
{
  "status": "running",
  "starttime": "2026-08-20T20:27:54+00:00",
  "configstatus": "configured",
  "version": "1.300071.0b1720"
}
  ✓ Agent installed on cwagent-vm-test
```

AWS CloudShell
```
~ $ curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/aws/setup.sh \
>     | CWAGENT_PLATFORM=azure_vm \
>       CWAGENT_AZURE_TENANT_ID=<tenant-id> \
>       CWAGENT_AWS_REGION=us-east-1 \
>       sh
  ✓ AWS account: <account-id> (<alias>)
  ✓ AWS identity: arn:aws:sts::<account-id>:assumed-role/Admin/<role-session-name>

Configuring AWS trust...
  ✓ OIDC provider exists
  ✓ IAM role CloudWatchAgentServerRole trust policy up to date
  ✓ Managed policy CloudWatchAgentServerPolicy attached
  ✓ Role ARN: arn:aws:iam::<account-id>:role/CloudWatchAgentServerRole
  ✓ Trust configured. Install runs on the Azure side (azure/setup.sh) with the role ARN above.
```

### AKS
Azure CloudShell
```
[ ~ ]$   curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/azure/setup.sh \
    | CWAGENT_PLATFORM=azure_aks \
      CWAGENT_AZURE_RESOURCE_ID='/subscriptions/<subscription-id>/resourceGroups/cwagent-otel-aks-rg/providers/Microsoft.ContainerService/managedClusters/cwagent-otel-aks' \
      CWAGENT_AWS_ROLE_ARN='arn:aws:iam::<account-id>:role/CloudWatchAgentServerRole' \
      CWAGENT_AWS_REGION=us-east-1 \
      sh
  ✓ Azure subscription: <subscription-id> (<subscription-name>)

Configuring AKS cluster...
  ✓ OIDC issuer and workload identity enabled
  ✓ OIDC issuer: https://eastus.oic.prod-aks.azure.com/<tenant-id>/<cluster-issuer-id>/

Installing CloudWatch Observability Helm chart on cwagent-otel-aks...
  + Configuring kubeconfig for cwagent-otel-aks
Merged "cwagent-otel-aks" as current context in /home/<username>/.kube/config
  + Installing via Helm
"aws-observability" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "aws-observability" chart repository
Update Complete. ⎈Happy Helming!⎈
Release "amazon-cloudwatch-observability" has been upgraded. Happy Helming!
NAME: amazon-cloudwatch-observability
LAST DEPLOYED: Thu Aug 20 20:39:57 2026
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 6
DESCRIPTION: Upgrade complete
TEST SUITE: None
  ✓ Chart installed on cwagent-otel-aks
```

AWS CloudShell
```
~ $   curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/aws/setup.sh \
>     | CWAGENT_PLATFORM=azure_aks \
>       CWAGENT_AZURE_OIDC_ISSUER='https://eastus.oic.prod-aks.azure.com/<tenant-id>/<cluster-issuer-id>/' \
>       CWAGENT_AWS_REGION=us-east-1 \
>       sh

  ✓ AWS account: <account-id> (<alias>)
  ✓ AWS identity: arn:aws:sts::<account-id>:assumed-role/Admin/<role-session-name>

Configuring AWS trust...
  ✓ OIDC provider exists
  ✓ IAM role CloudWatchAgentServerRole trust policy up to date
  ✓ Managed policy CloudWatchAgentServerPolicy attached
  ✓ Role ARN: arn:aws:iam::<account-id>:role/CloudWatchAgentServerRole
  ✓ Trust configured. Install runs on the Azure side (azure/setup.sh) with the role ARN above.
```

### EC2
```
~ $   curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/aws/setup.sh \
>     | CWAGENT_PLATFORM=aws_ec2 \
>       CWAGENT_AWS_INSTANCE_ID=<instance-id> \
>       CWAGENT_AWS_REGION=us-east-1 \
>       sh
  ✓ AWS account: <account-id> (<alias>)
  ✓ AWS identity: arn:aws:sts::<account-id>:assumed-role/Admin/<role-session-name>

Configuring IAM role...
  ✓ IAM role CloudWatchAgentServerRole trust policy up to date
  ✓ Managed policy CloudWatchAgentServerPolicy attached

Configuring instance profile...
  ✓ Instance profile CloudWatchAgentServerRole exists
  + Associating instance profile with <instance-id>
  ✓ Role ARN: arn:aws:iam::<account-id>:role/CloudWatchAgentServerRole

Installing agent on <instance-id>...
  + Running install via SSM
Amazon CloudWatch Agent installed and running.
{
  "status": "running",
  "starttime": "2026-08-20T21:48:37",
  "configstatus": "configured",
  "version": "1.300071.0b1720"
}
  ✓ Agent installed on <instance-id>
```

### ECS
```
~ $   curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/aws/setup.sh \
>     | CWAGENT_PLATFORM=aws_ecs \
>       CWAGENT_AWS_REGION=us-east-1 \
>       sh
  ✓ AWS account: <account-id> (<alias>)
  ✓ AWS identity: arn:aws:sts::<account-id>:assumed-role/Admin/<role-session-name>

Configuring IAM task role...
  + Merging trust statement into CloudWatchAgentServerRole
  ✓ Managed policy CloudWatchAgentServerPolicy attached
  ✓ Role ARN: arn:aws:iam::<account-id>:role/CloudWatchAgentServerRole

Add this container to the task definition's containerDefinitions:

    {
      "name": "cloudwatch-agent",
      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
      "essential": false,
      "environment": [
        { "name": "USE_DEFAULT_CONFIG", "value": "otel" }
      ],
      "logConfiguration": {
        "logDriver": "awslogs",
        "options": {
          "awslogs-create-group": "True",
          "awslogs-group": "/ecs/cloudwatch-agent",
          "awslogs-region": "us-east-1",
          "awslogs-stream-prefix": "agent"
        }
      }
    }

Also set on the task definition:
  "taskRoleArn": "arn:aws:iam::<account-id>:role/CloudWatchAgentServerRole"
```

Deployed and tested in ECS cluster as a sidecar to a task with telemetrygen.

### EKS
```
~ $  curl -fsSL https://raw.githubusercontent.com/aws/amazon-cloudwatch-agent/setup-scripts/scripts/aws/setup.sh  \
>     | CWAGENT_PLATFORM=aws_eks \
>       CWAGENT_K8S_CLUSTER_NAME=cwagent-otel-eks \
>       CWAGENT_AWS_REGION=us-east-1 \
>       sh
  ✓ AWS account: <account-id> (<alias>)
  ✓ AWS identity: arn:aws:sts::<account-id>:assumed-role/Admin/<role-session-name>

Configuring EKS Pod Identity...
  ✓ Pod Identity Agent addon installed

Configuring IAM role...
  ✓ IAM role CloudWatchAgentServerRole trust policy up to date
  ✓ Managed policy CloudWatchAgentServerPolicy attached

Configuring pod identity association...
  ✓ Pod identity association exists
  ✓ Role ARN: arn:aws:iam::<account-id>:role/CloudWatchAgentServerRole

Installing the CloudWatch Observability add-on on cwagent-otel-eks...
  + Creating add-on
  ✓ Add-on active on cwagent-otel-eks
```

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.