### PR TITLE
chore: fix Succesfully typo in launch configuration cleanup log

### DIFF
--- a/.github/workflows/PR-test.yml
+++ b/.github/workflows/PR-test.yml
@@ -407,15 +407,22 @@ jobs:
     if: always()
     steps:
       - name: Check Job Status
-        env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
+          # The needs context is written to a file rather than exported as an environment
+          # variable. With this many dependencies - several of which are matrix jobs - the
+          # serialised context exceeds the kernel's limit on the environment passed to
+          # execve, and the step fails before running with "Argument list too long". The
+          # quoted heredoc delimiter keeps the shell from expanding the contents.
+          cat <<'NEEDS_JSON_EOF' > "$RUNNER_TEMP/needs.json"
+          ${{ toJSON(needs) }}
+          NEEDS_JSON_EOF
+
           failed_jobs=()
           successful_jobs=()
 
           # Loop through all jobs in needs context
-          for job in $(echo "$NEEDS_JSON" | jq -r 'keys[]'); do
-            result=$(echo "$NEEDS_JSON" | jq -r ".[\"$job\"].result")
+          for job in $(jq -r 'keys[]' "$RUNNER_TEMP/needs.json"); do
+            result=$(jq -r --arg job "$job" '.[$job].result' "$RUNNER_TEMP/needs.json")
 
             if [[ "$result" == "failure" ]]; then
               failed_jobs+=("$job")

--- a/tool/clean/clean_launch_configuration/clean_launch_configuration.go
+++ b/tool/clean/clean_launch_configuration/clean_launch_configuration.go
@@ -52,7 +52,7 @@ func cleanLaunchConfiguration() error {
 			if err != nil {
 				return err
 			}
-			log.Printf("Succesfully deleted %s", *launchConfig.LaunchConfigurationName)
+			log.Printf("Successfully deleted %s", *launchConfig.LaunchConfigurationName)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description of the issue
Typo in log message. Also fixed PR test workflow

# Description of changes
Fixed the typo. PR Test workflow was failing `Argument list too long`, so now it saves to a file locally and than reads from it.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
All workflows tests in this PR must pass

# Requirements
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`




