### PR TITLE
Fix neuron per core multi runtime

### DIFF
--- a/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_eks_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/combined_v1_v2_eks_config.yaml
@@ -642,6 +642,7 @@ processors:
             - k8s.pod.name
             - k8s.namespace.name
             - k8s.container.name
+            - runtime_tag
     groupbyattrs/files:
         keys:
             - log.file.name
@@ -1129,15 +1130,9 @@ processors:
     transform/cw_k8s_ci_v0_neuron_promote:
         error_mode: ignore
         metric_statements:
-            - context: datapoint
+            - context: resource
               statements:
-                - set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil
-                - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
-                - set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil
-                - set(resource.attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
-                - delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil
-                - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
-                - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
+                - set(attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
                 - delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil
     transform/cw_k8s_ci_v0_promote_node_name:
         error_mode: ignore

--- a/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_node_config.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/container_insights_node_config.yaml
@@ -209,6 +209,7 @@ processors:
             - k8s.pod.name
             - k8s.namespace.name
             - k8s.container.name
+            - runtime_tag
     k8sattributes/cw_k8s_ci_v0_node:
         auth_type: serviceAccount
         exclude:
@@ -765,15 +766,9 @@ processors:
     transform/cw_k8s_ci_v0_neuron_promote:
         error_mode: ignore
         metric_statements:
-            - context: datapoint
+            - context: resource
               statements:
-                - set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil
-                - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
-                - set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil
-                - set(resource.attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
-                - delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil
-                - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
-                - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
+                - set(attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
                 - delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil
     transform/cw_k8s_ci_v0_node_logs_set_log_destination:
         error_mode: ignore

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_aks.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_aks.yaml
@@ -281,6 +281,7 @@ processors:
             - k8s.pod.name
             - k8s.namespace.name
             - k8s.container.name
+            - runtime_tag
     k8sattributes/cw_k8s_ci_v0_node:
         auth_type: serviceAccount
         exclude:
@@ -763,15 +764,9 @@ processors:
     transform/cw_k8s_ci_v0_neuron_promote:
         error_mode: ignore
         metric_statements:
-            - context: datapoint
+            - context: resource
               statements:
-                - set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil
-                - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
-                - set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil
-                - set(resource.attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
-                - delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil
-                - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
-                - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
+                - set(attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
                 - delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil
     transform/cw_k8s_ci_v0_promote_node_name:
         error_mode: ignore

--- a/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_gke.yaml
+++ b/translator/tocwconfig/sampleConfig/opentelemetry/default_otel_config_gke.yaml
@@ -281,6 +281,7 @@ processors:
             - k8s.pod.name
             - k8s.namespace.name
             - k8s.container.name
+            - runtime_tag
     k8sattributes/cw_k8s_ci_v0_node:
         auth_type: serviceAccount
         exclude:
@@ -762,15 +763,9 @@ processors:
     transform/cw_k8s_ci_v0_neuron_promote:
         error_mode: ignore
         metric_statements:
-            - context: datapoint
+            - context: resource
               statements:
-                - set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil
-                - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
-                - set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil
-                - set(resource.attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
-                - delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil
-                - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
-                - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
+                - set(attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
                 - delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil
     transform/cw_k8s_ci_v0_promote_node_name:
         error_mode: ignore

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron.yaml
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron.yaml
@@ -89,18 +89,13 @@ processors:
     - k8s.pod.name
     - k8s.namespace.name
     - k8s.container.name
+    - runtime_tag
   transform/cw_k8s_ci_v0_neuron_promote:
     error_mode: ignore
     metric_statements:
-    - context: datapoint
+    - context: resource
       statements:
-      - set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil
-      - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
-      - set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil
-      - set(resource.attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
-      - delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil
-      - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
-      - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
+      - set(attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
       - delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil
   transform/cw_k8s_ci_v0_neuron_hw_attrs:
     error_mode: ignore

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron_multiruntime_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron_multiruntime_test.go
@@ -1,22 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
-// Per-core Neuron data loss on multi-runtime nodes.
+// Per-core Neuron attribution on multi-runtime nodes.
 //
-// The shipped neuron.yaml is run for real here -- groupbyattrs then the promote
-// transform, built from the embedded template -- against synthetic metrics in the
-// shape neuron-monitor emits when two Neuron runtimes share a node: every core
-// reported by every runtime, with the non-owning pairs at zero.
+// Invariant: when several Neuron runtimes share a node, every (core, runtime)
+// reading must reach the exporter under its own identity. neuron-monitor reports
+// every core from every runtime -- the owning pair real, the rest zero -- so
+// runtime_tag is the only attribute separating a core's real reading from another
+// runtime's zero for that same core. Stop separating them and two datapoints share
+// an identity, the last write wins, and for one core that is a plausible-looking 0.
 //
-// The defect: the promote ran in `context: datapoint` while writing
-// resource.attributes. Resource attributes are per-ResourceMetrics, so the
-// statement ran once per datapoint and the last write won; it then deleted
-// runtime_tag from the datapoint, the only attribute separating one runtime's real
-// reading for a core from another runtime's zero for that same core. Two datapoints
-// collapsed onto one identity and a core pinned at 75% reported 0.
-//
-// TestNeuronMultiRuntimePreFixConfigLosesData pins that failure mode, so the
-// assertions below are known to discriminate rather than merely pass.
+// These run the shipped neuron.yaml -- groupbyattrs then the promote transform,
+// rendered from the embedded template rather than restated, so a config change that
+// breaks the invariant fails here. TestNeuronMultiRuntimeCollapsedConfigLosesData
+// runs a config that violates it, proving the assertions discriminate.
 
 package containerinsights
 
@@ -54,8 +51,6 @@ const (
 )
 
 // renderedNeuronProcessors returns the processors block of the shipped neuron.yaml.
-// Read from the embedded template rather than restated, so reverting the config
-// fails this test.
 func renderedNeuronProcessors(t *testing.T) map[string]any {
 	t.Helper()
 	tmpl, err := template.New("neuron").Parse(neuronYAML)
@@ -115,8 +110,8 @@ func (componenttestNopHost) GetExtensions() map[component.ID]component.Component
 
 // multiRuntimeMetrics is what neuron-monitor emits for 2 cores x 2 runtimes on one
 // node: the owning pair real, the other zero. Pod identity is identical across all
-// four, which is the collapse-prone case -- one pod holding both cores, as measured
-// on solstice-gpu-test.
+// four -- one pod holding both cores, which occurs in practice and is the
+// collapse-prone case, since pod identity alone cannot separate the datapoints.
 func multiRuntimeMetrics() pmetric.Metrics {
 	md := pmetric.NewMetrics()
 	sm := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
@@ -176,8 +171,8 @@ func consume(t *testing.T, chain processor.Metrics, md pmetric.Metrics) {
 	require.NoError(t, chain.ConsumeMetrics(context.Background(), md))
 }
 
-// TestNeuronMultiRuntimeKeepsEveryCorePerRuntime runs the SHIPPED config and
-// requires all four (core, runtime) readings to survive with their real values.
+// TestNeuronMultiRuntimeKeepsEveryCorePerRuntime requires all four (core, runtime)
+// readings to survive the shipped config with their real values.
 func TestNeuronMultiRuntimeKeepsEveryCorePerRuntime(t *testing.T) {
 	processors := renderedNeuronProcessors(t)
 	chain, sink := buildChain(t,
@@ -192,7 +187,7 @@ func TestNeuronMultiRuntimeKeepsEveryCorePerRuntime(t *testing.T) {
 		"core=1 tag=burn-core1 value=75.3",
 	}, observed(t, sink),
 		"both busy cores must survive with their own runtime tag; a missing 75.x "+
-			"reading is the per-core data-loss defect")
+			"reading means one runtime's datapoint was shadowed by another's zero")
 }
 
 // TestNeuronMultiRuntimeSeparatesRuntimesIntoResources pins the mechanism: one
@@ -219,9 +214,9 @@ func TestNeuronMultiRuntimeSeparatesRuntimesIntoResources(t *testing.T) {
 	assert.Equal(t, map[string]int{tagA: 1, tagB: 1}, tags)
 }
 
-// TestNeuronMultiRuntimePromotesPodIdentity guards the six promote statements
-// removed by the fix: groupbyattrs already moves pod/namespace/container to the
-// resource and deletes the datapoint copies, so dropping them changed nothing.
+// TestNeuronMultiRuntimePromotesPodIdentity requires pod identity to land on the
+// resource and NOT remain on the datapoint. groupbyattrs moves its grouping keys
+// rather than copying them, so nothing downstream needs to re-promote them.
 func TestNeuronMultiRuntimePromotesPodIdentity(t *testing.T) {
 	processors := renderedNeuronProcessors(t)
 	chain, sink := buildChain(t,
@@ -262,16 +257,22 @@ func TestNeuronMultiRuntimePromotesPodIdentity(t *testing.T) {
 	}
 }
 
-// TestNeuronMultiRuntimePreFixConfigLosesData is the negative control. It runs the
-// PRE-FIX config -- groupbyattrs without the runtime_tag key, promote in
-// `context: datapoint` -- and asserts the loss, so the tests above are known to
-// discriminate. If this ever starts passing the collapse has stopped reproducing
-// and these assertions no longer prove anything.
-func TestNeuronMultiRuntimePreFixConfigLosesData(t *testing.T) {
-	preFixGBA := map[string]any{
+// TestNeuronMultiRuntimeCollapsedConfigLosesData is the negative control: it runs a
+// config that drops the runtime dimension and asserts the loss, so the tests above
+// are known to discriminate rather than merely pass. If it ever starts passing, the
+// collapse has stopped reproducing and those assertions prove nothing.
+//
+// The collapse needs both halves. groupbyattrs omits the runtime_tag key, so the
+// runtimes are not split into separate resources; the promote then runs in
+// `context: datapoint` while writing resource.attributes, which are
+// per-ResourceMetrics -- so the statement executes once per datapoint and the last
+// write wins -- and deletes runtime_tag from the datapoint. This is the shape the
+// agent shipped with.
+func TestNeuronMultiRuntimeCollapsedConfigLosesData(t *testing.T) {
+	collapsedGBA := map[string]any{
 		"keys": []any{"k8s.pod.name", "k8s.namespace.name", "k8s.container.name"},
 	}
-	preFixPromote := map[string]any{
+	collapsedPromote := map[string]any{
 		"error_mode": "ignore",
 		"metric_statements": []any{
 			map[string]any{
@@ -290,7 +291,7 @@ func TestNeuronMultiRuntimePreFixConfigLosesData(t *testing.T) {
 		},
 	}
 
-	chain, sink := buildChain(t, preFixGBA, preFixPromote)
+	chain, sink := buildChain(t, collapsedGBA, collapsedPromote)
 	consume(t, chain, multiRuntimeMetrics())
 	got := observed(t, sink)
 

--- a/translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron_multiruntime_test.go
+++ b/translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron_multiruntime_test.go
@@ -1,0 +1,336 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+// Per-core Neuron data loss on multi-runtime nodes.
+//
+// The shipped neuron.yaml is run for real here -- groupbyattrs then the promote
+// transform, built from the embedded template -- against synthetic metrics in the
+// shape neuron-monitor emits when two Neuron runtimes share a node: every core
+// reported by every runtime, with the non-owning pairs at zero.
+//
+// The defect: the promote ran in `context: datapoint` while writing
+// resource.attributes. Resource attributes are per-ResourceMetrics, so the
+// statement ran once per datapoint and the last write won; it then deleted
+// runtime_tag from the datapoint, the only attribute separating one runtime's real
+// reading for a core from another runtime's zero for that same core. Two datapoints
+// collapsed onto one identity and a core pinned at 75% reported 0.
+//
+// TestNeuronMultiRuntimePreFixConfigLosesData pins that failure mode, so the
+// assertions below are known to discriminate rather than merely pass.
+
+package containerinsights
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"text/template"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processortest"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	neuronGroupByAttrs = "groupbyattrs/cw_k8s_ci_v0_neuron"
+	neuronPromote      = "transform/cw_k8s_ci_v0_neuron_promote"
+
+	testPod       = "neuron-burn-abcde-12345"
+	testNamespace = "default"
+	testContainer = "burn"
+	tagA          = "burn-core0"
+	tagB          = "burn-core1"
+)
+
+// renderedNeuronProcessors returns the processors block of the shipped neuron.yaml.
+// Read from the embedded template rather than restated, so reverting the config
+// fails this test.
+func renderedNeuronProcessors(t *testing.T) map[string]any {
+	t.Helper()
+	tmpl, err := template.New("neuron").Parse(neuronYAML)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, tmpl.Execute(&buf, templateData{
+		ClusterName:        "test-cluster",
+		Region:             "us-west-2",
+		CollectionInterval: "30s",
+		ScrapeTimeout:      "10s",
+		NodeName:           "test-node",
+		HostIP:             "127.0.0.1",
+	}))
+
+	var parsed map[string]any
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &parsed))
+	processors, ok := parsed["processors"].(map[string]any)
+	require.True(t, ok, "neuron.yaml has no processors block")
+	return processors
+}
+
+func processorConfig(t *testing.T, processors map[string]any, name string) map[string]any {
+	t.Helper()
+	raw, ok := processors[name]
+	require.True(t, ok, "neuron.yaml is missing %s", name)
+	cfg, ok := raw.(map[string]any)
+	require.True(t, ok, "%s is not a mapping", name)
+	return cfg
+}
+
+// buildChain wires groupbyattrs -> promote -> sink from the given configs.
+func buildChain(t *testing.T, gbaCfg, promoteCfg map[string]any) (processor.Metrics, *consumertest.MetricsSink) {
+	t.Helper()
+	sink := new(consumertest.MetricsSink)
+
+	promote := newProcessor(t, transformprocessor.NewFactory(), "transform", promoteCfg, sink)
+	gba := newProcessor(t, groupbyattrsprocessor.NewFactory(), "groupbyattrs", gbaCfg, promote)
+	return gba, sink
+}
+
+func newProcessor(
+	t *testing.T, factory processor.Factory, typ string, cfg map[string]any, next consumer.Metrics,
+) processor.Metrics {
+	t.Helper()
+	c := factory.CreateDefaultConfig()
+	require.NoError(t, confmap.NewFromStringMap(cfg).Unmarshal(c))
+	p, err := factory.CreateMetrics(
+		context.Background(), processortest.NewNopSettings(component.MustNewType(typ)), c, next)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(context.Background(), componenttestNopHost{}))
+	return p
+}
+
+type componenttestNopHost struct{}
+
+func (componenttestNopHost) GetExtensions() map[component.ID]component.Component { return nil }
+
+// multiRuntimeMetrics is what neuron-monitor emits for 2 cores x 2 runtimes on one
+// node: the owning pair real, the other zero. Pod identity is identical across all
+// four, which is the collapse-prone case -- one pod holding both cores, as measured
+// on solstice-gpu-test.
+func multiRuntimeMetrics() pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	sm := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("neuroncore_utilization_ratio")
+	dps := m.SetEmptyGauge().DataPoints()
+
+	add := func(core, tag string, value float64) {
+		dp := dps.AppendEmpty()
+		dp.SetDoubleValue(value)
+		a := dp.Attributes()
+		a.PutStr("neuroncore", core)
+		a.PutStr("runtime_tag", tag)
+		a.PutStr("k8s.pod.name", testPod)
+		a.PutStr("k8s.namespace.name", testNamespace)
+		a.PutStr("k8s.container.name", testContainer)
+	}
+	add("0", tagA, 75.1)
+	add("1", tagA, 0)
+	add("0", tagB, 0)
+	add("1", tagB, 75.3)
+	return md
+}
+
+// observed flattens the sink into "core=<n> tag=<t> value=<v>" triples, reading the
+// tag from the RESOURCE (where the promote puts it) and the core from the datapoint.
+func observed(t *testing.T, sink *consumertest.MetricsSink) []string {
+	t.Helper()
+	var out []string
+	for _, md := range sink.AllMetrics() {
+		for i := 0; i < md.ResourceMetrics().Len(); i++ {
+			rm := md.ResourceMetrics().At(i)
+			tag := "<none>"
+			if v, ok := rm.Resource().Attributes().Get("aws.neuron.runtime.tag"); ok {
+				tag = v.Str()
+			}
+			for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+				ms := rm.ScopeMetrics().At(j).Metrics()
+				for k := 0; k < ms.Len(); k++ {
+					dps := ms.At(k).Gauge().DataPoints()
+					for d := 0; d < dps.Len(); d++ {
+						dp := dps.At(d)
+						core, _ := dp.Attributes().Get("neuroncore")
+						out = append(out, fmt.Sprintf("core=%s tag=%s value=%.1f",
+							core.Str(), tag, dp.DoubleValue()))
+					}
+				}
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func consume(t *testing.T, chain processor.Metrics, md pmetric.Metrics) {
+	t.Helper()
+	require.NoError(t, chain.ConsumeMetrics(context.Background(), md))
+}
+
+// TestNeuronMultiRuntimeKeepsEveryCorePerRuntime runs the SHIPPED config and
+// requires all four (core, runtime) readings to survive with their real values.
+func TestNeuronMultiRuntimeKeepsEveryCorePerRuntime(t *testing.T) {
+	processors := renderedNeuronProcessors(t)
+	chain, sink := buildChain(t,
+		processorConfig(t, processors, neuronGroupByAttrs),
+		processorConfig(t, processors, neuronPromote))
+	consume(t, chain, multiRuntimeMetrics())
+
+	assert.Equal(t, []string{
+		"core=0 tag=burn-core0 value=75.1",
+		"core=0 tag=burn-core1 value=0.0",
+		"core=1 tag=burn-core0 value=0.0",
+		"core=1 tag=burn-core1 value=75.3",
+	}, observed(t, sink),
+		"both busy cores must survive with their own runtime tag; a missing 75.x "+
+			"reading is the per-core data-loss defect")
+}
+
+// TestNeuronMultiRuntimeSeparatesRuntimesIntoResources pins the mechanism: one
+// ResourceMetrics per runtime is what stops the datapoints colliding.
+func TestNeuronMultiRuntimeSeparatesRuntimesIntoResources(t *testing.T) {
+	processors := renderedNeuronProcessors(t)
+	chain, sink := buildChain(t,
+		processorConfig(t, processors, neuronGroupByAttrs),
+		processorConfig(t, processors, neuronPromote))
+	consume(t, chain, multiRuntimeMetrics())
+
+	tags := map[string]int{}
+	total := 0
+	for _, md := range sink.AllMetrics() {
+		for i := 0; i < md.ResourceMetrics().Len(); i++ {
+			rm := md.ResourceMetrics().At(i)
+			v, ok := rm.Resource().Attributes().Get("aws.neuron.runtime.tag")
+			require.True(t, ok, "resource is missing aws.neuron.runtime.tag")
+			tags[v.Str()]++
+			total++
+		}
+	}
+	assert.Equal(t, 2, total, "expected one ResourceMetrics per runtime")
+	assert.Equal(t, map[string]int{tagA: 1, tagB: 1}, tags)
+}
+
+// TestNeuronMultiRuntimePromotesPodIdentity guards the six promote statements
+// removed by the fix: groupbyattrs already moves pod/namespace/container to the
+// resource and deletes the datapoint copies, so dropping them changed nothing.
+func TestNeuronMultiRuntimePromotesPodIdentity(t *testing.T) {
+	processors := renderedNeuronProcessors(t)
+	chain, sink := buildChain(t,
+		processorConfig(t, processors, neuronGroupByAttrs),
+		processorConfig(t, processors, neuronPromote))
+	consume(t, chain, multiRuntimeMetrics())
+
+	for _, md := range sink.AllMetrics() {
+		for i := 0; i < md.ResourceMetrics().Len(); i++ {
+			rm := md.ResourceMetrics().At(i)
+			for _, kv := range []struct{ key, want string }{
+				{"k8s.pod.name", testPod},
+				{"k8s.namespace.name", testNamespace},
+				{"k8s.container.name", testContainer},
+			} {
+				v, ok := rm.Resource().Attributes().Get(kv.key)
+				require.True(t, ok, "resource is missing %s", kv.key)
+				assert.Equal(t, kv.want, v.Str())
+			}
+
+			for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+				ms := rm.ScopeMetrics().At(j).Metrics()
+				for k := 0; k < ms.Len(); k++ {
+					dps := ms.At(k).Gauge().DataPoints()
+					for d := 0; d < dps.Len(); d++ {
+						attrs := dps.At(d).Attributes()
+						for _, key := range []string{
+							"k8s.pod.name", "k8s.namespace.name", "k8s.container.name", "runtime_tag",
+						} {
+							_, present := attrs.Get(key)
+							assert.False(t, present,
+								"%s must be moved off the datapoint, not left on it", key)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestNeuronMultiRuntimePreFixConfigLosesData is the negative control. It runs the
+// PRE-FIX config -- groupbyattrs without the runtime_tag key, promote in
+// `context: datapoint` -- and asserts the loss, so the tests above are known to
+// discriminate. If this ever starts passing the collapse has stopped reproducing
+// and these assertions no longer prove anything.
+func TestNeuronMultiRuntimePreFixConfigLosesData(t *testing.T) {
+	preFixGBA := map[string]any{
+		"keys": []any{"k8s.pod.name", "k8s.namespace.name", "k8s.container.name"},
+	}
+	preFixPromote := map[string]any{
+		"error_mode": "ignore",
+		"metric_statements": []any{
+			map[string]any{
+				"context": "datapoint",
+				"statements": []any{
+					`set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil`,
+					`set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil`,
+					`set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil`,
+					`set(resource.attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil`,
+					`delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil`,
+					`delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil`,
+					`delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil`,
+					`delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil`,
+				},
+			},
+		},
+	}
+
+	chain, sink := buildChain(t, preFixGBA, preFixPromote)
+	consume(t, chain, multiRuntimeMetrics())
+	got := observed(t, sink)
+
+	// One resource, one surviving tag: the four datapoints keep only two identities.
+	assert.Len(t, got, 4, "the pre-fix chain still emits four datapoints")
+	tags := map[string]struct{}{}
+	for _, md := range sink.AllMetrics() {
+		for i := 0; i < md.ResourceMetrics().Len(); i++ {
+			if v, ok := md.ResourceMetrics().At(i).Resource().Attributes().Get("aws.neuron.runtime.tag"); ok {
+				tags[v.Str()] = struct{}{}
+			}
+		}
+	}
+	assert.Len(t, tags, 1,
+		"pre-fix, all runtimes collapse onto ONE resource tag; got %v", tags)
+
+	// With one tag on the resource, (core, tag) is no longer unique: each core
+	// appears twice, once with its real value and once with another runtime's zero.
+	// Downstream that is a duplicate identity and one value is lost.
+	perCore := map[string][]float64{}
+	for _, md := range sink.AllMetrics() {
+		for i := 0; i < md.ResourceMetrics().Len(); i++ {
+			rm := md.ResourceMetrics().At(i)
+			for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+				ms := rm.ScopeMetrics().At(j).Metrics()
+				for k := 0; k < ms.Len(); k++ {
+					dps := ms.At(k).Gauge().DataPoints()
+					for d := 0; d < dps.Len(); d++ {
+						dp := dps.At(d)
+						core, _ := dp.Attributes().Get("neuroncore")
+						perCore[core.Str()] = append(perCore[core.Str()], dp.DoubleValue())
+					}
+				}
+			}
+		}
+	}
+	for core, values := range perCore {
+		assert.Len(t, values, 2,
+			"pre-fix, core %s carries two datapoints under one identity %v — whichever "+
+				"arrives last wins, and for one core that is a legitimate-looking 0",
+			core, values)
+	}
+}


### PR DESCRIPTION
# Description of the issue

On a node running more than one Neuron runtime, roughly half of every per-core Neuron
metric is silently replaced by zero. A NeuronCore pinned at 75% utilization reports 0.

`transform/cw_k8s_ci_v0_neuron_promote` runs in `context: datapoint` but writes
`resource.attributes`. Resource attributes are per-`ResourceMetrics`, so with N runtimes
in one RM the statement executes N times and the last write wins. It then deletes
`runtime_tag` from the datapoint — the only attribute distinguishing one runtime's real
reading for a core from another runtime's zero for that same core — so two datapoints
collapse onto one identity with different values.

A debug exporter on the pipeline shows the agent emitting **four** datapoints with only
**two** distinct attribute sets:

```
aws.neuron.core=0  Value: 75.154815   <- real
aws.neuron.core=1  Value:  0.000000
aws.neuron.core=0  Value:  0.000000   <- same identity, shadows the real one
aws.neuron.core=1  Value: 75.363968
```

Impact on a multi-runtime Neuron node: a saturated core renders as idle, a
low-utilization alarm fires falsely, and an idle-reclaim decision could reclaim a busy
core. Confirmed on `neuroncore_utilization_ratio` and all five
`neuroncore_memory_usage_*` families.

Single-runtime nodes are unaffected, which is why this went unnoticed — it needs ≥2
Neuron runtimes on one node to appear.

**`neuron-monitor` is not at fault.** Scraping its own `/metrics` endpoint at the same
instant shows it emitting the full `(core × runtime_tag)` cross-product correctly, with
only the matching pairs non-zero.

# Description of changes

Aggregation is not needed — `groupbyattrs` already does the right thing, it just wasn't
given the runtime dimension.

1. Add `runtime_tag` to the `groupbyattrs/cw_k8s_ci_v0_neuron` keys, so each runtime
   lands in its own `ResourceMetrics` and the datapoints can no longer collide.
2. Reduce `transform/cw_k8s_ci_v0_neuron_promote` to a `context: resource` rename of
   `runtime_tag` → `aws.neuron.runtime.tag`.

The six `set`/`delete_key` statements for `k8s.pod.name`, `k8s.namespace.name` and
`k8s.container.name` are removed as redundant: those keys are already in the
`groupbyattrs` keys, and `groupbyattrs` *moves* its grouping keys — see
`processor/groupbyattrsprocessor/processor.go`:

```go
// These attributes are going to be moved from datapoint to resource level,
// so we can delete those on the datapoint
deleteAttributes(requiredAttributes, attributes)
```

so the promote was re-doing work already done one processor earlier, and its
datapoint-context write was the vehicle for the defect.

Net effect: 11 lines changed in `neuron.yaml` plus the four regenerated golden configs.

### Trade-off

This publishes the full cross-product, so series count grows multiplicatively with
runtime count — 2 → 4 on a 2-core/2-runtime node; a 32-core `trn1` with 4 runtimes goes
32 → 128 series per per-core metric. **This is the cardinality `neuron-monitor` already
emits**; the previous behaviour reduced it only by discarding data.

The alternative is to aggregate the runtime dimension away in-agent (`max` per core),
which keeps the count flat but loses per-runtime attribution. Rejected here because the
PromQL/OTLP surface *can* carry the runtime dimension, and a runtime legitimately spans
multiple cores, so "which runtime is using this core" is a question this surface should
be able to answer.

Reviewers may want to weigh in on whether the cardinality growth is acceptable for large
`trn1` topologies. It has not been measured beyond a 2-core node.

### Scope

**This does not affect the EMF / Container Insights path.** `neuron.yaml`'s pipeline
exports to the `forward/opentelemetry` connector, which is consumed only by
`metrics/opentelemetry` → `otlphttp/metrics`. In the combined v1+v2 config the sole
pipeline touching an EMF exporter is `logs/emf_logs` (receiver `udplog`, one batch
processor, no Neuron processors). The EMF Neuron path is a separate pipeline —
`awscontainerinsightreceiver` → `gpuattributes` → `awsemf/containerinsights` — and shares
no component instance with this one. Its own `max`-per-core reduction in
`gpuattributes/internal/awsneuron_metric_modifier.go` is unchanged and remains correct
for that surface, which does not publish `runtime_tag` as a dimension.

**This alone does not fix EKS add-on clusters.** The `amazon-cloudwatch-observability`
Helm chart carries an independent copy of this same pipeline in
`templates/linux/_otel-container-insights-config.tpl` with the identical defect, and that
is the copy the EKS add-on renders into `AmazonCloudWatchAgent.spec.otelConfig`. This PR
fixes the translator path (config built from `cwagentconfig.json`); the chart fix is
aws-observability/helm-charts#365. Both are needed.

# License

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.

# Tests

**New unit tests** —
`translator/translate/otel/pipeline/opentelemetry/containerinsights/neuron_multiruntime_test.go`.
Instantiates the real `groupbyattrs` and `transform` processors from the `//go:embed`ed
`neuron.yaml`, chains them, and feeds synthetic metrics in the multi-runtime shape
(2 cores × 2 runtimes, non-owning pairs at zero, all four sharing one pod). No cluster or
Neuron hardware required; runs in ~25ms.

| Test | Asserts |
| --- | --- |
| `KeepsEveryCorePerRuntime` | all four `(core, tag, value)` triples survive — both 75.x readings |
| `SeparatesRuntimesIntoResources` | one `ResourceMetrics` per runtime |
| `PromotesPodIdentity` | pod/namespace/container on the resource, absent from datapoints |
| `PreFixConfigLosesData` | negative control — the pre-fix config collapses to one tag and two datapoints per core |

Config is read from the embedded template rather than restated, so a revert fails the
test. **Verified by mutation:** removing `- runtime_tag` from the `groupbyattrs` keys in
`neuron.yaml` fails three of the four.

The negative control matters because it keeps the other three honest — if the collapse
ever stops reproducing, `PreFixConfigLosesData` starts passing and tells us the
assertions have gone vacuous.

**Existing suites** — `go test ./translator/tocwconfig/...` and
`./translator/translate/otel/pipeline/opentelemetry/containerinsights/...` pass. The four
golden configs in this diff are the regenerated snapshots.

**Live cluster** — verified on a 2-core `inf2.xlarge` running two Neuron runtimes:

- Before: 2 series on the PromQL surface, core 0 reading 0 while pinned at ~75%.
- After: 4 correctly-labelled series, core 0 → 75.15 under its own runtime tag, core 1 →
  75.23 under the other.
- Reverting the config on the live agent reproduced the loss (2 series, core 0 back to 0);
  re-applying restored it. So the fix is doing the work, not a caching artifact.
- No attribute regression: 8 existing Neuron integration tests / 26 subtests pass,
  including `TestNeuronPodName`, `TestNeuronNamespace`, `TestNeuronDeviceAttributes` and
  `TestNeuronNoPromotedDatapointKeys` — the last of which specifically asserts
  pod/namespace/container are *not* left on the datapoint, covering the six statements
  removed here.

**Integration test coverage** for the multi-runtime case is a companion change to
`amazon-cloudwatch-agent-test` (adds a second co-located burn deployment so a node runs
two runtimes, plus 8 assertions on the resulting series shape). Worth noting that the
pre-existing integration tests could *not* catch this defect:
`TestNeuronRuntimeTagInResourceScope` passes on the broken code because the collapsed
resource still carries one tag, and `TestNeuronNoDuplicateSeries` passes because the
collision happens in-agent — the surface shows too *few* series rather than duplicated
ones. Cardinality is the signal, not duplication.

https://github.com/aws/amazon-cloudwatch-agent-test/pull/749

# Requirements

- [x] `make fmt` and `make fmt-sh` — no changes produced
- [x] `make lint` — 0 issues (license and import-order checks pass)
