### PR TITLE
feat(scripts): make tenant id more prominent and improve logging in setup scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,6 +84,7 @@ CWAGENT_PLATFORM=azure_aks CWAGENT_AWS_ROLE_ARN=arn:aws:iam::123456789012:role/C
 |-----------------------------------------|--------------------------------------------------------------------------|
 | `CWAGENT_PLATFORM`                      | `aws_ec2` \| `aws_ecs` \| `aws_eks` \| `azure_vm` \| `azure_aks`         |
 | `CWAGENT_AWS_ROLE_NAME`                 | IAM role name (default: `CloudWatchAgentServerRole`)                     |
+| `CWAGENT_AWS_ROLE_ARN`                  | IAM role ARN. `aws/setup.sh` derives the role name from it and fails when its partition or account does not match the shell's credentials. On Azure platforms, when set `azure/setup.sh` also installs |
 | `CWAGENT_AWS_REGION`                    | AWS region telemetry is sent to (required)                               |
 | `CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH` | When set (`1`/`true`/`yes`/`on`), enable Transaction Search if it is off |
 
@@ -99,7 +100,6 @@ CWAGENT_PLATFORM=azure_aks CWAGENT_AWS_ROLE_ARN=arn:aws:iam::123456789012:role/C
 | `CWAGENT_AZURE_SUBSCRIPTION`       | `azure_vm`, `azure_aks` | Subscription ID or name (Cloud Shell's default is used when unset)                      |
 | `CWAGENT_AZURE_RESOURCE_GROUP`     | `azure_vm`, `azure_aks` | Resource group (not needed when `CWAGENT_AZURE_RESOURCE_ID` is set)                     |
 | `CWAGENT_AZURE_VM_NAME`            | `azure_vm`              | VM name (not needed when `CWAGENT_AZURE_RESOURCE_ID` is set)                            |
-| `CWAGENT_AWS_ROLE_ARN`             | `azure_vm`, `azure_aks` | IAM role ARN; when set, `azure/setup.sh` also installs                                  |
 | `CWAGENT_AZURE_TENANT_ID`          | `azure_vm`              | Azure tenant ID (produced by `azure/setup.sh`, consumed by `aws/setup.sh`)              |
 | `CWAGENT_AZURE_OIDC_ISSUER`        | `azure_aks`             | AKS OIDC issuer URL (produced by `azure/setup.sh`, consumed by `aws/setup.sh`)          |
 

--- a/scripts/aws/setup.sh
+++ b/scripts/aws/setup.sh
@@ -318,11 +318,11 @@ check_prerequisites() {
      AWS_ARN=$(printf '%s' "${AWS_IDENTITY}" | cut -f2)
      AWS_ALIAS=$(aws iam list-account-aliases --query 'AccountAliases[0]' --output text 2>/dev/null || true)
      if [ -n "${AWS_ALIAS}" ] && [ "${AWS_ALIAS}" != "None" ]; then
-          log "AWS account: '${AWS_ACCOUNT}' ('${AWS_ALIAS}')"
+          log "AWS account: ${AWS_ACCOUNT} (${AWS_ALIAS})"
      else
-          log "AWS account: '${AWS_ACCOUNT}'"
+          log "AWS account: ${AWS_ACCOUNT}"
      fi
-     log "AWS identity: '${AWS_ARN}'"
+     log "AWS identity: ${AWS_ARN}"
 }
 
 # =============================================================================
@@ -589,7 +589,7 @@ trust_aws_ec2() {
 
           section "Using existing instance profile..."
           log "Instance profile '${PROFILE_NAME}' attached to '${INSTANCE_ID}'"
-          log "Role: '${EXISTING_ROLE}'"
+          log "Role: ${EXISTING_ROLE}"
           if [ -n "${ROLE_ARN_INPUT}" ] && [ "${EXISTING_ROLE}" != "${ROLE_NAME}" ]; then
                logwarn "using this role instead of the provided '${ROLE_ARN_INPUT}'"
           fi
@@ -865,7 +865,7 @@ run_via_ssm() {
                --command-id "${COMMAND_ID}" \
                --instance-id "${INSTANCE_ID}" \
                --region "${REGION}" --query 'StandardErrorContent' --output text >&2
-          die "SSM command finished with status: '${SSM_STATUS_DETAIL}'"
+          die "SSM command finished with status: ${SSM_STATUS_DETAIL}"
      fi
 }
 
@@ -1053,7 +1053,7 @@ main() {
      ROLE_ARN=$(aws iam get-role \
           --role-name "${ROLE_NAME}" \
           --query Role.Arn --output text)
-     log "Role ARN: '${ROLE_ARN}'"
+     log "Role ARN: ${ROLE_ARN}"
 
      ensure_transaction_search
 

--- a/scripts/aws/setup.sh
+++ b/scripts/aws/setup.sh
@@ -293,11 +293,9 @@ interactive_setup() {
      # Skip when a role was already identified through the environment. An ARN
      # is preferred (it pins the account), but a plain name is still accepted:
      # this script often creates the role, so a first run may have no ARN yet.
-     if [ -z "${ROLE_ARN_INPUT}" ] && [ -z "${CWAGENT_AWS_ROLE_NAME:-}" ]; then
-          ask "IAM role ARN or name [create/use ${ROLE_NAME} in this account]:"
+     if [ -z "${CWAGENT_AWS_ROLE_ARN:-}" ] && [ -z "${CWAGENT_AWS_ROLE_NAME:-}" ]; then
+          ask "IAM role ARN or name [create/use '${ROLE_NAME}' in this account]:"
           read -r role_input || die "no input for IAM role"
-          # A plain if, not a trailing && list: an empty answer keeps the
-          # default role name and must not fail the function under set -e.
           if [ -n "${role_input}" ]; then
                case "${role_input}" in
                arn:*) ROLE_ARN_INPUT="${role_input}" ;;
@@ -320,11 +318,11 @@ check_prerequisites() {
      AWS_ARN=$(printf '%s' "${AWS_IDENTITY}" | cut -f2)
      AWS_ALIAS=$(aws iam list-account-aliases --query 'AccountAliases[0]' --output text 2>/dev/null || true)
      if [ -n "${AWS_ALIAS}" ] && [ "${AWS_ALIAS}" != "None" ]; then
-          log "AWS account: ${AWS_ACCOUNT} (${AWS_ALIAS})"
+          log "AWS account: '${AWS_ACCOUNT}' ('${AWS_ALIAS}')"
      else
-          log "AWS account: ${AWS_ACCOUNT}"
+          log "AWS account: '${AWS_ACCOUNT}'"
      fi
-     log "AWS identity: ${AWS_ARN}"
+     log "AWS identity: '${AWS_ARN}'"
 }
 
 # =============================================================================
@@ -373,14 +371,19 @@ Pass the role ARN or the role name, not both with different targets."
 
      caller_partition=$(printf '%s' "${AWS_ARN}" | cut -d: -f2)
      if [ "${arn_partition}" != "${caller_partition}" ]; then
-          die "the role ARN is in partition ${arn_partition} but this shell's credentials are in ${caller_partition}. Rerun with credentials for the account the role lives in"
+          die "the role ARN is in partition '${arn_partition}' but this shell's credentials are in '${caller_partition}'. Rerun with credentials for the '${arn_partition}' partition"
      fi
      if [ "${arn_account}" != "${AWS_ACCOUNT}" ]; then
-          die "the role ARN is for account ${arn_account} but this shell is authenticated against account ${AWS_ACCOUNT}. Rerun with credentials for account ${arn_account}"
+          die "the role ARN is for account '${arn_account}' but this shell is authenticated against account '${AWS_ACCOUNT}'. Rerun with credentials for account '${arn_account}'"
      fi
      log "Role ARN account matches this shell's credentials"
 
      ROLE_NAME="${arn_role_name}"
+
+     arn_resource="${ROLE_ARN_INPUT#*:role/}"
+     case "${arn_resource}" in
+     */*) ROLE_PATH="/${arn_resource%/*}/" ;;
+     esac
 }
 
 # =============================================================================
@@ -395,9 +398,10 @@ ensure_iam_role() {
      # a failure means the role is absent, so create it and return.
      if ! existing=$(aws iam get-role --role-name "${ROLE_NAME}" \
           --query 'Role.AssumeRolePolicyDocument' --output json 2>/dev/null); then
-          logaction "Creating IAM role ${ROLE_NAME}"
+          logaction "Creating IAM role '${ROLE_NAME}'"
           aws iam create-role \
                --role-name "${ROLE_NAME}" \
+               --path "${ROLE_PATH:-/}" \
                --assume-role-policy-document "${full_policy}" \
                >/dev/null
           return
@@ -419,18 +423,18 @@ ensure_iam_role() {
              else "stale" end')
 
      if [ "${state}" = "current" ]; then
-          log "IAM role ${ROLE_NAME} trust policy up to date"
+          log "IAM role '${ROLE_NAME}' trust policy up to date"
           return
      fi
 
      if [ "${state}" = "stale" ]; then
-          logaction "Updating trust statement on ${ROLE_NAME}"
+          logaction "Updating trust statement on '${ROLE_NAME}'"
           merged=$(printf '%s' "${existing}" | jq \
                --arg principal "${new_principal}" \
                --argjson stmt "${new_statement}" \
                '.Statement = ([.Statement[] | select((.Principal | if type == "object" then to_entries[0].value else . end) != $principal)] + [$stmt])')
      else
-          logaction "Merging trust statement into ${ROLE_NAME}"
+          logaction "Merging trust statement into '${ROLE_NAME}'"
           merged=$(printf '%s' "${existing}" | jq \
                --argjson stmt "${new_statement}" \
                '.Statement += [$stmt]')
@@ -487,7 +491,7 @@ ensure_transaction_search() {
      TRACE_DEST=$(aws xray get-trace-segment-destination --region "${REGION}" --query 'Destination' --output text 2>/dev/null) || TRACE_DEST_RC=$?
 
      if [ -n "${TRACE_DEST_RC}" ]; then
-          logwarn "Could not check Transaction Search. OTLP traces need it enabled in ${REGION}:"
+          logwarn "Could not check Transaction Search. OTLP traces need it enabled in '${REGION}':"
           logwarn "${TXN_SEARCH_DOC}"
           return
      fi
@@ -496,20 +500,20 @@ ensure_transaction_search() {
      fi
 
      if [ -t 0 ] && ! is_true "${EMIT_ENV}" && ! is_true "${ENABLE_TXN_SEARCH}"; then
-          ask "Enable Transaction Search for the whole account in ${REGION}? [y/N]"
+          ask "Enable Transaction Search for the whole account in '${REGION}'? [y/N]"
           read -r answer || answer=""
           case "${answer}" in [yY]*) ENABLE_TXN_SEARCH="true" ;; esac
      fi
 
      if ! is_true "${ENABLE_TXN_SEARCH}"; then
-          logwarn "OTLP traces need Transaction Search, which is off in ${REGION}. Enabling it"
+          logwarn "OTLP traces need Transaction Search, which is off in '${REGION}'. Enabling it"
           logwarn "changes how X-Ray traces are ingested for the whole account in this region."
           logwarn "Rerun with CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH=true to enable it, or:"
           logwarn "${TXN_SEARCH_DOC}"
           return
      fi
 
-     logaction "Enabling Transaction Search in ${REGION}"
+     logaction "Enabling Transaction Search in '${REGION}'"
      # Two steps: a resource policy letting X-Ray write spans into CloudWatch
      # Logs, then flipping the trace segment destination. Without the policy the
      # destination flips but X-Ray can't write, so spans never land.
@@ -580,12 +584,15 @@ trust_aws_ec2() {
                --query 'InstanceProfile.Roles[0].RoleName' --output text 2>/dev/null || true)
 
           if [ -z "${EXISTING_ROLE}" ] || [ "${EXISTING_ROLE}" = "None" ]; then
-               die "Instance profile ${PROFILE_NAME} has no role attached"
+               die "Instance profile '${PROFILE_NAME}' has no role attached"
           fi
 
           section "Using existing instance profile..."
-          log "Instance profile ${PROFILE_NAME} attached to ${INSTANCE_ID}"
-          log "Role: ${EXISTING_ROLE}"
+          log "Instance profile '${PROFILE_NAME}' attached to '${INSTANCE_ID}'"
+          log "Role: '${EXISTING_ROLE}'"
+          if [ -n "${ROLE_ARN_INPUT}" ] && [ "${EXISTING_ROLE}" != "${ROLE_NAME}" ]; then
+               logwarn "using this role instead of the provided '${ROLE_ARN_INPUT}'"
+          fi
           ROLE_NAME="${EXISTING_ROLE}"
 
           # Nothing to do if the policy is already there, so a re-run stays quiet
@@ -598,12 +605,12 @@ trust_aws_ec2() {
           fi
 
           if [ -t 0 ] && ! is_true "${EMIT_ENV}" && ! is_true "${UPDATE_INSTANCE_ROLE}"; then
-               ask "Attach CloudWatchAgentServerPolicy to ${ROLE_NAME}? [y/N]"
+               ask "Attach CloudWatchAgentServerPolicy to '${ROLE_NAME}'? [y/N]"
                read -r answer || answer=""
                case "${answer}" in [yY]*) UPDATE_INSTANCE_ROLE="true" ;; esac
           fi
           if ! is_true "${UPDATE_INSTANCE_ROLE}"; then
-               die "${ROLE_NAME} is missing CloudWatchAgentServerPolicy. Attach it manually, or set CWAGENT_AWS_UPDATE_INSTANCE_ROLE=true to have this script attach it"
+               die "'${ROLE_NAME}' is missing CloudWatchAgentServerPolicy. Attach it manually, or set CWAGENT_AWS_UPDATE_INSTANCE_ROLE=true to have this script attach it"
           fi
 
           attach_permissions_policy
@@ -619,7 +626,7 @@ trust_aws_ec2() {
 
      section "Configuring instance profile..."
      ensure_instance_profile "${PROFILE_NAME}"
-     logaction "Associating instance profile with ${INSTANCE_ID}"
+     logaction "Associating instance profile with '${INSTANCE_ID}'"
      aws ec2 associate-iam-instance-profile \
           --instance-id "${INSTANCE_ID}" \
           --iam-instance-profile Name="${PROFILE_NAME}" --region "${REGION}" >/dev/null
@@ -630,10 +637,10 @@ trust_aws_ec2() {
 ensure_instance_profile() {
      profile="$1"
      if aws iam get-instance-profile --instance-profile-name "${profile}" >/dev/null 2>&1; then
-          log "Instance profile ${profile} exists"
+          log "Instance profile '${profile}' exists"
           return
      fi
-     logaction "Creating instance profile ${profile}"
+     logaction "Creating instance profile '${profile}'"
      aws iam create-instance-profile --instance-profile-name "${profile}" >/dev/null
      aws iam add-role-to-instance-profile \
           --instance-profile-name "${profile}" --role-name "${ROLE_NAME}" >/dev/null
@@ -708,7 +715,7 @@ trust_aws_eks() {
           if [ "${EXISTING_ROLE}" = "${ROLE_ARN}" ]; then
                log "Pod identity association exists"
           else
-               logaction "Updating association role to ${ROLE_ARN}"
+               logaction "Updating association role to '${ROLE_ARN}'"
                aws eks update-pod-identity-association \
                     --cluster-name "${CLUSTER_NAME}" \
                     --association-id "${EXISTING_ASSOC}" \
@@ -858,7 +865,7 @@ run_via_ssm() {
                --command-id "${COMMAND_ID}" \
                --instance-id "${INSTANCE_ID}" \
                --region "${REGION}" --query 'StandardErrorContent' --output text >&2
-          die "SSM command finished with status: ${SSM_STATUS_DETAIL}"
+          die "SSM command finished with status: '${SSM_STATUS_DETAIL}'"
      fi
 }
 
@@ -884,19 +891,19 @@ install_aws_ec2() {
           if [ "${INSTANCE_PLATFORM}" = "windows" ]; then
                if INSTALL_CMD=$(windows_install_cmd); then
                     run_via_ssm "AWS-RunPowerShellScript" "${INSTALL_CMD}"
-                    log "Agent installed on ${INSTANCE_ID}"
+                    log "Agent installed on '${INSTANCE_ID}'"
                     return
                fi
           else
                if INSTALL_CMD=$(linux_install_cmd); then
                     run_via_ssm "AWS-RunShellScript" "${INSTALL_CMD}"
-                    log "Agent installed on ${INSTANCE_ID}"
+                    log "Agent installed on '${INSTANCE_ID}'"
                     return
                fi
           fi
           logwarn "could not build the install command (iconv is required for Windows targets)"
      else
-          logwarn "SSM agent is not available on ${INSTANCE_ID}"
+          logwarn "SSM agent is not available on '${INSTANCE_ID}'"
      fi
 
      printf '\n' >&3
@@ -944,9 +951,9 @@ install_aws_eks() {
      # create/update is async. Wait for active, but a slow activation shouldn't
      # fail the run, so on timeout just point at the status command.
      if aws eks wait addon-active --cluster-name "${CLUSTER_NAME}" --addon-name amazon-cloudwatch-observability --region "${REGION}" 2>/dev/null; then
-          log "Add-on active on ${CLUSTER_NAME}"
+          log "Add-on active on '${CLUSTER_NAME}'"
      else
-          logwarn "Add-on submitted, still activating. Check: aws eks describe-addon --cluster-name ${CLUSTER_NAME} --addon-name amazon-cloudwatch-observability --region ${REGION}"
+          logwarn "Add-on submitted, still activating. Check: aws eks describe-addon --cluster-name '${CLUSTER_NAME}' --addon-name amazon-cloudwatch-observability --region '${REGION}'"
      fi
 }
 
@@ -1046,13 +1053,7 @@ main() {
      ROLE_ARN=$(aws iam get-role \
           --role-name "${ROLE_NAME}" \
           --query Role.Arn --output text)
-     # The role in play can drift from a provided ARN: aws_ec2 swaps in an
-     # existing instance-profile role, and a pathed ARN for a role that did not
-     # exist yet is created at the default path. Flag either, neutrally.
-     if [ -n "${ROLE_ARN_INPUT}" ] && [ "${ROLE_ARN}" != "${ROLE_ARN_INPUT}" ]; then
-          logwarn "using ${ROLE_ARN} instead of the provided ${ROLE_ARN_INPUT}"
-     fi
-     log "Role ARN: ${ROLE_ARN}"
+     log "Role ARN: '${ROLE_ARN}'"
 
      ensure_transaction_search
 

--- a/scripts/aws/setup.sh
+++ b/scripts/aws/setup.sh
@@ -34,6 +34,11 @@
 #   Common:
 #     CWAGENT_PLATFORM                        aws_ec2 | aws_ecs | aws_eks | azure_vm | azure_aks
 #     CWAGENT_AWS_ROLE_NAME                   IAM role name (default: CloudWatchAgentServerRole)
+#     CWAGENT_AWS_ROLE_ARN                    IAM role ARN. The role name is derived
+#                                             from it (a CWAGENT_AWS_ROLE_NAME that
+#                                             disagrees is rejected), and its partition
+#                                             and account must match this shell's AWS
+#                                             credentials
 #     CWAGENT_AWS_REGION                      AWS region telemetry is sent to (required,
 #                                             falls back to the AWS CLI config if unset)
 #     CWAGENT_EMIT_ENV                        When set (1/true/yes/on), print eval-able
@@ -64,6 +69,7 @@ UPDATE_INSTANCE_ROLE="${CWAGENT_AWS_UPDATE_INSTANCE_ROLE:-}"
 ENABLE_TXN_SEARCH="${CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH:-}"
 CLUSTER_NAME="${CWAGENT_K8S_CLUSTER_NAME:-}"
 ROLE_NAME="${CWAGENT_AWS_ROLE_NAME:-CloudWatchAgentServerRole}"
+ROLE_ARN_INPUT="${CWAGENT_AWS_ROLE_ARN:-}"
 REGION="${CWAGENT_AWS_REGION:-}"
 EMIT_ENV="${CWAGENT_EMIT_ENV:-}"
 ECS_LAUNCH_TYPE="${CWAGENT_AWS_ECS_LAUNCH_TYPE:-}"
@@ -136,6 +142,9 @@ Environment variables:
   Common:
     CWAGENT_PLATFORM                        aws_ec2 | aws_ecs | aws_eks | azure_vm | azure_aks
     CWAGENT_AWS_ROLE_NAME                   IAM role name (default: CloudWatchAgentServerRole)
+    CWAGENT_AWS_ROLE_ARN                    IAM role ARN (its partition and account must
+                                            match the credentials; a disagreeing role
+                                            name is rejected)
     CWAGENT_AWS_REGION                      AWS region telemetry is sent to (required)
     CWAGENT_EMIT_ENV                        Print eval-able KEY='value' lines on stdout
     CWAGENT_AWS_ENABLE_TRANSACTION_SEARCH   Enable Transaction Search in the region
@@ -281,11 +290,21 @@ interactive_setup() {
           prompt OIDC_ISSUER "AKS OIDC issuer URL"
           ;;
      esac
-     # `prompt` returns early on a non-empty current value, and ROLE_NAME always
-     # has one (the built-in default), so ask directly with the default filled in.
-     ask "IAM role name [${ROLE_NAME}]:"
-     read -r role_input || die "no input for IAM role name"
-     [ -n "${role_input}" ] && ROLE_NAME="${role_input}"
+     # Skip when a role was already identified through the environment. An ARN
+     # is preferred (it pins the account), but a plain name is still accepted:
+     # this script often creates the role, so a first run may have no ARN yet.
+     if [ -z "${ROLE_ARN_INPUT}" ] && [ -z "${CWAGENT_AWS_ROLE_NAME:-}" ]; then
+          ask "IAM role ARN or name [create/use ${ROLE_NAME} in this account]:"
+          read -r role_input || die "no input for IAM role"
+          # A plain if, not a trailing && list: an empty answer keeps the
+          # default role name and must not fail the function under set -e.
+          if [ -n "${role_input}" ]; then
+               case "${role_input}" in
+               arn:*) ROLE_ARN_INPUT="${role_input}" ;;
+               *) ROLE_NAME="${role_input}" ;;
+               esac
+          fi
+     fi
 }
 
 check_prerequisites() {
@@ -306,6 +325,62 @@ check_prerequisites() {
           log "AWS account: ${AWS_ACCOUNT}"
      fi
      log "AWS identity: ${AWS_ARN}"
+}
+
+# =============================================================================
+# Role ARN validation
+#
+# When CWAGENT_AWS_ROLE_ARN is provided (e.g. populated by the console UI), the
+# account baked into it must match the account this shell is authenticated
+# against: creating the role and trust in the wrong account does not fail here,
+# it fails later and silently on the assume-role side. The role name used
+# everywhere downstream is derived from the ARN.
+# =============================================================================
+
+validate_role_arn() {
+     [ -n "${ROLE_ARN_INPUT}" ] || return 0
+
+     case "${ROLE_ARN_INPUT}" in
+     arn:*:iam::*:role/?*) ;;
+     *) die "invalid IAM role ARN: ${ROLE_ARN_INPUT} (expected arn:<partition>:iam::<account-id>:role/<name>)" ;;
+     esac
+
+     # The role name is the last path segment, so an ARN with a path
+     # (arn:...:role/path/Name) resolves to the plain name the IAM CLI wants.
+     arn_role_name="${ROLE_ARN_INPUT##*/}"
+     [ -n "${arn_role_name}" ] || die "invalid IAM role ARN: ${ROLE_ARN_INPUT} (empty role name)"
+
+     # A redundantly-supplied role name is fine when it agrees with the ARN
+     # (the conflict rule CWAGENT_AZURE_RESOURCE_ID uses); a disagreement has
+     # no defined winner, so it fails loudly. The built-in default is exempt:
+     # the dispatcher always exports CWAGENT_AWS_ROLE_NAME, defaulted, so a
+     # default-valued name is indistinguishable from an unset one and the ARN
+     # wins.
+     if [ -n "${CWAGENT_AWS_ROLE_NAME:-}" ] &&
+          [ "${CWAGENT_AWS_ROLE_NAME}" != "CloudWatchAgentServerRole" ] &&
+          [ "${CWAGENT_AWS_ROLE_NAME}" != "${arn_role_name}" ]; then
+          die "CWAGENT_AWS_ROLE_NAME='${CWAGENT_AWS_ROLE_NAME}' conflicts with CWAGENT_AWS_ROLE_ARN (which resolves to '${arn_role_name}')
+Pass the role ARN or the role name, not both with different targets."
+     fi
+
+     arn_partition=$(printf '%s' "${ROLE_ARN_INPUT}" | cut -d: -f2)
+     arn_account=$(printf '%s' "${ROLE_ARN_INPUT}" | cut -d: -f5)
+
+     case "${arn_account}" in
+     [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]) ;;
+     *) die "invalid IAM role ARN: ${ROLE_ARN_INPUT} (the account ID must be 12 digits)" ;;
+     esac
+
+     caller_partition=$(printf '%s' "${AWS_ARN}" | cut -d: -f2)
+     if [ "${arn_partition}" != "${caller_partition}" ]; then
+          die "the role ARN is in partition ${arn_partition} but this shell's credentials are in ${caller_partition}. Rerun with credentials for the account the role lives in"
+     fi
+     if [ "${arn_account}" != "${AWS_ACCOUNT}" ]; then
+          die "the role ARN is for account ${arn_account} but this shell is authenticated against account ${AWS_ACCOUNT}. Rerun with credentials for account ${arn_account}"
+     fi
+     log "Role ARN account matches this shell's credentials"
+
+     ROLE_NAME="${arn_role_name}"
 }
 
 # =============================================================================
