### PR TITLE
Add EKS Addon and IPv6 to OTelCI test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -199,6 +199,91 @@ jobs:
       eks_installation_type: "HELM_CHART"
     secrets: inherit
 
+  EKSE2EOTELContainerInsightsTestAddon:
+    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    name: 'EKSE2EOtelContainerInsightsTestAddon'
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/eks-e2e-test.yml
+    with:
+      terraform_dir: terraform/eks/e2e
+      job_id: eks-e2e-otelcontainerinsights-test-addon
+      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_containerinsights_matrix }}
+      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
+      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
+      cloudwatch_agent_tag: ${{ inputs.build_sha || github.sha }}
+      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
+      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
+      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+      agent_config: resources/cwagent_configs_eks_addon/ci_node.json
+      sample_app: resources/sample_apps/nginx.yaml
+      eks_installation_type: "EKS_ADDON"
+    secrets: inherit
+
+  EKSE2EOTELContainerInsightsTestHelmIPv6:
+    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    name: 'EKSE2EOtelContainerInsightsTestHelmIPv6'
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/eks-e2e-test.yml
+    with:
+      terraform_dir: terraform/eks/e2e
+      job_id: eks-e2e-otelcontainerinsights-test-helm-ipv6
+      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_containerinsights_matrix }}
+      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
+      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
+      cloudwatch_agent_tag: ${{ inputs.build_sha || github.sha }}
+      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
+      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
+      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+      agent_config: resources/cwagent_configs_helm_chart/ci_node.json
+      sample_app: resources/sample_apps/nginx.yaml
+      eks_installation_type: "HELM_CHART"
+      ip_family: "ipv6"
+      vpc_name: "ipv6-eks-integ-test/VPC"
+    secrets: inherit
+
+  EKSE2EOTELContainerInsightsTestAddonIPv6:
+    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    name: 'EKSE2EOtelContainerInsightsTestAddonIPv6'
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/eks-e2e-test.yml
+    with:
+      terraform_dir: terraform/eks/e2e
+      job_id: eks-e2e-otelcontainerinsights-test-addon-ipv6
+      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_containerinsights_matrix }}
+      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
+      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
+      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
+      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
+      cloudwatch_agent_tag: ${{ inputs.build_sha || github.sha }}
+      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
+      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
+      region: ${{ inputs.region || 'us-west-2' }}
+      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
+      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
+      agent_config: resources/cwagent_configs_eks_addon/ci_node.json
+      sample_app: resources/sample_apps/nginx.yaml
+      eks_installation_type: "EKS_ADDON"
+      ip_family: "ipv6"
+      vpc_name: "ipv6-eks-integ-test/VPC"
+    secrets: inherit
+
   EKSE2EJVMTomcatTestHelm:
     needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -172,17 +172,43 @@ jobs:
           echo "eks_e2e_jmx_matrix: $EKS_E2E_JMX_MATRIX"
           echo "eks_e2e_containerinsights_matrix: $EKS_E2E_CONTAINERINSIGHTS_MATRIX"
 
-  EKSE2EOTELContainerInsightsTestHelm:
+  EKSE2EOtelContainerInsightsTest:
     needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    name: 'EKSE2EOtelContainerInsightsTestHelm'
+    name: '${{ matrix.name }}'
     permissions:
       id-token: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 'EKSE2EOtelContainerInsightsTestHelm'
+            eks_installation_type: "HELM_CHART"
+            ip_family: "ipv4"
+            job_id: eks-e2e-otelcontainerinsights-test-helm
+            agent_config: resources/cwagent_configs_helm_chart/ci_node.json
+          - name: 'EKSE2EOtelContainerInsightsTestAddon'
+            eks_installation_type: "EKS_ADDON"
+            ip_family: "ipv4"
+            job_id: eks-e2e-otelcontainerinsights-test-addon
+            agent_config: resources/cwagent_configs_eks_addon/ci_node.json
+          - name: 'EKSE2EOtelContainerInsightsTestHelmIPv6'
+            eks_installation_type: "HELM_CHART"
+            ip_family: "ipv6"
+            job_id: eks-e2e-otelcontainerinsights-test-helm-ipv6
+            agent_config: resources/cwagent_configs_helm_chart/ci_node.json
+            vpc_name: "ipv6-eks-integ-test/VPC"
+          - name: 'EKSE2EOtelContainerInsightsTestAddonIPv6'
+            eks_installation_type: "EKS_ADDON"
+            ip_family: "ipv6"
+            job_id: eks-e2e-otelcontainerinsights-test-addon-ipv6
+            agent_config: resources/cwagent_configs_eks_addon/ci_node.json
+            vpc_name: "ipv6-eks-integ-test/VPC"
     uses: ./.github/workflows/eks-e2e-test.yml
     with:
       terraform_dir: terraform/eks/e2e
-      job_id: eks-e2e-otelcontainerinsights-test-helm
+      job_id: ${{ matrix.job_id }}
       test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_containerinsights_matrix }}
       test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
       test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
@@ -194,94 +220,11 @@ jobs:
       region: ${{ inputs.region || 'us-west-2' }}
       helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
       terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      agent_config: resources/cwagent_configs_helm_chart/ci_node.json
+      agent_config: ${{ matrix.agent_config }}
       sample_app: resources/sample_apps/nginx.yaml
