### PR TITLE
Fix container integration test tags

### DIFF
--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -80,6 +80,7 @@ jobs:
       ContainerRepositoryNameAndTag: "cwagent-integration-test:${{ github.sha }}"
       BucketKey: "integration-test/binary/${{ github.sha }}"
       PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
+      ArchTagSuffix: "-${{ github.sha }}"
 
   BuildDistributor:
     needs: [BuildAndUpload, BuildAndUploadPackages, BuildDocker]

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -57,6 +57,7 @@ jobs:
       ContainerRepositoryNameAndTag: "cwagent-integration-test:${{ github.sha }}"
       BucketKey: "integration-test/binary/${{ github.sha }}"
       PackageBucketKey: "integration-test/packaging/${{ github.sha }}"
+      ArchTagSuffix: "-${{ github.sha }}"
 
   DeploySoakTest:
     name: "DeploySoakTest"

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -115,7 +115,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64
+            ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64-${{ github.sha }}
           platforms: linux/amd64
           provenance: false
 
@@ -127,7 +127,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64
+            ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64-${{ github.sha }}
           platforms: linux/arm64
           provenance: false
 
@@ -319,8 +319,8 @@ jobs:
           REPOSITORYWindows: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:windows
           REPO2022: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:2022
           REPO2019: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:2019
-          REPOLinuxAmd: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64
-          REPOLinuxArm: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64
+          REPOLinuxAmd: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64-${{ github.sha }}
+          REPOLinuxArm: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64-${{ github.sha }}
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_binaries.outputs.cache-hit == false
         run: |
           docker manifest create $REGISTRY/$REPOSITORYWindows --amend $REGISTRY/$REPO2022 --amend $REGISTRY/$REPO2019

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -26,6 +26,11 @@ on:
         description: "Integration tests put the MSI and PKG in a different bucket path than the binaries."
         required: true
         type: string
+      ArchTagSuffix:
+        description: "Optional suffix appended to per-arch image tags (e.g. -<sha>)."
+        required: false
+        type: string
+        default: ""
   workflow_call:
     inputs:
       ContainerRepositoryNameAndTag:
@@ -46,6 +51,11 @@ on:
         description: "Integration tests put the MSI and PKG in a different bucket path than the binaries."
         required: true
         type: string
+      ArchTagSuffix:
+        description: "Optional suffix appended to per-arch image tags (e.g. -<sha>)."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   MakeBinary:
@@ -115,7 +125,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64-${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64${{ inputs.ArchTagSuffix }}
           platforms: linux/amd64
           provenance: false
 
@@ -127,7 +137,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64-${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64${{ inputs.ArchTagSuffix }}
           platforms: linux/arm64
           provenance: false
 
@@ -319,8 +329,8 @@ jobs:
           REPOSITORYWindows: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:windows
           REPO2022: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:2022
           REPO2019: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:2019
-          REPOLinuxAmd: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64-${{ github.sha }}
-          REPOLinuxArm: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64-${{ github.sha }}
+          REPOLinuxAmd: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-amd64${{ inputs.ArchTagSuffix }}
+          REPOLinuxArm: ${{ steps.repo_name.outputs.ContainerRepositoryName }}:linux-arm64${{ inputs.ArchTagSuffix }}
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_binaries.outputs.cache-hit == false
         run: |
           docker manifest create $REGISTRY/$REPOSITORYWindows --amend $REGISTRY/$REPO2022 --amend $REGISTRY/$REPO2019


### PR DESCRIPTION
### Description of the issue
Container integration tests (ECS OTLP, EKS Container Insights) failed with 0 metrics. The per-commit image cwagent-integration-test:<sha> could resolve to a stale agent build. The :<sha> manifest was built from mutable, non-SHA arch tags (:linux-amd64/:linux-arm64) overwritten every build, so a commit's manifest could capture another commit's arch image. The stale agent couldn't translate the opentelemetry config, crash-looped on startup, and exported nothing.

### Description of changes
  -  Gate the arch tags to only integration test.
  - `:linux-amd64` to `:linux-amd64-${{ github.sha }}`
  - `:linux-arm64` to `:linux-arm64-${{ github.sha }}`
  - manifest `create --amend` now points at the SHA-scoped arch tags

Container image path only; host/Windows/mac and the build cache are untouched.

### License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

#### Tests
Built artifacts for the branch (`build-test-artifacts` with `run-tests=false`), verified in ECR that the `sha` resolves to the correct image (arch tags `linux-amd64-<sha>`/`linux-arm64-<sha>` present;  OTLP integration tests passes

  # Requirements
  1. Run `make fmt` and `make fmt-sh`
  2. Run `make lint`



