### PR TITLE
feat: self-telemetry endpoint + watch_replicaset config

### DIFF
--- a/extension/selftelemetry/config.go
+++ b/extension/selftelemetry/config.go
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package selftelemetry
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+const defaultDiscoveryInterval = 10 * time.Second
+
+type Config struct {
+	// DiscoveryInterval is how often the registries are rescanned for metric families that appeared
+	// after the last scan, since receivers register theirs well after extensions start.
+	DiscoveryInterval time.Duration `mapstructure:"discovery_interval,omitempty"`
+}
+
+var _ component.Config = (*Config)(nil)
+
+func (c *Config) discoveryInterval() time.Duration {
+	if c.DiscoveryInterval <= 0 {
+		return defaultDiscoveryInterval
+	}
+	return c.DiscoveryInterval
+}

--- a/extension/selftelemetry/extension.go
+++ b/extension/selftelemetry/extension.go
@@ -1,0 +1,241 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// Package selftelemetry publishes the agent's prometheus scrape and discovery registries on the
+// collector's own service::telemetry endpoint. The collector builds that endpoint's registry
+// privately, so the only way onto it is to record through the MeterProvider every component is
+// given, which is what this extension bridges into.
+package selftelemetry
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+)
+
+const (
+	scopeName = "github.com/aws/amazon-cloudwatch-agent/extension/selftelemetry"
+
+	// familyPrefix limits the bridge to the discovery and scrape families. The registries also hold
+	// go_ and process_ collectors, which the collector already reports as otelcol_process_ metrics.
+	familyPrefix = "prometheus_"
+
+	receiverLabel = "receiver"
+	// telegrafReceiver identifies the Telegraf prometheus plugin, whose series carry no receiver
+	// label of their own, so every published series still names where it came from.
+	telegrafReceiver = "telegraf/prometheus"
+)
+
+// source pairs a registry with the receiver label to apply when its series lack one.
+type source struct {
+	gatherer prometheus.Gatherer
+	fallback string
+}
+
+type selfTelemetry struct {
+	logger *zap.Logger
+	cfg    *Config
+	meter  otelmetric.Meter
+
+	cancel context.CancelFunc
+
+	// sources is a field so tests can supply registries instead of the process-wide ones.
+	sources func() []source
+
+	// instruments and registration are only touched by the sync goroutine; each callback closes over
+	// its own snapshot, so the observe path needs no locking.
+	instruments  map[string]otelmetric.Float64Observable
+	registration otelmetric.Registration
+	shutdownOnce sync.Once
+}
+
+var _ extension.Extension = (*selfTelemetry)(nil)
+
+func newSelfTelemetry(settings extension.Settings, cfg *Config) *selfTelemetry {
+	return &selfTelemetry{
+		logger:      settings.Logger,
+		cfg:         cfg,
+		meter:       settings.MeterProvider.Meter(scopeName),
+		sources:     processSources,
+		instruments: map[string]otelmetric.Float64Observable{},
+	}
+}
+
+// processSources is resolved on every pass so receivers that start or stop later are picked up.
+// SharedGatherer already labels each series with its receiver; the Telegraf plugin's registry does
+// not, so it gets a fallback label.
+func processSources() []source {
+	return []source{
+		{gatherer: prometheusreceiver.SharedGatherer()},
+		{gatherer: prometheus.DefaultGatherer, fallback: telegrafReceiver},
+	}
+}
+
+func (s *selfTelemetry) Start(_ context.Context, _ component.Host) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	go s.run(ctx)
+	return nil
+}
+
+// run rescans on an interval because extensions start before receivers, so nothing is registered yet
+// on the first pass, and families keep appearing as counters are first incremented.
+func (s *selfTelemetry) run(ctx context.Context) {
+	ticker := time.NewTicker(s.cfg.discoveryInterval())
+	defer ticker.Stop()
+	s.sync()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sync()
+		}
+	}
+}
+
+func (s *selfTelemetry) sync() {
+	var added bool
+	for _, src := range s.sources() {
+		families, err := src.gatherer.Gather()
+		if err != nil {
+			// Gather returns partial results alongside errors, so keep the families it did return.
+			s.logger.Debug("partial self-telemetry gather", zap.Error(err))
+		}
+		for _, mf := range families {
+			if !strings.HasPrefix(mf.GetName(), familyPrefix) {
+				continue
+			}
+			if _, exists := s.instruments[mf.GetName()]; exists {
+				continue
+			}
+			inst, err := s.newInstrument(mf)
+			if err != nil {
+				s.logger.Warn("unable to publish self-telemetry family",
+					zap.String("name", mf.GetName()), zap.Error(err))
+				continue
+			}
+			if inst == nil {
+				continue
+			}
+			s.instruments[mf.GetName()] = inst
+			added = true
+		}
+	}
+	if added {
+		s.reregister()
+	}
+}
+
+// newInstrument returns nil for histograms and summaries, which have no observable equivalent.
+func (s *selfTelemetry) newInstrument(mf *dto.MetricFamily) (otelmetric.Float64Observable, error) {
+	desc := otelmetric.WithDescription(mf.GetHelp())
+	switch mf.GetType() {
+	case dto.MetricType_GAUGE, dto.MetricType_UNTYPED:
+		return s.meter.Float64ObservableGauge(mf.GetName(), desc)
+	case dto.MetricType_COUNTER:
+		return s.meter.Float64ObservableCounter(mf.GetName(), desc)
+	default:
+		return nil, nil
+	}
+}
+
+// reregister swaps in a single callback covering every instrument, so one gather serves a collection
+// no matter how many passes it took to discover them.
+func (s *selfTelemetry) reregister() {
+	snapshot := make(map[string]otelmetric.Float64Observable, len(s.instruments))
+	observables := make([]otelmetric.Observable, 0, len(s.instruments))
+	for name, inst := range s.instruments {
+		snapshot[name] = inst
+		observables = append(observables, inst)
+	}
+	if s.registration != nil {
+		if err := s.registration.Unregister(); err != nil {
+			s.logger.Warn("unable to replace self-telemetry callback", zap.Error(err))
+			return
+		}
+		s.registration = nil
+	}
+	registration, err := s.meter.RegisterCallback(s.observe(snapshot), observables...)
+	if err != nil {
+		s.logger.Error("unable to register self-telemetry callback", zap.Error(err))
+		return
+	}
+	s.registration = registration
+	s.logger.Debug("publishing self-telemetry families", zap.Int("count", len(observables)))
+}
+
+func (s *selfTelemetry) observe(snapshot map[string]otelmetric.Float64Observable) otelmetric.Callback {
+	return func(_ context.Context, observer otelmetric.Observer) error {
+		for _, src := range s.sources() {
+			families, err := src.gatherer.Gather()
+			if err != nil {
+				s.logger.Debug("partial self-telemetry gather", zap.Error(err))
+			}
+			for _, mf := range families {
+				inst, ok := snapshot[mf.GetName()]
+				if !ok {
+					continue
+				}
+				for _, m := range mf.GetMetric() {
+					value, ok := valueOf(mf.GetType(), m)
+					if !ok {
+						continue
+					}
+					observer.ObserveFloat64(inst, value,
+						otelmetric.WithAttributes(seriesAttributes(m, src.fallback)...))
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func valueOf(t dto.MetricType, m *dto.Metric) (float64, bool) {
+	switch t {
+	case dto.MetricType_GAUGE:
+		return m.GetGauge().GetValue(), true
+	case dto.MetricType_UNTYPED:
+		return m.GetUntyped().GetValue(), true
+	case dto.MetricType_COUNTER:
+		return m.GetCounter().GetValue(), true
+	default:
+		return 0, false
+	}
+}
+
+// seriesAttributes copies a scraped series' own prometheus labels onto its OTel datapoint, applying
+// the receiver fallback when the source registry did not label the series itself (the Telegraf case).
+func seriesAttributes(m *dto.Metric, fallback string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(m.GetLabel())+1)
+	var hasReceiver bool
+	for _, l := range m.GetLabel() {
+		if l.GetName() == receiverLabel {
+			hasReceiver = true
+		}
+		attrs = append(attrs, attribute.String(l.GetName(), l.GetValue()))
+	}
+	if !hasReceiver && fallback != "" {
+		attrs = append(attrs, attribute.String(receiverLabel, fallback))
+	}
+	return attrs
+}
+
+func (s *selfTelemetry) Shutdown(_ context.Context) error {
+	s.shutdownOnce.Do(func() {
+		if s.cancel != nil {
+			s.cancel()
+		}
+	})
+	return nil
+}

--- a/extension/selftelemetry/extension.go
+++ b/extension/selftelemetry/extension.go
@@ -42,19 +42,33 @@ type source struct {
 	fallback string
 }
 
+// publishedInstrument records the metric type an instrument was created for, so the observe path
+// only feeds it series of that type even if two source registries expose the same family name with
+// different types.
+type publishedInstrument struct {
+	observable otelmetric.Float64Observable
+	metricType dto.MetricType
+}
+
 type selfTelemetry struct {
 	logger *zap.Logger
 	cfg    *Config
 	meter  otelmetric.Meter
 
 	cancel context.CancelFunc
+	// done is closed when run() returns, so Shutdown can wait for the sync goroutine to stop before
+	// touching registration.
+	done chan struct{}
 
 	// sources is a field so tests can supply registries instead of the process-wide ones.
 	sources func() []source
 
-	// instruments and registration are only touched by the sync goroutine; each callback closes over
-	// its own snapshot, so the observe path needs no locking.
-	instruments  map[string]otelmetric.Float64Observable
+	// instruments, registration, and dirty are only touched by the sync goroutine; each callback
+	// closes over its own snapshot, so the observe path needs no locking.
+	instruments map[string]publishedInstrument
+	// dirty is set when the instrument set changes and cleared only once reregister() fully succeeds,
+	// so a failed Unregister/RegisterCallback is retried on the next pass instead of stranding metrics.
+	dirty        bool
 	registration otelmetric.Registration
 	shutdownOnce sync.Once
 }
@@ -67,7 +81,7 @@ func newSelfTelemetry(settings extension.Settings, cfg *Config) *selfTelemetry {
 		cfg:         cfg,
 		meter:       settings.MeterProvider.Meter(scopeName),
 		sources:     processSources,
-		instruments: map[string]otelmetric.Float64Observable{},
+		instruments: map[string]publishedInstrument{},
 	}
 }
 
@@ -84,6 +98,7 @@ func processSources() []source {
 func (s *selfTelemetry) Start(_ context.Context, _ component.Host) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
+	s.done = make(chan struct{})
 	go s.run(ctx)
 	return nil
 }
@@ -91,6 +106,7 @@ func (s *selfTelemetry) Start(_ context.Context, _ component.Host) error {
 // run rescans on an interval because extensions start before receivers, so nothing is registered yet
 // on the first pass, and families keep appearing as counters are first incremented.
 func (s *selfTelemetry) run(ctx context.Context) {
+	defer close(s.done)
 	ticker := time.NewTicker(s.cfg.discoveryInterval())
 	defer ticker.Stop()
 	s.sync()
@@ -105,7 +121,6 @@ func (s *selfTelemetry) run(ctx context.Context) {
 }
 
 func (s *selfTelemetry) sync() {
-	var added bool
 	for _, src := range s.sources() {
 		families, err := src.gatherer.Gather()
 		if err != nil {
@@ -128,11 +143,13 @@ func (s *selfTelemetry) sync() {
 			if inst == nil {
 				continue
 			}
-			s.instruments[mf.GetName()] = inst
-			added = true
+			s.instruments[mf.GetName()] = publishedInstrument{observable: inst, metricType: mf.GetType()}
+			s.dirty = true
 		}
 	}
-	if added {
+	// Retry whenever the callback is out of sync with the instrument set, not only when new families
+	// appeared this pass: a prior reregister() may have failed and left dirty set.
+	if s.dirty {
 		s.reregister()
 	}
 }
@@ -153,29 +170,32 @@ func (s *selfTelemetry) newInstrument(mf *dto.MetricFamily) (otelmetric.Float64O
 // reregister swaps in a single callback covering every instrument, so one gather serves a collection
 // no matter how many passes it took to discover them.
 func (s *selfTelemetry) reregister() {
-	snapshot := make(map[string]otelmetric.Float64Observable, len(s.instruments))
+	snapshot := make(map[string]publishedInstrument, len(s.instruments))
 	observables := make([]otelmetric.Observable, 0, len(s.instruments))
 	for name, inst := range s.instruments {
 		snapshot[name] = inst
-		observables = append(observables, inst)
+		observables = append(observables, inst.observable)
 	}
 	if s.registration != nil {
 		if err := s.registration.Unregister(); err != nil {
-			s.logger.Warn("unable to replace self-telemetry callback", zap.Error(err))
+			// Leave dirty set and the old callback in place so the next pass retries the swap.
+			s.logger.Warn("unable to replace self-telemetry callback; will retry", zap.Error(err))
 			return
 		}
 		s.registration = nil
 	}
 	registration, err := s.meter.RegisterCallback(s.observe(snapshot), observables...)
 	if err != nil {
-		s.logger.Error("unable to register self-telemetry callback", zap.Error(err))
+		// Leave dirty set so the next pass retries; registration is already nil here.
+		s.logger.Error("unable to register self-telemetry callback; will retry", zap.Error(err))
 		return
 	}
 	s.registration = registration
+	s.dirty = false
 	s.logger.Debug("publishing self-telemetry families", zap.Int("count", len(observables)))
 }
 
-func (s *selfTelemetry) observe(snapshot map[string]otelmetric.Float64Observable) otelmetric.Callback {
+func (s *selfTelemetry) observe(snapshot map[string]publishedInstrument) otelmetric.Callback {
 	return func(_ context.Context, observer otelmetric.Observer) error {
 		for _, src := range s.sources() {
 			families, err := src.gatherer.Gather()
@@ -187,12 +207,17 @@ func (s *selfTelemetry) observe(snapshot map[string]otelmetric.Float64Observable
 				if !ok {
 					continue
 				}
+				// Only observe series matching the type the instrument was built for, so a same-named
+				// family from another registry with a different type cannot feed the wrong instrument.
+				if mf.GetType() != inst.metricType {
+					continue
+				}
 				for _, m := range mf.GetMetric() {
-					value, ok := valueOf(mf.GetType(), m)
+					value, ok := valueOf(inst.metricType, m)
 					if !ok {
 						continue
 					}
-					observer.ObserveFloat64(inst, value,
+					observer.ObserveFloat64(inst.observable, value,
 						otelmetric.WithAttributes(seriesAttributes(m, src.fallback)...))
 				}
 			}
@@ -231,10 +256,27 @@ func seriesAttributes(m *dto.Metric, fallback string) []attribute.KeyValue {
 	return attrs
 }
 
-func (s *selfTelemetry) Shutdown(_ context.Context) error {
+func (s *selfTelemetry) Shutdown(ctx context.Context) error {
 	s.shutdownOnce.Do(func() {
 		if s.cancel != nil {
 			s.cancel()
+		}
+		if s.done == nil {
+			return // Start was never called: no goroutine and no callback to clean up.
+		}
+		select {
+		case <-s.done:
+			// run() has returned, so nothing else touches registration; safe to unregister here.
+			if s.registration != nil {
+				if err := s.registration.Unregister(); err != nil {
+					s.logger.Warn("unable to unregister self-telemetry callback on shutdown", zap.Error(err))
+				}
+				s.registration = nil
+			}
+		case <-ctx.Done():
+			// Don't touch registration if the sync goroutine may still be running.
+			s.logger.Warn("self-telemetry shutdown timed out waiting for the sync loop to stop",
+				zap.Error(ctx.Err()))
 		}
 	})
 	return nil

--- a/extension/selftelemetry/extension_test.go
+++ b/extension/selftelemetry/extension_test.go
@@ -4,7 +4,10 @@
 package selftelemetry
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +39,7 @@ func newTestBridge(t *testing.T, sources func() []source) (*selfTelemetry, *prom
 		cfg:         &Config{},
 		meter:       provider.Meter(scopeName),
 		sources:     sources,
-		instruments: map[string]otelmetric.Float64Observable{},
+		instruments: map[string]publishedInstrument{},
 	}, out
 }
 
@@ -179,4 +182,75 @@ func TestSyncPicksUpLateFamilies(t *testing.T) {
 
 	bridge.sync()
 	assert.Contains(t, served(t, out), "prometheus_target_scrape_pool_targets")
+}
+
+// flakyMeter fails the first N RegisterCallback calls, then delegates, to exercise reregister failure.
+type flakyMeter struct {
+	otelmetric.Meter
+	failNext int
+}
+
+func (m *flakyMeter) RegisterCallback(cb otelmetric.Callback, instruments ...otelmetric.Observable) (otelmetric.Registration, error) {
+	if m.failNext > 0 {
+		m.failNext--
+		return nil, errors.New("induced RegisterCallback failure")
+	}
+	return m.Meter.RegisterCallback(cb, instruments...)
+}
+
+// TestReregisterRetriesAfterFailure is the M1 guard: a failed reregister must not strand the metrics.
+// The next pass has to retry even though no new families appeared, since 'added' alone would not.
+func TestReregisterRetriesAfterFailure(t *testing.T) {
+	out := prometheus.NewRegistry()
+	exporter, err := otelprom.New(
+		otelprom.WithRegisterer(out),
+		otelprom.WithoutCounterSuffixes(),
+		otelprom.WithoutUnits(),
+		otelprom.WithoutScopeInfo(),
+		otelprom.WithoutTargetInfo(),
+	)
+	require.NoError(t, err)
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+
+	src := receiverRegistry(t, "prometheus/alpha")
+	bridge := &selfTelemetry{
+		logger:      zap.NewNop(),
+		cfg:         &Config{},
+		meter:       &flakyMeter{Meter: provider.Meter(scopeName), failNext: 1},
+		sources:     func() []source { return []source{{gatherer: src}} },
+		instruments: map[string]publishedInstrument{},
+	}
+
+	// First pass: instruments are created but RegisterCallback fails, so nothing is published yet.
+	bridge.sync()
+	assert.Empty(t, served(t, out), "callback registration failed, so no series should be published")
+	assert.True(t, bridge.dirty, "a failed reregister must stay dirty so the next pass retries")
+
+	// Second pass: no new families, but dirty drives a retry that now succeeds.
+	bridge.sync()
+	assert.Contains(t, served(t, out), "prometheus_target_scrape_pool_targets",
+		"the family must be published once the reregister retry succeeds")
+	assert.False(t, bridge.dirty, "dirty must clear once reregister succeeds")
+}
+
+// TestShutdownStopsGoroutineAndUnregisters is the M2 guard: Shutdown must wait for the sync loop to
+// exit and unregister the callback rather than returning while it is still running.
+func TestShutdownStopsGoroutineAndUnregisters(t *testing.T) {
+	src := receiverRegistry(t, "prometheus/alpha")
+	bridge, out := newTestBridge(t, func() []source { return []source{{gatherer: src}} })
+
+	require.NoError(t, bridge.Start(context.Background(), nil))
+	require.Eventually(t, func() bool { return len(served(t, out)) > 0 }, 2*time.Second, 20*time.Millisecond,
+		"the sync goroutine should register the callback shortly after Start")
+
+	require.NoError(t, bridge.Shutdown(context.Background()))
+
+	// Shutdown only returns after run() closes done, so reading these fields here is race-free.
+	assert.Nil(t, bridge.registration, "Shutdown must unregister the callback")
+	select {
+	case <-bridge.done:
+	default:
+		t.Fatal("Shutdown returned before the sync goroutine exited")
+	}
 }

--- a/extension/selftelemetry/extension_test.go
+++ b/extension/selftelemetry/extension_test.go
@@ -1,0 +1,182 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package selftelemetry
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.uber.org/zap"
+)
+
+// newTestBridge wires the extension to a real prometheus-backed MeterProvider, so the assertions run
+// against what a scraper would actually see rather than against the instruments.
+func newTestBridge(t *testing.T, sources func() []source) (*selfTelemetry, *prometheus.Registry) {
+	t.Helper()
+	out := prometheus.NewRegistry()
+	exporter, err := otelprom.New(
+		otelprom.WithRegisterer(out),
+		otelprom.WithoutCounterSuffixes(),
+		otelprom.WithoutUnits(),
+		otelprom.WithoutScopeInfo(),
+		otelprom.WithoutTargetInfo(),
+	)
+	require.NoError(t, err)
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+
+	return &selfTelemetry{
+		logger:      zap.NewNop(),
+		cfg:         &Config{},
+		meter:       provider.Meter(scopeName),
+		sources:     sources,
+		instruments: map[string]otelmetric.Float64Observable{},
+	}, out
+}
+
+// served flattens the exposition into name -> label set for readable assertions.
+func served(t *testing.T, reg *prometheus.Registry) map[string][]map[string]string {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	result := map[string][]map[string]string{}
+	for _, mf := range families {
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range m.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+			result[mf.GetName()] = append(result[mf.GetName()], labels)
+		}
+	}
+	return result
+}
+
+func receiverRegistry(t *testing.T, receiverID string) *prometheus.Registry {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{receiverLabel: receiverID}, reg)
+	targets := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "prometheus_target_scrape_pool_targets",
+		Help: "Current number of targets in this scrape pool.",
+	}, []string{"scrape_job"})
+	wrapped.MustRegister(targets)
+	targets.WithLabelValues("ebs_csi_node").Set(3)
+	targets.WithLabelValues("dcgm").Set(0)
+	return reg
+}
+
+// TestPublishesReceiverAndTelegrafRegistries covers the reason the bridge exists: both runtimes'
+// registries have to land on the one endpoint, each series naming the receiver it came from.
+func TestPublishesReceiverAndTelegrafRegistries(t *testing.T) {
+	telegraf := prometheus.NewRegistry()
+	telegrafTargets := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "prometheus_sd_discovered_targets",
+		Help: "Current number of discovered targets.",
+	}, []string{"config"})
+	telegraf.MustRegister(telegrafTargets)
+	telegrafTargets.WithLabelValues("kubernetes-pods").Set(12)
+
+	bridge, out := newTestBridge(t, func() []source {
+		return []source{
+			{gatherer: receiverRegistry(t, "prometheus/alpha")},
+			{gatherer: telegraf, fallback: telegrafReceiver},
+		}
+	})
+	bridge.sync()
+
+	got := served(t, out)
+	require.Len(t, got["prometheus_target_scrape_pool_targets"], 2)
+	for _, labels := range got["prometheus_target_scrape_pool_targets"] {
+		assert.Equal(t, "prometheus/alpha", labels[receiverLabel])
+	}
+	require.Len(t, got["prometheus_sd_discovered_targets"], 1)
+	assert.Equal(t, telegrafReceiver, got["prometheus_sd_discovered_targets"][0][receiverLabel],
+		"telegraf series must be labelled so the endpoint says where each series came from")
+}
+
+// TestZeroTargetPoolIsPublished is the signal the whole feature is for: a pool that discovered
+// nothing has to be visible, since that failure is otherwise silent.
+func TestZeroTargetPoolIsPublished(t *testing.T) {
+	bridge, out := newTestBridge(t, func() []source {
+		return []source{{gatherer: receiverRegistry(t, "prometheus/alpha")}}
+	})
+	bridge.sync()
+
+	var zeroTargetJobs []string
+	families, err := out.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() != "prometheus_target_scrape_pool_targets" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if m.GetGauge().GetValue() != 0 {
+				continue
+			}
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "scrape_job" {
+					zeroTargetJobs = append(zeroTargetJobs, l.GetValue())
+				}
+			}
+		}
+	}
+	assert.Equal(t, []string{"dcgm"}, zeroTargetJobs)
+}
+
+// TestSkipsUnrelatedAndUnsupportedFamilies keeps the endpoint to the scrape and discovery signals,
+// and proves a summary does not fail the whole pass.
+func TestSkipsUnrelatedAndUnsupportedFamilies(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	unrelated := prometheus.NewGauge(prometheus.GaugeOpts{Name: "go_goroutines", Help: "unrelated"})
+	summary := prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "prometheus_target_interval_length_seconds",
+		Help: "Actual intervals between scrapes.",
+	})
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_target_scrapes_sample_out_of_order_total",
+		Help: "Total number of samples rejected.",
+	})
+	reg.MustRegister(unrelated, summary, counter)
+	unrelated.Set(42)
+	summary.Observe(15.2)
+	counter.Add(7)
+
+	bridge, out := newTestBridge(t, func() []source {
+		return []source{{gatherer: reg, fallback: telegrafReceiver}}
+	})
+	bridge.sync()
+
+	got := served(t, out)
+	assert.NotContains(t, got, "go_goroutines", "only the scrape and discovery families belong here")
+	assert.NotContains(t, got, "prometheus_target_interval_length_seconds", "summaries have no observable form")
+	assert.Contains(t, got, "prometheus_target_scrapes_sample_out_of_order_total")
+}
+
+// TestSyncPicksUpLateFamilies matters because extensions start before receivers, so the first pass
+// sees an empty registry and later passes have to add what appeared since.
+func TestSyncPicksUpLateFamilies(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	bridge, out := newTestBridge(t, func() []source {
+		return []source{{gatherer: reg, fallback: telegrafReceiver}}
+	})
+
+	bridge.sync()
+	assert.Empty(t, served(t, out), "nothing is registered yet")
+
+	targets := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "prometheus_target_scrape_pool_targets",
+		Help: "Current number of targets in this scrape pool.",
+	}, []string{"scrape_job"})
+	reg.MustRegister(targets)
+	targets.WithLabelValues("apiserver").Set(1)
+
+	bridge.sync()
+	assert.Contains(t, served(t, out), "prometheus_target_scrape_pool_targets")
+}

