### PR TITLE
fix(ci): Avoid argument size limit for PR test verify-all gate

### DIFF
--- a/.github/workflows/PR-test.yml
+++ b/.github/workflows/PR-test.yml
@@ -408,29 +408,15 @@ jobs:
     steps:
       - name: Check Job Status
         env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
+          # toJSON(needs) carries every job's outputs and can exceed the argument size limit,
+          # so gate on the results alone.
+          RESULTS: ${{ join(needs.*.result, ' ') }}
         run: |
-          failed_jobs=()
-          successful_jobs=()
-
-          # Loop through all jobs in needs context
-          for job in $(echo "$NEEDS_JSON" | jq -r 'keys[]'); do
-            result=$(echo "$NEEDS_JSON" | jq -r ".[\"$job\"].result")
-
-            if [[ "$result" == "failure" ]]; then
-              failed_jobs+=("$job")
-            elif [[ "$result" == "success" ]]; then
-              successful_jobs+=("$job")
+          echo "Job results: ${RESULTS}"
+          for result in ${RESULTS}; do
+            if [ "${result}" = "failure" ]; then
+              echo "One or more required jobs failed."
+              exit 1
             fi
           done
-
-          echo "Successfully validated jobs:"
-          printf '%s\n' "${successful_jobs[@]}"
-
-          if [ ${#failed_jobs[@]} -ne 0 ]; then
-            echo -e "\nFailed jobs:"
-            printf '%s\n' "${failed_jobs[@]}"
-            exit 1
-          fi
-
-          echo -e "\nAll required jobs completed without failures!"
+          echo "All required jobs completed without failures!"


### PR DESCRIPTION
# Description of the issue
The `PR-test` workflow's `Verify All PR Test Jobs` job is consistently failing (https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33211930467/job/99653605070) due to the argument list being too long.

> Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/amazon-cloudwatch-agent/amazon-cloudwatch-agent'. Argument list too long

This is because the `needs` context (https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context) carries all the outputs of every job in the list including the `GenerateTestMatrix`.

# Description of changes
Changed the job to only look at the results of the jobs in the `needs` context.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33535514408?pr=2265

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



