### PR TITLE
chore: Pin shfmt to 3.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ install-goimports:
 	GOBIN=$(TOOLS_BIN_DIR) go install golang.org/x/tools/cmd/goimports
 
 install-shfmt:
-	GOBIN=$(TOOLS_BIN_DIR) go install mvdan.cc/sh/v3/cmd/shfmt@latest
+	GOBIN=$(TOOLS_BIN_DIR) go install mvdan.cc/sh/v3/cmd/shfmt@v3.14.0
 
 install-impi:
 	GOBIN=$(TOOLS_BIN_DIR) go install github.com/pavius/impi/cmd/impi@v0.0.3

--- a/packaging/debian/preinst
+++ b/packaging/debian/preinst
@@ -13,6 +13,6 @@ if ! grep "^cwagent:" /etc/group >/dev/null 2>&1; then
 fi
 
 if ! id cwagent >/dev/null 2>&1; then
-     useradd -r -M cwagent -d /home/cwagent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh))) >/dev/null 2>&1
+     useradd -r -M cwagent -d /home/cwagent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh) ) ) >/dev/null 2>&1
      echo "create user cwagent, result: $?"
 fi


### PR DESCRIPTION
# Description of the issue
We use `shfmt` to keep the shell scripts in the package uniform. `shfmt` released a new version today https://github.com/mvdan/sh/releases/tag/v3.14.0, which changed the formatting

> Space nested closing parentheses like the opening ones

and started to cause the lint steps in our build workflows to fail.

https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33207725472/job/98973865950?pr=2123

```
/home/runner/work/amazon-cloudwatch-agent/amazon-cloudwatch-agent/build/tools/shfmt -w -d -i 5 .
diff packaging/debian/preinst.orig packaging/debian/preinst
--- packaging/debian/preinst.orig
+++ packaging/debian/preinst
@@ -13,6 +13,6 @@
 fi
 
 if ! id cwagent >/dev/null 2>&1; then
-     useradd -r -M cwagent -d /home/cwagent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh))) >/dev/null 2>&1
+     useradd -r -M cwagent -d /home/cwagent -g cwagent -c "Cloudwatch Agent" -s $(test -x /sbin/nologin && echo /sbin/nologin || (test -x /usr/sbin/nologin && echo /usr/sbin/nologin || (test -x /bin/false && echo /bin/false || echo /bin/sh) ) ) >/dev/null 2>&1
      echo "create user cwagent, result: $?"
 fi
make: *** [Makefile:201: fmt-sh] Error 1
make: *** Waiting for unfinished jobs....
```

# Description of changes
Pins the shfmt version to 3.14.0 (latest) to prevent surprise failures and applies the formatting.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran `make fmt-sh`. All of the script changes are whitespace, but ran `make package-deb` as well.

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