--- a/extension/selftelemetry/factory.go
+++ b/extension/selftelemetry/factory.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package selftelemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
+)
+
+var TypeStr, _ = component.NewType("selftelemetry")
+
+func NewFactory() extension.Factory {
+	return extension.NewFactory(
+		TypeStr,
+		createDefaultConfig,
+		createExtension,
+		component.StabilityLevelAlpha,
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{}
+}
+
+func createExtension(_ context.Context, settings extension.Settings, cfg component.Config) (extension.Extension, error) {
+	return newSelfTelemetry(settings, cfg.(*Config)), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2 => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutilv2 v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/containerinsight v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs v0.0.0-20260806162807-5cc6f180ecb6
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20260806162807-5cc6f180ecb6
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20260812230351-ed061c5ec857
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/metrics v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/proxy v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/xray v0.0.0-20260806162807-5cc6f180ecb6
@@ -63,14 +63,14 @@ replace (
 )
 
 replace (
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20260806162807-5cc6f180ecb6
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20260812230351-ed061c5ec857
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsefareceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsefareceiver v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsekshyperpodreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsekshyperpodreceiver v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20260806162807-5cc6f180ecb6
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.0.0-20260806162807-5cc6f180ecb6
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20260806162807-5cc6f180ecb6
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20260812230351-ed061c5ec857
 	// Cherry-pick of upstream Query XML support for windowseventlogreceiver https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39055
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver => github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260806162807-5cc6f180ecb6
 )

--- a/go.mod
+++ b/go.mod
@@ -554,7 +554,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20220216144756-c35f1ee13d7c // indirect
 	github.com/prometheus/alertmanager v0.28.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common/assets v0.2.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.14.0 // indirect
@@ -632,10 +632,10 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
-	go.opentelemetry.io/contrib/otelconf v0.15.0 // indirect
+	go.opentelemetry.io/contrib/otelconf v0.15.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0 // indirect
 	go.opentelemetry.io/contrib/zpages v0.60.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.11.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.35.0 // indirect
@@ -643,15 +643,15 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.35.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/prometheus v0.57.0 // indirect
+	go.opentelemetry.io/otel/exporters/prometheus v0.57.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.17.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.35.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/zap/exp v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cont
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/containerinsight v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:DwMzm9PGyRRVkekICZdCOHt/kf6A/z9YQ7G2DqspJ4g=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs v0.0.0-20260806162807-5cc6f180ecb6 h1:cUjRJTNQeTODo32Y8NaDpJ5/6jn4kB09ZF/wT2kXnIw=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:TFjXft/gNwEk5EIrNz3glFCx6mMbJNgORAnpKunDw4Y=
-github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20260806162807-5cc6f180ecb6 h1:eEcHXBViGf5RpZJkKEIq3xcq72hWLrBxdqRjEkEtx/8=
-github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:g0K7XRwXDigDe6QLvoUwCFglvzBZYepLDq3JGcYc8t0=
+github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20260812230351-ed061c5ec857 h1:Dg9r/FViJg2BjBNA2S5axy5dTttTKogdMnsQVBfJCHQ=
+github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-20260812230351-ed061c5ec857/go.mod h1:g0K7XRwXDigDe6QLvoUwCFglvzBZYepLDq3JGcYc8t0=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/metrics v0.0.0-20260806162807-5cc6f180ecb6 h1:8ni51ULYFvlwOaJC/pdeqg78QWVHNKWa4BtpA4mxBbs=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/metrics v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:AYAFBvDLMHLC5jJCIfUtfmLAzUdwlkBk8IyZ42ZKAco=
 github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/proxy v0.0.0-20260806162807-5cc6f180ecb6 h1:A+cmIAO8uWANE0mVNZWb2v94RP/qgP/7xrvQxZUsQPI=
@@ -262,8 +262,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/processor/cumulat
 github.com/amazon-contributing/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:MhLjAHeQxgPyj1yyEAqTFfcU/U9tp4yLWYUV4f+xwYw=
 github.com/amazon-contributing/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.0.0-20260806162807-5cc6f180ecb6 h1:ANw8SDX+289uvhflvD5WD9MYsMeuY12q/tEUt+rzC84=
 github.com/amazon-contributing/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:BsyajnM+KIXy6wlP7NCfWf8tEFAIIG4RmK2zbb3k8Vo=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20260806162807-5cc6f180ecb6 h1:3RVN7gOc3zyNU+HwKKxZspYFSkHDzcN/iYQbRdpCmQU=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:zFCrWSeArOUe0UgX0XUli3ECGUOZ9BKD7AM+kpbaIv8=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20260812230351-ed061c5ec857 h1:IQ81oDJXzay9XuEoZsxllxPbAv7C0e+gi5F1IOc9TN0=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.0.0-20260812230351-ed061c5ec857/go.mod h1:zFCrWSeArOUe0UgX0XUli3ECGUOZ9BKD7AM+kpbaIv8=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver v0.0.0-20260806162807-5cc6f180ecb6 h1:f4asA9AGuw7OvZl1gUevOarUS07fd592d2oeVpBInQo=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:7FA4owN95eAy2RD/7IOC5d1be2P0DyZT7nOQZruwtls=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/awsefareceiver v0.0.0-20260806162807-5cc6f180ecb6 h1:ZYbB0h3fmwpM4wzPzm431sILzW/rD+tOavMObblu/Oo=
@@ -276,8 +276,8 @@ github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxrecei
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/jmxreceiver v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:wQV77sHJJdUMIvbJna8LjlNb0omEdiVSrwQnoVAlTMM=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.0.0-20260806162807-5cc6f180ecb6 h1:wmrPq+IvRyYUov4jMlqrEi+NFcv9ZfDa37hhjUrjXoo=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:DdKZOg4y/ac/f/ENvYWWg6e6r+INsAkx6DqRXzps1TU=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20260806162807-5cc6f180ecb6 h1:98qCHXkAmin7jg0Re84so9qurK+sfWDtY9jWzPErfRQ=
-github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:pa2WwKwnYyS/Wviu8P/uCm7JmtrxtB+IG1f8+b+VJF0=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20260812230351-ed061c5ec857 h1:zNtA7ZXUuLidI6d58wsWj1luyPpLuIZjGWZJBimcHHA=
+github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20260812230351-ed061c5ec857/go.mod h1:BKcdMP07goM2i5PESzJl36lMGAVhTEeo3HWG3FF9RJ4=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260806162807-5cc6f180ecb6 h1:us1ciP95rb9fymy92ozdOLmWXjGJWtpY6eSjcps74bE=
 github.com/amazon-contributing/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260806162807-5cc6f180ecb6/go.mod h1:hfCxzEKq6utMJEq/mqehk55jpp7zCoiNs1yDp7WZ+dY=
 github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9 h1:FXrPTd8Rdlc94dKccl7KPmdmIbVh/OjelJ8/vgMRzcQ=

--- a/service/defaultcomponents/components.go
+++ b/service/defaultcomponents/components.go
@@ -82,6 +82,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/extension/entitystore"
 	"github.com/aws/amazon-cloudwatch-agent/extension/k8smetadata"
 	"github.com/aws/amazon-cloudwatch-agent/extension/nodemetadatacache"
+	"github.com/aws/amazon-cloudwatch-agent/extension/selftelemetry"
 	"github.com/aws/amazon-cloudwatch-agent/extension/server"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/outputs/cloudwatch"
 	"github.com/aws/amazon-cloudwatch-agent/plugins/processors/awsapplicationsignals"
@@ -186,6 +187,7 @@ func Factories() (otelcol.Factories, error) {
 		entitystore.NewFactory(),
 		k8smetadata.NewFactory(),
 		nodemetadatacache.NewFactory(),
+		selftelemetry.NewFactory(),
 		server.NewFactory(),
 		ecsobserver.NewFactory(),
 		filestorage.NewFactory(),

--- a/service/defaultcomponents/components_test.go
+++ b/service/defaultcomponents/components_test.go
@@ -129,6 +129,7 @@ func TestComponents(t *testing.T) {
 		"nodemetadatacache",
 		"oidctoken",
 		"pprof",
+		"selftelemetry",
 		"server",
 		"sigv4auth",
 		"zpages",

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1845,6 +1845,10 @@
         "collect": {
           "type": "object",
           "properties": {
+            "watch_replicaset": {
+              "description": "Whether to watch ReplicaSets cluster-wide to attribute pods to their Deployment (sets k8s.deployment.name) for the k8sattributes enrichment shared by all opentelemetry.collect pipelines. Set to false to stop the ReplicaSet watch without enabling Container Insights; k8s.replicaset.name is unaffected. Default true.",
+              "type": "boolean"
+            },
             "database_insights": {
               "type": "object",
               "properties": {

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -1900,6 +1900,10 @@
                   "type": "string",
                   "enum": ["node", "cluster"]
                 },
+                "watch_replicaset": {
+                  "description": "Whether to watch ReplicaSets cluster-wide to attribute pods to their Deployment (sets k8s.deployment.name). Set to false to stop the ReplicaSet watch; k8s.replicaset.name is unaffected. Default true.",
+                  "type": "boolean"
+                },
                 "logs": {
                   "type": "object",
                   "properties": {

--- a/translator/config/schema.json
+++ b/translator/config/schema.json
@@ -25,6 +25,10 @@
       "type": "object",
       "description": "General configuration for Amazon CloudWatch Agent",
       "properties": {
+        "self_telemetry": {
+          "description": "Serves the agent's own metrics on a loopback prometheus endpoint for a prometheus receiver on the same host to scrape",
+          "$ref": "#/definitions/selfTelemetryDefinition"
+        },
         "metrics_collection_interval": {
           "description": "How often the metrics defined will be collected",
           "$ref": "#/definitions/timeIntervalDefinition"
@@ -1802,6 +1806,24 @@
           "additionalProperties": false
         }
       }
+    },
+    "selfTelemetryDefinition": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "port": {
+          "description": "Loopback port to bind. The endpoint is always on 127.0.0.1",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "additionalProperties": false
     },
     "opentelemetryDefinition": {
       "type": "object",

--- a/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_eks_config.yaml
@@ -1664,6 +1664,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     otlp/grpc_0_0_0_0_4315:
         protocols:
             grpc:

--- a/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_and_k8s_config.yaml
@@ -1665,6 +1665,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     otlp/grpc_0_0_0_0_4315:
         protocols:
             grpc:

--- a/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_fallback_and_eks_config.yaml
@@ -1664,6 +1664,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     otlp/grpc_0_0_0_0_4315:
         protocols:
             grpc:

--- a/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.yaml
+++ b/translator/tocwconfig/sampleConfig/appsignals_over_fallback_config.yaml
@@ -1664,6 +1664,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     otlp/grpc_0_0_0_0_4315:
         protocols:
             grpc:

--- a/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/base_container_insights_config.yaml
@@ -226,6 +226,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     tcplog/emf_logs:
         encoding: utf-8
         id: tcp_input

--- a/translator/tocwconfig/sampleConfig/container_insights_jmx.yaml
+++ b/translator/tocwconfig/sampleConfig/container_insights_jmx.yaml
@@ -539,6 +539,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     otlp/http_0_0_0_0_4314:
         protocols:
             http:

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_config.yaml
@@ -827,6 +827,7 @@ receivers:
         role_arn: ""
         shared_credentials_file:
             - /root/.aws/credentials
+        skip_replicaset_watch: false
     tcplog/emf_logs:
         encoding: utf-8
         id: tcp_input

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_config.yaml
@@ -1601,6 +1601,7 @@ receivers:
         role_arn: ""
         shared_credentials_file:
             - /root/.aws/credentials
+        skip_replicaset_watch: false
     tcplog/emf_logs:
         encoding: utf-8
         id: tcp_input

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_high_frequency_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_gpu_high_frequency_config.yaml
@@ -1625,6 +1625,7 @@ receivers:
         role_arn: ""
         shared_credentials_file:
             - /root/.aws/credentials
+        skip_replicaset_watch: false
     tcplog/emf_logs:
         encoding: utf-8
         id: tcp_input

--- a/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_kueue_config.yaml
+++ b/translator/tocwconfig/sampleConfig/emf_and_kubernetes_with_kueue_config.yaml
@@ -929,6 +929,7 @@ receivers:
         role_arn: ""
         shared_credentials_file:
             - /root/.aws/credentials
+        skip_replicaset_watch: false
     awscontainerinsightskueuereceiver:
         cluster_name: TestCluster
         collection_interval: 1m0s

--- a/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kubernetes_on_prem_config.yaml
@@ -784,6 +784,7 @@ receivers:
         role_arn: ""
         shared_credentials_file:
             - fake-path
+        skip_replicaset_watch: false
 service:
     extensions:
         - agenthealth/logs

--- a/translator/tocwconfig/sampleConfig/kueue_container_insights_config.yaml
+++ b/translator/tocwconfig/sampleConfig/kueue_container_insights_config.yaml
@@ -326,6 +326,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     awscontainerinsightskueuereceiver:
         cluster_name: TestCluster
         collection_interval: 1m0s

--- a/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
+++ b/translator/tocwconfig/sampleConfig/log_ecs_metric_only.yaml
@@ -169,6 +169,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     tcplog/emf_logs:
         encoding: utf-8
         id: tcp_input

--- a/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/logs_and_kubernetes_config.yaml
@@ -819,6 +819,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     tcplog/emf_logs:
         encoding: utf-8
         id: tcp_input

--- a/translator/tocwconfig/sampleConfig/otlp_metrics_cloudwatchlogs_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/otlp_metrics_cloudwatchlogs_eks_config.yaml
@@ -837,6 +837,7 @@ receivers:
         request_timeout_seconds: 0
         resource_arn: ""
         role_arn: ""
+        skip_replicaset_watch: false
     otlp/grpc_0_0_0_0_1234:
         protocols:
             grpc:

--- a/translator/tocwconfig/sampleConfig/prometheus_and_kubernetes_config.yaml
+++ b/translator/tocwconfig/sampleConfig/prometheus_and_kubernetes_config.yaml
@@ -826,6 +826,7 @@ receivers:
         role_arn: ""
         shared_credentials_file:
             - /root/.aws/credentials
+        skip_replicaset_watch: false
     telegraf_prometheus:
         collection_interval: 1m0s
         initial_delay: 1s

--- a/translator/tocwconfig/sampleConfig/self_telemetry_config.conf
+++ b/translator/tocwconfig/sampleConfig/self_telemetry_config.conf
@@ -1,0 +1,15 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false

--- a/translator/tocwconfig/sampleConfig/self_telemetry_config.json
+++ b/translator/tocwconfig/sampleConfig/self_telemetry_config.json
@@ -1,0 +1,9 @@
+{
+  "agent": {
+    "region": "us-east-1",
+    "self_telemetry": {
+      "enabled": true,
+      "port": 28888
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/self_telemetry_config.yaml
+++ b/translator/tocwconfig/sampleConfig/self_telemetry_config.yaml
@@ -1,0 +1,51 @@
+exporters:
+    nop: {}
+extensions:
+    selftelemetry: {}
+    server:
+        listen_addr: :4311
+        tls_ca_path: /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt
+        tls_cert_path: /etc/amazon-cloudwatch-observability-agent-server-cert/server.crt
+        tls_key_path: /etc/amazon-cloudwatch-observability-agent-server-cert/server.key
+receivers:
+    nop: {}
+service:
+    extensions:
+        - server
+        - selftelemetry
+    pipelines:
+        metrics/nop:
+            exporters:
+                - nop
+            processors: []
+            receivers:
+                - nop
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: Basic
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 28888
+                            with_resource_constant_labels:
+                                included:
+                                    - NodeName
+                            without_scope_info: true
+                            without_type_suffix: true
+                            without_units: true
+        resource:
+            NodeName: ${env:K8S_NODE_NAME}
+        traces:
+            level: None

--- a/translator/tocwconfig/sampleConfig/self_telemetry_ec2_config.conf
+++ b/translator/tocwconfig/sampleConfig/self_telemetry_ec2_config.conf
@@ -1,0 +1,30 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "1s"
+  flush_jitter = "0s"
+  hostname = ""
+  interval = "60s"
+  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+  logtarget = "lumberjack"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  omit_hostname = false
+  precision = ""
+  quiet = false
+  round_interval = false
+
+[inputs]
+
+  [[inputs.cpu]]
+    fieldpass = ["usage_active"]
+    percpu = false
+    report_active = true
+    totalcpu = true
+
+  [[inputs.mem]]
+    fieldpass = ["used_percent"]
+
+[outputs]
+
+  [[outputs.cloudwatch]]

--- a/translator/tocwconfig/sampleConfig/self_telemetry_ec2_config.json
+++ b/translator/tocwconfig/sampleConfig/self_telemetry_ec2_config.json
@@ -1,0 +1,19 @@
+{
+  "agent": {
+    "region": "us-east-1",
+    "self_telemetry": {
+      "enabled": true,
+      "port": 28888
+    }
+  },
+  "metrics": {
+    "metrics_collected": {
+      "cpu": {
+        "measurement": ["usage_active"]
+      },
+      "mem": {
+        "measurement": ["mem_used_percent"]
+      }
+    }
+  }
+}

--- a/translator/tocwconfig/sampleConfig/self_telemetry_ec2_config.yaml
+++ b/translator/tocwconfig/sampleConfig/self_telemetry_ec2_config.yaml
@@ -1,0 +1,90 @@
+exporters:
+    awscloudwatch:
+        backoff_retry_base: 200ms
+        force_flush_interval: 1m0s
+        max_concurrent_publishers: 10
+        max_datums_per_call: 1000
+        max_retry_count: 5
+        max_values_per_datum: 150
+        middleware: agenthealth/metrics
+        namespace: CWAgent
+        region: us-east-1
+        resource_to_telemetry_conversion:
+            enabled: true
+extensions:
+    agenthealth/metrics:
+        is_usage_data_enabled: true
+        stats:
+            operations:
+                - PutMetricData
+            usage_flags:
+                mode: ""
+                region_type: ACJ
+    agenthealth/statuscode:
+        is_status_code_enabled: true
+        is_usage_data_enabled: true
+        stats:
+            usage_flags:
+                mode: ""
+                region_type: ACJ
+    entitystore:
+        mode: ec2
+        region: us-east-1
+    selftelemetry: {}
+processors:
+    awsentity/resource:
+        entity_type: Resource
+        platform: ec2
+receivers:
+    telegraf_cpu:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
+    telegraf_mem:
+        collection_interval: 1m0s
+        initial_delay: 1s
+        timeout: 0s
+service:
+    extensions:
+        - agenthealth/metrics
+        - agenthealth/statuscode
+        - entitystore
+        - selftelemetry
+    pipelines:
+        metrics/host:
+            exporters:
+                - awscloudwatch
+            processors:
+                - awsentity/resource
+            receivers:
+                - telegraf_cpu
+                - telegraf_mem
+    telemetry:
+        logs:
+            encoding: console
+            level: info
+            output_paths:
+                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+            sampling:
+                enabled: true
+                initial: 2
+                thereafter: 500
+                tick: 10s
+        metrics:
+            level: Basic
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 28888
+                            with_resource_constant_labels:
+                                included:
+                                    - NodeName
+                            without_scope_info: true
+                            without_type_suffix: true
+                            without_units: true
+        resource:
+            NodeName: i-1234567890abcdef0
+        traces:
+            level: None

--- a/translator/tocwconfig/tocwconfig_test.go
+++ b/translator/tocwconfig/tocwconfig_test.go
@@ -81,6 +81,30 @@ func TestBaseContainerInsightsConfig(t *testing.T) {
 	checkTranslation(t, "base_container_insights_config", "darwin", nil, "")
 }
 
+func TestSelfTelemetryConfig(t *testing.T) {
+	resetContext(t)
+	t.Setenv(config.HOST_NAME, "host_name_from_env")
+	t.Setenv(config.HOST_IP, "127.0.0.1")
+	// Kubernetes (EKS) DaemonSet: self_telemetry adds the loopback metrics reader + bridge extension
+	// and stamps the NodeName resource label (K8S_NODE_NAME, operator-injected in Kubernetes).
+	context.CurrentContext().SetKubernetesMode(config.ModeEKS)
+	checkTranslation(t, "self_telemetry_config", "linux", nil, "")
+}
+
+func TestSelfTelemetryEC2Config(t *testing.T) {
+	resetContext(t)
+	t.Setenv(config.HOST_NAME, "host_name_from_env")
+	t.Setenv(config.HOST_IP, "127.0.0.1")
+	// EC2 host (no Kubernetes): NodeName resolves from the {instance_id} placeholder, not the
+	// K8S_NODE_NAME env ref. Stub the metadata so {instance_id} is deterministic.
+	original := translateutil.Ec2MetadataInfoProvider
+	translateutil.Ec2MetadataInfoProvider = func() *translateutil.Metadata {
+		return &translateutil.Metadata{InstanceID: "i-1234567890abcdef0"}
+	}
+	t.Cleanup(func() { translateutil.Ec2MetadataInfoProvider = original })
+	checkTranslation(t, "self_telemetry_ec2_config", "linux", nil, "")
+}
+
 func TestGenericAppSignalsConfig(t *testing.T) {
 	resetContext(t)
 	context.CurrentContext().SetRunInContainer(false)

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -31,6 +31,7 @@ const (
 	LogsCollectedKey                               = "logs_collected"
 	TracesCollectedKey                             = "traces_collected"
 	OpenTelemetryKey                               = "opentelemetry"
+	SelfTelemetryKey                               = "self_telemetry"
 	CollectKey                                     = "collect"
 	ResourceAttributesKey                          = "resource_attributes"
 	HostMetricsKey                                 = "host_metrics"

--- a/translator/translate/otel/common/common.go
+++ b/translator/translate/otel/common/common.go
@@ -36,6 +36,7 @@ const (
 	ResourceAttributesKey                          = "resource_attributes"
 	HostMetricsKey                                 = "host_metrics"
 	OtelContainerInsightsKey                       = "container_insights"
+	WatchReplicaSetKey                             = "watch_replicaset"
 	MetricsDestinationsKey                         = "metrics_destinations"
 	ECSKey                                         = "ecs"
 	KubernetesKey                                  = "kubernetes"
@@ -433,6 +434,17 @@ func GetOrDefaultBool(conf *confmap.Conf, key string, defaultVal bool) bool {
 		}
 	}
 	return defaultVal
+}
+
+// WatchReplicaSet reports whether the cluster-wide ReplicaSet informer (sets k8s.deployment.name) runs.
+// Default true; disabled when the collect-level or container_insights-level watch_replicaset key is false.
+func WatchReplicaSet(conf *confmap.Conf) bool {
+	if conf == nil {
+		return true
+	}
+	collectKey := ConfigKey(OpenTelemetryKey, CollectKey, WatchReplicaSetKey)
+	ciKey := ConfigKey(OpenTelemetryKey, CollectKey, OtelContainerInsightsKey, WatchReplicaSetKey)
+	return GetOrDefaultBool(conf, collectKey, true) && GetOrDefaultBool(conf, ciKey, true)
 }
 
 // GetNumber gets the number value for the key. The switch works through

--- a/translator/translate/otel/extension/selftelemetry/translator.go
+++ b/translator/translate/otel/extension/selftelemetry/translator.go
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package selftelemetry
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/extension"
+
+	"github.com/aws/amazon-cloudwatch-agent/extension/selftelemetry"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
+)
+
+const (
+	// SectionKey is the agent sub-section that turns the endpoint on.
+	SectionKey = common.SelfTelemetryKey
+
+	// Host is fixed to loopback. The endpoint exists for a prometheus receiver on the same node to
+	// scrape, so it never needs to be reachable from anywhere else and offers no bind address knob.
+	Host = "127.0.0.1"
+	// DefaultPort follows the collector's own service::telemetry default.
+	DefaultPort = 8888
+
+	// NodeNameLabel matches the existing Container Insights CloudWatch dimension, so one alarm or
+	// dashboard dimension works across ECI, OCI, and self telemetry alike.
+	NodeNameLabel = "NodeName"
+	// NodeNameEnvRef is expanded per pod by the config provider from the operator-injected env var.
+	NodeNameEnvRef = "${env:K8S_NODE_NAME}"
+
+	enabledKey = "enabled"
+	portKey    = "port"
+)
+
+type translator struct {
+	name    string
+	factory extension.Factory
+}
+
+var _ common.ComponentTranslator = (*translator)(nil)
+
+func NewTranslator() common.ComponentTranslator {
+	return &translator{
+		factory: selftelemetry.NewFactory(),
+	}
+}
+
+func (t *translator) ID() component.ID {
+	return component.NewIDWithName(t.factory.Type(), t.name)
+}
+
+func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
+	return t.factory.CreateDefaultConfig().(*selftelemetry.Config), nil
+}
+
+func configKey(key string) string {
+	return common.ConfigKey(common.AgentKey, SectionKey, key)
+}
+
+// Enabled reports whether agent::self_telemetry turns the endpoint on.
+func Enabled(conf *confmap.Conf) bool {
+	enabled, _ := common.GetBool(conf, configKey(enabledKey))
+	return enabled
+}
+
+// Port returns the loopback port the collector's metrics reader should bind.
+func Port(conf *confmap.Conf) int {
+	if v, ok := common.GetNumber(conf, configKey(portKey)); ok && v > 0 {
+		return int(v)
+	}
+	return DefaultPort
+}

--- a/translator/translate/otel/extension/selftelemetry/translator_test.go
+++ b/translator/translate/otel/extension/selftelemetry/translator_test.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package selftelemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/aws/amazon-cloudwatch-agent/translator/jsonconfig"
+)
+
+func agentConf(selfTelemetry map[string]any) *confmap.Conf {
+	agent := map[string]any{"region": "us-west-2"}
+	if selfTelemetry != nil {
+		agent["self_telemetry"] = selfTelemetry
+	}
+	return confmap.NewFromStringMap(map[string]any{"agent": agent})
+}
+
+func TestEnabled(t *testing.T) {
+	testCases := map[string]struct {
+		input map[string]any
+		want  bool
+	}{
+		"WithoutBlock": {input: nil, want: false},
+		"WithEmpty":    {input: map[string]any{}, want: false},
+		"WithDisabled": {input: map[string]any{"enabled": false}, want: false},
+		"WithEnabled":  {input: map[string]any{"enabled": true}, want: true},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, Enabled(agentConf(testCase.input)))
+		})
+	}
+}
+
+// TestEnabledIgnoresRootSection pins that the block is read from under agent, so a stale root-level
+// block from an earlier config shape does not silently turn the endpoint on.
+func TestEnabledIgnoresRootSection(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"self_telemetry": map[string]any{"enabled": true},
+	})
+	assert.False(t, Enabled(conf))
+}
+
+func TestPort(t *testing.T) {
+	assert.Equal(t, DefaultPort, Port(agentConf(map[string]any{"enabled": true})))
+	assert.Equal(t, 28889, Port(agentConf(map[string]any{"enabled": true, "port": 28889})))
+	assert.Equal(t, DefaultPort, Port(agentConf(map[string]any{"enabled": true, "port": 0})))
+}
+
+func TestTranslate(t *testing.T) {
+	translator := NewTranslator()
+	assert.Equal(t, "selftelemetry", translator.ID().String())
+	cfg, err := translator.Translate(confmap.New())
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+}
+
+// TestSectionSurvivesJSONMerge is why the block lives under agent: the agent merge rule copies
+// sub-keys it has no rule for, so no dedicated merge rule is needed. A root-level section without
+// one is dropped before translation, which is the failure this guards against.
+func TestSectionSurvivesJSONMerge(t *testing.T) {
+	source := map[string]any{
+		"agent": map[string]any{
+			"region":         "us-west-2",
+			"self_telemetry": map[string]any{"enabled": true, "port": 28889},
+		},
+		// A root section with no rule is dropped, which is what nesting under agent avoids.
+		"not_a_registered_section": map[string]any{"enabled": true},
+	}
+	result := map[string]any{}
+	jsonconfig.Merge(source, result)
+
+	require.NotContains(t, result, "not_a_registered_section")
+	require.Contains(t, result, "agent")
+	assert.Equal(t, source["agent"].(map[string]any)["self_telemetry"],
+		result["agent"].(map[string]any)["self_telemetry"])
+
+	conf := confmap.NewFromStringMap(result)
+	assert.True(t, Enabled(conf))
+	assert.Equal(t, 28889, Port(conf))
+}

--- a/translator/translate/otel/pipeline/nop/translator.go
+++ b/translator/translate/otel/pipeline/nop/translator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/exporter"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/selftelemetry"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/receiver"
 )
 
@@ -42,7 +43,9 @@ func (t *translator) ID() pipeline.ID {
 }
 
 func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
-	if conf == nil || !conf.IsSet(logAgentKey) {
+	// Self telemetry needs this placeholder too: a config carrying only service::telemetry has no
+	// pipeline, and a pipeline-less service fails validation, so nothing would be emitted at all.
+	if conf == nil || !(conf.IsSet(logAgentKey) || selftelemetry.Enabled(conf)) {
 		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: fmt.Sprint(logAgentKey)}
 	}
 

--- a/translator/translate/otel/pipeline/nop/translator.go
+++ b/translator/translate/otel/pipeline/nop/translator.go
@@ -45,7 +45,7 @@ func (t *translator) ID() pipeline.ID {
 func (t *translator) Translate(conf *confmap.Conf) (*common.ComponentTranslators, error) {
 	// Self telemetry needs this placeholder too: a config carrying only service::telemetry has no
 	// pipeline, and a pipeline-less service fails validation, so nothing would be emitted at all.
-	if conf == nil || !(conf.IsSet(logAgentKey) || selftelemetry.Enabled(conf)) {
+	if conf == nil || (!conf.IsSet(logAgentKey) && !selftelemetry.Enabled(conf)) {
 		return nil, &common.MissingKeyError{ID: t.ID(), JsonKey: fmt.Sprint(logAgentKey)}
 	}
 

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/cadvisor.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/cadvisor.yaml
@@ -146,7 +146,9 @@ processors:
       metadata:
       - k8s.pod.uid
       - k8s.node.name
+{{- if .WatchReplicaSet }}
       - k8s.deployment.name
+{{- end }}
       - k8s.statefulset.name
       - k8s.daemonset.name
       - k8s.replicaset.name

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/common.go
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/common.go
@@ -134,10 +134,10 @@ func solutionNamespace(conf *confmap.Conf, name, defaultNamespace string) string
 	return defaultNamespace
 }
 
-// watchReplicaSet returns container_insights.watch_replicaset (default true).
-// When false the k8sattributes ReplicaSet informer is not started.
+// watchReplicaSet reports whether the CI k8sattributes ReplicaSet informer runs (default true;
+// disabled by either watch_replicaset key — see common.WatchReplicaSet).
 func watchReplicaSet(conf *confmap.Conf) bool {
-	return common.GetOrDefaultBool(conf, common.ConfigKey(ciConfigKey, "watch_replicaset"), true)
+	return common.WatchReplicaSet(conf)
 }
 
 // getRole resolves the container insights pipeline role using the following

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/common.go
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/common.go
@@ -41,6 +41,10 @@ type templateData struct {
 	NodeLogStream      string
 	KarpenterNamespace string
 	KedaNamespace      string
+	// WatchReplicaSet gates k8s.deployment.name in the k8sattributes metadata.
+	// When false the pod->RS->Deployment owner walk (and its cluster-wide
+	// ReplicaSet informer) is not started. Default true.
+	WatchReplicaSet bool
 }
 
 // rawMapConfig wraps a raw config map and passes it through serialization unchanged.
@@ -128,6 +132,12 @@ func solutionNamespace(conf *confmap.Conf, name, defaultNamespace string) string
 		}
 	}
 	return defaultNamespace
+}
+
+// watchReplicaSet returns container_insights.watch_replicaset (default true).
+// When false the k8sattributes ReplicaSet informer is not started.
+func watchReplicaSet(conf *confmap.Conf) bool {
+	return common.GetOrDefaultBool(conf, common.ConfigKey(ciConfigKey, "watch_replicaset"), true)
 }
 
 // getRole resolves the container insights pipeline role using the following

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/dcgm.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/dcgm.yaml
@@ -93,7 +93,9 @@ processors:
       metadata:
       - k8s.pod.uid
       - k8s.node.name
+{{- if .WatchReplicaSet }}
       - k8s.deployment.name
+{{- end }}
       - k8s.statefulset.name
       - k8s.daemonset.name
       - k8s.replicaset.name

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/efa.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/efa.yaml
@@ -102,7 +102,9 @@ processors:
       metadata:
       - k8s.pod.uid
       - k8s.node.name
+{{- if .WatchReplicaSet }}
       - k8s.deployment.name
+{{- end }}
       - k8s.statefulset.name
       - k8s.daemonset.name
       - k8s.replicaset.name

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/filelog_app.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/filelog_app.yaml
@@ -90,7 +90,9 @@ processors:
       metadata:
       - k8s.pod.uid
       - k8s.node.name
+{{- if .WatchReplicaSet }}
       - k8s.deployment.name
+{{- end }}
       - k8s.statefulset.name
       - k8s.daemonset.name
       - k8s.replicaset.name

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/kube_state_metrics.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/kube_state_metrics.yaml
@@ -135,7 +135,9 @@ processors:
       metadata:
       - k8s.pod.uid
       - k8s.node.name
+{{- if .WatchReplicaSet }}
       - k8s.deployment.name
+{{- end }}
       - k8s.statefulset.name
       - k8s.daemonset.name
       - k8s.replicaset.name

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/kubeletstats.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/kubeletstats.yaml
@@ -74,7 +74,9 @@ processors:
       metadata:
       - k8s.pod.uid
       - k8s.node.name
+{{- if .WatchReplicaSet }}
       - k8s.deployment.name
+{{- end }}
       - k8s.statefulset.name
       - k8s.daemonset.name
       - k8s.replicaset.name

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron.yaml
@@ -122,7 +122,9 @@ processors:
       metadata:
       - k8s.pod.uid
       - k8s.node.name
+{{- if .WatchReplicaSet }}
       - k8s.deployment.name
+{{- end }}
       - k8s.statefulset.name
       - k8s.daemonset.name
       - k8s.replicaset.name

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/translator.go
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/translator.go
@@ -177,6 +177,7 @@ func (t *yamlPipelineTranslator) Translate(conf *confmap.Conf) (*common.Componen
 		NodeLogStream:      envOrPlaceholder("K8S_NODE_NAME") + "-host",
 		KarpenterNamespace: solutionNamespace(conf, "karpenter", defaultKarpenterNamespace),
 		KedaNamespace:      solutionNamespace(conf, "keda", defaultKedaNamespace),
+		WatchReplicaSet:    watchReplicaSet(conf),
 	}
 
 	// Execute template

--- a/translator/translate/otel/processor/k8sattributesprocessor/translator.go
+++ b/translator/translate/otel/processor/k8sattributesprocessor/translator.go
@@ -35,8 +35,31 @@ func (t *translator) ID() component.ID {
 	return component.NewIDWithName(t.factory.Type(), t.name)
 }
 
-func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
+func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 	cfg := t.factory.CreateDefaultConfig()
+
+	metadata := []string{
+		"k8s.namespace.name",
+		"k8s.deployment.name",
+		"k8s.replicaset.name",
+		"k8s.statefulset.name",
+		"k8s.daemonset.name",
+		"k8s.job.name",
+		"k8s.cronjob.name",
+		"k8s.node.name",
+		"k8s.pod.name",
+		"k8s.pod.uid",
+		"k8s.pod.start_time",
+		"k8s.container.name",
+	}
+	// container_insights.watch_replicaset is on by default; false drops k8s.deployment.name,
+	// which stops this processor's cluster-wide ReplicaSet informer (the pod->RS->Deployment
+	// walk). k8s.replicaset.name stays (pod ownerRef, no informer). App Signals is unaffected
+	// (it never uses this processor). Only co-enabled raw OTLP telemetry loses deployment.name.
+	watchRSKey := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtelContainerInsightsKey, "watch_replicaset")
+	if conf != nil && !common.GetOrDefaultBool(conf, watchRSKey, true) {
+		metadata = removeString(metadata, "k8s.deployment.name")
+	}
 
 	cfgMap := map[string]interface{}{
 		"auth_type":   "serviceAccount",
@@ -45,20 +68,7 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 			"node_from_env_var": "K8S_NODE_NAME",
 		},
 		"extract": map[string]interface{}{
-			"metadata": []string{
-				"k8s.namespace.name",
-				"k8s.deployment.name",
-				"k8s.replicaset.name",
-				"k8s.statefulset.name",
-				"k8s.daemonset.name",
-				"k8s.job.name",
-				"k8s.cronjob.name",
-				"k8s.node.name",
-				"k8s.pod.name",
-				"k8s.pod.uid",
-				"k8s.pod.start_time",
-				"k8s.container.name",
-			},
+			"metadata": metadata,
 			"annotations": []map[string]interface{}{
 				{"tag_name": "resource.opentelemetry.io/service.name", "key": "resource.opentelemetry.io/service.name", "from": "pod"},
 				{"tag_name": "resource.opentelemetry.io/service.namespace", "key": "resource.opentelemetry.io/service.namespace", "from": "pod"},
@@ -81,4 +91,14 @@ func (t *translator) Translate(_ *confmap.Conf) (component.Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func removeString(s []string, target string) []string {
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		if v != target {
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/translator/translate/otel/processor/k8sattributesprocessor/translator.go
+++ b/translator/translate/otel/processor/k8sattributesprocessor/translator.go
@@ -52,12 +52,9 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		"k8s.pod.start_time",
 		"k8s.container.name",
 	}
-	// container_insights.watch_replicaset is on by default; false drops k8s.deployment.name,
-	// which stops this processor's cluster-wide ReplicaSet informer (the pod->RS->Deployment
-	// walk). k8s.replicaset.name stays (pod ownerRef, no informer). App Signals is unaffected
-	// (it never uses this processor). Only co-enabled raw OTLP telemetry loses deployment.name.
-	watchRSKey := common.ConfigKey(common.OpenTelemetryKey, common.CollectKey, common.OtelContainerInsightsKey, "watch_replicaset")
-	if conf != nil && !common.GetOrDefaultBool(conf, watchRSKey, true) {
+	// watch_replicaset (default true) drops k8s.deployment.name when false, stopping the cluster-wide
+	// ReplicaSet informer; common.WatchReplicaSet resolves the collect-level and container_insights keys.
+	if !common.WatchReplicaSet(conf) {
 		metadata = removeString(metadata, "k8s.deployment.name")
 	}
 

--- a/translator/translate/otel/processor/k8sattributesprocessor/translator_test.go
+++ b/translator/translate/otel/processor/k8sattributesprocessor/translator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
 )
 
 func TestNewTranslator(t *testing.T) {
@@ -38,4 +39,39 @@ func TestTranslate(t *testing.T) {
 	assert.Len(t, k8sCfg.Extract.Metadata, 12)
 	assert.Len(t, k8sCfg.Extract.Annotations, 4)
 	assert.Len(t, k8sCfg.Extract.Labels, 3)
+}
+
+func TestTranslateWatchReplicaSetDisabled(t *testing.T) {
+	// container_insights.watch_replicaset=false drops k8s.deployment.name (stops the RS
+	// informer) while keeping k8s.replicaset.name (pod ownerRef). Key absent -> default true.
+	off := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"container_insights": map[string]interface{}{"watch_replicaset": false},
+			},
+		},
+	})
+	cfg, err := NewTranslator("otlp").Translate(off)
+	require.NoError(t, err)
+	k8sCfg := cfg.(*k8sattributesprocessor.Config)
+	assert.NotContains(t, k8sCfg.Extract.Metadata, "k8s.deployment.name")
+	assert.Contains(t, k8sCfg.Extract.Metadata, "k8s.replicaset.name")
+	assert.Len(t, k8sCfg.Extract.Metadata, 11)
+
+	// Default (key absent) keeps deployment.name.
+	baseCfg, err := NewTranslator("otlp").Translate(confmap.New())
+	require.NoError(t, err)
+	assert.Contains(t, baseCfg.(*k8sattributesprocessor.Config).Extract.Metadata, "k8s.deployment.name")
+
+	// Explicit watch_replicaset=true keeps deployment.name.
+	on := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"container_insights": map[string]interface{}{"watch_replicaset": true},
+			},
+		},
+	})
+	onCfg, err := NewTranslator("otlp").Translate(on)
+	require.NoError(t, err)
+	assert.Contains(t, onCfg.(*k8sattributesprocessor.Config).Extract.Metadata, "k8s.deployment.name")
 }

