### PR TITLE
Trim host.type resource attribute to only machine type for GCE

### DIFF
--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_gce.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_gce.yaml
@@ -508,7 +508,8 @@ processors:
               error_mode: ignore
               statements:
                 - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
-                - set(resource.attributes["cloud.resource_id"], Format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", [resource.attributes["cloud.account.id"], resource.attributes["cloud.availability_zone"], resource.attributes["host.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["host.name"] != nil and resource.attributes["cloud.platform"] == "gcp_compute_engine"
+                - replace_pattern(resource.attributes["host.type"], "^projects/.+/machineTypes/", "") where resource.attributes["host.type"] != nil
+                - set(resource.attributes["cloud.resource_id"], Format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", [resource.attributes["cloud.account.id"], resource.attributes["cloud.availability_zone"], resource.attributes["host.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["host.name"] != nil
                 - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["cloud.account.id"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.account.id"] != nil
                 - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
         metric_statements:
@@ -516,7 +517,8 @@ processors:
               error_mode: ignore
               statements:
                 - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
-                - set(resource.attributes["cloud.resource_id"], Format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", [resource.attributes["cloud.account.id"], resource.attributes["cloud.availability_zone"], resource.attributes["host.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["host.name"] != nil and resource.attributes["cloud.platform"] == "gcp_compute_engine"
+                - replace_pattern(resource.attributes["host.type"], "^projects/.+/machineTypes/", "") where resource.attributes["host.type"] != nil
+                - set(resource.attributes["cloud.resource_id"], Format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", [resource.attributes["cloud.account.id"], resource.attributes["cloud.availability_zone"], resource.attributes["host.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["host.name"] != nil
                 - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["cloud.account.id"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.account.id"] != nil
                 - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
         trace_statements:
@@ -524,7 +526,8 @@ processors:
               error_mode: ignore
               statements:
                 - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
-                - set(resource.attributes["cloud.resource_id"], Format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", [resource.attributes["cloud.account.id"], resource.attributes["cloud.availability_zone"], resource.attributes["host.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["host.name"] != nil and resource.attributes["cloud.platform"] == "gcp_compute_engine"
+                - replace_pattern(resource.attributes["host.type"], "^projects/.+/machineTypes/", "") where resource.attributes["host.type"] != nil
+                - set(resource.attributes["cloud.resource_id"], Format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", [resource.attributes["cloud.account.id"], resource.attributes["cloud.availability_zone"], resource.attributes["host.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["host.name"] != nil
                 - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["cloud.account.id"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.account.id"] != nil
                 - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
     transform/logs_cleanup:

--- a/translator/translate/otel/processor/transformprocessor/transform_identity_gce.yaml
+++ b/translator/translate/otel/processor/transformprocessor/transform_identity_gce.yaml
@@ -4,7 +4,10 @@ trace_statements:
     context: resource
     statements: &identity_statements
       - set(resource.attributes["service.name"], "unknown_service") where resource.attributes["service.name"] == nil
-      - set(resource.attributes["cloud.resource_id"], Format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", [resource.attributes["cloud.account.id"], resource.attributes["cloud.availability_zone"], resource.attributes["host.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["host.name"] != nil and resource.attributes["cloud.platform"] == "gcp_compute_engine"
+      # host.type: GCE metadata returns the full projects/<num>/machineTypes/<type> path. Keep only the
+      # machine type name so host.type carries the machine type as the semantic convention expects.
+      - replace_pattern(resource.attributes["host.type"], "^projects/.+/machineTypes/", "") where resource.attributes["host.type"] != nil
+      - set(resource.attributes["cloud.resource_id"], Format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", [resource.attributes["cloud.account.id"], resource.attributes["cloud.availability_zone"], resource.attributes["host.name"]])) where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["host.name"] != nil
       - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], resource.attributes["cloud.account.id"]], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.account.id"] != nil
       - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], "default"], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil
 metric_statements:


### PR DESCRIPTION
# Description of the issue
GCE support was added as part of https://github.com/aws/amazon-cloudwatch-agent/pull/2255, but the `host.type` resource attribute it produces is incorrect `projects/{{project-number}}/machineTypes/e2-medium`. This is because the `resourcedetection` processor (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/47797bb2cc528058339cf10f6600df32fccda43f/processor/resourcedetectionprocessor/internal/gcp/gcp.go#L48) uses a GCP package (https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/detectors/gcp/gce.go#L40), which in turn relies on the GCP SDK, which calls GCE's metadata server.

https://docs.cloud.google.com/compute/docs/metadata/predefined-metadata-keys#instance-metadata
> machine-type | The machine type for this VM. This value has the following format: projects/PROJECT_NUM/machineTypes/MACHINE_TYPE

Semconv expects only the machine type in `host.type`.

https://opentelemetry.io/docs/specs/semconv/resource/host/
> [host.type](https://opentelemetry.io/docs/specs/semconv/registry/attributes/host/) | Development | Recommended | string | Type of host. For Cloud, this must be the machine type. | n1-standard-1

# Description of changes
Trims the host type for GCE so `projects/{{project-number}}/machineTypes/e2-medium` becomes `e2-medium`.

Removed unnecessary `resource.attributes["cloud.platform"] == "gcp_compute_engine"` guard from the `transform_identity_gce.yaml`. At that point, we've already detected that we're on GCE and selected that specific file.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Built and deployed to GCE instance. Verified the resource attribute in CloudWatch.
<img width="2529" height="892" alt="image" src="https://github.com/user-attachments/assets/ae931431-9f36-4752-a91e-d85b518c00a1" />

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



