### PR TITLE
feat(agent): enable service.profilesSupport feature gate by default

### DIFF
--- a/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
+++ b/cmd/amazon-cloudwatch-agent/amazon-cloudwatch-agent.go
@@ -28,6 +28,7 @@ import (
 	"github.com/influxdata/wlog"
 	"github.com/kardianos/service"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
 
@@ -377,6 +378,7 @@ func runAgent(ctx context.Context,
 	for _, uri := range otelConfigs {
 		e = append(e, "--config="+uri)
 	}
+	e = append(e, collectorFeatureGateArgs(featuregate.GlobalRegistry())...)
 	cmd.SetArgs(e)
 	return cmd.Execute()
 }

--- a/cmd/amazon-cloudwatch-agent/featuregates.go
+++ b/cmd/amazon-cloudwatch-agent/featuregates.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"log"
+	"strings"
+
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+// profilesSupportGateID is the collector gate that unlocks profiles pipelines. The
+// agent enables it so operators get profiles support without having to pass
+// --feature-gates themselves.
+const profilesSupportGateID = "service.profilesSupport"
+
+// defaultEnabledFeatureGates are the collector feature gates the agent turns on at
+// startup.
+var defaultEnabledFeatureGates = []string{profilesSupportGateID}
+
+// collectorFeatureGateArgs builds the --feature-gates arguments for the collector
+// command. A gate is only requested when the registry still holds it and still
+// accepts being enabled: the collector fails startup on an unknown gate ID, so once
+// a gate graduates and is deleted upstream, asking for it would turn a routine
+// collector dependency bump into a fatal startup failure. Skipping it makes
+// graduation a no-op instead.
+func collectorFeatureGateArgs(reg *featuregate.Registry) []string {
+	var gates []string
+	for _, id := range defaultEnabledFeatureGates {
+		if !canEnableFeatureGate(reg, id) {
+			log.Printf("I! Feature gate %q cannot be enabled in this collector build, skipping", id)
+			continue
+		}
+		gates = append(gates, "+"+id)
+	}
+	if len(gates) == 0 {
+		return nil
+	}
+	return []string{"--feature-gates=" + strings.Join(gates, ",")}
+}
+
+// canEnableFeatureGate reports whether reg holds a gate with the given id that can be
+// enabled. A deprecated gate is treated the same as a missing one because
+// featuregate.Registry.Set rejects enabling it.
+func canEnableFeatureGate(reg *featuregate.Registry, id string) bool {
+	var enableable bool
+	reg.VisitAll(func(g *featuregate.Gate) {
+		if g.ID() == id {
+			enableable = g.Stage() != featuregate.StageDeprecated
+		}
+	})
+	return enableable
+}

--- a/cmd/amazon-cloudwatch-agent/featuregates_test.go
+++ b/cmd/amazon-cloudwatch-agent/featuregates_test.go
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+func TestCollectorFeatureGateArgs(t *testing.T) {
+	testCases := map[string]struct {
+		register func(*testing.T, *featuregate.Registry)
+		want     []string
+	}{
+		"GateRegistered": {
+			register: func(t *testing.T, reg *featuregate.Registry) {
+				_, err := reg.Register(profilesSupportGateID, featuregate.StageAlpha)
+				require.NoError(t, err)
+			},
+			want: []string{"--feature-gates=+" + profilesSupportGateID},
+		},
+		// A gate that graduated to stable is still enableable, so keep passing it until
+		// it is removed from the registry entirely.
+		"GateStable": {
+			register: func(t *testing.T, reg *featuregate.Registry) {
+				_, err := reg.Register(profilesSupportGateID, featuregate.StageStable,
+					featuregate.WithRegisterToVersion("v1.0.0"))
+				require.NoError(t, err)
+			},
+			want: []string{"--feature-gates=+" + profilesSupportGateID},
+		},
+		// The gate graduated and was deleted upstream: emit nothing rather than an arg
+		// the collector would reject at startup.
+		"GateAbsent": {
+			register: func(_ *testing.T, _ *featuregate.Registry) {},
+			want:     nil,
+		},
+		// Registry.Set refuses to enable a deprecated gate, so it is as unusable as an
+		// absent one.
+		"GateDeprecated": {
+			register: func(t *testing.T, reg *featuregate.Registry) {
+				_, err := reg.Register(profilesSupportGateID, featuregate.StageDeprecated,
+					featuregate.WithRegisterToVersion("v1.0.0"))
+				require.NoError(t, err)
+			},
+			want: nil,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			reg := featuregate.NewRegistry()
+			testCase.register(t, reg)
+
+			got := collectorFeatureGateArgs(reg)
+			assert.Equal(t, testCase.want, got)
+
+			// The args are handed to the collector command verbatim, so check they parse
+			// against the real feature gate flag rather than trusting the string above.
+			flagSet := new(flag.FlagSet)
+			reg.RegisterFlags(flagSet)
+			require.NoError(t, flagSet.Parse(got))
+		})
+	}
+}
+
+func TestCollectorFeatureGateArgsEnablesGate(t *testing.T) {
+	reg := featuregate.NewRegistry()
+	gate, err := reg.Register(profilesSupportGateID, featuregate.StageAlpha)
+	require.NoError(t, err)
+	require.False(t, gate.IsEnabled())
+
+	flagSet := new(flag.FlagSet)
+	reg.RegisterFlags(flagSet)
+	require.NoError(t, flagSet.Parse(collectorFeatureGateArgs(reg)))
+
+	assert.True(t, gate.IsEnabled())
+}
+
+func TestCanEnableFeatureGate(t *testing.T) {
+	reg := featuregate.NewRegistry()
+	_, err := reg.Register("other.gate", featuregate.StageAlpha)
+	require.NoError(t, err)
+
+	assert.False(t, canEnableFeatureGate(reg, profilesSupportGateID))
+	assert.True(t, canEnableFeatureGate(reg, "other.gate"))
+}