--- a/translator/translate/otel/processor/k8sattributesprocessor/translator_test.go
+++ b/translator/translate/otel/processor/k8sattributesprocessor/translator_test.go
@@ -75,3 +75,22 @@ func TestTranslateWatchReplicaSetDisabled(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, onCfg.(*k8sattributesprocessor.Config).Extract.Metadata, "k8s.deployment.name")
 }
+
+// TestTranslateWatchReplicaSetCollectLevel is the decoupling contract: the collect-level key stops the
+// ReplicaSet informer with no container_insights key (which would otherwise activate CI on bare presence).
+func TestTranslateWatchReplicaSetCollectLevel(t *testing.T) {
+	off := confmap.NewFromStringMap(map[string]interface{}{
+		"opentelemetry": map[string]interface{}{
+			"collect": map[string]interface{}{
+				"watch_replicaset": false,
+			},
+		},
+	})
+	cfg, err := NewTranslator("otlp").Translate(off)
+	require.NoError(t, err)
+	k8sCfg := cfg.(*k8sattributesprocessor.Config)
+	assert.NotContains(t, k8sCfg.Extract.Metadata, "k8s.deployment.name")
+	assert.Contains(t, k8sCfg.Extract.Metadata, "k8s.replicaset.name")
+	// No container_insights key was set, so the CI pipelines are never activated by this toggle.
+	assert.NotContains(t, off.AllKeys(), "opentelemetry::collect::container_insights")
+}

