### PR TITLE
[translator] Enable isolated-pod Summary metrics on the EKS container-insights path

### DIFF
--- a/translator/translate/otel/receiver/awscontainerinsight/translator.go
+++ b/translator/translate/otel/receiver/awscontainerinsight/translator.go
@@ -121,6 +121,14 @@ func (t *translator) Translate(conf *confmap.Conf) (component.Config, error) {
 		t.setHostName(conf, cfg)
 		t.setHostIP(conf, cfg)
 		cfg.RunOnSystemd = !context.CurrentContext().RunInContainer()
+
+		// Recover container-scope metrics for VM-isolated pods (e.g. RuntimeClass
+		// isolated-sandbox / confidential-sandbox) via the kubelet Summary API.
+		// The receiver gates this strictly to isolated RuntimeClasses at runtime,
+		// so normal pods and their metering are unaffected. Enabled here for the
+		// EKS path so it activates on the isolated-pod (piso) cluster without an
+		// additional agent-config key.
+		cfg.EnableIsolatedPodSummaryMetrics = true
 	}
 	cfg.MiddlewareID = &agenthealth.StatusCodeID
 	cfg.PrefFullPodName = cfg.PrefFullPodName || common.GetOrDefaultBool(conf, common.ConfigKey(common.LogsKey, common.MetricsCollectedKey, common.KubernetesKey, common.PreferFullPodName), false)


### PR DESCRIPTION
Sets EnableIsolatedPodSummaryMetrics on the awscontainerinsightreceiver
config for the EKS path so the receiver recovers container-scope metrics
for VM-isolated pods (RuntimeClass isolated-sandbox / confidential-sandbox)
via the kubelet Summary API. The receiver gates this strictly to isolated
RuntimeClasses at runtime, so normal pods and their metering are unaffected.

Note: depends on the awscontainerinsightreceiver change in
amazon-contributing/opentelemetry-collector-contrib; the go.mod replace
bump to the merged receiver commit is a follow-up once that lands.
