### PR TITLE
fix(ci): Do not copy extended attributes for darwin build

### DIFF
--- a/.github/workflows/test-build-packages.yml
+++ b/.github/workflows/test-build-packages.yml
@@ -118,16 +118,16 @@ jobs:
         working-directory: cwa
         run: |
           echo cw agent version $(cat CWAGENT_VERSION)
-          cp -r build/bin/darwin/amd64/. /tmp/
-          cp -r build/bin/darwin/arm64/. /tmp/arm64/
+          cp -Xr build/bin/darwin/amd64/. /tmp/
+          cp -Xr build/bin/darwin/arm64/. /tmp/arm64/
           cp build/bin/CWAGENT_VERSION /tmp/CWAGENT_VERSION
 
       - name: Create pkg dep folder and copy deps
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_binaries.outputs.cache-hit == false
         working-directory: test
         run: |
-          cp -r pkg/tools/. /tmp/
-          cp -r pkg/tools/. /tmp/arm64/
+          cp -Xr pkg/tools/. /tmp/
+          cp -Xr pkg/tools/. /tmp/arm64/
 
       - name: Build And Upload PKG
         if: contains(inputs.BucketKey, 'test') == false || steps.cached_binaries.outputs.cache-hit == false


### PR DESCRIPTION
# Description of the issue
The `MakeMacPkg` job in the `Build Test Artifacts` workflow has started failing at the "Copy binary" step:
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33896579998/job/101133623806
```
cp: build/bin/darwin/amd64/.: unable to copy extended attributes to /tmp/.: Operation not permitted
```
On macOS, `cp` attempts to replicate the source directory's extended attributes onto the target directory (`/tmp`). The only difference between the [previously passing run](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/33748512957/job/100627529059) and this failure is that the GitHub macOS runner image was updated from [20260727.0256](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260727.0256) to [20260829.0321](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260829.0321) and now seems to deny the copy, which breaks the darwin package build.

# Description of changes
Added the `-X` flag to the `cp` commands that copy the build output and pkg dependencies into `/tmp`.
```
$ man cp
...
     -X    Do not copy Extended Attributes (EAs) or resource forks.
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Ran the workflow against the branch
https://github.com/aws/amazon-cloudwatch-agent/actions/runs/34255505664/job/102166185058

# Requirements
_Before commiting your code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make lint`

-------
### Integration Tests
To run integration tests against this PR, add the `ready for testing` label.



