### PR TITLE
Add SLES 16 support

### DIFF
--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -40,7 +40,7 @@ var imagePrefixes = []string{
 	"cloudwatch-agent-integration-test-rocky-linux-9",
 	"cloudwatch-agent-integration-test-rocky-linux-10",
 	"cloudwatch-agent-integration-test-sles-15",
-	"cloudwatch-agent-integration-test-sles-16-arm64",
+	"cloudwatch-agent-integration-test-sles-16",
 	"cloudwatch-agent-integration-test-ubuntu-24",
 	"cloudwatch-agent-integration-test-ubuntu-LTS-22",
 	"cloudwatch-agent-integration-test-ubuntu-25",

--- a/tool/clean/clean_ami/clean_ami.go
+++ b/tool/clean/clean_ami/clean_ami.go
@@ -40,6 +40,7 @@ var imagePrefixes = []string{
 	"cloudwatch-agent-integration-test-rocky-linux-9",
 	"cloudwatch-agent-integration-test-rocky-linux-10",
 	"cloudwatch-agent-integration-test-sles-15",
+	"cloudwatch-agent-integration-test-sles-16-arm64",
 	"cloudwatch-agent-integration-test-ubuntu-24",
 	"cloudwatch-agent-integration-test-ubuntu-LTS-22",
 	"cloudwatch-agent-integration-test-ubuntu-25",


### PR DESCRIPTION
# Description of the issue
Add SLES 16 to the integration test matrix for CloudWatch Agent OS onboarding (arm64 and x86-64).

Related PR: https://github.com/aws/amazon-cloudwatch-agent-test/pull/740

# Description of changes
Added `cloudwatch-agent-integration-test-sles-16` to the `imagePrefixes` array in `tool/clean/clean_ami/clean_ami.go` so old SLES 16 test AMIs get cleaned up after 60 days. The non-suffixed prefix covers both the x86-64 (`...-sles-16`) and arm64 (`...-sles-16-arm64`) pipeline AMIs, matching the existing SLES 15 convention.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the integration test with the OS filter sles-16 — all sles-16 tests passed on both arm64 and x86-64.

Workflow run: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/31484708388