-      eks_installation_type: "HELM_CHART"
-    secrets: inherit
-
-  EKSE2EOTELContainerInsightsTestAddon:
-    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    name: 'EKSE2EOtelContainerInsightsTestAddon'
-    permissions:
-      id-token: write
-      contents: read
-    uses: ./.github/workflows/eks-e2e-test.yml
-    with:
-      terraform_dir: terraform/eks/e2e
-      job_id: eks-e2e-otelcontainerinsights-test-addon
-      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_containerinsights_matrix }}
-      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
-      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
-      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
-      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
-      cloudwatch_agent_tag: ${{ inputs.build_sha || github.sha }}
-      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
-      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
-      region: ${{ inputs.region || 'us-west-2' }}
-      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
-      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      agent_config: resources/cwagent_configs_eks_addon/ci_node.json
-      sample_app: resources/sample_apps/nginx.yaml
-      eks_installation_type: "EKS_ADDON"
-    secrets: inherit
-
-  EKSE2EOTELContainerInsightsTestHelmIPv6:
-    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    name: 'EKSE2EOtelContainerInsightsTestHelmIPv6'
-    permissions:
-      id-token: write
-      contents: read
-    uses: ./.github/workflows/eks-e2e-test.yml
-    with:
-      terraform_dir: terraform/eks/e2e
-      job_id: eks-e2e-otelcontainerinsights-test-helm-ipv6
-      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_containerinsights_matrix }}
-      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
-      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
-      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
-      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
-      cloudwatch_agent_tag: ${{ inputs.build_sha || github.sha }}
-      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
-      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
-      region: ${{ inputs.region || 'us-west-2' }}
-      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
-      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      agent_config: resources/cwagent_configs_helm_chart/ci_node.json
-      sample_app: resources/sample_apps/nginx.yaml
-      eks_installation_type: "HELM_CHART"
-      ip_family: "ipv6"
-      vpc_name: "ipv6-eks-integ-test/VPC"
-    secrets: inherit
-
-  EKSE2EOTELContainerInsightsTestAddonIPv6:
-    needs: [ GetLatestOperatorCommitSHA, GenerateTestMatrix, OutputEnvVariables ]
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    name: 'EKSE2EOtelContainerInsightsTestAddonIPv6'
-    permissions:
-      id-token: write
-      contents: read
-    uses: ./.github/workflows/eks-e2e-test.yml
-    with:
-      terraform_dir: terraform/eks/e2e
-      job_id: eks-e2e-otelcontainerinsights-test-addon-ipv6
-      test_props: ${{ needs.GenerateTestMatrix.outputs.eks_e2e_containerinsights_matrix }}
-      test_repo_name: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_NAME }}
-      test_repo_url: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_URL }}
-      test_repo_branch: ${{ needs.OutputEnvVariables.outputs.CWA_GITHUB_TEST_REPO_BRANCH }}
-      cloudwatch_agent_repository: ${{ needs.OutputEnvVariables.outputs.ECR_INTEGRATION_TEST_REPO }}
-      cloudwatch_agent_tag: ${{ inputs.build_sha || github.sha }}
-      cloudwatch_agent_operator_repository: ${{ needs.OutputEnvVariables.outputs.ECR_OPERATOR_REPO }}
-      cloudwatch_agent_operator_tag: ${{ needs.GetLatestOperatorCommitSHA.outputs.operator_commit_sha }}
-      region: ${{ inputs.region || 'us-west-2' }}
-      helm_charts_branch: ${{ inputs.helm-charts-branch || 'main' }}
-      terraform_assume_role: ${{ vars.TERRAFORM_AWS_ASSUME_ROLE }}
-      agent_config: resources/cwagent_configs_eks_addon/ci_node.json
-      sample_app: resources/sample_apps/nginx.yaml
-      eks_installation_type: "EKS_ADDON"
-      ip_family: "ipv6"
-      vpc_name: "ipv6-eks-integ-test/VPC"
+      eks_installation_type: ${{ matrix.eks_installation_type }}
+      ip_family: ${{ matrix.ip_family }}
+      vpc_name: ${{ matrix.vpc_name }}
     secrets: inherit
 
   EKSE2EJVMTomcatTestHelm:


### PR DESCRIPTION
### Description of the issue
The OTel Container Insights EKS e2e test only ran the Helm installation path and only on IPv4. The EKS add-on install path (now released) and IPv6 were not covered, unlike the JMX e2e suite which runs both Helm and add-on on IPv4/IPv6.

### Description of changes
- Refactored the single OTelCI job into one matrix-driven job (`EKSE2EOtelContainerInsightsTest`) fanning out over install type × IP family: Helm/Addon on IPv4/IPv6. 
- Add-on entries use `cwagent_configs_eks_addon/ci_node.json`.
- IPv6 entries set `ip_family:ipv6`. Mirrors the JMX suite's structure

 ### Integration Tests
OTELContainerInsights EKS Addon and IPv6 test passed:[Addon path and IPv6](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/34507361916)

-------------
  # License
  By submitting this pull request, I confirm that you can use, modify, copy, and
  redistribute this contribution, under the terms of your choice.

  # Requirements
  1. Run `make fmt` and `make fmt-sh`
  2. Run `make lint`





