### PR TITLE
Fix TestOIDCTokenGatedOnAzureMode by injecting cluster name

### DIFF
--- a/translator/translate/otel/translate_otel_test.go
+++ b/translator/translate/otel/translate_otel_test.go
@@ -274,6 +274,9 @@ func TestTranslator(t *testing.T) {
 
 func TestOIDCTokenGatedOnAzureMode(t *testing.T) {
 	t.Setenv("SYSTEM_METRICS_ENABLED", "false")
+	// Short-circuit cluster-name resolution so the metrics translator does not reach the live
+	// ec2:DescribeTags lookup, which hangs on retries and panics off a real EC2 host.
+	t.Setenv("K8S_CLUSTER_NAME", "test-cluster")
 	testutil.SetPrometheusRemoteWriteTestingEnv(t)
 	translator.SetTargetPlatform("linux")
 	oidcID := component.MustNewID("oidctoken")


### PR DESCRIPTION
# Description of the issue
`TestOIDCTokenGatedOnAzureMode` fails and hangs when IMDS is not accessible when fetching tags

# Description of changes
Hardcode  cluster name to avoid the failure

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



