### PR TITLE
fix(state): Make Enqueue slow path non-blocking

### DIFF
--- a/internal/state/manager.go
+++ b/internal/state/manager.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"sync/atomic"
 	"time"
 )
 
@@ -15,6 +16,8 @@ const (
 	defaultSaveInterval = 100 * time.Millisecond
 	// defaultQueueSize is the default capacity of the offset queue
 	defaultQueueSize = 2000
+	// dropLogInterval is the minimum duration between offset range drop logs.
+	dropLogInterval = 30 * time.Second
 )
 
 type rangeManager struct {
@@ -24,6 +27,10 @@ type rangeManager struct {
 	saveInterval      time.Duration
 	maxPersistedItems int
 	replaceTrackerCh  chan RangeTracker
+
+	// dropped counts offset ranges discarded because the queue was full. Accessed atomically.
+	dropped     atomic.Uint64
+	lastDropLog atomic.Int64
 }
 
 // FileRangeManager is a state manager that handles the Range.
@@ -53,14 +60,44 @@ func (m *rangeManager) ID() string {
 }
 
 // Enqueue the Range. Will drop the oldest in the queue if full.
+//
+// Both operations are non-blocking by design: Run drains the queue concurrently, so a queue
+// observed full at the send may already be empty at the receive. Dropping the oldest keeps the
+// freshest offsets, costing duplicate records after a restart rather than lost ones. Each
+// iteration either enqueues the item or frees a slot, so the loop always terminates.
 func (m *rangeManager) Enqueue(item Range) {
-	select {
-	case m.queue <- item:
-	default:
-		old := <-m.queue
-		log.Printf("D! Offset range queue is full for %s. Dropping oldest offset range: %s", m.stateFilePath, old)
-		m.queue <- item
+	for {
+		select {
+		case m.queue <- item:
+			return
+		default:
+		}
+		select {
+		case old := <-m.queue:
+			m.reportDrop(old)
+		default:
+		}
 	}
+}
+
+// reportDrop records a dropped Range and logs at most once per dropLogInterval.
+func (m *rangeManager) reportDrop(item Range) {
+	total := m.dropped.Add(1)
+	now := time.Now()
+	last := m.lastDropLog.Load()
+	if now.UnixNano()-last < int64(dropLogInterval) {
+		return
+	}
+	// Only the CAS winner logs.
+	if !m.lastDropLog.CompareAndSwap(last, now.UnixNano()) {
+		return
+	}
+	log.Printf("D! Offset range queue is full for %s. Dropped offset range: %s (%d dropped in total)", m.stateFilePath, item, total)
+}
+
+// Dropped returns the number of offset ranges discarded because the queue was full.
+func (m *rangeManager) Dropped() uint64 {
+	return m.dropped.Load()
 }
 
 // Restore the ranges if the state file exists.

--- a/internal/state/manager_test.go
+++ b/internal/state/manager_test.go
@@ -5,9 +5,12 @@
 package state
 
 import (
+	"io"
+	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -280,6 +283,56 @@ func TestFileRangeManager(t *testing.T) {
 		assert.Equal(t, RangeList{
 			Range{start: 0, end: numThreads * rangePerThread},
 		}, restored)
+	})
+	t.Run("Enqueue/NonBlocking", func(t *testing.T) {
+		// Regression test: Enqueue must never block. With a competing receiver
+		// draining the queue, the full queue observed by the fast path select can
+		// be empty by the time the slow path runs.
+		prevOutput := log.Writer()
+		log.SetOutput(io.Discard)
+		t.Cleanup(func() { log.SetOutput(prevOutput) })
+
+		manager := NewFileRangeManager(ManagerConfig{
+			StateFileDir: t.TempDir(),
+			Name:         "nonblocking.log",
+			QueueSize:    1,
+		})
+		m := manager.(*rangeManager)
+
+		stop := make(chan struct{})
+		var consumerWg sync.WaitGroup
+		consumerWg.Add(1)
+		go func() {
+			defer consumerWg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-m.queue:
+				default:
+					runtime.Gosched()
+				}
+			}
+		}()
+
+		producerDone := make(chan struct{})
+		go func() {
+			defer close(producerDone)
+			var r Range
+			for i := 0; i < 500000; i++ {
+				r.ShiftInt64(int64(i))
+				manager.Enqueue(r)
+			}
+		}()
+
+		select {
+		case <-producerDone:
+		case <-time.After(30 * time.Second):
+			t.Fatal("Enqueue blocked: producer did not complete")
+		}
+		close(stop)
+		consumerWg.Wait()
+		assert.Greater(t, m.Dropped(), uint64(0))
 	})
 	t.Run("Run/Notification/Delete", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
# Description of the issue

`(*rangeManager).Enqueue` in `internal/state/manager.go` uses blocking channel operations in its queue-full slow path, so it can block the calling goroutine. The offset range queue is a lossy ring by design (it drops the oldest entry when full), so `Enqueue` should never block its caller.

# Description of changes

- `Enqueue` now uses only non-blocking channel operations, in a loop: try the send; if the queue is full, try a non-blocking drop of the oldest entry; repeat until the item is enqueued. The fast path and the drop-oldest semantics are unchanged, and the caller's item is always enqueued.
- Added drop accounting: an atomic counter exposed via a `Dropped()` accessor, and drop logging rate-limited to at most one line per 30 seconds instead of one line per drop.

# Tests

- New regression test `Enqueue/NonBlocking`: a producer performs 500k Enqueues against a capacity-1 queue while a competing receiver drains it in a tight loop, with a 30 second deadline. It fails against the previous implementation and passes against this change. It also asserts the drop counter advanced.
- Existing `internal/state` tests pass unchanged, including `Enqueue/QueueOverflow`, which guards the drop-oldest semantics.
- Full package run passes with `-race`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
