### PR TITLE
feat(configprovider): validate profiles_endpoint and otlp_http exporter names

### DIFF
--- a/service/configprovider/otlphttp_validator.go
+++ b/service/configprovider/otlphttp_validator.go
@@ -47,14 +47,15 @@ func (v *otlphttpValidator) Convert(_ context.Context, conf *confmap.Conf) error
 		return nil
 	}
 	for name, cfg := range exporters {
-		if name != "otlphttp" && !strings.HasPrefix(name, "otlphttp/") {
+		exporterType, _, _ := strings.Cut(name, "/")
+		if exporterType != "otlphttp" && exporterType != "otlp_http" {
 			continue
 		}
 		exporterCfg, ok := cfg.(map[string]any)
 		if !ok {
 			continue
 		}
-		for _, key := range []string{"endpoint", "metrics_endpoint", "traces_endpoint", "logs_endpoint"} {
+		for _, key := range []string{"endpoint", "metrics_endpoint", "traces_endpoint", "logs_endpoint", "profiles_endpoint"} {
 			if ep, ok := exporterCfg[key].(string); ok && ep != "" {
 				if !isAWSEndpoint(ep) {
 					return fmt.Errorf("invalid AWS endpoint: %q", ep)

--- a/service/configprovider/otlphttp_validator_test.go
+++ b/service/configprovider/otlphttp_validator_test.go
@@ -69,6 +69,46 @@ func TestOTLPHTTPValidator(t *testing.T) {
 			},
 		},
 		{
+			name: "valid profiles_endpoint",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp": map[string]any{
+						"profiles_endpoint": "https://monitoring.us-east-1.amazonaws.com/v1development/profiles",
+					},
+				},
+			},
+		},
+		{
+			name: "valid otlp_http endpoint",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlp_http": map[string]any{
+						"endpoint": "https://monitoring.us-east-1.amazonaws.com",
+					},
+				},
+			},
+		},
+		{
+			name: "valid otlp_http named instance profiles_endpoint",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlp_http/profiles": map[string]any{
+						"profiles_endpoint": "https://monitoring.us-east-1.amazonaws.com/v1development/profiles",
+					},
+				},
+			},
+		},
+		{
+			name: "valid otlphttp named instance profiles_endpoint",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp/profiles": map[string]any{
+						"profiles_endpoint": "https://monitoring.us-east-1.amazonaws.com/v1development/profiles",
+					},
+				},
+			},
+		},
+		{
 			name: "valid endpoint without scheme",
 			config: map[string]any{
 				"exporters": map[string]any{
@@ -133,11 +173,65 @@ func TestOTLPHTTPValidator(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid third party profiles_endpoint",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp": map[string]any{
+						"profiles_endpoint": "https://pyroscope.example.com/v1development/profiles",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid third party otlp_http endpoint",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlp_http": map[string]any{
+						"endpoint": "https://example.com/v1/metrics",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid third party otlp_http named instance profiles_endpoint",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlp_http/profiles": map[string]any{
+						"profiles_endpoint": "https://pyroscope.example.com/v1development/profiles",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid third party otlphttp named instance profiles_endpoint",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttp/profiles": map[string]any{
+						"profiles_endpoint": "https://pyroscope.example.com/v1development/profiles",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "non-otlphttp exporter is ignored",
 			config: map[string]any{
 				"exporters": map[string]any{
 					"prometheus": map[string]any{
 						"endpoint": "https://example.com/metrics",
+					},
+				},
+			},
+		},
+		{
+			name: "near-miss exporter name is ignored",
+			config: map[string]any{
+				"exporters": map[string]any{
+					"otlphttpx": map[string]any{
+						"endpoint": "https://example.com/v1/metrics",
 					},
 				},
 			},


### PR DESCRIPTION
# Description of the issue
The otlphttp exporter endpoint validator restricts `endpoint`, `metrics_endpoint`,
`traces_endpoint`, and `logs_endpoint` to AWS domains, so the agent cannot be
configured to ship telemetry to a non-AWS destination. Two endpoint keys are not
covered: `profiles_endpoint`, and any endpoint on an exporter keyed with the
`otlp_http` type name.

# Description of changes
- Adds `profiles_endpoint` to the set of otlphttp exporter endpoint keys checked
  against the AWS DNS-suffix allowlist, so it is validated exactly like the other
  four signal endpoints.
- Matches the exporter type as `otlp_http` in addition to `otlphttp`. The
  exporter translator derives its component key from the factory type
  (`component.NewIDWithName(t.factory.Type(), name)`), so covering both names
  keeps the allowlist applied regardless of which name the vendored collector
  registers.
- Selects exporters by splitting the component key on `/` and comparing the type
  exactly, matching the convention used in `cmd/amazon-cloudwatch-agent/merge.go`.
  Near-miss names such as `otlphttpx` are not matched.

Configurations that do not set `profiles_endpoint` are unaffected. A non-AWS
`profiles_endpoint`, and a non-AWS endpoint on an `otlp_http`-keyed exporter,
are now rejected at startup, consistent with the existing signal endpoints.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Added unit test cases to `TestOTLPHTTPValidator` covering, for each of the
`otlphttp` and `otlp_http` type names in both bare and named-instance form
(`<type>/profiles`): a valid AWS endpoint accepted, and a third-party endpoint
rejected. Also added a case asserting a near-miss name (`otlphttpx`) is not
matched.

Commands run locally:
- `go build ./...` — clean
- `make test` — 267 packages pass
- `make lint` — 0 issues
- `make fmt`, `make fmt-sh` — no changes produced
- `make check_secrets` — reports a match on its own definition in the `Makefile`;
  reproduces on an unmodified checkout

## PR checklist
- [x] Commits are squashed into a logical, reviewable set (one commit for a single change)
- [x] Commits and PR description comply with Amazon internal guidelines
- [x] `make` passes locally — ran `go build ./...`, `make test`, `make lint`, `make fmt`, `make fmt-sh` (see Tests)
- [x] All GitHub Actions checks on the PR are passing
- [x] Integration test evidence: N/A — the change only affects validation during config loading and adds no runtime pipeline behavior; covered by unit tests
- [x] New or updated integration test coverage: N/A — no new integration surface
- [x] New functionality has unit tests; bug fixes have a reproducing test
- [x] Config translation changes include updated golden files: N/A — no translator changes
- [x] Breaking or customer-visible changes are called out in the PR description
