### PR TITLE
docs: fix typo compatability -> compatibility

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -38,7 +38,7 @@ Example:
 
 #### PreVistaSupport
 
-Bool, if set to `true` will use the localized PerfCounter interface that is present before Vista for backwards compatability.
+Bool, if set to `true` will use the localized PerfCounter interface that is present before Vista for backwards compatibility.
 
 It is recommended NOT to use this on OSes starting with Vista and newer because it requires more configuration to use this than the newer interface present since Vista.
 


### PR DESCRIPTION
One-word typo fix in `plugins/inputs/win_perf_counters/README.md:41`.