@@ -946,6 +1021,7 @@ main() {
      esac
 
      check_prerequisites
+     validate_role_arn
 
      # Region is baked into the role/endpoint and is where telemetry lands, so
      # never guess it: fail rather than default silently.
@@ -970,6 +1046,12 @@ main() {
      ROLE_ARN=$(aws iam get-role \
           --role-name "${ROLE_NAME}" \
           --query Role.Arn --output text)
+     # The role in play can drift from a provided ARN: aws_ec2 swaps in an
+     # existing instance-profile role, and a pathed ARN for a role that did not
+     # exist yet is created at the default path. Flag either, neutrally.
+     if [ -n "${ROLE_ARN_INPUT}" ] && [ "${ROLE_ARN}" != "${ROLE_ARN_INPUT}" ]; then
+          logwarn "using ${ROLE_ARN} instead of the provided ${ROLE_ARN_INPUT}"
+     fi
      log "Role ARN: ${ROLE_ARN}"
 
      ensure_transaction_search

--- a/scripts/aws/setup.sh
+++ b/scripts/aws/setup.sh
@@ -330,7 +330,7 @@ check_prerequisites() {
 # =============================================================================
 # Role ARN validation
 #
-# When CWAGENT_AWS_ROLE_ARN is provided (e.g. populated by the console UI), the
+# When CWAGENT_AWS_ROLE_ARN is provided, the
 # account baked into it must match the account this shell is authenticated
 # against: creating the role and trust in the wrong account does not fail here,
 # it fails later and silently on the assume-role side. The role name used

--- a/scripts/azure/setup.sh
+++ b/scripts/azure/setup.sh
@@ -364,9 +364,9 @@ Pass the resource ID or the individual values, not both with different targets."
           fi
      fi
      if [ -n "${AZ_NAME}" ]; then
-          log "Azure subscription: '${AZ_SUB}' ('${AZ_NAME}')"
+          log "Azure subscription: ${AZ_SUB} (${AZ_NAME})"
      else
-          log "Azure subscription: '${AZ_SUB}'"
+          log "Azure subscription: ${AZ_SUB}"
      fi
 }
 
@@ -470,7 +470,7 @@ setup_azure_vm() {
      # surface it before the slow identity and install steps: the user can
      # start the AWS side in parallel. Repeated at the end for easy copying.
      TENANT_ID="${AZ_TENANT}"
-     log "Tenant ID (for the AWS setup): '${TENANT_ID}'"
+     log "Tenant ID (for the AWS setup): ${TENANT_ID}"
 
      section "Configuring Azure VM identity..."
 
@@ -500,7 +500,7 @@ setup_azure_vm() {
           if INSTALL_CMD=$(windows_install_cmd "${ps_prelude}"); then
                run_via_az "RunPowerShellScript" "${INSTALL_CMD}"
                log "Agent installed on '${VM_NAME}'"
-               log "Tenant ID (for the AWS setup): '${TENANT_ID}'"
+               log "Tenant ID (for the AWS setup): ${TENANT_ID}"
                return
           fi
      else
@@ -508,7 +508,7 @@ setup_azure_vm() {
           if INSTALL_CMD=$(linux_install_cmd "${install_env}"); then
                run_via_az "RunShellScript" "${INSTALL_CMD}"
                log "Agent installed on '${VM_NAME}'"
-               log "Tenant ID (for the AWS setup): '${TENANT_ID}'"
+               log "Tenant ID (for the AWS setup): ${TENANT_ID}"
                return
           fi
      fi
@@ -571,14 +571,12 @@ setup_azure_aks() {
                --query "oidcIssuerProfile.issuerUrl" -o tsv)
      fi
 
-     log "OIDC issuer: '${OIDC_ISSUER}'"
-
      add_env CWAGENT_PLATFORM "${PLATFORM}"
      add_env CWAGENT_AZURE_OIDC_ISSUER "${OIDC_ISSUER}"
 
      # No ARN yet: identity is done, emit the OIDC issuer for the AWS trust step and stop.
      if [ -z "${ROLE_ARN}" ]; then
-          print_await_arn
+          print_await_arn "OIDC issuer (for the AWS setup): ${OIDC_ISSUER}"
           return
      fi
 
@@ -639,6 +637,8 @@ setup_azure_aks() {
                printf '    --create-namespace\n'
           } >&3
      fi
+
+     log "OIDC issuer (for the AWS setup): ${OIDC_ISSUER}"
 }
 
 main() {

--- a/scripts/azure/setup.sh
+++ b/scripts/azure/setup.sh
@@ -218,8 +218,6 @@ version_ge() {
 print_await_arn() {
      printf '\n' >&3
      log "Azure identity configured (install pending the IAM role ARN)"
-     # A plain if, not a trailing && list, which would fail the function under
-     # set -e when no line is passed.
      if [ -n "${1:-}" ]; then
           log "$1"
      fi
@@ -366,9 +364,9 @@ Pass the resource ID or the individual values, not both with different targets."
           fi
      fi
      if [ -n "${AZ_NAME}" ]; then
-          log "Azure subscription: ${AZ_SUB} (${AZ_NAME})"
+          log "Azure subscription: '${AZ_SUB}' ('${AZ_NAME}')"
      else
-          log "Azure subscription: ${AZ_SUB}"
+          log "Azure subscription: '${AZ_SUB}'"
      fi
 }
 
@@ -442,7 +440,7 @@ run_via_az() {
 
      if ! printf '%s' "${STDOUT}" | grep -q 'Amazon CloudWatch Agent installed and running\.'; then
           [ -n "${STDERR}" ] && printf '%s\n' "${STDERR}" >&2
-          die "Install script failed on ${VM_NAME}"
+          die "Install script failed on '${VM_NAME}'"
      fi
 }
 
@@ -464,7 +462,7 @@ setup_azure_vm() {
           --resource-group "${RESOURCE_GROUP}" \
           --name "${VM_NAME}" \
           --query "[[identity.principalId, storageProfile.osDisk.osType]]" -o tsv) ||
-          die "cannot find VM ${VM_NAME} in resource group ${RESOURCE_GROUP} (check the names against the subscription logged above)"
+          die "cannot find or access VM '${VM_NAME}' in resource group '${RESOURCE_GROUP}' (see the az error above)"
      IDENTITY=$(printf '%s' "${VM_INFO}" | cut -f1)
      VM_OS=$(printf '%s' "${VM_INFO}" | cut -f2)
 
@@ -472,19 +470,19 @@ setup_azure_vm() {
      # surface it before the slow identity and install steps: the user can
      # start the AWS side in parallel. Repeated at the end for easy copying.
      TENANT_ID="${AZ_TENANT}"
-     log "Tenant ID (for the AWS setup): ${TENANT_ID}"
+     log "Tenant ID (for the AWS setup): '${TENANT_ID}'"
 
      section "Configuring Azure VM identity..."
 
      if [ -n "${IDENTITY}" ] && [ "${IDENTITY}" != "None" ]; then
-          log "Managed identity enabled on ${VM_NAME}"
+          log "Managed identity enabled on '${VM_NAME}'"
      else
           logaction "Enabling managed identity (this may take a few minutes)"
           az_scoped vm identity assign \
                --resource-group "${RESOURCE_GROUP}" \
                --name "${VM_NAME}" \
                --output none
-          log "Managed identity enabled on ${VM_NAME}"
+          log "Managed identity enabled on '${VM_NAME}'"
      fi
 
      add_env CWAGENT_PLATFORM "${PLATFORM}"
@@ -501,14 +499,16 @@ setup_azure_vm() {
           ps_prelude="\$env:CWAGENT_CLOUD='azure'; \$env:CWAGENT_AWS_ROLE_ARN='${ROLE_ARN}'; \$env:CWAGENT_AWS_REGION='${REGION}'; "
           if INSTALL_CMD=$(windows_install_cmd "${ps_prelude}"); then
                run_via_az "RunPowerShellScript" "${INSTALL_CMD}"
-               log "Agent installed on ${VM_NAME} in tenant ${TENANT_ID}"
+               log "Agent installed on '${VM_NAME}'"
+               log "Tenant ID (for the AWS setup): '${TENANT_ID}'"
                return
           fi
      else
           install_env="CWAGENT_CLOUD=azure CWAGENT_AWS_ROLE_ARN=${ROLE_ARN} CWAGENT_AWS_REGION=${REGION}"
           if INSTALL_CMD=$(linux_install_cmd "${install_env}"); then
                run_via_az "RunShellScript" "${INSTALL_CMD}"
-               log "Agent installed on ${VM_NAME} in tenant ${TENANT_ID}"
+               log "Agent installed on '${VM_NAME}'"
+               log "Tenant ID (for the AWS setup): '${TENANT_ID}'"
                return
           fi
      fi
@@ -571,7 +571,7 @@ setup_azure_aks() {
                --query "oidcIssuerProfile.issuerUrl" -o tsv)
      fi
 
-     log "OIDC issuer: ${OIDC_ISSUER}"
+     log "OIDC issuer: '${OIDC_ISSUER}'"
 
      add_env CWAGENT_PLATFORM "${PLATFORM}"
      add_env CWAGENT_AZURE_OIDC_ISSUER "${OIDC_ISSUER}"
@@ -586,7 +586,7 @@ setup_azure_aks() {
      # commands to run from a shell that has them.
      if command -v helm >/dev/null 2>&1 && command -v kubectl >/dev/null 2>&1; then
           section "Installing CloudWatch Observability Helm chart on ${CLUSTER_NAME}..."
-          logaction "Configuring kubeconfig for ${CLUSTER_NAME}"
+          logaction "Configuring kubeconfig for '${CLUSTER_NAME}'"
           az_scoped aks get-credentials --resource-group "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --overwrite-existing >&3
 
           logaction "Installing via Helm"
@@ -613,7 +613,7 @@ setup_azure_aks() {
                --set-string 'agents[1].config=default' \
                --namespace "${K8S_NAMESPACE}" \
                --create-namespace >&3
-          log "Chart installed on ${CLUSTER_NAME}"
+          log "Chart installed on '${CLUSTER_NAME}'"
      else
           printf '\n' >&3
           printf 'Done. Install the Amazon CloudWatch Observability Helm chart (requires kubeconfig for %s):\n' "${CLUSTER_NAME}" >&3

--- a/scripts/azure/setup.sh
+++ b/scripts/azure/setup.sh
@@ -213,9 +213,16 @@ version_ge() {
 
 # ARN-unknown mode: identity is done but install waits on the AWS trust setup.
 # Emitted to fd 3 so it never lands on stdout's CWAGENT_EMIT_ENV KEY='value' lines.
+# $1 = optional identity line to repeat, so the value to copy into aws/setup.sh
+# sits at the very end of the output rather than scrolled past the slow steps.
 print_await_arn() {
      printf '\n' >&3
      log "Azure identity configured (install pending the IAM role ARN)"
+     # A plain if, not a trailing && list, which would fail the function under
+     # set -e when no line is passed.
+     if [ -n "${1:-}" ]; then
+          log "$1"
+     fi
      printf '\nNext: run aws/setup.sh with the identity value above to create the IAM\n' >&3
      printf 'role and trust, then rerun this with CWAGENT_AWS_ROLE_ARN set to install the\n' >&3
      printf 'agent.\n' >&3
@@ -446,17 +453,28 @@ run_via_az() {
 setup_azure_vm() {
      if [ -z "${RESOURCE_GROUP}" ] || [ -z "${VM_NAME}" ]; then usage; fi
 
-     section "Configuring Azure VM identity..."
-
      # One az vm show for the identity (whether to assign one) and the OS type
      # (which install payload). The nested [[...]] emits one tab-separated row
      # (null renders "None"); a flat [...] would print one value per line.
+     # Probing first also verifies the VM exists, so a wrong name or group
+     # fails here, before any setup output or slow identity work. az's own
+     # stderr is not suppressed: a permissions or throttling failure should
+     # show its real error above the message here, not read as not-found.
      VM_INFO=$(az_scoped vm show \
           --resource-group "${RESOURCE_GROUP}" \
           --name "${VM_NAME}" \
-          --query "[[identity.principalId, storageProfile.osDisk.osType]]" -o tsv 2>/dev/null || true)
+          --query "[[identity.principalId, storageProfile.osDisk.osType]]" -o tsv) ||
+          die "cannot find VM ${VM_NAME} in resource group ${RESOURCE_GROUP} (check the names against the subscription logged above)"
      IDENTITY=$(printf '%s' "${VM_INFO}" | cut -f1)
      VM_OS=$(printf '%s' "${VM_INFO}" | cut -f2)
+
+     # The tenant ID is what the AWS trust step (aws/setup.sh) needs, so
+     # surface it before the slow identity and install steps: the user can
+     # start the AWS side in parallel. Repeated at the end for easy copying.
+     TENANT_ID="${AZ_TENANT}"
+     log "Tenant ID (for the AWS setup): ${TENANT_ID}"
+
+     section "Configuring Azure VM identity..."
 
      if [ -n "${IDENTITY}" ] && [ "${IDENTITY}" != "None" ]; then
           log "Managed identity enabled on ${VM_NAME}"
@@ -469,15 +487,12 @@ setup_azure_vm() {
           log "Managed identity enabled on ${VM_NAME}"
      fi
 
-     TENANT_ID="${AZ_TENANT}"
-     log "Tenant: ${TENANT_ID}"
-
      add_env CWAGENT_PLATFORM "${PLATFORM}"
      add_env CWAGENT_AZURE_TENANT_ID "${TENANT_ID}"
 
      # No ARN yet: identity is done, emit the tenant ID for the AWS trust step and stop.
      if [ -z "${ROLE_ARN}" ]; then
-          print_await_arn
+          print_await_arn "Tenant ID (for the AWS setup): ${TENANT_ID}"
           return
      fi
 
@@ -486,14 +501,14 @@ setup_azure_vm() {
           ps_prelude="\$env:CWAGENT_CLOUD='azure'; \$env:CWAGENT_AWS_ROLE_ARN='${ROLE_ARN}'; \$env:CWAGENT_AWS_REGION='${REGION}'; "
           if INSTALL_CMD=$(windows_install_cmd "${ps_prelude}"); then
                run_via_az "RunPowerShellScript" "${INSTALL_CMD}"
-               log "Agent installed on ${VM_NAME}"
+               log "Agent installed on ${VM_NAME} in tenant ${TENANT_ID}"
                return
           fi
      else
           install_env="CWAGENT_CLOUD=azure CWAGENT_AWS_ROLE_ARN=${ROLE_ARN} CWAGENT_AWS_REGION=${REGION}"
           if INSTALL_CMD=$(linux_install_cmd "${install_env}"); then
                run_via_az "RunShellScript" "${INSTALL_CMD}"
-               log "Agent installed on ${VM_NAME}"
+               log "Agent installed on ${VM_NAME} in tenant ${TENANT_ID}"
                return
           fi
      fi


### PR DESCRIPTION
# Description of the issue

The onboarding setup scripts (`scripts/`) had two usability gaps in the Azure-to-AWS flow:

1. **Wrong-account failure mode.** The Azure-side setup takes the full IAM role ARN, but `aws/setup.sh` only took a role *name* and trusted whatever account the shell was authenticated against. Running it in the wrong account's credential context created the role and trust there, and the failure only surfaced later — silently — on the assume-role side.

2. **Buried tenant ID.** In the Azure VM flow, the tenant ID (the value the AWS trust step needs) was logged mid-output, after the minutes-long identity assignment, making it easy to miss and hard to copy. A mistyped VM name was also only discovered mid-run, via a raw CLI error from the identity step.

# Description of changes

**`aws/setup.sh`** now also accepts `CWAGENT_AWS_ROLE_ARN`. When set, it validates the ARN format, fails fast when the ARN's partition or account does not match the shell's credentials (`sts get-caller-identity`), and derives the role name from the ARN. A `CWAGENT_AWS_ROLE_NAME` that disagrees with the ARN is rejected; an agreeing or default-valued one is allowed (the dispatcher always exports the default). The interactive prompt now asks for an ARN, still accepting a plain role name or empty input for the default. A warning is printed if the resulting role differs from the provided ARN (e.g. an existing EC2 instance-profile role takes precedence). Validation runs before any IAM mutation.

**`azure/setup.sh`** (azure_vm flow): the `az vm show` probe now fails fast with a clear message when the VM cannot be found (az's own stderr is preserved so permission or throttling errors are not misread as not-found); the tenant ID is emitted before the slow identity and install steps, so the user can start the AWS side in parallel; and it is repeated at the very end for easy copying — in the install-success message ("Agent installed on <VM> in tenant <id>") and above the next-steps text of the identity-only flow.

**`README.md`**: `CWAGENT_AWS_ROLE_ARN` documented in the common environment variable table.

No breaking changes: all existing inputs and flows behave as before when the new variable is unset.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
1. Ran `make fmt` and `make fmt-sh`
2. Ran `make lint`