--- a/go.mod
+++ b/go.mod
@@ -246,6 +246,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.124.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.124.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.124.0
+	go.opentelemetry.io/collector/featuregate v1.30.0
 	go.opentelemetry.io/collector/filter v0.124.0
 	go.opentelemetry.io/collector/otelcol v0.124.0
 	go.opentelemetry.io/collector/otelcol/otelcoltest v0.124.0
@@ -611,7 +612,6 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.124.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.124.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.124.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.30.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.124.0 // indirect
 	go.opentelemetry.io/collector/internal/memorylimiter v0.124.0 // indirect
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.124.0 // indirect


### PR DESCRIPTION
# Description of the issue

Issue: https://github.com/aws/amazon-cloudwatch-agent/issues/2273

Configuring a profiles pipeline makes the agent fail to start, because the
collector's profiles signal is gated behind `service.profilesSupport` (alpha, off
by default in collector v0.124.0):

    pipeline "profiles": profiling signal support is at alpha level, gated under the "service.profilesSupport" feature gate

The agent builds the collector's arguments itself and only ever passes
`--config=`, so an operator has no supported way to enable the gate.

# Description of changes

The agent now appends `--feature-gates=+service.profilesSupport` to the arguments
it builds for the collector command, so profiles pipelines start without the
operator needing to know the gate exists.

The flag is only appended after checking the collector's feature-gate registry
for an enableable gate with that ID. `featuregate.Registry.Set` returns an error
for an unknown gate ID, which surfaces as a flag-parse failure and a fatal
startup error. Without the guard, the moment the gate graduates and is deleted
upstream, a routine collector dependency bump would produce an agent that
refuses to start. With it, graduation is a no-op.

The guard also treats `StageDeprecated` as not enableable, because `Set` rejects
enabling a deprecated gate with the same class of error, and deprecated is the
pre-deletion state of a graduating gate. A `StageStable` gate that is still
registered remains enableable, so the flag keeps being passed until the gate is
removed from the registry entirely.

New file `cmd/amazon-cloudwatch-agent/featuregates.go` holds
`collectorFeatureGateArgs` and the registry check. `amazon-cloudwatch-agent.go`
gains one line at the existing `cmd.SetArgs` site. `featuregate` moves from the
indirect to the direct require block in `go.mod` (no version change).

# License

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.

# Tests

New unit tests in `cmd/amazon-cloudwatch-agent/featuregates_test.go` cover all
four registry states: gate registered at alpha (flag passed), gate at stable
(flag still passed), gate absent (no flag, no error), and gate deprecated (no
flag, no error).

Rather than string-comparing the produced arguments, each case parses them
through a real `featuregate` registry flag set, and a separate test asserts the
gate actually flips to enabled -- so the tests validate the flag name and `+`
syntax against the library rather than against a hardcoded expectation.

- `go build ./...` -- pass
- `go test ./cmd/amazon-cloudwatch-agent/` -- pass (whole package)
- `make fmt` -- pass, no changes
- `make fmt-sh` -- pass, no changes


# Requirements

- [x] Commits are squashed into a logical, reviewable set (one commit for a single change)
- [x] Commits and PR description comply with Amazon internal guidelines
- [x] `make` passes locally (build, unit tests, lint) — `go build ./...` and `go test ./cmd/amazon-cloudwatch-agent/` pass; `make lint` exits non-zero with pre-existing repo-wide findings that also fail on unmodified `main`, none in the new file or on either line added to `amazon-cloudwatch-agent.go`
- [ ] All GitHub Actions checks on the PR are passing — PR Build / PR Test workflows require maintainer approval to run for a first-time contributor
- [x] Integration test evidence: N/A — no existing integration test category exercises profiles, and the JSON config translator cannot yet emit a profiles pipeline (#2275 adds that). The gate-argument logic is fully unit-tested; end-to-end profiles evidence lands with a follow-up test PR against amazon-cloudwatch-agent-test.
- [x] New or updated integration test coverage: N/A — profiles integration coverage will be added in a follow-up amazon-cloudwatch-agent-test PR once #2275 makes profiles configurable.
- [x] New functionality has unit tests; bug fixes have a reproducing test
- [x] Config translation changes include updated golden files — N/A, no translator changes
- [x] Breaking or customer-visible changes are called out in the PR description — configurations that already contain a profiles pipeline (via `-otelconfig`) previously failed at startup and now start with the gate enabled; all other configurations see no behavior change