--- a/translator/translate/otel/receiver/awscontainerinsight/translator.go
+++ b/translator/translate/otel/receiver/awscontainerinsight/translator.go
@@ -104,7 +104,7 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		cfg.TagService = common.GetOrDefaultBool(conf, tagServiceKey, true)
 		// watch_replicaset is on by default; set it to false to stop the cluster-wide
 		// ReplicaSet informer. The receiver models this as SkipReplicaSetWatch, so invert.
-		watchRSKey := common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.KubernetesKey, "watch_replicaset")
+		watchRSKey := common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.KubernetesKey, common.WatchReplicaSetKey)
 		cfg.SkipReplicaSetWatch = !common.GetOrDefaultBool(conf, watchRSKey, true)
 
 		if context.CurrentContext().Mode() == config.ModeOnPrem || context.CurrentContext().Mode() == config.ModeOnPremise {

--- a/translator/translate/otel/receiver/awscontainerinsight/translator.go
+++ b/translator/translate/otel/receiver/awscontainerinsight/translator.go
@@ -102,6 +102,10 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		cfg.LeaderLockUsingConfigMapOnly = true
 		tagServiceKey := common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.KubernetesKey, "tag_service")
 		cfg.TagService = common.GetOrDefaultBool(conf, tagServiceKey, true)
+		// watch_replicaset is on by default; set it to false to stop the cluster-wide
+		// ReplicaSet informer. The receiver models this as SkipReplicaSetWatch, so invert.
+		watchRSKey := common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.KubernetesKey, "watch_replicaset")
+		cfg.SkipReplicaSetWatch = !common.GetOrDefaultBool(conf, watchRSKey, true)
 
 		if context.CurrentContext().Mode() == config.ModeOnPrem || context.CurrentContext().Mode() == config.ModeOnPremise {
 			cfg.LocalMode = true

--- a/translator/translate/otel/receiver/awscontainerinsight/translator_test.go
+++ b/translator/translate/otel/receiver/awscontainerinsight/translator_test.go
@@ -143,6 +143,29 @@ func TestTranslator(t *testing.T) {
 				AcceleratedComputeGPUMetricsCollectionInterval: 60 * time.Second, // Default value
 			},
 		},
+		"WithKubernetes/WatchReplicaSetDisabled": {
+			input: map[string]interface{}{
+				"logs": map[string]interface{}{
+					"metrics_collected": map[string]interface{}{
+						"kubernetes": map[string]interface{}{
+							"watch_replicaset": false,
+							"cluster_name":     "TestCluster",
+						},
+					},
+				},
+			},
+			want: &awscontainerinsightreceiver.Config{
+				ContainerOrchestrator:        eks,
+				CollectionInterval:           60 * time.Second,
+				TagService:                   true,
+				SkipReplicaSetWatch:          true,
+				LeaderLockName:               defaultLeaderLockName,
+				LeaderLockUsingConfigMapOnly: true,
+				ClusterName:                  "TestCluster",
+				KubeConfigPath:               "",
+				AcceleratedComputeGPUMetricsCollectionInterval: 60 * time.Second, // Default value
+			},
+		},
 		"WithKubernetes/WithCollectionRoleLeader": {
 			input: map[string]interface{}{
 				"logs": map[string]interface{}{
@@ -399,6 +422,7 @@ func TestTranslator(t *testing.T) {
 				require.Equal(t, testCase.want.AddContainerNameMetricLabel, gotCfg.AddContainerNameMetricLabel)
 				require.Equal(t, testCase.want.AddFullPodNameMetricLabel, gotCfg.AddFullPodNameMetricLabel)
 				require.Equal(t, testCase.want.TagService, gotCfg.TagService)
+				require.Equal(t, testCase.want.SkipReplicaSetWatch, gotCfg.SkipReplicaSetWatch)
 				require.Equal(t, testCase.want.LeaderLockName, gotCfg.LeaderLockName)
 				require.Equal(t, testCase.want.LeaderLockUsingConfigMapOnly, gotCfg.LeaderLockUsingConfigMapOnly)
 				require.Equal(t, testCase.want.EnableControlPlaneMetrics, gotCfg.EnableControlPlaneMetrics)

--- a/translator/translate/otel/selftelemetry_test.go
+++ b/translator/translate/otel/selftelemetry_test.go
@@ -13,8 +13,11 @@ import (
 
 	selftelemetryextension "github.com/aws/amazon-cloudwatch-agent/extension/selftelemetry"
 	"github.com/aws/amazon-cloudwatch-agent/translator"
+	"github.com/aws/amazon-cloudwatch-agent/translator/config"
+	"github.com/aws/amazon-cloudwatch-agent/translator/context"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline"
+	translateutil "github.com/aws/amazon-cloudwatch-agent/translator/translate/util"
 )
 
 func selfTelemetryID() component.ID {
@@ -149,6 +152,9 @@ func TestNoSelfTelemetryWithoutPipelinesStillFails(t *testing.T) {
 func TestSelfTelemetryStampsNodeViaResource(t *testing.T) {
 	agent.Global_Config.Region = "us-west-2"
 	translator.SetTargetPlatform("linux")
+	// NodeName is stamped only in Kubernetes, where the operator injects K8S_NODE_NAME.
+	context.CurrentContext().SetKubernetesMode(config.ModeEKS)
+	t.Cleanup(func() { context.CurrentContext().SetKubernetesMode("") })
 
 	got, err := TranslateWithoutValidation(selfTelemetryInput(map[string]any{"enabled": true}), "linux")
 	require.NoError(t, err)
@@ -172,4 +178,68 @@ func TestSelfTelemetryOffLeavesNoResource(t *testing.T) {
 	got, err := TranslateWithoutValidation(selfTelemetryInput(nil), "linux")
 	require.NoError(t, err)
 	assert.NotContains(t, got.Service.Telemetry.Resource, "NodeName")
+}
+
+// TestSelfTelemetryOnEC2UsesInstanceID is the EC2/off-Kubernetes contract: there is no operator-injected
+// K8S_NODE_NAME, so the per-host identity comes from the resolved {instance_id} placeholder instead of a
+// runtime env ref. Large fleets still get a distinct node label per host.
+func TestSelfTelemetryOnEC2UsesInstanceID(t *testing.T) {
+	t.Setenv("SYSTEM_METRICS_ENABLED", "false")
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+	context.CurrentContext().SetKubernetesMode("") // not Kubernetes (e.g. EC2 host)
+
+	// Stub the metadata so {instance_id} resolves deterministically instead of the test host's IMDS.
+	original := translateutil.Ec2MetadataInfoProvider
+	translateutil.Ec2MetadataInfoProvider = func() *translateutil.Metadata {
+		return &translateutil.Metadata{InstanceID: "i-1234567890abcdef0"}
+	}
+	t.Cleanup(func() { translateutil.Ec2MetadataInfoProvider = original })
+
+	got, err := TranslateWithoutValidation(map[string]any{
+		"agent": map[string]any{
+			"region":         "us-west-2",
+			"self_telemetry": map[string]any{"enabled": true, "port": 28888},
+		},
+	}, "linux")
+	require.NoError(t, err)
+
+	// Self telemetry works: the reader binds and the bridge extension is present.
+	require.Len(t, got.Service.Telemetry.Metrics.Readers, 1)
+	assert.Contains(t, got.Service.Extensions, selfTelemetryID())
+
+	// The node label carries the resolved instance ID (not a K8S_NODE_NAME env ref), and the reader
+	// still promotes it as a constant label.
+	require.Contains(t, got.Service.Telemetry.Resource, "NodeName")
+	assert.Equal(t, "i-1234567890abcdef0", *got.Service.Telemetry.Resource["NodeName"])
+	require.NotNil(t, got.Service.Telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.WithResourceConstantLabels)
+}
+
+// TestSelfTelemetryOnNonEC2FallsBackToHostname is the non-EC2/off-Kubernetes contract: when IMDS has no
+// instance id (ECS/on-prem/Azure), NodeName falls back to the resolved hostname so hosts stay distinct
+// instead of all colliding on the i-UNKNOWN sentinel.
+func TestSelfTelemetryOnNonEC2FallsBackToHostname(t *testing.T) {
+	t.Setenv("SYSTEM_METRICS_ENABLED", "false")
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+	context.CurrentContext().SetKubernetesMode("") // not Kubernetes
+
+	// No instance id (non-EC2): {instance_id} resolves to i-UNKNOWN, so the code must fall back to hostname.
+	original := translateutil.Ec2MetadataInfoProvider
+	translateutil.Ec2MetadataInfoProvider = func() *translateutil.Metadata {
+		return &translateutil.Metadata{Hostname: "onprem-host-7"}
+	}
+	t.Cleanup(func() { translateutil.Ec2MetadataInfoProvider = original })
+
+	got, err := TranslateWithoutValidation(map[string]any{
+		"agent": map[string]any{
+			"region":         "us-west-2",
+			"self_telemetry": map[string]any{"enabled": true, "port": 28888},
+		},
+	}, "linux")
+	require.NoError(t, err)
+
+	require.Contains(t, got.Service.Telemetry.Resource, "NodeName")
+	assert.Equal(t, "onprem-host-7", *got.Service.Telemetry.Resource["NodeName"])
+	assert.NotEqual(t, translateutil.UnknownInstanceID, *got.Service.Telemetry.Resource["NodeName"])
 }

--- a/translator/translate/otel/selftelemetry_test.go
+++ b/translator/translate/otel/selftelemetry_test.go
@@ -1,0 +1,175 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package otel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configtelemetry"
+
+	selftelemetryextension "github.com/aws/amazon-cloudwatch-agent/extension/selftelemetry"
+	"github.com/aws/amazon-cloudwatch-agent/translator"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/agent"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline"
+)
+
+func selfTelemetryID() component.ID {
+	return component.NewID(selftelemetryextension.TypeStr)
+}
+
+func selfTelemetryInput(selfTelemetry map[string]any) map[string]any {
+	agentSection := map[string]any{"region": "us-west-2"}
+	if selfTelemetry != nil {
+		agentSection["self_telemetry"] = selfTelemetry
+	}
+	return map[string]any{
+		"agent": agentSection,
+		"logs": map[string]any{
+			"metrics_collected": map[string]any{
+				"kubernetes": map[string]any{"cluster_name": "TestCluster"},
+			},
+		},
+	}
+}
+
+// TestSelfTelemetryOffByDefault pins the existing behaviour: without the block the collector reports
+// nothing and binds no port.
+func TestSelfTelemetryOffByDefault(t *testing.T) {
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+
+	got, err := TranslateWithoutValidation(selfTelemetryInput(nil), "linux")
+	require.NoError(t, err)
+	assert.Equal(t, configtelemetry.LevelNone, got.Service.Telemetry.Metrics.Level)
+	assert.Empty(t, got.Service.Telemetry.Metrics.Readers)
+	assert.NotContains(t, got.Service.Extensions, selfTelemetryID())
+}
+
+// TestSelfTelemetryEnabledAddsReaderAndExtension is the whole contract of the config key: one option
+// turns on the collector's own metrics and the bridge that puts the scrape registries on them.
+func TestSelfTelemetryEnabledAddsReaderAndExtension(t *testing.T) {
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+
+	got, err := TranslateWithoutValidation(selfTelemetryInput(map[string]any{
+		"enabled": true,
+		"port":    28888,
+	}), "linux")
+	require.NoError(t, err)
+
+	assert.Equal(t, configtelemetry.LevelBasic, got.Service.Telemetry.Metrics.Level)
+	require.Len(t, got.Service.Telemetry.Metrics.Readers, 1)
+	prom := got.Service.Telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus
+	require.NotNil(t, prom)
+	assert.Equal(t, 28888, *prom.Port)
+
+	// Without these the SDK renames the series and a scraper no longer recognizes them.
+	assert.True(t, *prom.WithoutTypeSuffix)
+	assert.True(t, *prom.WithoutUnits)
+	assert.True(t, *prom.WithoutScopeInfo)
+
+	assert.Contains(t, got.Service.Extensions, selfTelemetryID())
+}
+
+// TestSelfTelemetryAlwaysBindsLoopback is the security property of the design: there is no bind
+// address option, so enabling it can never publish the endpoint off the host.
+func TestSelfTelemetryAlwaysBindsLoopback(t *testing.T) {
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+
+	for _, selfTelemetry := range []map[string]any{
+		{"enabled": true},
+		{"enabled": true, "port": 39001},
+		// A stray host key is rejected by the schema and ignored here; loopback still wins.
+		{"enabled": true, "host": "0.0.0.0"},
+	} {
+		got, err := TranslateWithoutValidation(selfTelemetryInput(selfTelemetry), "linux")
+		require.NoError(t, err)
+		require.Len(t, got.Service.Telemetry.Metrics.Readers, 1)
+		assert.Equal(t, "127.0.0.1",
+			*got.Service.Telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.Host)
+	}
+}
+
+func TestSelfTelemetryDefaultPort(t *testing.T) {
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+
+	got, err := TranslateWithoutValidation(selfTelemetryInput(map[string]any{"enabled": true}), "linux")
+	require.NoError(t, err)
+	require.Len(t, got.Service.Telemetry.Metrics.Readers, 1)
+	assert.Equal(t, 8888, *got.Service.Telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.Port)
+}
+
+// TestSelfTelemetryWithoutPipelines covers the cluster-scraper shape, whose JSON config carries only
+// the region and gets every pipeline from the supplied OTEL config. Without a placeholder pipeline
+// the translation yields nothing at all and the endpoint never binds.
+func TestSelfTelemetryWithoutPipelines(t *testing.T) {
+	t.Setenv("SYSTEM_METRICS_ENABLED", "false")
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+
+	got, err := TranslateWithoutValidation(map[string]any{
+		"agent": map[string]any{
+			"region":         "us-west-2",
+			"self_telemetry": map[string]any{"enabled": true, "port": 28889},
+		},
+	}, "linux")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.NotEmpty(t, got.Service.Pipelines, "a pipeline is required or the config is discarded")
+	assert.Equal(t, configtelemetry.LevelBasic, got.Service.Telemetry.Metrics.Level)
+	require.Len(t, got.Service.Telemetry.Metrics.Readers, 1)
+	assert.Equal(t, 28889, *got.Service.Telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.Port)
+	assert.Contains(t, got.Service.Extensions, selfTelemetryID())
+}
+
+// TestNoSelfTelemetryWithoutPipelinesStillFails pins that the placeholder is only added for self
+// telemetry, so an otherwise empty config is still rejected as it was before.
+func TestNoSelfTelemetryWithoutPipelinesStillFails(t *testing.T) {
+	t.Setenv("SYSTEM_METRICS_ENABLED", "false")
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+
+	_, err := TranslateWithoutValidation(map[string]any{
+		"agent": map[string]any{"region": "us-west-2"},
+	}, "linux")
+	assert.ErrorIs(t, err, pipeline.ErrNoPipelines)
+}
+
+// TestSelfTelemetryStampsNodeViaResource pins the native node-identity path: the collector's own
+// resource carries NodeName from the env ref, and the prometheus reader promotes it to a constant
+// label on every series. This replaces the hand-rolled per-datapoint stamping and also covers the
+// otelcol_* series, which the bridge never touched.
+func TestSelfTelemetryStampsNodeViaResource(t *testing.T) {
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+
+	got, err := TranslateWithoutValidation(selfTelemetryInput(map[string]any{"enabled": true}), "linux")
+	require.NoError(t, err)
+
+	require.Contains(t, got.Service.Telemetry.Resource, "NodeName")
+	require.NotNil(t, got.Service.Telemetry.Resource["NodeName"])
+	assert.Equal(t, "${env:K8S_NODE_NAME}", *got.Service.Telemetry.Resource["NodeName"])
+
+	require.Len(t, got.Service.Telemetry.Metrics.Readers, 1)
+	prom := got.Service.Telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus
+	require.NotNil(t, prom.WithResourceConstantLabels)
+	assert.Equal(t, []string{"NodeName"}, prom.WithResourceConstantLabels.Included)
+}
+
+// TestSelfTelemetryOffLeavesNoResource keeps the resource empty when the feature is off, so nothing
+// changes for configs that do not opt in.
+func TestSelfTelemetryOffLeavesNoResource(t *testing.T) {
+	agent.Global_Config.Region = "us-west-2"
+	translator.SetTargetPlatform("linux")
+
+	got, err := TranslateWithoutValidation(selfTelemetryInput(nil), "linux")
+	require.NoError(t, err)
+	assert.NotContains(t, got.Service.Telemetry.Resource, "NodeName")
+}

--- a/translator/translate/otel/translate_otel.go
+++ b/translator/translate/otel/translate_otel.go
@@ -42,6 +42,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/prometheus"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/systemmetrics"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline/xray"
+	translateutil "github.com/aws/amazon-cloudwatch-agent/translator/translate/util"
 	"github.com/aws/amazon-cloudwatch-agent/translator/util/ecsutil"
 )
 
@@ -209,7 +210,16 @@ func getSelfTelemetryResource(conf *confmap.Conf) map[string]*string {
 	if !selftelemetry.Enabled(conf) {
 		return nil
 	}
+	// NodeName = per-host identity: K8s uses the K8S_NODE_NAME env ref; off-K8s the EC2 {instance_id},
+	// falling back to {hostname} when not on EC2 so non-EC2 hosts don't collide on i-UNKNOWN.
 	nodeName := selftelemetry.NodeNameEnvRef
+	if context.CurrentContext().KubernetesMode() == "" {
+		md := translateutil.GetMetadataInfo(translateutil.Ec2MetadataInfoProvider)
+		nodeName = translateutil.ResolvePlaceholder("{instance_id}", md)
+		if nodeName == translateutil.UnknownInstanceID {
+			nodeName = translateutil.ResolvePlaceholder("{hostname}", md)
+		}
+	}
 	return map[string]*string{selftelemetry.NodeNameLabel: &nodeName}
 }
 

--- a/translator/translate/otel/translate_otel.go
+++ b/translator/translate/otel/translate_otel.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/telemetry"
+	otelconfig "go.opentelemetry.io/contrib/otelconf/v0.3.0"
 	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/common"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/entitystore"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/oidctoken"
+	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/selftelemetry"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/server"
 	"github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/extension/sigv4auth"
 	pipelinetranslator "github.com/aws/amazon-cloudwatch-agent/translator/translate/otel/pipeline"
@@ -124,6 +126,10 @@ func translateInternal(jsonConfig interface{}, os string, validate bool) (*otelc
 		pipelines.Translators.Extensions.Set(oidctoken.NewTranslator())
 	}
 
+	if selftelemetry.Enabled(conf) {
+		pipelines.Translators.Extensions.Set(selftelemetry.NewTranslator())
+	}
+
 	cfg := &otelcol.Config{
 		Receivers:  map[component.ID]component.Config{},
 		Exporters:  map[component.ID]component.Config{},
@@ -132,9 +138,10 @@ func translateInternal(jsonConfig interface{}, os string, validate bool) (*otelc
 		Extensions: map[component.ID]component.Config{},
 		Service: service.Config{
 			Telemetry: telemetry.Config{
-				Logs:    getLoggingConfig(conf),
-				Metrics: telemetry.MetricsConfig{Level: configtelemetry.LevelNone},
-				Traces:  telemetry.TracesConfig{Level: configtelemetry.LevelNone},
+				Logs:     getLoggingConfig(conf),
+				Metrics:  getSelfTelemetryConfig(conf),
+				Traces:   telemetry.TracesConfig{Level: configtelemetry.LevelNone},
+				Resource: getSelfTelemetryResource(conf),
 			},
 			Pipelines:  pipelines.Pipelines,
 			Extensions: pipelines.Translators.Extensions.Keys(),
@@ -159,6 +166,51 @@ func hasSigv4auth(extensions common.ComponentTranslatorMap) bool {
 		}
 	}
 	return false
+}
+
+// getSelfTelemetryConfig turns the root self_telemetry block into the collector's own metrics reader.
+// The suffix and scope options are off so prometheus names survive the round trip through the SDK,
+// keeping series such as prometheus_target_scrape_pool_targets recognizable to a scraper.
+func getSelfTelemetryConfig(conf *confmap.Conf) telemetry.MetricsConfig {
+	if !selftelemetry.Enabled(conf) {
+		return telemetry.MetricsConfig{Level: configtelemetry.LevelNone}
+	}
+	host, port := selftelemetry.Host, selftelemetry.Port(conf)
+	without := true
+	return telemetry.MetricsConfig{
+		Level: configtelemetry.LevelBasic,
+		MeterProvider: otelconfig.MeterProvider{
+			Readers: []otelconfig.MetricReader{{
+				Pull: &otelconfig.PullMetricReader{
+					Exporter: otelconfig.PullMetricExporter{
+						Prometheus: &otelconfig.Prometheus{
+							Host:              &host,
+							Port:              &port,
+							WithoutScopeInfo:  &without,
+							WithoutTypeSuffix: &without,
+							WithoutUnits:      &without,
+							// Promote the node resource attribute onto every series as a constant label,
+							// so a DaemonSet's identical series stay distinct per node.
+							WithResourceConstantLabels: &otelconfig.IncludeExclude{
+								Included: []string{selftelemetry.NodeNameLabel},
+							},
+						},
+					},
+				},
+			}},
+		},
+	}
+}
+
+// getSelfTelemetryResource tags all self telemetry with the node name via the collector's own
+// resource mechanism. The env ref is expanded per pod by the config provider's expandconverter, so
+// the same generated config yields a distinct node label on every node with no per-pod rendering.
+func getSelfTelemetryResource(conf *confmap.Conf) map[string]*string {
+	if !selftelemetry.Enabled(conf) {
+		return nil
+	}
+	nodeName := selftelemetry.NodeNameEnvRef
+	return map[string]*string{selftelemetry.NodeNameLabel: &nodeName}
 }
 
 // parseAgentLogLevel returns the logging level from the JSON config, or the

--- a/translator/translate/util/placeholderUtil.go
+++ b/translator/translate/util/placeholderUtil.go
@@ -25,7 +25,7 @@ const (
 	datePlaceholder          = "{date}"
 	accountIdPlaceholder     = "{account_id}"
 
-	unknownInstanceID   = "i-UNKNOWN"
+	UnknownInstanceID   = "i-UNKNOWN"
 	unknownHostname     = "UNKNOWN-HOST"
 	unknownIPAddress    = "UNKNOWN-IP"
 	unknownAwsRegion    = "UNKNOWN-REGION"
@@ -88,7 +88,7 @@ func GetMetadataInfo(provider MetadataInfoProvider) map[string]string {
 	md := provider()
 	localHostname := getHostName()
 
-	instanceID := defaultIfEmpty(md.InstanceID, unknownInstanceID)
+	instanceID := defaultIfEmpty(md.InstanceID, UnknownInstanceID)
 	hostname := defaultIfEmpty(md.Hostname, localHostname)
 	ipAddress := defaultIfEmpty(md.PrivateIP, getIpAddress())
 	awsRegion := defaultIfEmpty(agent.Global_Config.Region, unknownAwsRegion)
@@ -107,7 +107,7 @@ func GetMetadataInfo(provider MetadataInfoProvider) map[string]string {
 func getAWSMetadataInfo(provider MetadataInfoProvider) map[string]string {
 	md := provider()
 
-	instanceID := defaultIfEmpty(md.InstanceID, unknownInstanceID)
+	instanceID := defaultIfEmpty(md.InstanceID, UnknownInstanceID)
 	instanceType := defaultIfEmpty(md.InstanceType, unknownInstanceType)
 	imageID := defaultIfEmpty(md.ImageID, unknownImageID)
 
@@ -126,9 +126,9 @@ func getTagMetadata() map[string]string {
 	}
 
 	md := Ec2MetadataInfoProvider()
-	instanceID := defaultIfEmpty(md.InstanceID, unknownInstanceID)
+	instanceID := defaultIfEmpty(md.InstanceID, UnknownInstanceID)
 
-	if instanceID == unknownInstanceID {
+	if instanceID == UnknownInstanceID {
 		return map[string]string{}
 	}
 

--- a/translator/translate/util/placeholderUtil_test.go
+++ b/translator/translate/util/placeholderUtil_test.go
@@ -37,7 +37,7 @@ func TestGetMetadataInfo(t *testing.T) {
 
 func TestGetMetadataInfoEmptyInstanceId(t *testing.T) {
 	m := GetMetadataInfo(mockMetadataProvider("", dummyHostName, dummyPrivateIp, dummyAccountId))
-	assert.Equal(t, unknownInstanceID, m[instanceIdPlaceholder])
+	assert.Equal(t, UnknownInstanceID, m[instanceIdPlaceholder])
 }
 
 func TestGetMetadataInfoUsesLocalHostname(t *testing.T) {


### PR DESCRIPTION
## What
- **Self-telemetry**: opt-in loopback endpoint that serves the collector's own prometheus metrics (`otelcol_*` plus each prometheus receiver's discovery/scrape state) via a new `selftelemetry` extension. Configured under `agent.self_telemetry` (`{enabled, port}`). Loopback only — nothing is published off-node and no scrape is wired automatically.
- **watch_replicaset** (default `true`, i.e. current behavior), per pipeline:
  - ECI: `logs.metrics_collected.kubernetes.watch_replicaset` → awscontainerinsightreceiver `skip_replicaset_watch`.
  - OCI: `opentelemetry.collect.container_insights.watch_replicaset` → when `false`, drops `k8s.deployment.name` from the k8sattributes extract, which stops that processor's ReplicaSet informer. `k8s.replicaset.name` is unaffected.

## Testing
Builds and unit tests pass; new config validated through the schema. Exercised end-to-end via the linked chart PR.

## Merge order (3-repo stack) — this PR is #2
1. contrib — https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/623
2. agent (this PR) — https://github.com/aws/amazon-cloudwatch-agent/pull/2246
3. chart — https://github.com/aws-observability/helm-charts/pull/354

This PR builds against the contrib change, so contrib must merge first.